### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/harumiWeb/xlflow/security/code-scanning/1](https://github.com/harumiWeb/xlflow/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token access.

Best fix (without changing functionality): add

```yaml
permissions:
  contents: read
```

directly under the trigger section (`on:` block) and before `jobs:`. This is sufficient for `actions/checkout@v4` and keeps token scope minimal for lint/test operations. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow security configuration to restrict token permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->