### PR TITLE
Add VBA procedure and line-continuation lint checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added always-on `xlflow lint` syntax checks for unclosed or mismatched VBA `Sub`/`Function`/`Property` procedures and malformed line-continuation underscores, blocking `push`/`run` before Excel can open a VBE compile dialog.
+
 ## v0.7.0
 
 - Added `xlflow edit cell`, `edit range`, `edit rows`, and `edit columns` as minimal workbook-mutation helpers for AI-agent testing and visual tuning in a live Excel session.

--- a/README.ja.md
+++ b/README.ja.md
@@ -902,6 +902,8 @@ forbid_interactive_input = true
 
 対話前提の project で `UserForm` やダイアログを意図的に使う場合は、`forbid_interactive_input = false` にすると `VB007` 警告を抑止できます。これは lint だけに効き、`xlflow run --headless` の GUI 境界チェックは引き続きブロックします。
 
+typographic quote、C-style quote escape、閉じられていないまたは対応がずれた procedure、行継続 `_` の空白不足を検出する構文安全 lint は常に有効です。`push` や `run` が Excel を開く前に VBE compile dialog を防ぐためのルールです。
+
 ---
 
 ## JSON 出力

--- a/README.md
+++ b/README.md
@@ -899,6 +899,8 @@ forbid_interactive_input = true
 
 Set `forbid_interactive_input = false` when the project intentionally uses dialogs or UserForms and you want to suppress `VB007` warnings. This only affects lint output; `xlflow run --headless` still blocks GUI boundaries.
 
+Syntax safety lint rules for typographic quotes, C-style quote escapes, unclosed or mismatched procedures, and malformed line-continuation underscores are always enabled because they prevent VBE compile dialogs before `push` or `run` opens Excel.
+
 ---
 
 ## JSON output

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -276,8 +276,16 @@ End Sub
 - `VB005`: possible implicit `Variant`
 - `VB006`: module-level `Public` variable usage
 - `VB007`: automation-hostile GUI boundaries such as file pickers, modal dialogs, UserForms, message pumps, or external process launches. JSON findings may include `kind`, `symbol`, and `suggestion`.
+- `VB008`: typographic quote characters that can trigger VBE compile dialogs
+- `VB009`: likely C-style quote escapes in VBA string literals
+- `VB010`: unterminated `Sub`, `Function`, or `Property` procedure
+- `VB011`: unexpected `End Sub`, `End Function`, or `End Property`
+- `VB012`: mismatched procedure end statement
+- `VB013`: missing whitespace before a line-continuation underscore
 
 Projects that intentionally use interactive GUI entrypoints may set `[lint].forbid_interactive_input = false` to suppress `VB007`. This changes lint behavior only; `run --headless` still rejects GUI boundaries during preflight.
+
+Compile-dialog prevention findings `VB008` through `VB013` are always enabled and block source preflight before `push` or `run` opens Excel.
 
 ## Analysis Rules
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -2372,6 +2372,54 @@ func TestPushRejectsLikelyCStyleQuoteEscapesBeforeExcel(t *testing.T) {
 	}
 }
 
+func TestPushRejectsVBAProcedureSyntaxBeforeExcel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	if err := config.Write(filepath.Join(dir, config.FileName), cfg); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "Option Explicit\nPublic Sub Run()\nEnd Function\n"
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &app{cwd: dir}
+	root := a.rootCommand()
+	root.SetArgs([]string{"--json", "push"})
+	err := root.Execute()
+	if err == nil || output.ExitCode(err) != output.ExitValidation {
+		t.Fatalf("expected source validation failure before Excel, got err=%v exit=%d", err, output.ExitCode(err))
+	}
+}
+
+func TestPushRejectsMissingLineContinuationWhitespaceBeforeExcel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	if err := config.Write(filepath.Join(dir, config.FileName), cfg); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "Option Explicit\nPublic Sub Run()\n  Debug.Print \"hello\"_\nEnd Sub\n"
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &app{cwd: dir}
+	root := a.rootCommand()
+	root.SetArgs([]string{"--json", "push"})
+	err := root.Execute()
+	if err == nil || output.ExitCode(err) != output.ExitValidation {
+		t.Fatalf("expected source validation failure before Excel, got err=%v exit=%d", err, output.ExitCode(err))
+	}
+}
+
 func TestAnalyzeCommandReturnsValidationForFindings(t *testing.T) {
 	dir := t.TempDir()
 	cfg := config.Default()

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -183,7 +183,9 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 			logicalLine.WriteString(lineForProcedure)
 			lineForProcedure = logicalLine.String()
 		}
-		issues = append(issues, l.procedureBoundaryIssues(path, logicalStartLine, lineForProcedure, &procedures)...)
+		for _, statement := range splitStatements(lineForProcedure) {
+			issues = append(issues, l.procedureBoundaryIssues(path, logicalStartLine, statement, &procedures)...)
+		}
 		logicalLine.Reset()
 		logicalStartLine = 0
 	}
@@ -197,7 +199,9 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 		return nil, err
 	}
 	if logicalLine.Len() > 0 {
-		issues = append(issues, l.procedureBoundaryIssues(path, logicalStartLine, logicalLine.String(), &procedures)...)
+		for _, statement := range splitStatements(logicalLine.String()) {
+			issues = append(issues, l.procedureBoundaryIssues(path, logicalStartLine, statement, &procedures)...)
+		}
 	}
 	for _, procedure := range procedures {
 		issue := l.issue(path, procedure.LineNo, "VB010", "error", "Unterminated "+procedure.Kind+" procedure.")
@@ -418,6 +422,9 @@ func missingLineContinuationWhitespace(line string) bool {
 	if !strings.HasSuffix(trimmed, "_") || len(trimmed) < 2 {
 		return false
 	}
+	if endsWithIdentifierUnderscore(trimmed) {
+		return false
+	}
 	return trimmed[len(trimmed)-2] != ' ' && trimmed[len(trimmed)-2] != '\t'
 }
 
@@ -435,6 +442,52 @@ func removeLineContinuationMarker(line string) string {
 		return line
 	}
 	return trimmed[:len(trimmed)-1]
+}
+
+func splitStatements(line string) []string {
+	statements := make([]string, 0, 1)
+	start := 0
+	inString := false
+	for i := 0; i < len(line); i++ {
+		switch line[i] {
+		case '"':
+			if inString && i+1 < len(line) && line[i+1] == '"' {
+				i++
+				continue
+			}
+			inString = !inString
+		case ':':
+			if inString {
+				continue
+			}
+			statement := strings.TrimSpace(line[start:i])
+			if statement != "" {
+				statements = append(statements, statement)
+			}
+			start = i + 1
+		}
+	}
+	statement := strings.TrimSpace(line[start:])
+	if statement != "" {
+		statements = append(statements, statement)
+	}
+	return statements
+}
+
+func endsWithIdentifierUnderscore(line string) bool {
+	end := len(line) - 1
+	if end < 0 || line[end] != '_' {
+		return false
+	}
+	start := end
+	for start >= 0 && isIdentifierChar(line[start]) {
+		start--
+	}
+	return start < end-1
+}
+
+func isIdentifierChar(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
 func looksPublicVariable(line string) bool {

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -28,6 +28,12 @@ type Linter struct {
 	PathFilter func(string) bool
 }
 
+type procedureFrame struct {
+	Kind   string
+	Name   string
+	LineNo int
+}
+
 var (
 	selectRe          = regexp.MustCompile(`(?i)\.\s*select\b`)
 	activateRe        = regexp.MustCompile(`(?i)\.\s*activate\b`)
@@ -126,15 +132,22 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 
 	var issues []Issue
 	hasOptionExplicit := false
+	procedures := make([]procedureFrame, 0)
+	var logicalLine strings.Builder
+	logicalStartLine := 0
 	scanner := bufio.NewScanner(f)
 	lineNo := 0
 	for scanner.Scan() {
 		lineNo++
 		line := scanner.Text()
 		code := gui.StripComment(line)
+		detectionCode := maskStringLiterals(code)
 		trimmed := strings.TrimSpace(code)
 		if strings.EqualFold(trimmed, "Option Explicit") {
 			hasOptionExplicit = true
+		}
+		if missingLineContinuationWhitespace(detectionCode) {
+			issues = append(issues, l.issue(path, lineNo, "VB013", "error", "Line-continuation underscore must be preceded by whitespace."))
 		}
 		if l.Config.Lint.ForbidSelect && selectRe.MatchString(code) {
 			issues = append(issues, l.issue(path, lineNo, "VB002", "warning", "Avoid Select. Use direct object references instead."))
@@ -157,6 +170,22 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 		if containsLikelyCStyleQuoteEscape(code) {
 			issues = append(issues, l.issue(path, lineNo, "VB009", "error", "Likely C-style quote escape found in VBA source. Use doubled quotes, for example \"\"\"\", to represent a quote character."))
 		}
+		lineForProcedure := detectionCode
+		if logicalStartLine == 0 {
+			logicalStartLine = lineNo
+		}
+		if hasValidLineContinuation(detectionCode) {
+			logicalLine.WriteString(strings.TrimRight(removeLineContinuationMarker(lineForProcedure), " \t"))
+			logicalLine.WriteByte(' ')
+			continue
+		}
+		if logicalLine.Len() > 0 {
+			logicalLine.WriteString(lineForProcedure)
+			lineForProcedure = logicalLine.String()
+		}
+		issues = append(issues, l.procedureBoundaryIssues(path, logicalStartLine, lineForProcedure, &procedures)...)
+		logicalLine.Reset()
+		logicalStartLine = 0
 	}
 	if err := scanner.Err(); err != nil {
 		if closeErr := f.Close(); closeErr != nil {
@@ -166,6 +195,14 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 	}
 	if err := f.Close(); err != nil {
 		return nil, err
+	}
+	if logicalLine.Len() > 0 {
+		issues = append(issues, l.procedureBoundaryIssues(path, logicalStartLine, logicalLine.String(), &procedures)...)
+	}
+	for _, procedure := range procedures {
+		issue := l.issue(path, procedure.LineNo, "VB010", "error", "Unterminated "+procedure.Kind+" procedure.")
+		issue.Symbol = procedure.Name
+		issues = append(issues, issue)
 	}
 	if l.Config.Lint.RequireOptionExplicit && !hasOptionExplicit {
 		issues = append([]Issue{l.issue(path, 1, "VB001", "error", "Missing Option Explicit.")}, issues...)
@@ -194,7 +231,7 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 func PushBlockingIssues(issues []Issue) []Issue {
 	blocking := make([]Issue, 0)
 	for _, issue := range issues {
-		if issue.Code == "VB008" || issue.Code == "VB009" {
+		if issue.Code == "VB008" || issue.Code == "VB009" || issue.Code == "VB010" || issue.Code == "VB011" || issue.Code == "VB012" || issue.Code == "VB013" {
 			blocking = append(blocking, issue)
 		}
 	}
@@ -248,6 +285,156 @@ func containsLikelyCStyleQuoteEscape(line string) bool {
 		}
 	}
 	return false
+}
+
+func (l Linter) procedureBoundaryIssues(path string, lineNo int, line string, procedures *[]procedureFrame) []Issue {
+	var issues []Issue
+	if endKind, ok := procedureEndKind(line); ok {
+		if len(*procedures) == 0 {
+			issues = append(issues, l.issue(path, lineNo, "VB011", "error", "Unexpected End "+endKind+" without a matching procedure."))
+			return issues
+		}
+		top := (*procedures)[len(*procedures)-1]
+		*procedures = (*procedures)[:len(*procedures)-1]
+		if top.Kind != endKind {
+			issue := l.issue(path, lineNo, "VB012", "error", "Mismatched End "+endKind+" for "+top.Kind+" procedure.")
+			issue.Symbol = top.Name
+			issues = append(issues, issue)
+		}
+		return issues
+	}
+	if start, ok := procedureStart(line, lineNo); ok {
+		*procedures = append(*procedures, start)
+	}
+	return issues
+}
+
+func procedureEndKind(line string) (string, bool) {
+	fields := lowerFields(line)
+	if len(fields) < 2 || fields[0] != "end" {
+		return "", false
+	}
+	switch fields[1] {
+	case "sub":
+		return "Sub", true
+	case "function":
+		return "Function", true
+	case "property":
+		return "Property", true
+	default:
+		return "", false
+	}
+}
+
+func procedureStart(line string, lineNo int) (procedureFrame, bool) {
+	fields := lowerFields(line)
+	names := cleanedFields(line)
+	if len(fields) == 0 || fields[0] == "rem" || strings.HasPrefix(fields[0], "#") {
+		return procedureFrame{}, false
+	}
+	index := 0
+	for index < len(fields) {
+		switch fields[index] {
+		case "public", "private", "friend", "static":
+			index++
+		default:
+			goto afterModifiers
+		}
+	}
+afterModifiers:
+	if index >= len(fields) || fields[index] == "declare" {
+		return procedureFrame{}, false
+	}
+	switch fields[index] {
+	case "sub":
+		return procedureFrame{Kind: "Sub", Name: procedureName(names, index+1), LineNo: lineNo}, true
+	case "function":
+		return procedureFrame{Kind: "Function", Name: procedureName(names, index+1), LineNo: lineNo}, true
+	case "property":
+		if index+1 >= len(fields) {
+			return procedureFrame{}, false
+		}
+		switch fields[index+1] {
+		case "get", "let", "set":
+			return procedureFrame{Kind: "Property", Name: procedureName(names, index+2), LineNo: lineNo}, true
+		default:
+			return procedureFrame{}, false
+		}
+	default:
+		return procedureFrame{}, false
+	}
+}
+
+func procedureName(fields []string, index int) string {
+	if index >= len(fields) {
+		return ""
+	}
+	name, _, _ := strings.Cut(fields[index], "(")
+	return name
+}
+
+func lowerFields(line string) []string {
+	fields := cleanedFields(line)
+	for i, field := range fields {
+		fields[i] = strings.ToLower(field)
+	}
+	return fields
+}
+
+func cleanedFields(line string) []string {
+	fields := strings.Fields(line)
+	for i, field := range fields {
+		fields[i] = strings.Trim(field, "(),")
+	}
+	return fields
+}
+
+func maskStringLiterals(line string) string {
+	var b strings.Builder
+	b.Grow(len(line))
+	inString := false
+	for i := 0; i < len(line); i++ {
+		if line[i] != '"' {
+			if inString {
+				b.WriteByte(' ')
+			} else {
+				b.WriteByte(line[i])
+			}
+			continue
+		}
+		b.WriteByte('"')
+		if inString && i+1 < len(line) && line[i+1] == '"' {
+			b.WriteByte('"')
+			i++
+			continue
+		}
+		inString = !inString
+	}
+	return b.String()
+}
+
+func missingLineContinuationWhitespace(line string) bool {
+	trimmed := strings.TrimRight(line, " \t")
+	if !strings.HasSuffix(trimmed, "_") || len(trimmed) < 2 {
+		return false
+	}
+	return trimmed[len(trimmed)-2] != ' ' && trimmed[len(trimmed)-2] != '\t'
+}
+
+func hasValidLineContinuation(line string) bool {
+	trimmed := strings.TrimRight(line, " \t")
+	if !strings.HasSuffix(trimmed, "_") || len(trimmed) < 2 {
+		return false
+	}
+	return trimmed[len(trimmed)-2] == ' ' || trimmed[len(trimmed)-2] == '\t'
+}
+
+func removeLineContinuationMarker(line string) string {
+	trimmed := strings.TrimRight(line, " \t")
+	if !strings.HasSuffix(trimmed, "_") {
+		return line
+	}
+	return trimmed[:len(trimmed)-1]
 }
 
 func looksPublicVariable(line string) bool {

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -171,6 +171,186 @@ func TestLinterFindsLikelyCStyleQuoteEscapesThatTriggerVBECompileDialogs(t *test
 	}
 }
 
+func TestLinterAllowsValidProcedureBoundaries(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Public Sub Foo()
+End Sub
+
+Private Function Bar() As String
+End Function
+
+Friend Property Get Name() As String
+End Property
+
+Public Property Let Name(ByVal value As String)
+End Property
+
+Public Property Set Item(ByVal value As Object)
+End Property
+
+Public Declare PtrSafe Function GetTickCount Lib "kernel32" () As Long
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range issues {
+		if strings.HasPrefix(issue.Code, "VB01") {
+			t.Fatalf("valid procedure source should not trigger syntax lint: %+v", issues)
+		}
+	}
+}
+
+func TestLinterFindsProcedureBoundarySyntaxErrors(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Public Sub Unterminated()
+
+End Function
+
+End Property
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertIssue(t, issues, "VB012", 4)
+	assertIssue(t, issues, "VB011", 6)
+
+	blocking := PushBlockingIssues(issues)
+	assertIssue(t, blocking, "VB012", 4)
+	assertIssue(t, blocking, "VB011", 6)
+}
+
+func TestLinterFindsUnterminatedProcedureAtStartLine(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Public Function MissingClose() As String
+    MissingClose = "x"
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	issue := findIssue(t, issues, "VB010", 2)
+	if issue.Symbol == "" {
+		t.Fatalf("expected VB010 to include procedure symbol: %+v", issue)
+	}
+	assertIssue(t, PushBlockingIssues(issues), "VB010", 2)
+}
+
+func TestLinterProcedureScannerIgnoresCommentsStringsAndDesignerEnd(t *testing.T) {
+	dir := t.TempDir()
+	formsDir := filepath.Join(dir, "src", "forms")
+	if err := os.MkdirAll(formsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `VERSION 5.00
+Begin {C62A69F0-16DC-11CE-9E98-00AA00574A4F} UserForm1
+End
+Attribute VB_Name = "UserForm1"
+Option Explicit
+' Sub Fake()
+Public Sub Run()
+    Debug.Print "End Sub"
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(formsDir, "UserForm1.frm"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	cfg.UserForm.CodeSource = "frm"
+	issues, err := Linter{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range issues {
+		if issue.Code == "VB010" || issue.Code == "VB011" || issue.Code == "VB012" {
+			t.Fatalf("comments, strings, and designer End should not trigger procedure lint: %+v", issues)
+		}
+	}
+}
+
+func TestLinterHandlesContinuedProcedureDeclaration(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Public Sub Run( _
+    ByVal value As String)
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range issues {
+		if issue.Code == "VB010" || issue.Code == "VB011" || issue.Code == "VB012" || issue.Code == "VB013" {
+			t.Fatalf("valid continued declaration should not trigger syntax lint: %+v", issues)
+		}
+	}
+}
+
+func TestLinterFindsMissingWhitespaceBeforeLineContinuation(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Public Sub Run()
+    Debug.Print "hello"_
+    Debug.Print "hello" _
+    Debug.Print "abc_"
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertIssue(t, issues, "VB013", 3)
+	assertIssue(t, PushBlockingIssues(issues), "VB013", 3)
+	var count int
+	for _, issue := range issues {
+		if issue.Code == "VB013" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected one VB013 issue, got %+v", issues)
+	}
+}
+
 func TestLinterSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
 	dir := t.TempDir()
 	formsDir := filepath.Join(dir, "src", "forms")
@@ -203,4 +383,20 @@ func TestLinterSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
 	if vb009[0].File != "src/forms/code/UserForm1.bas" {
 		t.Fatalf("expected sidecar file to be authoritative, got %+v", vb009[0])
 	}
+}
+
+func assertIssue(t *testing.T, issues []Issue, code string, line int) {
+	t.Helper()
+	findIssue(t, issues, code, line)
+}
+
+func findIssue(t *testing.T, issues []Issue, code string, line int) Issue {
+	t.Helper()
+	for _, issue := range issues {
+		if issue.Code == code && issue.Line == line {
+			return issue
+		}
+	}
+	t.Fatalf("missing issue %s at line %d in %+v", code, line, issues)
+	return Issue{}
 }

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -351,6 +351,58 @@ End Sub
 	}
 }
 
+func TestLinterAllowsIdentifiersEndingWithUnderscore(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Public Sub Run()
+    Dim total_ As Long
+    total_ = 1
+    Debug.Print total_
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range issues {
+		if issue.Code == "VB013" {
+			t.Fatalf("identifier ending with underscore should not trigger VB013: %+v", issues)
+		}
+	}
+}
+
+func TestLinterHandlesOneLineProcedureStatements(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Sub Foo(): End Sub
+Function Bar() As String: Bar = "x": End Function
+Property Get Name() As String: Name = "x": End Property
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range issues {
+		if issue.Code == "VB010" || issue.Code == "VB011" || issue.Code == "VB012" {
+			t.Fatalf("one-line procedures should not trigger structure lint: %+v", issues)
+		}
+	}
+}
+
 func TestLinterSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
 	dir := t.TempDir()
 	formsDir := filepath.Join(dir, "src", "forms")

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -1,3 +1,19 @@
+# VBA Syntax Lint Spec
+
+## Goal
+
+Catch cheap VBA syntax mistakes before Excel/VBE can surface them as modal compile dialogs.
+
+## Contract
+
+- `xlflow lint` reports always-on `error` findings for malformed `Sub`, `Function`, and `Property Get/Let/Set` procedure boundaries.
+- `VB010` reports an unterminated procedure at the procedure start line.
+- `VB011` reports an unexpected `End Sub`, `End Function`, or `End Property` when no matching procedure is open.
+- `VB012` reports a mismatched procedure end when the open procedure kind differs from the `End ...` kind.
+- `VB013` reports a line-continuation underscore that is not preceded by whitespace.
+- The scanner ignores comments and string literal contents for token detection and underscore checks, and joins valid continued physical lines before procedure boundary detection.
+- These findings are push/run source-preflight blocking issues, matching existing compile-dialog prevention rules.
+
 # xlflow Folder Structure Spec
 
 ## UserForm Phase 1 Warning Spec

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,18 @@
+# VBA Syntax Lint Todo
+
+- [x] Add always-on lint findings for procedure boundary structure and line-continuation underscore whitespace.
+- [x] Include the new syntax findings in push/run source-preflight blocking issues.
+- [x] Add focused lint and CLI preflight regression tests.
+- [x] Update CLI contract and README lint rule documentation.
+- [x] Run `go test ./internal/lint ./internal/cli`, `go test ./...`, and `task lint`.
+
+## Verification Notes
+
+- `go test ./internal/lint ./internal/cli` passed.
+- `go test ./...` passed.
+- `task lint` passed.
+- Excel COM E2E was not run because this change only affects static lint/source preflight logic and does not change workbook import/export, VBIDE automation, or macro execution behavior.
+
 # xlflow Folder Structure Todo
 
 # UserForm Phase 1 Warning Todo


### PR DESCRIPTION
## Summary
- Added always-on `xlflow lint` checks for unclosed, unexpected, and mismatched VBA `Sub`/`Function`/`Property` procedures.
- Added a new line-continuation rule for missing whitespace before `_`.
- Wired the new findings into push/run source preflight so they block Excel before VBE compile dialogs can appear.
- Updated docs, README guidance, changelog, and regression coverage.

## Testing
- `go test ./internal/lint ./internal/cli` passed.
- `go test ./...` passed.
- `task lint` passed.