### PR TITLE
Scaffold workbook document modules during new projects

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -211,11 +211,15 @@ task run -- --help
 xlflow new Book.xlsm
 ```
 
+`new` は scaffold した VBA module を新しい workbook へ自動 `push` するため、その後の `pull` でも同じ初期状態から始められます。
+
 既存の Excel ブックから始める場合は `init` を使用します。
 
 ```bash
 xlflow init Book.xlsm
 ```
+
+`init` はコピーした workbook から `src/` へ自動 `pull` するため、追加の bootstrap `pull` なしでそのまま source 編集を始められます。
 
 AI エージェント向けの Skill も同時にインストールする場合:
 

--- a/README.md
+++ b/README.md
@@ -210,11 +210,15 @@ Create a new xlflow project and macro-enabled workbook:
 xlflow new Book.xlsm
 ```
 
+`new` automatically pushes the scaffolded VBA modules into the new workbook, so a later `pull` starts from the same initial source.
+
 Or start from an existing workbook:
 
 ```bash
 xlflow init Book.xlsm
 ```
+
+`init` automatically pulls VBA out of the copied workbook into `src/`, so you can edit source files immediately without a separate bootstrap `pull`.
 
 Install the AI agent Skill during project creation:
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -4,13 +4,13 @@
 
 This spec defines the MVP command, configuration, JSON output, and exit-code contracts for xlflow.
 
-xlflow is a Windows-first Go CLI that treats Excel VBA projects as source-controlled code. Excel operations use PowerShell and Excel COM. Non-Excel commands such as `init` and `lint` should remain testable without Excel installed.
+xlflow is a Windows-first Go CLI that treats Excel VBA projects as source-controlled code. Excel operations use PowerShell and Excel COM. Source-only commands such as `lint` should remain testable without Excel installed.
 
 ## Commands
 
 ```text
 xlflow [--json] new [workbook] [--with-skill] [--agent <provider>] [--no-update-check] [--keepalive] [--keepalive-interval <duration>]
-xlflow [--json] init <workbook> [--with-skill] [--agent <provider>] [--no-update-check]
+xlflow [--json] init <workbook> [--with-skill] [--agent <provider>] [--no-update-check] [--keepalive] [--keepalive-interval <duration>]
 xlflow [--json] doctor [--keepalive] [--keepalive-interval <duration>]
 xlflow [--json] attach --active [--keepalive] [--keepalive-interval <duration>]
 xlflow [--json] list forms [--session] [--keepalive] [--keepalive-interval <duration>]
@@ -61,13 +61,13 @@ xlflow [--json] version [--verbose]
 
 When `--json` is not set, output is optimized for humans rather than machines. Interactive terminals may use Bubble Tea/Lipgloss presentation, color, and progress spinners for Excel COM-backed commands. Non-interactive output, such as CI logs and pipes, stays static and text-oriented while preserving the same command result information. Machine consumers must use `--json` instead of parsing human output.
 
-Excel COM-backed commands support `--keepalive` for AI agent and task-runner environments that may treat long silent Excel COM operations as stalled. This includes `new`, `doctor`, `attach`, `list forms`, `inspect form`, `form snapshot`, `form build`, `form export-image`, `pull`, `push`, `trace enable/disable/status/inject/clean`, `run`, `export-image`, `edit cell/range/rows/columns`, `macros`, `ui button add/list/remove`, `test`, and `check`. When enabled, xlflow writes heartbeat lines to stderr while the PowerShell/Excel bridge is still running, starting immediately and then repeating every `--keepalive-interval` duration. The default interval is `5s`; non-positive intervals are CLI argument errors when keepalive is enabled. Keepalive output never writes to stdout, so `--json` stdout remains a single machine-readable envelope. At completion, xlflow writes a stderr marker such as `XLFLOW_DONE status=success command=pull` or `XLFLOW_DONE status=failed command=run code=macro_timeout`. Agents should not begin the next workbook-dependent step until the command exits and this marker has been observed.
+Excel COM-backed commands support `--keepalive` for AI agent and task-runner environments that may treat long silent Excel COM operations as stalled. This includes `new`, `init`, `doctor`, `attach`, `list forms`, `inspect form`, `form snapshot`, `form build`, `form export-image`, `pull`, `push`, `trace enable/disable/status/inject/clean`, `run`, `export-image`, `edit cell/range/rows/columns`, `macros`, `ui button add/list/remove`, `test`, and `check`. When enabled, xlflow writes heartbeat lines to stderr while the PowerShell/Excel bridge is still running, starting immediately and then repeating every `--keepalive-interval` duration. The default interval is `5s`; non-positive intervals are CLI argument errors when keepalive is enabled. Keepalive output never writes to stdout, so `--json` stdout remains a single machine-readable envelope. At completion, xlflow writes a stderr marker such as `XLFLOW_DONE status=success command=pull` or `XLFLOW_DONE status=failed command=run code=macro_timeout`. Agents should not begin the next workbook-dependent step until the command exits and this marker has been observed.
 
 Excel COM-backed commands also include top-level `bridge` metadata with `host`, `edition`, and `version`. This identifies the xlflow PowerShell bridge process only. If workbook VBA launches its own external PowerShell process, that workbook-side host may differ and must be inspected separately.
 
-`new` creates a fresh macro-enabled workbook under `build/` and scaffolds the same project layout as `init`. Without an argument it creates `build/Book.xlsm`; when the argument has no extension, `.xlsm` is appended. Any other extension is rejected because workbook creation always uses Excel macro-enabled format `52`. New projects write `[userform].code_source = "sidecar"` into `xlflow.toml`.
+`new` creates a fresh macro-enabled workbook under `build/`, scaffolds the same project layout as `init`, and then automatically `push`es the scaffolded VBA source into that workbook so the initial workbook and `src/` tree start in sync. Without an argument it creates `build/Book.xlsm`; when the argument has no extension, `.xlsm` is appended. Any other extension is rejected because workbook creation always uses Excel macro-enabled format `52`. New projects write `[userform].code_source = "sidecar"` into `xlflow.toml`.
 
-`init` accepts an existing workbook path, copies that workbook into the new project's `build/<basename>` path, and records that project-local `build/...` path in `xlflow.toml` under `[excel].path` (for example `build/Sales.xlsx`). Initialized projects write `[userform].code_source = "frm"` so existing `.frm`-embedded code remains authoritative by default.
+`init` accepts an existing workbook path, copies that workbook into the new project's `build/<basename>` path, records that project-local `build/...` path in `xlflow.toml` under `[excel].path` (for example `build/Sales.xlsx`), and then automatically `pull`s VBA from the copied workbook into `src/` so the initial source tree reflects workbook reality without a second command. Initialized projects write `[userform].code_source = "frm"` so existing `.frm`-embedded code remains authoritative by default. Because this bootstrap pull opens Excel/VBIDE, `init` is now an Excel COM-backed command and returns an environment failure if the automatic import cannot complete.
 
 `new` and `init` create or update a project-local `.gitignore`. The managed entries ignore Excel temporary files (`~$*.xls*`, `*.tmp`) and xlflow-generated state (`.xlflow/`, `build/`). Existing `.gitignore` content is preserved; missing managed entries are appended without duplicating entries that are already present.
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -842,56 +842,58 @@ func (a *app) newCommand() *cobra.Command {
 			if len(args) == 1 {
 				workbook = args[0]
 			}
-			var excelEnv output.Envelope
-			var excelCode int
-			result, err := project.New(a.cwd, workbook, func(path string) error {
-				env, code, err := a.runExcelWithProgress("Creating workbook", keepaliveOpts, func() (output.Envelope, int, error) {
-					return excel.Runner{RootDir: a.cwd}.New(path, keepaliveOpts)
-				})
-				excelEnv = env
-				excelCode = code
-				if err != nil {
-					return err
-				}
-				if code != output.ExitSuccess {
-					if env.Error != nil {
-						return errors.New(env.Error.Message)
+			return a.withScaffoldKeepalive("new", keepaliveOpts, func(runOpts excel.CommandOptions) error {
+				var excelEnv output.Envelope
+				var excelCode int
+				result, err := project.New(a.cwd, workbook, func(path string) error {
+					env, code, err := a.runExcelWithProgress("Creating workbook", runOpts, func() (output.Envelope, int, error) {
+						return excel.Runner{RootDir: a.cwd}.New(path, runOpts)
+					})
+					excelEnv = env
+					excelCode = code
+					if err != nil {
+						return err
 					}
-					return errors.New("workbook creation failed")
-				}
-				return nil
-			})
-			if err != nil {
-				if excelCode != 0 {
-					return a.write(excelEnv, excelCode)
-				}
-				return a.writeFailure("new", output.ExitConfig, "new_failed", err)
-			}
-			bootstrapEnv, bootstrapCode, bootstrapErr := a.bootstrapScaffoldPush(keepaliveOpts)
-			if bootstrapErr != nil {
-				return bootstrapErr
-			}
-			if bootstrapCode != output.ExitSuccess {
-				return a.write(bootstrapEnv, bootstrapCode)
-			}
-			var skillResult agentskill.InstallResult
-			if withSkill {
-				skillResult, err = agentskill.Install(skillOpts)
+					if code != output.ExitSuccess {
+						if env.Error != nil {
+							return errors.New(env.Error.Message)
+						}
+						return errors.New("workbook creation failed")
+					}
+					return nil
+				})
 				if err != nil {
-					return a.writeFailure("new", output.ExitConfig, "skill_install_failed", err)
+					if excelCode != 0 {
+						return a.write(excelEnv, excelCode)
+					}
+					return a.writeFailure("new", output.ExitConfig, "new_failed", err)
 				}
-			}
-			env := output.New("new")
-			env.Workbook = result.Workbook
-			env.Logs = []string{
-				"created " + result.ConfigPath,
-				"created " + result.Workbook,
-				"pushed scaffolded VBA source to workbook",
-			}
-			if withSkill {
-				env.Logs = append(env.Logs, "installed xlflow skill to "+skillResult.Path)
-			}
-			return a.write(env, output.ExitSuccess)
+				bootstrapEnv, bootstrapCode, bootstrapErr := a.bootstrapScaffoldPush(runOpts)
+				if bootstrapErr != nil {
+					return bootstrapErr
+				}
+				if bootstrapCode != output.ExitSuccess {
+					return a.write(bootstrapEnv, bootstrapCode)
+				}
+				var skillResult agentskill.InstallResult
+				if withSkill {
+					skillResult, err = agentskill.Install(skillOpts)
+					if err != nil {
+						return a.writeFailure("new", output.ExitConfig, "skill_install_failed", err)
+					}
+				}
+				env := output.New("new")
+				env.Workbook = result.Workbook
+				env.Logs = []string{
+					"created " + result.ConfigPath,
+					"created " + result.Workbook,
+					"pushed scaffolded VBA source to workbook",
+				}
+				if withSkill {
+					env.Logs = append(env.Logs, "installed xlflow skill to "+skillResult.Path)
+				}
+				return a.write(env, output.ExitSuccess)
+			})
 		},
 	}
 	cmd.Flags().BoolVar(&withSkill, "with-skill", false, "install the bundled xlflow AI agent skill")
@@ -927,35 +929,37 @@ func (a *app) initCommand() *cobra.Command {
 				}
 				skillOpts = opts
 			}
-			result, err := project.Init(a.cwd, args[0])
-			if err != nil {
-				return a.writeFailure("init", output.ExitConfig, "init_failed", err)
-			}
-			bootstrapEnv, bootstrapCode, bootstrapErr := a.bootstrapScaffoldPull(keepaliveOpts)
-			if bootstrapErr != nil {
-				return bootstrapErr
-			}
-			if bootstrapCode != output.ExitSuccess {
-				return a.write(bootstrapEnv, bootstrapCode)
-			}
-			var skillResult agentskill.InstallResult
-			if withSkill {
-				skillResult, err = agentskill.Install(skillOpts)
+			return a.withScaffoldKeepalive("init", keepaliveOpts, func(runOpts excel.CommandOptions) error {
+				result, err := project.Init(a.cwd, args[0])
 				if err != nil {
-					return a.writeFailure("init", output.ExitConfig, "skill_install_failed", err)
+					return a.writeFailure("init", output.ExitConfig, "init_failed", err)
 				}
-			}
-			env := output.New("init")
-			env.Workbook = result.Workbook
-			env.Logs = []string{
-				"created " + result.ConfigPath,
-				"copied workbook to " + result.Workbook,
-				"pulled workbook VBA into source",
-			}
-			if withSkill {
-				env.Logs = append(env.Logs, "installed xlflow skill to "+skillResult.Path)
-			}
-			return a.write(env, output.ExitSuccess)
+				bootstrapEnv, bootstrapCode, bootstrapErr := a.bootstrapScaffoldPull(runOpts)
+				if bootstrapErr != nil {
+					return bootstrapErr
+				}
+				if bootstrapCode != output.ExitSuccess {
+					return a.write(bootstrapEnv, bootstrapCode)
+				}
+				var skillResult agentskill.InstallResult
+				if withSkill {
+					skillResult, err = agentskill.Install(skillOpts)
+					if err != nil {
+						return a.writeFailure("init", output.ExitConfig, "skill_install_failed", err)
+					}
+				}
+				env := output.New("init")
+				env.Workbook = result.Workbook
+				env.Logs = []string{
+					"created " + result.ConfigPath,
+					"copied workbook to " + result.Workbook,
+					"pulled workbook VBA into source",
+				}
+				if withSkill {
+					env.Logs = append(env.Logs, "installed xlflow skill to "+skillResult.Path)
+				}
+				return a.write(env, output.ExitSuccess)
+			})
 		},
 	}
 	cmd.Flags().BoolVar(&withSkill, "with-skill", false, "install the bundled xlflow AI agent skill")
@@ -988,6 +992,20 @@ func (a *app) bootstrapScaffoldPull(keepaliveOpts excel.CommandOptions) (output.
 			Keepalive: keepaliveOpts,
 		})
 	})
+}
+
+func (a *app) withScaffoldKeepalive(command string, opts excel.CommandOptions, fn func(runOpts excel.CommandOptions) error) error {
+	reportDone := a.startCommandKeepalive(command, opts)
+	err := fn(withoutKeepalive(opts))
+	if reportDone != nil {
+		reportDone(err)
+	}
+	return err
+}
+
+func withoutKeepalive(opts excel.CommandOptions) excel.CommandOptions {
+	opts.Keepalive = false
+	return opts
 }
 
 func (a *app) doctorCommand() *cobra.Command {
@@ -3683,6 +3701,43 @@ func (a *app) withExcelProgress(label string, opts excel.CommandOptions, fn func
 		return fn()
 	}
 	return a.withSpinner(label, fn)
+}
+
+func (a *app) startCommandKeepalive(command string, opts excel.CommandOptions) func(error) {
+	if !opts.Keepalive {
+		return nil
+	}
+	w := a.stderrWriter()
+	interval := opts.KeepaliveInterval
+	if interval <= 0 {
+		interval = defaultKeepaliveInterval
+	}
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	started := time.Now()
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				elapsed := time.Since(started).Truncate(time.Second)
+				_, _ = fmt.Fprintf(w, "xlflow: %s still running... elapsed=%s\n", command, elapsed)
+			}
+		}
+	}()
+	return func(err error) {
+		close(done)
+		<-stopped
+		status := "success"
+		if err != nil {
+			status = "failed"
+		}
+		_, _ = fmt.Fprintf(w, "XLFLOW_DONE status=%s command=%s\n", status, command)
+	}
 }
 
 func (a *app) withSpinner(label string, fn func() error) error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -867,6 +867,13 @@ func (a *app) newCommand() *cobra.Command {
 				}
 				return a.writeFailure("new", output.ExitConfig, "new_failed", err)
 			}
+			bootstrapEnv, bootstrapCode, bootstrapErr := a.bootstrapScaffoldPush(keepaliveOpts)
+			if bootstrapErr != nil {
+				return bootstrapErr
+			}
+			if bootstrapCode != output.ExitSuccess {
+				return a.write(bootstrapEnv, bootstrapCode)
+			}
 			var skillResult agentskill.InstallResult
 			if withSkill {
 				skillResult, err = agentskill.Install(skillOpts)
@@ -879,6 +886,7 @@ func (a *app) newCommand() *cobra.Command {
 			env.Logs = []string{
 				"created " + result.ConfigPath,
 				"created " + result.Workbook,
+				"pushed scaffolded VBA source to workbook",
 			}
 			if withSkill {
 				env.Logs = append(env.Logs, "installed xlflow skill to "+skillResult.Path)
@@ -897,6 +905,7 @@ func (a *app) initCommand() *cobra.Command {
 	var withSkill bool
 	var skillAgent string
 	var noUpdateCheck bool
+	var keepalive keepaliveFlags
 
 	cmd := &cobra.Command{
 		Use:   "init <workbook>",
@@ -905,6 +914,10 @@ func (a *app) initCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := a.writeScaffoldWelcome("init", noUpdateCheck); err != nil {
 				return output.WithExitCode(output.ExitEnvironment, err)
+			}
+			keepaliveOpts, err := buildKeepaliveOptions(keepalive.enabled, keepalive.interval)
+			if err != nil {
+				return a.writeFailure("init", output.ExitConfig, "init_args_invalid", err)
 			}
 			var skillOpts agentskill.InstallOptions
 			if withSkill {
@@ -918,6 +931,13 @@ func (a *app) initCommand() *cobra.Command {
 			if err != nil {
 				return a.writeFailure("init", output.ExitConfig, "init_failed", err)
 			}
+			bootstrapEnv, bootstrapCode, bootstrapErr := a.bootstrapScaffoldPull(keepaliveOpts)
+			if bootstrapErr != nil {
+				return bootstrapErr
+			}
+			if bootstrapCode != output.ExitSuccess {
+				return a.write(bootstrapEnv, bootstrapCode)
+			}
 			var skillResult agentskill.InstallResult
 			if withSkill {
 				skillResult, err = agentskill.Install(skillOpts)
@@ -930,6 +950,7 @@ func (a *app) initCommand() *cobra.Command {
 			env.Logs = []string{
 				"created " + result.ConfigPath,
 				"copied workbook to " + result.Workbook,
+				"pulled workbook VBA into source",
 			}
 			if withSkill {
 				env.Logs = append(env.Logs, "installed xlflow skill to "+skillResult.Path)
@@ -940,7 +961,33 @@ func (a *app) initCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&withSkill, "with-skill", false, "install the bundled xlflow AI agent skill")
 	cmd.Flags().StringVar(&skillAgent, "agent", "", "skill provider target: agents, codex, claude, cursor, or gemini")
 	cmd.Flags().BoolVar(&noUpdateCheck, "no-update-check", false, "skip the interactive GitHub release update check during project scaffolding")
+	addKeepaliveFlags(cmd, &keepalive)
 	return cmd
+}
+
+func (a *app) bootstrapScaffoldPush(keepaliveOpts excel.CommandOptions) (output.Envelope, int, error) {
+	cfg, err := config.Load(a.cwd)
+	if err != nil {
+		return output.Envelope{}, 0, a.writeFailure("new", output.ExitConfig, "config_error", err)
+	}
+	return a.runExcelWithProgress("Importing scaffolded VBA source", keepaliveOpts, func() (output.Envelope, int, error) {
+		return excel.Runner{RootDir: a.cwd}.PushWithOptions(cfg, excel.PushOptions{
+			BackupMode: "never",
+			Keepalive:  keepaliveOpts,
+		})
+	})
+}
+
+func (a *app) bootstrapScaffoldPull(keepaliveOpts excel.CommandOptions) (output.Envelope, int, error) {
+	cfg, err := config.Load(a.cwd)
+	if err != nil {
+		return output.Envelope{}, 0, a.writeFailure("init", output.ExitConfig, "config_error", err)
+	}
+	return a.runExcelWithProgress("Exporting workbook VBA source", keepaliveOpts, func() (output.Envelope, int, error) {
+		return excel.Runner{RootDir: a.cwd}.PullWithOptions(cfg, excel.SessionCommandOptions{
+			Keepalive: keepaliveOpts,
+		})
+	})
 }
 
 func (a *app) doctorCommand() *cobra.Command {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1084,13 +1084,16 @@ func TestInitCommandRendersWelcomeForInteractiveTerminal(t *testing.T) {
 		t.Fatalf("init command error = %v, exit = %d", err, output.ExitCode(err))
 	}
 	got := stdout.String()
-	for _, want := range []string{"Welcome to xlflow", "Version: 1.2.3", "copied workbook to build/Input.xlsm"} {
+	for _, want := range []string{"Version: 1.2.3", "copied workbook to build/Input.xlsm"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("interactive init output missing %q:\n%s", want, got)
 		}
 	}
-	if strings.Index(got, "Welcome to xlflow") > strings.Index(got, "xlflow init") {
-		t.Fatalf("expected welcome before command summary:\n%s", got)
+	if strings.Contains(got, "Welcome to xlflow") {
+		t.Fatalf("interactive init output should not include welcome text:\n%s", got)
+	}
+	if strings.Index(got, "Version: 1.2.3") > strings.Index(got, "xlflow init") {
+		t.Fatalf("expected welcome UI before command summary:\n%s", got)
 	}
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -279,6 +281,7 @@ func TestRootCommandIncludesExcelCommandKeepaliveFlags(t *testing.T) {
 
 	for _, args := range [][]string{
 		{"new"},
+		{"init"},
 		{"doctor"},
 		{"attach"},
 		{"list", "forms"},
@@ -316,7 +319,6 @@ func TestRootCommandDoesNotAddKeepaliveToNonExcelCommands(t *testing.T) {
 	root := a.rootCommand()
 
 	for _, args := range [][]string{
-		{"init"},
 		{"lint"},
 		{"analyze"},
 		{"diff"},
@@ -363,6 +365,25 @@ func TestPullCommandRejectsInvalidKeepaliveIntervalBeforeConfigLoad(t *testing.T
 	a := &app{cwd: dir}
 	root := a.rootCommand()
 	root.SetArgs([]string{"pull", "--keepalive", "--keepalive-interval", "0s"})
+
+	err := root.Execute()
+	if err == nil || output.ExitCode(err) != output.ExitConfig {
+		t.Fatalf("expected config exit for invalid interval, got err=%v exit=%d", err, output.ExitCode(err))
+	}
+	if !strings.Contains(err.Error(), "--keepalive-interval") {
+		t.Fatalf("error = %v, want keepalive interval message", err)
+	}
+}
+
+func TestInitCommandRejectsInvalidKeepaliveIntervalBeforeScaffold(t *testing.T) {
+	dir := t.TempDir()
+	workbook := filepath.Join(dir, "Input.xlsm")
+	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := &app{cwd: dir}
+	root := a.rootCommand()
+	root.SetArgs([]string{"init", workbook, "--keepalive", "--keepalive-interval", "0s"})
 
 	err := root.Execute()
 	if err == nil || output.ExitCode(err) != output.ExitConfig {
@@ -1043,11 +1064,13 @@ func TestSkillInstallCommandInstallsProviderSkill(t *testing.T) {
 }
 
 func TestInitWithSkillInstallsProviderSkill(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "Input.xlsm")
 	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeTestPullScript(t, dir, false)
 	a := &app{cwd: dir}
 	root := a.rootCommand()
 	root.SetArgs([]string{"init", workbook, "--with-skill", "--agent", "codex"})
@@ -1063,11 +1086,13 @@ func TestInitWithSkillInstallsProviderSkill(t *testing.T) {
 }
 
 func TestInitCommandRendersWelcomeForInteractiveTerminal(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "Input.xlsm")
 	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeTestPullScript(t, dir, false)
 	var stdout bytes.Buffer
 	a := &app{
 		cwd:            dir,
@@ -1084,7 +1109,7 @@ func TestInitCommandRendersWelcomeForInteractiveTerminal(t *testing.T) {
 		t.Fatalf("init command error = %v, exit = %d", err, output.ExitCode(err))
 	}
 	got := stdout.String()
-	for _, want := range []string{"Version: 1.2.3", "copied workbook to build/Input.xlsm"} {
+	for _, want := range []string{"Version: 1.2.3", "copied workbook to build/Input.xlsm", "pulled workbook VBA into source"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("interactive init output missing %q:\n%s", want, got)
 		}
@@ -1098,11 +1123,13 @@ func TestInitCommandRendersWelcomeForInteractiveTerminal(t *testing.T) {
 }
 
 func TestInitCommandSkipsWelcomeForJSONOutput(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "Input.xlsm")
 	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeTestPullScript(t, dir, false)
 	var stdout bytes.Buffer
 	a := &app{
 		cwd:            dir,
@@ -1129,11 +1156,13 @@ func TestInitCommandSkipsWelcomeForJSONOutput(t *testing.T) {
 }
 
 func TestInitCommandShowsUpdateNoticeWhenNewReleaseIsAvailable(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "Input.xlsm")
 	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeTestPullScript(t, dir, false)
 	var stdout bytes.Buffer
 	a := &app{
 		cwd:            dir,
@@ -1156,11 +1185,13 @@ func TestInitCommandShowsUpdateNoticeWhenNewReleaseIsAvailable(t *testing.T) {
 }
 
 func TestInitCommandSilentlySkipsFailedUpdateCheck(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "Input.xlsm")
 	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeTestPullScript(t, dir, false)
 	var stdout bytes.Buffer
 	a := &app{
 		cwd:            dir,
@@ -1183,11 +1214,13 @@ func TestInitCommandSilentlySkipsFailedUpdateCheck(t *testing.T) {
 }
 
 func TestInitCommandSkipsUpdateCheckWithFlag(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "Input.xlsm")
 	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeTestPullScript(t, dir, false)
 	var stdout bytes.Buffer
 	a := &app{
 		cwd:            dir,
@@ -1209,6 +1242,7 @@ func TestInitCommandSkipsUpdateCheckWithFlag(t *testing.T) {
 }
 
 func TestInitCommandSkipsUpdateCheckWithEnv(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
 	t.Setenv(noUpdateCheckEnvVar, "1")
 
 	dir := t.TempDir()
@@ -1216,6 +1250,7 @@ func TestInitCommandSkipsUpdateCheckWithEnv(t *testing.T) {
 	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeTestPullScript(t, dir, false)
 	var stdout bytes.Buffer
 	a := &app{
 		cwd:            dir,
@@ -1233,6 +1268,58 @@ func TestInitCommandSkipsUpdateCheckWithEnv(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "Update available:") {
 		t.Fatalf("interactive init output should skip update notice when %s is set:\n%s", noUpdateCheckEnvVar, stdout.String())
+	}
+}
+
+func TestInitCommandAutoPullsWorkbookSource(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
+	dir := t.TempDir()
+	workbook := filepath.Join(dir, "Input.xlsm")
+	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestPullScript(t, dir, true)
+
+	a := &app{cwd: dir}
+	root := a.rootCommand()
+	root.SetArgs([]string{"init", workbook})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+
+	modulePath := filepath.Join(dir, "src", "modules", "Imported.bas")
+	body, err := os.ReadFile(modulePath)
+	if err != nil {
+		t.Fatalf("expected auto-pulled module at %s: %v", modulePath, err)
+	}
+	if !strings.Contains(string(body), `Attribute VB_Name = "Imported"`) {
+		t.Fatalf("unexpected pulled module body:\n%s", string(body))
+	}
+}
+
+func TestNewCommandAutoPushesScaffoldSource(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
+	dir := t.TempDir()
+	writeTestNewScript(t, dir)
+	writeTestPushScript(t, dir)
+
+	a := &app{cwd: dir}
+	root := a.rootCommand()
+	root.SetArgs([]string{"new", "Book.xlsm"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("new command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+
+	markerPath := filepath.Join(dir, ".xlflow", "push.called")
+	body, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("expected auto-push marker at %s: %v", markerPath, err)
+	}
+	text := string(body)
+	for _, want := range []string{"Main.bas", "App.bas", "Ui.bas", "XlflowAssert.bas"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected push marker to mention %s:\n%s", want, text)
+		}
 	}
 }
 
@@ -2625,5 +2712,101 @@ func TestFilterAnalysisFindingsIgnoresTraceHelperCodesForTraceRun(t *testing.T) 
 func TestIgnoredRunPreflightAnalysisCodesEmptyWithoutTrace(t *testing.T) {
 	if got := ignoredRunPreflightAnalysisCodes(excel.RunOptions{}); got != nil {
 		t.Fatalf("expected nil ignored codes without trace, got %+v", got)
+	}
+}
+
+func skipWindowsPowerShellOnlyTest(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		t.Skip("requires Windows PowerShell bridge")
+	}
+	if _, err := exec.LookPath("powershell"); err != nil {
+		t.Skip("powershell not available")
+	}
+}
+
+func writeTestPullScript(t *testing.T, root string, createModule bool) {
+	t.Helper()
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createModuleLiteral := "$false"
+	if createModule {
+		createModuleLiteral = "$true"
+	}
+	script := fmt.Sprintf(`param(
+  [string]$WorkbookPath,
+  [string]$ModulesDir,
+  [string]$ClassesDir,
+  [string]$FormsDir,
+  [string]$WorkbookDir
+)
+New-Item -ItemType Directory -Force -Path $ModulesDir, $ClassesDir, $FormsDir, $WorkbookDir | Out-Null
+if (%s) {
+  Set-Content -LiteralPath (Join-Path $ModulesDir 'Imported.bas') -Value "Attribute VB_Name = ""Imported""" -Encoding UTF8
+}
+@{
+  status = 'ok'
+  command = 'pull'
+  logs = @('stub pull ok')
+  workbook = @{ path = $WorkbookPath }
+} | ConvertTo-Json -Compress
+`, createModuleLiteral)
+	if err := os.WriteFile(filepath.Join(scriptsDir, "pull.ps1"), []byte(script), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTestNewScript(t *testing.T, root string) {
+	t.Helper()
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := `param(
+  [string]$WorkbookPath
+)
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $WorkbookPath) | Out-Null
+Set-Content -LiteralPath $WorkbookPath -Value 'fake workbook' -Encoding UTF8
+@{
+  status = 'ok'
+  command = 'new'
+  logs = @('stub new ok')
+  workbook = @{ path = $WorkbookPath }
+} | ConvertTo-Json -Compress
+`
+	if err := os.WriteFile(filepath.Join(scriptsDir, "new.ps1"), []byte(script), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTestPushScript(t *testing.T, root string) {
+	t.Helper()
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := `param(
+  [string]$WorkbookPath,
+  [string]$ModulesDir,
+  [string]$StatePath
+)
+$markerPath = Join-Path (Split-Path -Parent $StatePath) '..\push.called'
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $markerPath) | Out-Null
+$names = @()
+if (Test-Path -LiteralPath $ModulesDir) {
+  $names = @(Get-ChildItem -LiteralPath $ModulesDir -File | Select-Object -ExpandProperty Name)
+}
+Set-Content -LiteralPath $markerPath -Value ($names -join [Environment]::NewLine) -Encoding UTF8
+@{
+  status = 'ok'
+  command = 'push'
+  logs = @('stub push ok')
+  workbook = @{ path = $WorkbookPath }
+} | ConvertTo-Json -Compress
+`
+	if err := os.WriteFile(filepath.Join(scriptsDir, "push.ps1"), []byte(script), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1323,6 +1323,29 @@ func TestNewCommandAutoPushesScaffoldSource(t *testing.T) {
 	}
 }
 
+func TestNewCommandKeepaliveReportsOnlyFinalCommandDoneMarker(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
+	dir := t.TempDir()
+	writeTestNewScript(t, dir)
+	writeTestPushScript(t, dir)
+
+	var stderr bytes.Buffer
+	a := &app{cwd: dir, stderr: &stderr}
+	root := a.rootCommand()
+	root.SetArgs([]string{"new", "Book.xlsm", "--keepalive"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("new command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+
+	got := stderr.String()
+	if count := strings.Count(got, "XLFLOW_DONE status=success command=new"); count != 1 {
+		t.Fatalf("expected exactly one final new done marker, got %d:\n%s", count, got)
+	}
+	if strings.Contains(got, "command=push") {
+		t.Fatalf("expected internal bootstrap push not to emit its own done marker:\n%s", got)
+	}
+}
+
 func TestSkillInstallCommandRefusesOverwriteUnlessForced(t *testing.T) {
 	dir := t.TempDir()
 	a := &app{cwd: dir}

--- a/internal/cli/welcome.go
+++ b/internal/cli/welcome.go
@@ -56,9 +56,9 @@ func renderScaffoldWelcome(model scaffoldWelcomeModel, color bool) string {
 		logo = renderGradientBlock(scaffoldWelcomeLogo, welcomeTitleStart, welcomeTitleEnd)
 	}
 	if meta == "" {
-		return logo + "\n\n"
+		return "\n\n" + logo + "\n\n"
 	}
-	return logo + "\n\n" + meta + "\n\n"
+	return "\n\n" + logo + "\n\n" + meta + "\n\n"
 }
 
 func renderScaffoldWelcomeBadge(text string) string {

--- a/internal/cli/welcome.go
+++ b/internal/cli/welcome.go
@@ -26,7 +26,6 @@ type rgbColor struct {
 }
 
 var (
-	welcomeBadgeColor = rgbColor{r: 184, g: 245, b: 162}
 	welcomeTitleStart = rgbColor{r: 143, g: 211, b: 255}
 	welcomeTitleEnd   = rgbColor{r: 184, g: 245, b: 162}
 	welcomeInfoColor  = rgbColor{r: 208, g: 214, b: 220}
@@ -51,20 +50,15 @@ func shouldRenderScaffoldWelcome(command string, opts output.Options) bool {
 }
 
 func renderScaffoldWelcome(model scaffoldWelcomeModel, color bool) string {
-	badge := renderScaffoldWelcomeBadge("🏄‍♂️ Welcome to xlflow")
 	logo := strings.Join(scaffoldWelcomeLogo, "\n")
 	meta := renderScaffoldWelcomeMeta(model, color)
 	if color {
-		badge = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(welcomeBadgeColor.hex())).
-			Bold(true).
-			Render(badge)
 		logo = renderGradientBlock(scaffoldWelcomeLogo, welcomeTitleStart, welcomeTitleEnd)
 	}
 	if meta == "" {
-		return badge + "\n\n" + logo + "\n\n"
+		return logo + "\n\n"
 	}
-	return badge + "\n\n" + logo + "\n\n" + meta + "\n\n"
+	return logo + "\n\n" + meta + "\n\n"
 }
 
 func renderScaffoldWelcomeBadge(text string) string {

--- a/internal/cli/welcome_test.go
+++ b/internal/cli/welcome_test.go
@@ -56,10 +56,9 @@ func TestShouldRenderScaffoldWelcome(t *testing.T) {
 	}
 }
 
-func TestRenderScaffoldWelcomeIncludesBadgeAndLogo(t *testing.T) {
+func TestRenderScaffoldWelcomeIncludesLogoAndVersion(t *testing.T) {
 	got := renderScaffoldWelcome(scaffoldWelcomeModel{Version: "1.2.3"}, false)
 	for _, want := range []string{
-		"🏄‍♂️ Welcome to xlflow",
 		"Version: 1.2.3",
 		" ██╗  ██╗ ██╗      ███████╗ ██╗       ██████╗  ██╗    ██╗",
 		" ╚═╝  ╚═╝ ╚══════╝ ╚═╝      ╚══════╝  ╚═════╝   ╚══╝╚══╝",
@@ -67,6 +66,13 @@ func TestRenderScaffoldWelcomeIncludesBadgeAndLogo(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("welcome output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestRenderScaffoldWelcomeOmitsWelcomeBadge(t *testing.T) {
+	got := renderScaffoldWelcome(scaffoldWelcomeModel{Version: "1.2.3"}, false)
+	if strings.Contains(got, "Welcome to xlflow") {
+		t.Fatalf("welcome output should not include welcome badge:\n%s", got)
 	}
 }
 

--- a/internal/project/scaffold.go
+++ b/internal/project/scaffold.go
@@ -34,7 +34,7 @@ func Init(cwd, workbookPath string) (InitResult, error) {
 	destPath := filepath.Join(cwd, "build", filepath.Base(workbookPath))
 	result, err = createScaffold(cwd, destPath, projectName(workbookPath), func(path string) error {
 		return copyFile(workbookPath, path)
-	}, "frm")
+	}, "frm", false)
 	if err != nil {
 		return InitResult{}, err
 	}
@@ -50,17 +50,23 @@ func New(cwd, workbookName string, createWorkbook WorkbookCreator) (InitResult, 
 		return InitResult{}, err
 	}
 	destPath := filepath.Join(cwd, "build", name)
-	return createScaffold(cwd, destPath, projectName(name), createWorkbook, "")
+	return createScaffold(cwd, destPath, projectName(name), createWorkbook, "", true)
 }
 
-func createScaffold(cwd, destPath, name string, createWorkbook WorkbookCreator, userFormCodeSource string) (InitResult, error) {
+func createScaffold(cwd, destPath, name string, createWorkbook WorkbookCreator, userFormCodeSource string, scaffoldWorkbookModules bool) (InitResult, error) {
 	var result InitResult
 	configPath := filepath.Join(cwd, config.FileName)
 	assertPath := filepath.Join(cwd, "src", "modules", "XlflowAssert.bas")
 	mainPath := filepath.Join(cwd, "src", "modules", "Main.bas")
 	appPath := filepath.Join(cwd, "src", "modules", "App.bas")
 	uiPath := filepath.Join(cwd, "src", "modules", "Ui.bas")
-	for _, path := range []string{destPath, configPath, assertPath, mainPath, appPath, uiPath} {
+	thisWorkbookPath := filepath.Join(cwd, "src", "workbook", "ThisWorkbook.bas")
+	sheet1Path := filepath.Join(cwd, "src", "workbook", "Sheet1.bas")
+	protectedPaths := []string{destPath, configPath, assertPath, mainPath, appPath, uiPath}
+	if scaffoldWorkbookModules {
+		protectedPaths = append(protectedPaths, thisWorkbookPath, sheet1Path)
+	}
+	for _, path := range protectedPaths {
 		if _, err := os.Stat(path); err == nil {
 			return result, fmt.Errorf("refusing to overwrite existing file: %s", path)
 		} else if !errors.Is(err, os.ErrNotExist) {
@@ -118,6 +124,20 @@ func createScaffold(cwd, destPath, name string, createWorkbook WorkbookCreator, 
 			return result, err
 		}
 		result.Created = append(result.Created, filepath.ToSlash(rel(cwd, item.path)))
+	}
+	if scaffoldWorkbookModules {
+		for _, item := range []struct {
+			path string
+			body string
+		}{
+			{thisWorkbookPath, defaultDocumentModule},
+			{sheet1Path, defaultDocumentModule},
+		} {
+			if err := writeExclusive(item.path, item.body); err != nil {
+				return result, err
+			}
+			result.Created = append(result.Created, filepath.ToSlash(rel(cwd, item.path)))
+		}
 	}
 
 	gitignorePath := filepath.Join(cwd, ".gitignore")
@@ -355,4 +375,7 @@ Option Explicit
 Public Sub RunFromButton()
   Main.Run
 End Sub
+`
+
+const defaultDocumentModule = `Option Explicit
 `

--- a/internal/project/scaffold_test.go
+++ b/internal/project/scaffold_test.go
@@ -209,6 +209,31 @@ func TestNewScaffoldDefaultWorkbook(t *testing.T) {
 	if cfg.UserForm.CodeSource != "sidecar" {
 		t.Fatalf("new userform code source = %q, want sidecar", cfg.UserForm.CodeSource)
 	}
+	for _, path := range []string{"src/workbook/ThisWorkbook.bas", "src/workbook/Sheet1.bas"} {
+		body, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(path)))
+		if err != nil {
+			t.Fatalf("expected %s: %v", path, err)
+		}
+		if string(body) != defaultDocumentModule {
+			t.Fatalf("%s = %q, want %q", path, string(body), defaultDocumentModule)
+		}
+	}
+}
+
+func TestInitScaffoldDoesNotCreatePlaceholderWorkbookModules(t *testing.T) {
+	dir := t.TempDir()
+	workbook := filepath.Join(dir, "Input.xlsm")
+	if err := os.WriteFile(workbook, []byte("fake workbook"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Init(dir, workbook); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"src/workbook/ThisWorkbook.bas", "src/workbook/Sheet1.bas"} {
+		if _, err := os.Stat(filepath.Join(dir, filepath.FromSlash(path))); !os.IsNotExist(err) {
+			t.Fatalf("expected %s not to be scaffolded for init, got %v", path, err)
+		}
+	}
 }
 
 func TestNewScaffoldAppendsXlsmExtension(t *testing.T) {

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -1,3 +1,24 @@
+# new/init Bootstrap Sync Spec
+
+## Goal
+
+Remove the extra bootstrap commands after project creation so `new` and `init` leave workbook state and source state synchronized immediately.
+
+## Contract
+
+- `xlflow new` still scaffolds `src/modules/XlflowAssert.bas`, `Main.bas`, `App.bas`, and `Ui.bas`, then automatically `push`es that scaffolded source into the newly created workbook before reporting success.
+- `xlflow init` still copies the input workbook into `build/<basename>`, then automatically `pull`s VBA from that copied workbook into `src/` before reporting success.
+- `new` success output includes a log that scaffolded VBA was pushed to the workbook.
+- `init` success output includes a log that workbook VBA was pulled into source.
+- `init` is now an Excel COM-backed command for contract purposes: if the automatic bootstrap pull cannot complete because Excel, COM, PowerShell, or VBIDE access is unavailable, the command returns an environment failure instead of a partial success.
+- `init` supports the same `--keepalive` / `--keepalive-interval` heartbeat behavior used by other Excel COM-backed commands.
+
+## Verification
+
+- `new` followed immediately by `pull` must preserve the scaffolded modules instead of exporting an empty workbook VBA project.
+- `init` must materialize workbook VBA under `src/` without requiring a manual follow-up `pull`.
+- CLI regression tests must cover the new success logs, `init` keepalive flags, and the bootstrap `push` / `pull` command chaining.
+
 # VitePress Documentation Site Spec
 
 ## Goal

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -6,7 +6,7 @@ Remove the extra bootstrap commands after project creation so `new` and `init` l
 
 ## Contract
 
-- `xlflow new` still scaffolds `src/modules/XlflowAssert.bas`, `Main.bas`, `App.bas`, and `Ui.bas`, then automatically `push`es that scaffolded source into the newly created workbook before reporting success.
+- `xlflow new` still scaffolds `src/modules/XlflowAssert.bas`, `Main.bas`, `App.bas`, and `Ui.bas`, plus workbook document-module placeholders `src/workbook/ThisWorkbook.bas` and `src/workbook/Sheet1.bas`, then automatically `push`es that scaffolded source into the newly created workbook before reporting success.
 - `xlflow init` still copies the input workbook into `build/<basename>`, then automatically `pull`s VBA from that copied workbook into `src/` before reporting success.
 - `new` success output includes a log that scaffolded VBA was pushed to the workbook.
 - `init` success output includes a log that workbook VBA was pulled into source.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,19 @@
+# new/init Bootstrap Sync Todo
+
+- [x] Add automatic scaffold `push` after `xlflow new`.
+- [x] Add automatic bootstrap `pull` after `xlflow init`.
+- [x] Add `init` keepalive flag support and argument validation coverage.
+- [x] Add CLI regression tests using script overrides for bootstrap `push` / `pull`.
+- [x] Run focused Go tests, full `go test ./...`, and Windows Excel COM E2E verification.
+
+## Verification Notes
+
+- `go test ./internal/cli -run "TestRootCommandIncludesExcelCommandKeepaliveFlags|TestRootCommandDoesNotAddKeepaliveToNonExcelCommands|TestInitCommandRejectsInvalidKeepaliveIntervalBeforeScaffold|TestInitWithSkillInstallsProviderSkill|TestInitCommandRendersWelcomeForInteractiveTerminal|TestInitCommandSkipsWelcomeForJSONOutput|TestInitCommandShowsUpdateNoticeWhenNewReleaseIsAvailable|TestInitCommandSilentlySkipsFailedUpdateCheck|TestInitCommandSkipsUpdateCheckWithFlag|TestInitCommandSkipsUpdateCheckWithEnv|TestInitCommandAutoPullsWorkbookSource|TestNewCommandAutoPushesScaffoldSource"` passed.
+- `go test ./...` passed.
+- E2E workspace `C:\dev\go\xlflow\tmp_workspaces\bootstrap-sync-e2e`: `xlflow new --json`, `doctor --json`, immediate `pull --json`, and `lint --json` all passed. The pulled source tree retained `src/modules/Main.bas`, `App.bas`, `Ui.bas`, and `XlflowAssert.bas`, confirming `new` now bootstraps workbook VBA before the first pull.
+- E2E workspace `C:\dev\go\xlflow\tmp_workspaces\bootstrap-sync-init`: `xlflow init C:\dev\go\xlflow\tmp_workspaces\bootstrap-sync-e2e\build\Book.xlsm --json`, `pull --json`, and `lint --json` all passed. `init` success output included `pulled workbook VBA into source`, and `src/` already contained workbook exports before the manual follow-up `pull`.
+- Verification scope was intentionally narrowed to the `new` / `init` bootstrap sync paths rather than full release-gate coverage.
+
 # VitePress Documentation Site Todo
 
 - [x] Add VitePress site configuration for GitHub Pages, local search, nav, sidebars, edit links, and footer.


### PR DESCRIPTION
## Summary
- Add `src/workbook/ThisWorkbook.bas` and `src/workbook/Sheet1.bas` during `xlflow new` scaffolding.
- Keep both document-module placeholders to `Option Explicit` only so new projects have the expected workbook source tree before the first `push`.
- Leave `xlflow init` unchanged so imported workbooks still rely on their actual exported document modules.

## Testing
- Added project scaffold tests for `new` covering the new workbook module files and their contents.
- Added a regression test to confirm `init` does not create the placeholder workbook modules.
- Ran `go test ./internal/project ./internal/cli` and `go test ./...` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `xlflow init` automatically pulls VBA from workbooks into source files
  * `xlflow new` automatically pushes scaffolded VBA into created workbooks
  * `xlflow init` adds `--keepalive` and `--keepalive-interval` options for Excel operations

* **Documentation**
  * Updated CLI reference documenting new command behavior and flags
  * Enhanced quick-start guides with workflow clarifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harumiWeb/xlflow/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->