### PR TITLE
takt: task-instruction-xlflow-ui-but

### DIFF
--- a/.takt/facets/personas/supervisor.md
+++ b/.takt/facets/personas/supervisor.md
@@ -1,0 +1,31 @@
+# Supervisor
+
+You are the loop supervisor for xlflow workflows.
+
+Your job is to determine whether a repeated review-fix loop is still making concrete engineering progress or has stalled.
+
+## Responsibilities
+
+- Compare the latest fix attempt against the previous review findings.
+- Look for concrete forward movement such as resolved defects, added regression tests, narrowed scope, or clearer evidence.
+- Distinguish real progress from churn, retries, or repeated summaries with no material code or verification change.
+- Stop the loop when the work is stuck and should be aborted or re-planned by a human.
+
+## Progress Criteria
+
+- Count it as progress only when at least one previously-blocking issue is actually resolved or decisively reduced.
+- Treat new targeted tests, better verification evidence, or removal of incorrect changes as progress when they materially improve the patch.
+- Treat repeated failures, unchanged defects, or purely cosmetic edits as no progress.
+- Be conservative: if the latest cycle does not clearly improve the situation, judge it as no progress.
+
+## Decision Style
+
+- Return a simple judgment aligned to the workflow rules.
+- Prefer `進捗なし` when evidence is ambiguous.
+- Base the judgment on files, diff, tests, and review findings, not intent.
+
+## Avoid
+
+- Do not re-review the whole patch from scratch unless needed to assess progress.
+- Do not approve code quality or architecture; only judge loop progress.
+- Do not invent hidden progress without concrete evidence.

--- a/.takt/workflows/xlflow-orchestra-high.yaml
+++ b/.takt/workflows/xlflow-orchestra-high.yaml
@@ -202,13 +202,17 @@ steps:
   # SELF REVIEW
   # =========================================================
   - name: self_review
+    persona: reviewer
 
     edit: false
 
-    provider: opencode
-    model: opencode-go/deepseek-v4-pro
-
-    persona: reviewer
+    promotion:
+      - at: 3
+        provider: opencode
+        model: opencode-go/deepseek-v4-pro
+      - condition: ai("レビュアーが reject を続けて進捗が止まっている")
+        provider: codex
+        model: gpt-5.4
 
     knowledge:
       - architecture
@@ -238,7 +242,7 @@ steps:
 
     rules:
       - condition: 修正が必要
-        next: implementation
+        next: fix
 
       - condition: 実装品質が十分
         next: final_audit
@@ -250,6 +254,67 @@ steps:
       report:
         - name: self-review.md
           format: review-report
+
+  # =========================================================
+  # FIX
+  # =========================================================
+  - name: fix
+
+    edit: true
+
+    provider: opencode
+    model: opencode-go/deepseek-v4-pro
+
+    persona: implementer
+
+    policy:
+      - coding
+      - testing
+
+    knowledge:
+      - architecture
+      - coding-rules
+      - invariants
+
+    required_permission_mode: edit
+
+    instruction: |
+      Address the concrete findings from self_review with the smallest safe patch.
+
+      Requirements:
+      - fix the highest-severity review findings first
+      - keep the scope tightly limited to the reported defects
+      - add or adjust regression tests when a review finding exposes a missing proof
+      - preserve public APIs, workbook compatibility, and deterministic exports
+
+      After changes:
+      - run the relevant tests or verification commands
+      - confirm each addressed finding has concrete evidence in code or test output
+
+      Avoid:
+      - restarting broad implementation work
+      - unrelated refactors or cleanup
+      - repeating the same failed approach without new evidence
+
+    rules:
+      - condition: 修正が完了した
+        next: self_review
+
+      - condition: 再計画が必要
+        next: plan
+
+      - condition: 修正を継続できない
+        next: ABORT
+
+      - condition: ユーザー入力が必要
+        next: fix
+        requires_user_input: true
+        interactive_only: true
+
+    output_contracts:
+      report:
+        - name: fix-report.md
+          format: implementation-report
 
   # =========================================================
   # FINAL AUDIT
@@ -315,3 +380,15 @@ steps:
       report:
         - name: final-audit.md
           format: audit-report
+
+loop_monitors:
+  - cycle: [self_review, fix]
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction: "fix ループに進捗があるかを評価してください..."
+      rules:
+        - condition: "進捗あり"
+          next: fix
+        - condition: "進捗なし"
+          next: ABORT

--- a/.takt/workflows/xlflow-orchestra-high.yaml
+++ b/.takt/workflows/xlflow-orchestra-high.yaml
@@ -206,13 +206,8 @@ steps:
 
     edit: false
 
-    promotion:
-      - at: 3
-        provider: opencode
-        model: opencode-go/deepseek-v4-pro
-      - condition: ai("レビュアーが reject を続けて進捗が止まっている")
-        provider: codex
-        model: gpt-5.4
+    provider: opencode
+    model: opencode-go/deepseek-v4-pro
 
     knowledge:
       - architecture

--- a/.takt/workflows/xlflow-orchestra-low.yaml
+++ b/.takt/workflows/xlflow-orchestra-low.yaml
@@ -234,7 +234,7 @@ steps:
 
     rules:
       - condition: 修正が必要
-        next: implementation
+        next: fix
 
       - condition: 実装品質が十分
         next: final_audit
@@ -246,6 +246,67 @@ steps:
       report:
         - name: self-review.md
           format: review-report
+
+  # =========================================================
+  # FIX
+  # =========================================================
+  - name: fix
+
+    edit: true
+
+    provider: opencode
+    model: opencode-go/deepseek-v4-flash
+
+    persona: implementer
+
+    policy:
+      - coding
+      - testing
+
+    knowledge:
+      - architecture
+      - coding-rules
+      - invariants
+
+    required_permission_mode: edit
+
+    instruction: |
+      Address the concrete findings from self_review with the smallest safe patch.
+
+      Requirements:
+      - fix the highest-severity review findings first
+      - keep the scope tightly limited to the reported defects
+      - add or adjust regression tests when a review finding exposes a missing proof
+      - preserve public APIs, workbook compatibility, and deterministic exports
+
+      After changes:
+      - run the relevant tests or verification commands
+      - confirm each addressed finding has concrete evidence in code or test output
+
+      Avoid:
+      - restarting broad implementation work
+      - unrelated refactors or cleanup
+      - repeating the same failed approach without new evidence
+
+    rules:
+      - condition: 修正が完了した
+        next: self_review
+
+      - condition: 再計画が必要
+        next: plan
+
+      - condition: 修正を継続できない
+        next: ABORT
+
+      - condition: ユーザー入力が必要
+        next: fix
+        requires_user_input: true
+        interactive_only: true
+
+    output_contracts:
+      report:
+        - name: fix-report.md
+          format: implementation-report
 
   # =========================================================
   # FINAL AUDIT
@@ -307,3 +368,15 @@ steps:
       report:
         - name: final-audit.md
           format: audit-report
+
+loop_monitors:
+  - cycle: [self_review, fix]
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction: "fix ループに進捗があるかを評価してください..."
+      rules:
+        - condition: "進捗あり"
+          next: fix
+        - condition: "進捗なし"
+          next: ABORT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed `xlflow ui button add` so it auto-reuses a matching live session workbook when `.xlflow/session.json` points at the configured workbook, preventing the Excel SaveAs dialog that previously appeared when a session was active.
+- Extended `ui button add`, `ui button list`, and `ui button remove` to use the shared session-aware workbook open helper and explicit save/release cleanup, matching the behavior of `push`, `pull`, `run`, `trace`, and other workbook-backed commands.
 - Added `xlflow status` and `xlflow status --json` as a read-only project-level command that shows project, source, workbook, and session state in one output. Source freshness is a heuristic based on file mtimes; the command does not modify workbook files, source files, or `.xlflow/state`. `workbook_saved` is now derived from `save_required` instead of `dirty` to avoid contradictory results when the session probe reports `save_required=true` but `dirty` is unknown; baseline `session` payload now always includes `running`, `workbook_open`, and `metadata` for schema stability.
 - Added `xlflow init --with-module` so imported projects can immediately receive bundled runtime helper modules and sync them back into the copied workbook.
 - Added `xlflow module install [--push]` so existing xlflow projects can install bundled helper modules on demand without rerunning `new`.

--- a/docs/adr/ADR-0004-explicit-excel-session-mode.md
+++ b/docs/adr/ADR-0004-explicit-excel-session-mode.md
@@ -19,7 +19,7 @@ Alternatives considered:
 
 Add explicit session mode for normal agent development, then extend workbook-backed commands to auto-reuse a matching recorded session workbook when that reuse is unambiguous.
 
-`xlflow session start` opens the configured workbook in Excel and records `.xlflow/session.json`. `xlflow push --session`, `xlflow run --session`, `xlflow save --session`, and the development-time workbook mutation helpers under `xlflow edit ... --session` force attachment to that open workbook. When `pull`, `push`, `macros`, `run`, `export-image`, `test`, `trace`, or `save` target the configured workbook and `.xlflow/session.json` still points at the same live workbook, those commands auto-reuse that matching session even if `--session` is omitted. Result payloads and human output surface whether session usage was explicit or auto-reused. `xlflow session status` reports whether the recorded process still exists, whether the workbook is open, and whether the live workbook needs save. `xlflow session stop` saves, closes the workbook, quits Excel, and removes the metadata.
+`xlflow session start` opens the configured workbook in Excel and records `.xlflow/session.json`. `xlflow push --session`, `xlflow run --session`, `xlflow save --session`, and the development-time workbook mutation helpers under `xlflow edit ... --session` force attachment to that open workbook. When `pull`, `push`, `macros`, `run`, `export-image`, `test`, `trace`, `save`, or `ui button add/list/remove` target the configured workbook and `.xlflow/session.json` still points at the same live workbook, those commands auto-reuse that matching session even if `--session` is omitted. `ui button add` and `ui button remove` save the live session workbook explicitly via `Workbook.Save()` after successful mutation; `ui button list` is read-only and does not save. Result payloads and human output surface whether session usage was explicit or auto-reused. `xlflow session status` reports whether the recorded process still exists, whether the workbook is open, and whether the live workbook needs save. `xlflow session stop` saves, closes the workbook, quits Excel, and removes the metadata.
 
 `--session` remains available as an explicit, fail-fast assertion that the matching session workbook must already be running.
 
@@ -47,7 +47,7 @@ Negative consequences:
 ## Rationale
 
 - Tests: CLI option tests, script syntax tests, and Excel COM-backed workflow tests.
-- Code: `internal/cli`, `internal/excel`, `internal/excel/scripts/session.ps1`, `internal/excel/scripts/push.ps1`, `internal/excel/scripts/run.ps1`.
+- Code: `internal/cli`, `internal/excel`, `internal/excel/scripts/session.ps1`, `internal/excel/scripts/push.ps1`, `internal/excel/scripts/run.ps1`, `internal/excel/scripts/ui.ps1`.
 - Related specs: `docs/specs/cli-contract.md`, `docs/specs/runtime-debugging.md`, `docs/design.md`.
 
 ## Supersedes

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -41,9 +41,9 @@ xlflow [--json] edit range [workbook] --sheet <name> --range <A1:B2> (--fill <#R
 xlflow [--json] edit rows [workbook] --sheet <name> --rows <1:31> --height <points> --session
 xlflow [--json] edit columns [workbook] --sheet <name> --columns <A:AE> --width <chars> --session
 xlflow [--json] macros [--session]
-xlflow [--json] ui button add --sheet <name> --cell <A1> --text <caption> --macro <module.proc> [--id <id>] [--width <points>] [--height <points>] [--create-sheet] [--verify-macro]
-xlflow [--json] ui button list [--sheet <name>]
-xlflow [--json] ui button remove --id <id> [--sheet <name>]
+xlflow [--json] ui button add --sheet <name> --cell <A1> --text <caption> --macro <module.proc> [--id <id>] [--width <points>] [--height <points>] [--create-sheet] [--verify-macro] [--session]
+xlflow [--json] ui button list [--sheet <name>] [--session]
+xlflow [--json] ui button remove --id <id> [--sheet <name>] [--session]
 xlflow [--json] test [--filter <name>] [--module <name>] [--tag <tag>] [--msgbox <dialog-id=result>]... [--inputbox <dialog-id=value>]... [--filedialog <kind>:<dialog-id>=<value>]... [--ui-stream] [--session]
 xlflow [--json] diff <before-workbook> <after-workbook> [--vba-before <dir>] [--vba-after <dir>]
 xlflow [--json] inspect workbook [--session] [--format text|json|markdown]
@@ -157,7 +157,9 @@ New scaffolded projects also add `src/modules/XlflowUI.bas` and `src/modules/Xlf
 
 `macros` opens the configured workbook and discovers public runnable VBA entrypoints without executing user code. JSON output includes top-level `macros`, where each entry contains `module`, `name`, `qualified_name`, `kind` when available, and `args` when available. `macros --session` reads from the workbook opened by `session start`. Agents should use this command before guessing a `run` target.
 
-`ui button add` opens the configured workbook and adds or updates an xlflow-managed Excel form-control button. The target worksheet is selected by `--sheet`; if it does not exist, the command fails with `sheet_not_found` unless `--create-sheet` is set. `--cell` is the top-left placement anchor, `--text` becomes the button caption, and `--macro` is assigned to the button `OnAction`. `--width` and `--height` are in Excel points and default to `160` and `40`. The stable internal button name is `xlflow.button.<id>`, where `<id>` is the normalized `--id` value or, when omitted, a normalized value derived from `--macro`. Re-running `add` with the same id updates the existing button instead of creating duplicates. `--verify-macro` checks the workbook VBIDE project for the macro before saving; missing macros fail with `macro_not_found`, and unavailable VBIDE access is an environment failure.
+`ui button add`, `ui button list`, and `ui button remove` open the configured workbook through the same session-aware Excel bridge as other workbook-backed commands. `--session` forces attachment to the workbook kept open by `xlflow session start`. When `--session` is omitted and `.xlflow/session.json` points at the configured workbook, the commands auto-reuse that matching live session workbook instead of opening a fresh hidden instance. `add` and `remove` save the live session workbook explicitly via `Workbook.Save()` after successful mutation so the session workbook stays open; `list` is read-only and does not save. When `Workbook.Save()` fails after a successful add or remove, the command returns `save_failed` as an environment failure.
+
+`ui button add` adds or updates an xlflow-managed Excel form-control button. The target worksheet is selected by `--sheet`; if it does not exist, the command fails with `sheet_not_found` unless `--create-sheet` is set. `--cell` is the top-left placement anchor, `--text` becomes the button caption, and `--macro` is assigned to the button `OnAction`. `--width` and `--height` are in Excel points and default to `160` and `40`. The stable internal button name is `xlflow.button.<id>`, where `<id>` is the normalized `--id` value or, when omitted, a normalized value derived from `--macro`. Re-running `add` with the same id updates the existing button instead of creating duplicates. `--verify-macro` checks the workbook VBIDE project for the macro before saving; missing macros fail with `macro_not_found`, and unavailable VBIDE access is an environment failure.
 
 `ui button list` reports only xlflow-managed form-control buttons whose internal names start with `xlflow.button.`. When `--sheet` is provided, only that worksheet is inspected and a missing worksheet fails with `sheet_not_found`. `list` does not save the workbook.
 

--- a/internal/agentskill/skill_test.go
+++ b/internal/agentskill/skill_test.go
@@ -35,7 +35,7 @@ func TestInstallUsesProviderDefaultTarget(t *testing.T) {
 		"xlflow save --json",
 		"xlflow push --fast --session --no-save --json",
 		"When the macro argument is omitted, `xlflow run` uses `project.entry` from `xlflow.toml`.",
-		"Matching sessions are auto-reused for `list forms`, `inspect form`, `form snapshot`, `form build`, `form export-image`, `pull`, `push`, `macros`, `run`, `export-image`, `test`, `trace`, and `save`",
+		"Matching sessions are auto-reused for `list forms`, `inspect form`, `form snapshot`, `form build`, `form export-image`, `pull`, `push`, `macros`, `run`, `export-image`, `test`, `trace`, `save`, `ui button add`, `ui button list`, and `ui button remove`",
 		"Use `xlflow list forms --session --json` when you need workbook UserForm names",
 		"Use `xlflow form snapshot <FormName> --out src/forms/specs/<FormName>.yaml --session --json`",
 		"Use `xlflow form build <spec> --session --json`",
@@ -61,6 +61,9 @@ func TestInstallUsesProviderDefaultTarget(t *testing.T) {
 		"[lint].forbid_interactive_input = false",
 		"xlflow session stop",
 		"Interactive terminals show a spinner, non-interactive or --json runs fall back to a single stderr progress line",
+		"`ui button add`",
+		"`ui button list`",
+		"`ui button remove`",
 	} {
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("installed skill is missing %q:\n%s", want, body)

--- a/internal/agentskill/templates/xlflow/SKILL.md
+++ b/internal/agentskill/templates/xlflow/SKILL.md
@@ -39,7 +39,7 @@ Default safety rules for AI-agent work:
 For normal AI-agent development tasks, use an explicit xlflow session from task start to task end:
 
 1. Start with `xlflow session start` after reading `xlflow.toml` and resolving source-of-truth questions.
-2. Matching sessions are auto-reused for `list forms`, `inspect form`, `form snapshot`, `form build`, `form export-image`, `pull`, `push`, `macros`, `run`, `export-image`, `test`, `trace`, and `save` when the configured workbook path matches `.xlflow/session.json`; add `--session` when you want that reuse to be explicit.
+2. Matching sessions are auto-reused for `list forms`, `inspect form`, `form snapshot`, `form build`, `form export-image`, `pull`, `push`, `macros`, `run`, `export-image`, `test`, `trace`, `save`, `ui button add`, `ui button list`, and `ui button remove` when the configured workbook path matches `.xlflow/session.json`; add `--session` when you want that reuse to be explicit.
 3. Prefer `xlflow push --fast --session --no-save --json` while iterating, and use `xlflow run --session --json` or `xlflow run --headless --session --json` when `project.entry` is the intended entrypoint because structured compile diagnostics are on by default.
 4. Save with `xlflow save --json` before any disk-based verification step such as `xlflow inspect ...` when the live session workbook may be newer than disk.
 5. End with `xlflow save --json` when workbook changes must persist, then always run `xlflow session stop`.
@@ -203,7 +203,7 @@ When the user reports a runtime failure:
 - Plain `xlflow run --session --json` already compiles first, uses `project.entry` when the macro argument is omitted, and returns structured compile diagnostics by default.
 - Use `xlflow run --fast --session --gui-compile-errors` only when a human explicitly accepts GUI compile dialogs and you intentionally want the direct fast path. Plain `xlflow run --direct` already opts out of default compile diagnostics automatically.
 - Use `xlflow run --gui-compile-errors --interactive --json` only when a human explicitly wants raw compile dialogs instead of structured diagnostics.
-- Matching workbook sessions auto-reuse on `list forms`, `inspect form`, `form snapshot`, `form build`, `form export-image`, `pull`, `push`, `macros`, `run`, `export-image`, `test`, `trace`, and `save`; use explicit `--session` when you want that reuse to be deliberate and visible in the command line.
+- Matching workbook sessions auto-reuse on `list forms`, `inspect form`, `form snapshot`, `form build`, `form export-image`, `pull`, `push`, `macros`, `run`, `export-image`, `test`, `trace`, `save`, `ui button add`, `ui button list`, and `ui button remove`; use explicit `--session` when you want that reuse to be deliberate and visible in the command line.
 - Use `xlflow attach --active --json` before human-assisted sessions to confirm that the open Excel workbook matches `xlflow.toml`.
 - Use `xlflow run --trace --session` when tests are absent, the macro mutates workbook state, or a runtime failure needs trace events during a session.
 - Use `xlflow diff` to summarize workbook and optional exported VBA differences.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -767,6 +767,7 @@ func (a *app) uiButtonAddCommand() *cobra.Command {
 	cmd.Flags().IntVar(&opts.Height, "height", 40, "button height in points")
 	cmd.Flags().BoolVar(&opts.CreateSheet, "create-sheet", false, "create the target worksheet when it does not exist")
 	cmd.Flags().BoolVar(&opts.VerifyMacro, "verify-macro", false, "verify that the assigned macro exists before saving")
+	cmd.Flags().BoolVar(&opts.Session, "session", false, "force "+sessionUsageHint())
 	return cmd
 }
 
@@ -796,6 +797,7 @@ func (a *app) uiButtonListCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.Sheet, "sheet", "", "worksheet name")
+	cmd.Flags().BoolVar(&opts.Session, "session", false, "force "+sessionUsageHint())
 	return cmd
 }
 
@@ -830,6 +832,7 @@ func (a *app) uiButtonRemoveCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.ID, "id", "", "stable xlflow button id")
 	cmd.Flags().StringVar(&opts.Sheet, "sheet", "", "worksheet name")
+	cmd.Flags().BoolVar(&opts.Session, "session", false, "force "+sessionUsageHint())
 	return cmd
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -885,9 +885,29 @@ func TestRootCommandIncludesUIButtonCommands(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{"sheet", "cell", "text", "macro", "id", "width", "height", "create-sheet", "verify-macro"} {
+	for _, name := range []string{"sheet", "cell", "text", "macro", "id", "width", "height", "create-sheet", "verify-macro", "session"} {
 		if add.Flags().Lookup(name) == nil {
 			t.Fatalf("expected ui button add to define --%s", name)
+		}
+	}
+
+	list, _, err := root.Find([]string{"ui", "button", "list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"sheet", "session"} {
+		if list.Flags().Lookup(name) == nil {
+			t.Fatalf("expected ui button list to define --%s", name)
+		}
+	}
+
+	remove, _, err := root.Find([]string{"ui", "button", "remove"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"id", "sheet", "session"} {
+		if remove.Flags().Lookup(name) == nil {
+			t.Fatalf("expected ui button remove to define --%s", name)
 		}
 	}
 }
@@ -925,6 +945,66 @@ func TestBuildUIButtonAddOptionsValidatesRequiredFields(t *testing.T) {
 	_, err = buildUIButtonAddOptions(excel.UIButtonAddOptions{Sheet: "Menu", Cell: "B2", Text: "Run", Macro: "Main.Run", Width: 0, Height: 40})
 	if err == nil || !strings.Contains(err.Error(), "--width") {
 		t.Fatalf("expected width error, got %v", err)
+	}
+}
+
+func TestBuildUIButtonAddOptionsPreservesSessionFlag(t *testing.T) {
+	opts, err := buildUIButtonAddOptions(excel.UIButtonAddOptions{
+		Sheet:   "Menu",
+		Cell:    "B2",
+		Text:    "Run",
+		Macro:   "Main.Run",
+		Width:   160,
+		Height:  40,
+		Session: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opts.Session {
+		t.Fatalf("expected Session to be preserved as true, got false")
+	}
+}
+
+func TestBuildUIButtonAddOptionsDefaultsSessionFalse(t *testing.T) {
+	opts, err := buildUIButtonAddOptions(excel.UIButtonAddOptions{
+		Sheet:  "Menu",
+		Cell:   "B2",
+		Text:   "Run",
+		Macro:  "Main.Run",
+		Width:  160,
+		Height: 40,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Session {
+		t.Fatalf("expected Session to default to false, got true")
+	}
+}
+
+func TestBuildUIButtonRemoveOptionsPreservesSessionFlag(t *testing.T) {
+	opts, err := buildUIButtonRemoveOptions(excel.UIButtonRemoveOptions{
+		ID:      "mybutton",
+		Session: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opts.Session {
+		t.Fatalf("expected Session to be preserved as true, got false")
+	}
+}
+
+func TestBuildUIButtonRemoveOptionsDefaultsSessionFalse(t *testing.T) {
+	opts, err := buildUIButtonRemoveOptions(excel.UIButtonRemoveOptions{
+		ID: "mybutton",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Session {
+		t.Fatalf("expected Session to default to false, got true")
 	}
 }
 

--- a/internal/excel/bridge.go
+++ b/internal/excel/bridge.go
@@ -344,15 +344,18 @@ type UIButtonAddOptions struct {
 	Height      int
 	CreateSheet bool
 	VerifyMacro bool
+	Session     bool
 }
 
 type UIButtonListOptions struct {
-	Sheet string
+	Sheet   string
+	Session bool
 }
 
 type UIButtonRemoveOptions struct {
-	Sheet string
-	ID    string
+	Sheet   string
+	ID      string
+	Session bool
 }
 
 func (r Runner) Doctor(cfg config.Config, opts ...CommandOptions) (output.Envelope, int, error) {
@@ -955,6 +958,8 @@ func buildUIButtonAddScriptArgs(root string, cfg config.Config, opts UIButtonAdd
 		"Height":       strconv.Itoa(opts.Height),
 		"CreateSheet":  strconv.FormatBool(opts.CreateSheet),
 		"VerifyMacro":  strconv.FormatBool(opts.VerifyMacro),
+		"UseSession":   strconv.FormatBool(opts.Session),
+		"MetadataPath": filepath.Join(root, ".xlflow", "session.json"),
 	}
 }
 
@@ -968,6 +973,8 @@ func buildUIButtonListScriptArgs(root string, cfg config.Config, opts UIButtonLi
 		"WorkbookPath": workbookPath(root, cfg.Excel.Path),
 		"Visible":      strconv.FormatBool(cfg.Excel.Visible),
 		"Sheet":        opts.Sheet,
+		"UseSession":   strconv.FormatBool(opts.Session),
+		"MetadataPath": filepath.Join(root, ".xlflow", "session.json"),
 	}
 }
 
@@ -1017,6 +1024,8 @@ func buildUIButtonRemoveScriptArgs(root string, cfg config.Config, opts UIButton
 		"Visible":      strconv.FormatBool(cfg.Excel.Visible),
 		"Sheet":        opts.Sheet,
 		"Id":           opts.ID,
+		"UseSession":   strconv.FormatBool(opts.Session),
+		"MetadataPath": filepath.Join(root, ".xlflow", "session.json"),
 	}
 }
 

--- a/internal/excel/bridge_test.go
+++ b/internal/excel/bridge_test.go
@@ -1017,3 +1017,112 @@ func TestTraceInjectScriptArgsOmitModulesDirForStandaloneWorkbook(t *testing.T) 
 		t.Fatalf("standalone workbook should not receive ModulesDir: %+v", args)
 	}
 }
+
+func TestBuildUIButtonAddScriptArgsIncludesSessionMetadata(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonAddScriptArgs(root, cfg, UIButtonAddOptions{
+		Sheet: "Menu",
+		Cell:  "B2",
+		Text:  "Run",
+		Macro: "Main.Run",
+	})
+	if args["MetadataPath"] != filepath.Join(root, ".xlflow", "session.json") {
+		t.Fatalf("MetadataPath = %q, want %q", args["MetadataPath"], filepath.Join(root, ".xlflow", "session.json"))
+	}
+}
+
+func TestBuildUIButtonListScriptArgsIncludesSessionMetadata(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonListScriptArgs(root, cfg, UIButtonListOptions{Sheet: "Menu"})
+	if args["MetadataPath"] != filepath.Join(root, ".xlflow", "session.json") {
+		t.Fatalf("MetadataPath = %q, want %q", args["MetadataPath"], filepath.Join(root, ".xlflow", "session.json"))
+	}
+}
+
+func TestBuildUIButtonRemoveScriptArgsIncludesSessionMetadata(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonRemoveScriptArgs(root, cfg, UIButtonRemoveOptions{ID: "run"})
+	if args["MetadataPath"] != filepath.Join(root, ".xlflow", "session.json") {
+		t.Fatalf("MetadataPath = %q, want %q", args["MetadataPath"], filepath.Join(root, ".xlflow", "session.json"))
+	}
+}
+
+func TestBuildUIButtonAddScriptArgsPassSessionFlag(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonAddScriptArgs(root, cfg, UIButtonAddOptions{
+		Sheet:   "Menu",
+		Cell:    "B2",
+		Text:    "Run",
+		Macro:   "Main.Run",
+		Session: true,
+	})
+	if args["UseSession"] != "true" {
+		t.Fatalf("UseSession = %q, want true", args["UseSession"])
+	}
+	if args["MetadataPath"] != filepath.Join(root, ".xlflow", "session.json") {
+		t.Fatalf("MetadataPath = %q", args["MetadataPath"])
+	}
+}
+
+func TestBuildUIButtonListScriptArgsPassSessionFlag(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonListScriptArgs(root, cfg, UIButtonListOptions{Sheet: "Menu", Session: true})
+	if args["UseSession"] != "true" {
+		t.Fatalf("UseSession = %q, want true", args["UseSession"])
+	}
+	if args["MetadataPath"] != filepath.Join(root, ".xlflow", "session.json") {
+		t.Fatalf("MetadataPath = %q", args["MetadataPath"])
+	}
+}
+
+func TestBuildUIButtonRemoveScriptArgsPassSessionFlag(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonRemoveScriptArgs(root, cfg, UIButtonRemoveOptions{ID: "run", Session: true})
+	if args["UseSession"] != "true" {
+		t.Fatalf("UseSession = %q, want true", args["UseSession"])
+	}
+	if args["MetadataPath"] != filepath.Join(root, ".xlflow", "session.json") {
+		t.Fatalf("MetadataPath = %q", args["MetadataPath"])
+	}
+}
+
+func TestBuildUIButtonAddScriptArgsDefaultUseSessionFalse(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonAddScriptArgs(root, cfg, UIButtonAddOptions{
+		Sheet: "Menu",
+		Cell:  "B2",
+		Text:  "Run",
+		Macro: "Main.Run",
+	})
+	if args["UseSession"] != "false" {
+		t.Fatalf("UseSession = %q, want false when Session option is not set", args["UseSession"])
+	}
+	if args["MetadataPath"] != filepath.Join(root, ".xlflow", "session.json") {
+		t.Fatalf("MetadataPath = %q, want %q (always set for auto-detection)", args["MetadataPath"], filepath.Join(root, ".xlflow", "session.json"))
+	}
+}
+
+func TestBuildUIButtonListScriptArgsDefaultUseSessionFalse(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonListScriptArgs(root, cfg, UIButtonListOptions{Sheet: "Menu"})
+	if args["UseSession"] != "false" {
+		t.Fatalf("UseSession = %q, want false when Session option is not set", args["UseSession"])
+	}
+}
+
+func TestBuildUIButtonRemoveScriptArgsDefaultUseSessionFalse(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	args := buildUIButtonRemoveScriptArgs(root, cfg, UIButtonRemoveOptions{ID: "run"})
+	if args["UseSession"] != "false" {
+		t.Fatalf("UseSession = %q, want false when Session option is not set", args["UseSession"])
+	}
+}

--- a/internal/excel/scripts/scripts_test.go
+++ b/internal/excel/scripts/scripts_test.go
@@ -4547,9 +4547,10 @@ func TestUIScriptFinallyBlockGuardOrder(t *testing.T) {
 			continue
 		}
 		for _, ch := range trimmed {
-			if ch == '{' {
+			switch ch {
+			case '{':
 				braceDepth++
-			} else if ch == '}' {
+			case '}':
 				braceDepth--
 			}
 		}

--- a/internal/excel/scripts/scripts_test.go
+++ b/internal/excel/scripts/scripts_test.go
@@ -4523,12 +4523,63 @@ func TestUIScriptReportsSaveFailureAsError(t *testing.T) {
 	}
 }
 
+func TestUIScriptCatchBlockRefreshesSaveState(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+
+	switchEnd := strings.Index(text, "switch ($Action)")
+	if switchEnd < 0 {
+		t.Fatalf("switch block not found in ui.ps1")
+	}
+
+	outerCatch := strings.Index(text[switchEnd:], "\n} catch {")
+	if outerCatch < 0 {
+		t.Fatalf("outer catch block not found after switch in ui.ps1")
+	}
+
+	catchStart := switchEnd + outerCatch
+	finallyBlock := strings.Index(text[catchStart:], "\n} finally {")
+	if finallyBlock < 0 {
+		t.Fatalf("finally block not found after catch in ui.ps1")
+	}
+
+	catchSection := text[catchStart : catchStart+finallyBlock]
+
+	saveStateLine := strings.Index(catchSection, "Get-XlflowWorkbookSaveState")
+	workbookResultLine := strings.Index(catchSection, "New-XlflowWorkbookResult")
+
+	if saveStateLine < 0 {
+		t.Fatal("outer catch block must refresh $saveState via Get-XlflowWorkbookSaveState before constructing $result.workbook")
+	}
+	if workbookResultLine < 0 {
+		t.Fatal("outer catch block must construct $result.workbook via New-XlflowWorkbookResult")
+	}
+	if saveStateLine > workbookResultLine {
+		t.Fatalf("Get-XlflowWorkbookSaveState must appear before New-XlflowWorkbookResult in catch block so $saveState is fresh")
+	}
+}
+
 func TestUIScriptFinallyBlockGuardOrder(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
 	if err != nil {
 		t.Fatalf("failed to read ui.ps1: %v", err)
 	}
 	lines := strings.Split(string(data), "\n")
+
+	switchLine := -1
+	for i, line := range lines {
+		if strings.Contains(line, "switch ($Action)") {
+			switchLine = i
+			break
+		}
+	}
+	if switchLine < 0 {
+		t.Fatalf("switch ($Action) not found in ui.ps1")
+	}
+
 	inFinally := false
 	braceDepth := 0
 	var statusCheckLine, saveGuardLine, saveCallLine, catchLine int
@@ -4536,9 +4587,10 @@ func TestUIScriptFinallyBlockGuardOrder(t *testing.T) {
 	saveGuardLine = -1
 	saveCallLine = -1
 	catchLine = -1
-	for i, line := range lines {
+	for i := switchLine; i < len(lines); i++ {
+		line := lines[i]
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "} finally {") || strings.TrimPrefix(trimmed, "} finally {") != trimmed {
+		if strings.HasPrefix(trimmed, "} finally {") {
 			inFinally = true
 			braceDepth = 1
 			continue
@@ -4663,6 +4715,18 @@ func TestUIScriptPreservesSaveStateOnFailurePaths(t *testing.T) {
 }
 
 func TestUIScriptWarningsGuardPreventsNullElement(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `if (-not $result.Contains("warnings") -or $null -eq $result["warnings"])`) {
+		t.Fatalf("ui.ps1 must guard $result[\"warnings\"] before accessing it:\n%s", text)
+	}
+	if !strings.Contains(text, `$result.warnings = @($result.warnings | Where-Object { $_.code -ne "save_required" })`) {
+		t.Fatalf("ui.ps1 should filter out save_required warning after save:\n%s", text)
+	}
+
 	if _, err := exec.LookPath("pwsh"); err != nil {
 		t.Skip("pwsh is not available")
 	}

--- a/internal/excel/scripts/scripts_test.go
+++ b/internal/excel/scripts/scripts_test.go
@@ -4453,3 +4453,419 @@ End Sub
 		t.Fatalf("expected sidecar push/pull roundtrip to preserve B code-behind: %+v", got)
 	}
 }
+
+func TestUIScriptAcceptsSessionParameters(t *testing.T) {
+	if _, err := exec.LookPath("pwsh"); err != nil {
+		t.Skip("pwsh is not available")
+	}
+	for _, parameter := range []string{"MetadataPath", "UseSession"} {
+		t.Run(parameter, func(t *testing.T) {
+			cmd := exec.Command(
+				"pwsh",
+				"-NoProfile",
+				"-Command",
+				fmt.Sprintf("$command = Get-Command ./ui.ps1; $command.Parameters.ContainsKey('%s')", parameter),
+			)
+			cmd.Dir = "."
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("ui script %s parameter check failed: %v\n%s", parameter, err, out)
+			}
+			if strings.TrimSpace(string(out)) != "True" {
+				t.Fatalf("expected ui.ps1 to expose %s, got %q", parameter, out)
+			}
+		})
+	}
+}
+
+func TestUIScriptUsesSharedWorkbookOpenHelper(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "Open-XlflowWorkbookForCommand") {
+		t.Fatalf("ui.ps1 should use Open-XlflowWorkbookForCommand for session-aware workbook open:\n%s", text)
+	}
+	if !strings.Contains(text, "-MetadataPath $MetadataPath") {
+		t.Fatalf("ui.ps1 should pass MetadataPath to workbook open helper:\n%s", text)
+	}
+}
+
+func TestUIScriptUsesSessionAwareReleaseAndSave(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "Release-XlflowComReferences") {
+		t.Fatalf("ui.ps1 should use Release-XlflowComReferences for session-attached cleanup instead of always closing:\n%s", text)
+	}
+	if !strings.Contains(text, "$workbook.Save()") {
+		t.Fatalf("ui.ps1 should call Workbook.Save() explicitly instead of relying only on close-save:\n%s", text)
+	}
+	if !strings.Contains(text, "if ($sessionAttached)") {
+		t.Fatalf("ui.ps1 should branch cleanup on $sessionAttached (Release-XlflowComReferences for session, Close-XlflowCom for non-session):\n%s", text)
+	}
+	if !strings.Contains(text, "Close-XlflowCom") {
+		t.Fatalf("ui.ps1 should include Close-XlflowCom in the non-session cleanup branch:\n%s", text)
+	}
+}
+
+func TestUIScriptReportsSaveFailureAsError(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `Set-XlflowError -Result $result -Code "save_failed"`) {
+		t.Fatalf("ui.ps1 should report save failure via Set-XlflowError with code save_failed instead of silently swallowing:\n%s", text)
+	}
+}
+
+func TestUIScriptFinallyBlockGuardOrder(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	inFinally := false
+	braceDepth := 0
+	var statusCheckLine, saveGuardLine, saveCallLine, catchLine int
+	statusCheckLine = -1
+	saveGuardLine = -1
+	saveCallLine = -1
+	catchLine = -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "} finally {") || strings.TrimPrefix(trimmed, "} finally {") != trimmed {
+			inFinally = true
+			braceDepth = 1
+			continue
+		}
+		if !inFinally {
+			continue
+		}
+		for _, ch := range trimmed {
+			if ch == '{' {
+				braceDepth++
+			} else if ch == '}' {
+				braceDepth--
+			}
+		}
+		if braceDepth == 0 {
+			break
+		}
+		if strings.Contains(trimmed, `$result.status -ne "ok"`) {
+			statusCheckLine = i + 1
+		}
+		if strings.Contains(trimmed, "$saveWorkbook -and") {
+			saveGuardLine = i + 1
+		}
+		if strings.Contains(trimmed, "$workbook.Save()") {
+			saveCallLine = i + 1
+		}
+		if strings.Contains(trimmed, `Set-XlflowError`) && strings.Contains(trimmed, `"save_failed"`) {
+			catchLine = i + 1
+		}
+	}
+	if statusCheckLine == -1 {
+		t.Fatalf("ui.ps1 finally block must check $result.status before save:\n%s", string(data))
+	}
+	if saveGuardLine == -1 {
+		t.Fatalf("ui.ps1 finally block must guard save with $saveWorkbook check:\n%s", string(data))
+	}
+	if saveCallLine == -1 {
+		t.Fatalf("ui.ps1 finally block must call $workbook.Save():\n%s", string(data))
+	}
+	if catchLine == -1 {
+		t.Fatalf("ui.ps1 finally block must use Set-XlflowError with save_failed in catch:\n%s", string(data))
+	}
+	if statusCheckLine >= saveGuardLine {
+		t.Fatalf("ui.ps1 finally block: status check (line %d) must appear before save guard (line %d) so save is correctly suppressed on failure", statusCheckLine, saveGuardLine)
+	}
+	if saveGuardLine >= saveCallLine {
+		t.Fatalf("ui.ps1 finally block: save guard (line %d) must appear before $workbook.Save() (line %d)", saveGuardLine, saveCallLine)
+	}
+	if saveCallLine >= catchLine {
+		t.Fatalf("ui.ps1 finally block: $workbook.Save() (line %d) must appear before save_failed Set-XlflowError in catch (line %d)", saveCallLine, catchLine)
+	}
+}
+
+func TestUIScriptGathersWorkbookSaveState(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"Get-XlflowWorkbookSaveState",
+		"$saveState",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("ui.ps1 missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestUIScriptPopulatesTargetAndSessionMetadata(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"$result.target = New-XlflowTargetResult",
+		"$result.session = New-XlflowSessionResult",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("ui.ps1 missing %q:\n%s", want, text)
+		}
+	}
+	if count := strings.Count(text, "New-XlflowSessionResult -Active $sessionAttached"); count < 2 {
+		t.Fatalf("expected New-XlflowSessionResult on success and failure paths, found %d:\n%s", count, text)
+	}
+}
+
+func TestUIScriptEmitsSaveRequiredWarning(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`Add-XlflowStateWarning -Result $result -Code "save_required"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("ui.ps1 missing %q:\n%s", want, text)
+		}
+	}
+	if count := strings.Count(text, `Add-XlflowStateWarning -Result $result -Code "save_required"`); count < 2 {
+		t.Fatalf("expected save_required warning on success and failure paths, found %d:\n%s", count, text)
+	}
+}
+
+func TestUIScriptPreservesSaveStateOnFailurePaths(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"-Dirty $saveState.dirty",
+		"-NeedsSave $saveState.needs_save",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("ui.ps1 missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestUIScriptWarningsGuardPreventsNullElement(t *testing.T) {
+	if _, err := exec.LookPath("pwsh"); err != nil {
+		t.Skip("pwsh is not available")
+	}
+
+	script := `
+$r = [ordered]@{ status = "ok" }
+if (-not $r.Contains("warnings") -or $null -eq $r["warnings"]) { $r["warnings"] = @() }
+$r.warnings = @($r.warnings | Where-Object { $_.code -ne "save_required" })
+$json = $r | ConvertTo-Json -Compress
+if ($json -match '\[null\]') { throw "BUG: warnings contains [null]" }
+Write-Output "OK"
+`
+	cmd := exec.Command("pwsh", "-NoProfile", "-Command", script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("warnings guard test failed: %v\n%s", err, out)
+	}
+}
+
+func TestCommonScriptGetXlflowWorkbookSaveStateBehavior(t *testing.T) {
+	if _, err := exec.LookPath("pwsh"); err != nil {
+		t.Skip("pwsh is not available")
+	}
+
+	cmd := exec.Command(
+		"pwsh",
+		"-NoProfile",
+		"-Command",
+		". ./common.ps1; $state = Get-XlflowWorkbookSaveState -Workbook $null -SessionAttached $false; Write-Output ($state.dirty, $state.needs_save); $state = Get-XlflowWorkbookSaveState -Workbook $null -SessionAttached $true; Write-Output ($state.dirty, $state.needs_save)",
+	)
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Get-XlflowWorkbookSaveState behavior test failed: %v\n%s", err, out)
+	}
+	lines := strings.Fields(strings.TrimSpace(string(out)))
+	if len(lines) != 4 {
+		t.Fatalf("unexpected output length %d: %q", len(lines), out)
+	}
+	if lines[0] != "False" || lines[1] != "False" {
+		t.Fatalf("expected non-session-attached dirty/needs_save to be False/False, got %s/%s", lines[0], lines[1])
+	}
+	if lines[2] != "True" || lines[3] != "True" {
+		t.Fatalf("expected session-attached (null workbook) dirty/needs_save to be True/True, got %s/%s", lines[2], lines[3])
+	}
+}
+
+func TestUIScriptSoftFailureIncludesTargetSession(t *testing.T) {
+	if _, err := exec.LookPath("pwsh"); err != nil {
+		t.Skip("pwsh is not available")
+	}
+
+	cmd := exec.Command(
+		"pwsh",
+		"-NoProfile",
+		"-Command",
+		`$ErrorActionPreference = 'Stop'
+$result = [ordered]@{
+  skip = $false
+  skipReason = ''
+  status = ''
+  errorCode = ''
+  hasTarget = $false
+  hasSession = $false
+  targetKind = ''
+  sessionMode = ''
+}
+$excel = $null
+$workbook = $null
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString('N'))
+try {
+  New-Item -ItemType Directory -Force -Path $root | Out-Null
+  $wbPath = Join-Path $root 'soft-failure-target-session.xlsm'
+
+  try {
+    $excel = New-Object -ComObject Excel.Application
+  } catch {
+    $result.skip = $true
+    $result.skipReason = 'Excel COM is unavailable: ' + $_.Exception.Message
+    $result | ConvertTo-Json -Compress
+    exit 0
+  }
+  $excel.Visible = $false
+  $excel.DisplayAlerts = $false
+  $workbook = $excel.Workbooks.Add()
+  try {
+    $module = $workbook.VBProject.VBComponents.Add(1)
+    $module.Name = 'Main'
+    $module.CodeModule.AddFromString(('Option Explicit', 'Public Sub Run()', 'End Sub') -join [Environment]::NewLine)
+  } catch {
+    $result.skip = $true
+    $result.skipReason = 'VBProject access is unavailable: ' + $_.Exception.Message
+    $result | ConvertTo-Json -Compress
+    exit 0
+  }
+  $workbook.SaveAs($wbPath, 52)
+  $workbook.Close($true) | Out-Null
+  [System.Runtime.InteropServices.Marshal]::ReleaseComObject($workbook) | Out-Null
+  $workbook = $null
+  $excel.Quit() | Out-Null
+  [System.Runtime.InteropServices.Marshal]::ReleaseComObject($excel) | Out-Null
+  $excel = $null
+  [GC]::Collect()
+  [GC]::WaitForPendingFinalizers()
+
+  $r = & ./ui.ps1 -Action add -Sheet 'MissingSheet' -Cell 'B2' -Text 'Run' -Macro 'Main.Run' -Id 'run' -WorkbookPath $wbPath | ConvertFrom-Json
+  $result.status = $r.status
+  if ($null -ne $r.error) {
+    $result.errorCode = $r.error.code
+  }
+  $result.hasTarget = ($null -ne $r.target)
+  $result.hasSession = ($null -ne $r.session)
+  if ($null -ne $r.target) {
+    $result.targetKind = [string]$r.target.kind
+  }
+  if ($null -ne $r.session) {
+    $result.sessionMode = [string]$r.session.mode
+  }
+  $result | ConvertTo-Json -Compress
+} catch {
+  $result.status = 'command_failed'
+  $result.errorCode = $_.Exception.Message
+  $result | ConvertTo-Json -Compress
+  exit 1
+} finally {
+  if ($null -ne $workbook) {
+    try { $workbook.Close($false) | Out-Null } catch {}
+    try { [System.Runtime.InteropServices.Marshal]::ReleaseComObject($workbook) | Out-Null } catch {}
+  }
+  if ($null -ne $excel) {
+    try { $excel.Quit() | Out-Null } catch {}
+    try { [System.Runtime.InteropServices.Marshal]::ReleaseComObject($excel) | Out-Null } catch {}
+  }
+  [GC]::Collect()
+  [GC]::WaitForPendingFinalizers()
+  if (Test-Path -LiteralPath $root) {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}`,
+	)
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ui soft failure target/session check failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Skip        bool   `json:"skip"`
+		SkipReason  string `json:"skipReason"`
+		Status      string `json:"status"`
+		ErrorCode   string `json:"errorCode"`
+		HasTarget   bool   `json:"hasTarget"`
+		HasSession  bool   `json:"hasSession"`
+		TargetKind  string `json:"targetKind"`
+		SessionMode string `json:"sessionMode"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("failed to parse soft failure output: %v\n%s", err, out)
+	}
+	if got.Skip {
+		t.Skip(got.SkipReason)
+	}
+	if got.Status != "failed" || got.ErrorCode != "sheet_not_found" {
+		t.Fatalf("expected sheet_not_found failure, got status=%q errorCode=%q output=%s", got.Status, got.ErrorCode, out)
+	}
+	if !got.HasTarget {
+		t.Fatal("expected target metadata on soft failure path (workbook opened but action failed)")
+	}
+	if !got.HasSession {
+		t.Fatal("expected session metadata on soft failure path (workbook opened but action failed)")
+	}
+}
+
+func TestUIScriptUseSessionPassedToOpenHelper(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "-UseSession $UseSession") {
+		t.Fatalf("ui.ps1 must pass UseSession parameter through to Open-XlflowWorkbookForCommand:\n%s", text)
+	}
+}
+
+func TestUIScriptTargetSessionPopulatedBeforeCatch(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "ui.ps1"))
+	if err != nil {
+		t.Fatalf("failed to read ui.ps1: %v", err)
+	}
+	text := string(data)
+
+	switchEnd := strings.Index(text, "switch ($Action)")
+	if switchEnd < 0 {
+		t.Fatalf("switch block not found in ui.ps1")
+	}
+	outerCatch := strings.Index(text[switchEnd:], "\n} catch {")
+	if outerCatch < 0 {
+		t.Fatalf("outer catch block not found after switch in ui.ps1")
+	}
+	postSwitchSection := text[switchEnd : switchEnd+outerCatch]
+
+	if !strings.Contains(postSwitchSection, "$result.target = New-XlflowTargetResult") {
+		t.Fatal("expected $result.target = New-XlflowTargetResult in the section between switch and outer catch (needs to be set on soft failure paths)")
+	}
+	if !strings.Contains(postSwitchSection, "$result.session = New-XlflowSessionResult") {
+		t.Fatal("expected $result.session = New-XlflowSessionResult in the section between switch and outer catch (needs to be set on soft failure paths)")
+	}
+}

--- a/internal/excel/scripts/ui.ps1
+++ b/internal/excel/scripts/ui.ps1
@@ -188,6 +188,7 @@ try {
   }
 } catch {
   Set-XlflowError -Result $result -Code "ui_button_failed" -Message $_.Exception.Message -Source $_.Exception.Source -Number $_.Exception.HResult
+  $saveState = Get-XlflowWorkbookSaveState -Workbook $workbook -SessionAttached $sessionAttached
   if ($null -ne $WorkbookPath) {
     $result.workbook = New-XlflowWorkbookResult -WorkbookPath $WorkbookPath -SessionAttached $sessionAttached -SessionMode $sessionMode -Dirty $saveState.dirty -NeedsSave $saveState.needs_save
     $result.target = New-XlflowTargetResult -Kind $(if ($sessionAttached) { "live_session" } else { "file" }) -Path $WorkbookPath

--- a/internal/excel/scripts/ui.ps1
+++ b/internal/excel/scripts/ui.ps1
@@ -10,7 +10,9 @@ param(
   [int]$Width = 160,
   [int]$Height = 40,
   [string]$CreateSheet = "false",
-  [string]$VerifyMacro = "false"
+  [string]$VerifyMacro = "false",
+  [string]$MetadataPath = "",
+  [string]$UseSession = "false"
 )
 
 . "$PSScriptRoot/common.ps1"
@@ -19,6 +21,9 @@ $result = New-XlflowResult -Command "ui"
 $excel = $null
 $workbook = $null
 $saveWorkbook = $false
+$sessionAttached = $false
+$sessionMode = "none"
+$saveState = [ordered]@{ dirty = $false; needs_save = $false }
 
 function Set-UIButtonValidationError {
   param([string]$Message)
@@ -37,10 +42,13 @@ try {
     exit
   }
 
-  $excel = New-Object -ComObject Excel.Application
-  $excel.Visible = ConvertTo-XlflowBool $Visible
-  $workbook = Open-XlflowWorkbookWithXlflowDefaults -Excel $excel -WorkbookPath $WorkbookPath -DisplayAlerts $false -DisableAutomationMacros $true
-  $result.workbook = [ordered]@{ path = $WorkbookPath }
+  $openResult = Open-XlflowWorkbookForCommand -WorkbookPath $WorkbookPath -Visible $Visible -DisplayAlerts "false" -DisableAutomationMacros "true" -MetadataPath $MetadataPath -UseSession $UseSession
+  $excel = $openResult.excel
+  $workbook = $openResult.workbook
+  $sessionAttached = [bool]$openResult.session_attached
+  $sessionMode = [string]$openResult.session_mode
+  $saveState = Get-XlflowWorkbookSaveState -Workbook $workbook -SessionAttached $sessionAttached
+  $result.workbook = New-XlflowWorkbookResult -WorkbookPath $WorkbookPath -SessionAttached $sessionAttached -SessionMode $sessionMode -Dirty $saveState.dirty -NeedsSave $saveState.needs_save
 
   switch ($Action) {
     "add" {
@@ -169,16 +177,60 @@ try {
       $result.logs = @("removed workbook button " + $buttonName)
     }
   }
+  if ($null -ne $workbook) {
+    $result.target = New-XlflowTargetResult -Kind $(if ($sessionAttached) { "live_session" } else { "file" }) -Path $WorkbookPath
+    $result.session = New-XlflowSessionResult -Active $sessionAttached -WorkbookPath $WorkbookPath -Dirty $saveState.dirty -SaveRequired $saveState.needs_save -Mode $sessionMode
+  }
+  if ($result.status -eq "ok") {
+    if ($saveState.needs_save) {
+      Add-XlflowStateWarning -Result $result -Code "save_required" -Message "The live workbook is newer than disk. Run `xlflow save --session` to persist workbook changes."
+    }
+  }
 } catch {
   Set-XlflowError -Result $result -Code "ui_button_failed" -Message $_.Exception.Message -Source $_.Exception.Source -Number $_.Exception.HResult
   if ($null -ne $WorkbookPath) {
-    $result.workbook = [ordered]@{ path = $WorkbookPath }
+    $result.workbook = New-XlflowWorkbookResult -WorkbookPath $WorkbookPath -SessionAttached $sessionAttached -SessionMode $sessionMode -Dirty $saveState.dirty -NeedsSave $saveState.needs_save
+    $result.target = New-XlflowTargetResult -Kind $(if ($sessionAttached) { "live_session" } else { "file" }) -Path $WorkbookPath
+    $result.session = New-XlflowSessionResult -Active $sessionAttached -WorkbookPath $WorkbookPath -Dirty $saveState.dirty -SaveRequired $saveState.needs_save -Mode $sessionMode
+    if ($saveState.needs_save) {
+      Add-XlflowStateWarning -Result $result -Code "save_required" -Message "The live workbook is newer than disk. Run `xlflow save --session` to persist workbook changes."
+    }
   }
 } finally {
   if ($result.status -ne "ok") {
     $saveWorkbook = $false
   }
-  Close-XlflowCom -Workbook $workbook -Excel $excel -Save $saveWorkbook
+  if ($saveWorkbook -and $null -ne $workbook) {
+    try {
+      $workbook.Save()
+      $saveState = Get-XlflowWorkbookSaveState -Workbook $workbook -SessionAttached $sessionAttached
+      $result.workbook = New-XlflowWorkbookResult -WorkbookPath $WorkbookPath -SessionAttached $sessionAttached -SessionMode $sessionMode -Dirty $saveState.dirty -NeedsSave $saveState.needs_save
+      $result.target = New-XlflowTargetResult -Kind $(if ($sessionAttached) { "live_session" } else { "file" }) -Path $WorkbookPath
+      $result.session = New-XlflowSessionResult -Active $sessionAttached -WorkbookPath $WorkbookPath -Dirty $saveState.dirty -SaveRequired $saveState.needs_save -Mode $sessionMode
+      if (-not $result.Contains("warnings") -or $null -eq $result["warnings"]) {
+        $result["warnings"] = @()
+      }
+      $result.warnings = @($result.warnings | Where-Object { $_.code -ne "save_required" })
+      if ($saveState.needs_save) {
+        Add-XlflowStateWarning -Result $result -Code "save_required" -Message "The live workbook is newer than disk. Run `xlflow save --session` to persist workbook changes."
+      }
+    } catch {
+      Set-XlflowError -Result $result -Code "save_failed" -Message ("Failed to save workbook: " + $_.Exception.Message) -Source "Excel"
+      $result.workbook = New-XlflowWorkbookResult -WorkbookPath $WorkbookPath -SessionAttached $sessionAttached -SessionMode $sessionMode -Dirty $true -NeedsSave $true
+      $result.target = New-XlflowTargetResult -Kind $(if ($sessionAttached) { "live_session" } else { "file" }) -Path $WorkbookPath
+      $result.session = New-XlflowSessionResult -Active $sessionAttached -WorkbookPath $WorkbookPath -Dirty $true -SaveRequired $true -Mode $sessionMode
+      if (-not $result.Contains("warnings") -or $null -eq $result["warnings"]) {
+        $result["warnings"] = @()
+      }
+      $result.warnings = @($result.warnings | Where-Object { $_.code -ne "save_required" })
+      Add-XlflowStateWarning -Result $result -Code "save_required" -Message "The live workbook is newer than disk. Run `xlflow save --session` to persist workbook changes."
+    }
+  }
+  if ($sessionAttached) {
+    Release-XlflowComReferences -Workbook $workbook -Excel $excel
+  } else {
+    Close-XlflowCom -Workbook $workbook -Excel $excel -Save $false
+  }
 }
 
 Write-XlflowJson -Result $result

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -243,3 +243,24 @@ foreach ($moduleGroup in $selected | Group-Object module) {
 - `docs/specs/cli-contract.md`
 - `vitepress/commands/test.md`
 - `docs/adr/NNNN-lifecycle-hooks.md`
+
+---
+
+# Takt Workflow Spec: supervisor monitor support
+
+## Goal
+
+Align `.takt/workflows/xlflow-orchestra-high.yaml` with the added `loop_monitors` entry for the `self_review` / `fix` cycle.
+
+## Required Changes
+
+- Add a `fix` step that performs focused remediation after `self_review`.
+- Change `self_review` so `修正が必要` transitions to `fix` instead of `implementation`.
+- Add a `supervisor` persona under `.takt/facets/personas/` for loop monitor judgments.
+
+## Behavioral Contract
+
+- `self_review -> fix -> self_review` becomes the dedicated remediation loop.
+- `fix` is narrower than `implementation`; it should address review findings with minimal scope and fresh verification.
+- The `supervisor` persona judges whether repeated `self_review` / `fix` cycles show concrete progress or should abort.
+- Apply the same structure to both `.takt/workflows/xlflow-orchestra-high.yaml` and `.takt/workflows/xlflow-orchestra-low.yaml`, preserving each workflow's existing model assignments.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -46,3 +46,16 @@
 ## Unverified
 
 - None
+
+---
+
+# Takt workflow monitor alignment
+
+## Todo
+
+- [x] Inspect existing `.takt` workflow and persona patterns
+- [x] Define minimal `self_review -> fix -> self_review` loop
+- [x] Add `.takt/facets/personas/supervisor.md`
+- [x] Add `fix` step and reroute `self_review` to it
+- [x] Validate YAML/persona references and summarize residual risks
+- [x] Mirror the same loop-monitor structure into `.takt/workflows/xlflow-orchestra-low.yaml`

--- a/vitepress/commands/ui.md
+++ b/vitepress/commands/ui.md
@@ -12,17 +12,17 @@ xlflow ui button remove --id <id> [--session]
 
 ## Options and Arguments
 
-| Option / argument | Description                                   | Default          |
-| ----------------- | --------------------------------------------- | ---------------- |
-| `button add`      | Create or update a worksheet button.          | -                |
-| `button list`     | List xlflow-owned buttons.                    | -                |
-| `button remove`   | Remove a managed button.                      | -                |
-| `--sheet <name>`  | Target worksheet.                             | required for add |
-| `--cell <addr>`   | Anchor cell.                                  | required for add |
-| `--text <label>`  | Button text.                                  | required for add |
-| `--macro <entry>` | Assigned macro entrypoint.                    | required for add |
-| `--verify-macro`  | Fail if the target macro is not discoverable. | false            |
-| `--session`       | Operate against the managed live session workbook. | false       |
+| Option / argument | Description                                        | Default          |
+| ----------------- | -------------------------------------------------- | ---------------- |
+| `button add`      | Create or update a worksheet button.               | -                |
+| `button list`     | List xlflow-owned buttons.                         | -                |
+| `button remove`   | Remove a managed button.                           | -                |
+| `--sheet <name>`  | Target worksheet.                                  | required for add |
+| `--cell <addr>`   | Anchor cell.                                       | required for add |
+| `--text <label>`  | Button text.                                       | required for add |
+| `--macro <entry>` | Assigned macro entrypoint.                         | required for add |
+| `--verify-macro`  | Fail if the target macro is not discoverable.      | false            |
+| `--session`       | Operate against the managed live session workbook. | false            |
 
 ## Examples
 

--- a/vitepress/commands/ui.md
+++ b/vitepress/commands/ui.md
@@ -5,9 +5,9 @@ Manage xlflow-owned worksheet buttons.
 ## Usage
 
 ```bash
-xlflow ui button add --sheet <sheet> --cell <cell> --text <label> --macro <entry>
-xlflow ui button list
-xlflow ui button remove --id <id>
+xlflow ui button add --sheet <sheet> --cell <cell> --text <label> --macro <entry> [--session]
+xlflow ui button list [--session]
+xlflow ui button remove --id <id> [--session]
 ```
 
 ## Options and Arguments
@@ -22,6 +22,7 @@ xlflow ui button remove --id <id>
 | `--text <label>`  | Button text.                                  | required for add |
 | `--macro <entry>` | Assigned macro entrypoint.                    | required for add |
 | `--verify-macro`  | Fail if the target macro is not discoverable. | false            |
+| `--session`       | Operate against the managed live session workbook. | false       |
 
 ## Examples
 
@@ -36,6 +37,8 @@ xlflow ui button list --json
 Give buttons stable ids or anchors so rerunning the command can update the intended control.
 :::
 
+When an xlflow session is active and `.xlflow/session.json` points at the configured workbook, `ui button` commands auto-reuse that matching live session workbook instead of opening a fresh hidden instance. `add` and `remove` save the live session workbook after successful mutation so the session workbook stays open; `list` is read-only and does not save.
+
 ## JSON Output Example
 
 Successful `--json` output uses the xlflow envelope plus command-specific fields.
@@ -43,8 +46,22 @@ Successful `--json` output uses the xlflow envelope plus command-specific fields
 ```json
 {
   "status": "ok",
-  "command": "ui button add",
-  "button": { "sheet": "Home", "text": "Run", "macro": "Main.Run" }
+  "command": "ui",
+  "ui": {
+    "button": {
+      "id": "36c99bbe-f155-459e-9474-215b6b7db5c4",
+      "name": "xlflow.button.36c99bbe-f155-459e-9474-215b6b7db5c4",
+      "sheet": "Home",
+      "cell": "B2",
+      "text": "Run",
+      "macro": "Main.Run",
+      "left": 100,
+      "top": 50,
+      "width": 160,
+      "height": 40,
+      "updated": false
+    }
+  }
 }
 ```
 

--- a/vitepress/commands/ui.md
+++ b/vitepress/commands/ui.md
@@ -39,6 +39,10 @@ Give buttons stable ids or anchors so rerunning the command can update the inten
 
 When an xlflow session is active and `.xlflow/session.json` points at the configured workbook, `ui button` commands auto-reuse that matching live session workbook instead of opening a fresh hidden instance. `add` and `remove` save the live session workbook after successful mutation so the session workbook stays open; `list` is read-only and does not save.
 
+::: warning save_failed failure mode
+If the workbook save fails after a successful button mutation, the command sets `"status": "error"` with error code `save_failed`. In this state the live session still holds the mutation, but the workbook file on disk may not reflect it. Run `xlflow save --session` to retry persisting the changes.
+:::
+
 ## JSON Output Example
 
 Successful `--json` output uses the xlflow envelope plus command-specific fields.
@@ -64,6 +68,8 @@ Successful `--json` output uses the xlflow envelope plus command-specific fields
   }
 }
 ```
+
+The `updated` field indicates whether an existing button was updated (`true`) or a new button was created (`false`). This field only appears for the `button add` action.
 
 ## Related
 


### PR DESCRIPTION
Closes #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--session` to `ui button add/list/remove`; commands auto-reuse a live workbook session when available. `add`/`remove` now persist changes to the live session; `list` remains read-only.

* **Bug Fixes**
  * Prevented unexpected Excel SaveAs dialog during active sessions.

* **Documentation**
  * Updated CLI docs and examples; introduced `save_failed` warning behavior and guidance to retry disk persistence when saves fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harumiWeb/xlflow/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->