### PR TITLE
feat: introduce Excel bridge provider abstraction and command-line flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added an Excel bridge provider abstraction in Go, moved PowerShell invocation behind `PowerShellProvider`, and added bridge selection via persistent `--bridge`, `XLFLOW_EXCEL_BRIDGE`, and `[excel].bridge` while keeping `auto` on the existing PowerShell behavior for now.
 - Added `xlflow fmt` as a conservative, non-destructive VBA source formatter for `.bas` and `.cls` files. Supports `--write`, `--check`, `--diff`, `--json`, and `--stdin` modes. The formatter uses 4-space indentation, strips trailing whitespace, normalizes blank lines, preserves class module metadata, and is idempotent. Typical workflow: `fmt -> lint -> push -> run/test`.
 - Refined the interactive `xlflow new` / `init` welcome screen with a new `Welcome to` heading, a command reference URL, and softer muted version/info text below the ASCII logo.
 - Hardened the bundled TAKT orchestra, PR review, and issue bug workflows with explicit verification, audit-triage, and release-gate handling, broader loop monitoring around remediation and final audit, and clearer guidance to treat allowed untracked files and auto-staging state as non-blocking.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -9,10 +9,10 @@ xlflow is a Windows-first Go CLI that treats Excel VBA projects as source-contro
 ## Commands
 
 ```text
-xlflow [--json] new [workbook] [--with-skill] [--agent <provider>] [--no-update-check]
-xlflow [--json] init <workbook> [--with-module] [--with-skill] [--agent <provider>] [--no-update-check]
-xlflow [--json] doctor
-xlflow [--json] attach --active
+xlflow [--json] [--bridge <auto|powershell|dotnet>] new [workbook] [--with-skill] [--agent <provider>] [--no-update-check]
+xlflow [--json] [--bridge <auto|powershell|dotnet>] init <workbook> [--with-module] [--with-skill] [--agent <provider>] [--no-update-check]
+xlflow [--json] [--bridge <auto|powershell|dotnet>] doctor
+xlflow [--json] [--bridge <auto|powershell|dotnet>] attach --active
 xlflow [--json] backup list
 xlflow [--json] list forms [--session]
 xlflow [--json] inspect form <name> [--runtime|--designer|--both] [--initializer <method>] [--session] [--format text|json|markdown]
@@ -67,6 +67,8 @@ xlflow [--json] version [--verbose]
 ```
 
 `--json` is a persistent global flag and can be used with every command, including `new` and `init`.
+
+`--bridge` is also a persistent global flag for Excel bridge-backed commands. Supported values are `auto`, `powershell`, and `dotnet`. Resolution order is `--bridge`, then `XLFLOW_EXCEL_BRIDGE`, then `[excel].bridge`, then the default `auto`. In the current phase, `auto` resolves to the PowerShell bridge. Explicit `--bridge dotnet` is strict and does not implicitly fall back to PowerShell.
 
 When `--json` is not set, output is optimized for humans rather than machines. Interactive terminals may use Bubble Tea/Lipgloss presentation, color, and progress spinners for Excel COM-backed commands. Non-interactive output, such as CI logs and pipes, stays static and text-oriented while preserving the same command result information. Machine consumers must use `--json` instead of parsing human output.
 
@@ -197,6 +199,7 @@ entry = "Main.Run"
 path = "build/Book.xlsm"
 visible = false
 display_alerts = false
+bridge = "auto"
 
 [src]
 modules = "src/modules"

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/diff"
 	"github.com/harumiWeb/xlflow/internal/excel"
+	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
 	"github.com/harumiWeb/xlflow/internal/excel/forms"
 	"github.com/harumiWeb/xlflow/internal/gui"
 	workbookinspect "github.com/harumiWeb/xlflow/internal/inspect"
@@ -4875,10 +4876,24 @@ func (a *app) stderrIsInteractive() bool {
 
 func (a *app) loadConfig(command string) (config.Config, error) {
 	cfg, err := config.Load(a.cwd)
+	if err != nil && errors.Is(err, config.ErrInvalidExcelBridge) && a.hasValidBridgeOverride() {
+		cfg, err = config.LoadAllowInvalidExcelBridge(a.cwd)
+	}
 	if err != nil {
 		return cfg, a.writeFailure(command, output.ExitConfig, "config_error", err)
 	}
 	return cfg, nil
+}
+
+func (a *app) hasValidBridgeOverride() bool {
+	for _, candidate := range []string{a.bridge, os.Getenv(excelbridge.EnvBridge)} {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		_, err := excelbridge.ParseMode(candidate)
+		return err == nil
+	}
+	return false
 }
 
 func (a *app) excelRunner() excel.Runner {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ import (
 
 type app struct {
 	json           bool
+	bridge         string
 	cwd            string
 	stdout         io.Writer
 	stderr         io.Writer
@@ -139,6 +140,7 @@ func (a *app) rootCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	root.PersistentFlags().BoolVar(&a.json, "json", false, "write machine-readable JSON output")
+	root.PersistentFlags().StringVar(&a.bridge, "bridge", "", "Excel bridge mode: auto, powershell, dotnet")
 	root.AddCommand(
 		a.newCommand(),
 		a.initCommand(),
@@ -325,7 +327,7 @@ func (a *app) macrosCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Reading VBA project", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.MacrosWithOptions(cfg, excel.MacrosOptions{Session: session, Entry: cfg.Project.Entry, RunnableOnly: runnable, Keepalive: commandOpts})
+				env, code, runErr = a.excelRunnerForConfig(cfg).MacrosWithOptions(cfg, excel.MacrosOptions{Session: session, Entry: cfg.Project.Entry, RunnableOnly: runnable, Keepalive: commandOpts})
 				return runErr
 			})
 			if err != nil {
@@ -490,7 +492,7 @@ func (a *app) formSnapshotCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Snapshotting workbook form", opts.Inspect.Keepalive, func() error {
 				var runErr error
-				scriptEnv, code, runErr = excel.Runner{RootDir: a.cwd}.InspectForm(cfg, opts.Inspect)
+				scriptEnv, code, runErr = a.excelRunnerForConfig(cfg).InspectForm(cfg, opts.Inspect)
 				return runErr
 			})
 			if err != nil {
@@ -570,7 +572,7 @@ func (a *app) formBuildCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Building workbook form", opts.Keepalive, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.FormWrite(cfg, excel.FormWriteOptions{
+				env, code, runErr = a.excelRunnerForConfig(cfg).FormWrite(cfg, excel.FormWriteOptions{
 					Action:    opts.Action,
 					SpecPath:  opts.SpecInput.DisplayPath,
 					Spec:      opts.Spec,
@@ -621,7 +623,7 @@ func (a *app) formApplyCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Applying workbook form spec", opts.Keepalive, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.FormWrite(cfg, excel.FormWriteOptions{
+				env, code, runErr = a.excelRunnerForConfig(cfg).FormWrite(cfg, excel.FormWriteOptions{
 					Action:    opts.Action,
 					SpecPath:  opts.SpecInput.DisplayPath,
 					Spec:      opts.Spec,
@@ -665,7 +667,7 @@ func (a *app) formExportImageCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Exporting workbook form image", opts.Keepalive, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.FormExportImage(cfg, opts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).FormExportImage(cfg, opts)
 				return runErr
 			})
 			if err != nil {
@@ -697,7 +699,7 @@ func (a *app) listFormsCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Listing workbook forms", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.ListForms(cfg, excel.SessionCommandOptions{Session: session, Keepalive: commandOpts})
+				env, code, runErr = a.excelRunnerForConfig(cfg).ListForms(cfg, excel.SessionCommandOptions{Session: session, Keepalive: commandOpts})
 				return runErr
 			})
 			if err != nil {
@@ -752,7 +754,7 @@ func (a *app) uiButtonAddCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Adding workbook button", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.UIButtonAdd(cfg, built, commandOpts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).UIButtonAdd(cfg, built, commandOpts)
 				return runErr
 			})
 			if err != nil {
@@ -790,7 +792,7 @@ func (a *app) uiButtonListCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Listing workbook buttons", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.UIButtonList(cfg, opts, commandOpts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).UIButtonList(cfg, opts, commandOpts)
 				return runErr
 			})
 			if err != nil {
@@ -824,7 +826,7 @@ func (a *app) uiButtonRemoveCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Removing workbook button", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.UIButtonRemove(cfg, built, commandOpts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).UIButtonRemove(cfg, built, commandOpts)
 				return runErr
 			})
 			if err != nil {
@@ -932,7 +934,7 @@ func (a *app) newCommand() *cobra.Command {
 				var excelCode int
 				result, err := project.New(a.cwd, workbook, func(path string) error {
 					env, code, err := a.runExcelWithProgress("Creating workbook", runOpts, func() (output.Envelope, int, error) {
-						return excel.Runner{RootDir: a.cwd}.New(path, runOpts)
+						return a.excelRunner().New(path, runOpts)
 					})
 					excelEnv = env
 					excelCode = code
@@ -1086,7 +1088,7 @@ func (a *app) bootstrapScaffoldPush(keepaliveOpts excel.CommandOptions) (output.
 		return output.Envelope{}, 0, a.writeFailure("new", output.ExitConfig, "config_error", err)
 	}
 	return a.runExcelWithProgress("Importing scaffolded VBA source", keepaliveOpts, func() (output.Envelope, int, error) {
-		return excel.Runner{RootDir: a.cwd}.PushWithOptions(cfg, excel.PushOptions{
+		return a.excelRunnerForConfig(cfg).PushWithOptions(cfg, excel.PushOptions{
 			BackupMode: "never",
 			Keepalive:  keepaliveOpts,
 		})
@@ -1099,7 +1101,7 @@ func (a *app) bootstrapScaffoldPull(keepaliveOpts excel.CommandOptions) (output.
 		return output.Envelope{}, 0, a.writeFailure("init", output.ExitConfig, "config_error", err)
 	}
 	return a.runExcelWithProgress("Exporting workbook VBA source", keepaliveOpts, func() (output.Envelope, int, error) {
-		return excel.Runner{RootDir: a.cwd}.PullWithOptions(cfg, excel.SessionCommandOptions{
+		return a.excelRunnerForConfig(cfg).PullWithOptions(cfg, excel.SessionCommandOptions{
 			Keepalive: keepaliveOpts,
 		})
 	})
@@ -1120,7 +1122,7 @@ func (a *app) doctorCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Checking Excel automation", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.Doctor(cfg, commandOpts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).Doctor(cfg, commandOpts)
 				return runErr
 			})
 			if err != nil {
@@ -1154,7 +1156,7 @@ func (a *app) attachCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Inspecting active workbook", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.Attach(cfg, active, commandOpts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).Attach(cfg, active, commandOpts)
 				return runErr
 			})
 			if err != nil {
@@ -1183,7 +1185,7 @@ func (a *app) pullCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Exporting VBA source", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.PullWithOptions(cfg, excel.SessionCommandOptions{Session: session, Keepalive: commandOpts})
+				env, code, runErr = a.excelRunnerForConfig(cfg).PullWithOptions(cfg, excel.SessionCommandOptions{Session: session, Keepalive: commandOpts})
 				return runErr
 			})
 			if err != nil {
@@ -1353,7 +1355,7 @@ func (a *app) pushSource(command string, cfg config.Config, pushOpts excel.PushO
 	var code int
 	run := func() error {
 		var runErr error
-		env, code, runErr = excel.Runner{RootDir: a.cwd}.PushWithOptions(cfg, pushOpts)
+		env, code, runErr = a.excelRunnerForConfig(cfg).PushWithOptions(cfg, pushOpts)
 		return runErr
 	}
 	err := a.withExcelProgress(progressLabel, pushOpts.Keepalive, run)
@@ -2113,7 +2115,7 @@ func (a *app) sessionCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				env, code, err := excel.Runner{RootDir: a.cwd}.Session(cfg, action)
+				env, code, err := a.excelRunnerForConfig(cfg).Session(cfg, action)
 				if err != nil {
 					return err
 				}
@@ -2136,7 +2138,7 @@ func (a *app) saveCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			env, code, err := excel.Runner{RootDir: a.cwd}.SaveSession(cfg, excel.SessionCommandOptions{Session: session})
+			env, code, err := a.excelRunnerForConfig(cfg).SaveSession(cfg, excel.SessionCommandOptions{Session: session})
 			if err != nil {
 				return err
 			}
@@ -2370,7 +2372,7 @@ func (a *app) runnerCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				env, code, err := excel.Runner{RootDir: a.cwd}.RunnerModule(cfg, action)
+				env, code, err := a.excelRunnerForConfig(cfg).RunnerModule(cfg, action)
 				if err != nil {
 					return err
 				}
@@ -2464,7 +2466,7 @@ func (a *app) runCommand() *cobra.Command {
 			var code int
 			run := func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.Run(cfg, opts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).Run(cfg, opts)
 				return runErr
 			}
 			err = a.withSpinner("Running macro", run)
@@ -2529,7 +2531,7 @@ func (a *app) exportImageCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Exporting worksheet range image", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.ExportImage(cfg, opts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).ExportImage(cfg, opts)
 				return runErr
 			})
 			if err != nil {
@@ -2602,7 +2604,7 @@ func (a *app) editCellCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Editing workbook cell", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.EditCell(cfg, opts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).EditCell(cfg, opts)
 				return runErr
 			})
 			if err != nil {
@@ -2650,7 +2652,7 @@ func (a *app) editRangeCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Editing workbook range", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.EditRange(cfg, opts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).EditRange(cfg, opts)
 				return runErr
 			})
 			if err != nil {
@@ -2695,7 +2697,7 @@ func (a *app) editRowsCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Editing workbook row heights", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.EditRows(cfg, opts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).EditRows(cfg, opts)
 				return runErr
 			})
 			if err != nil {
@@ -2739,7 +2741,7 @@ func (a *app) editColumnsCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Editing workbook column widths", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.EditColumns(cfg, opts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).EditColumns(cfg, opts)
 				return runErr
 			})
 			if err != nil {
@@ -2808,7 +2810,7 @@ func (a *app) traceLifecycleCommand(action, short string) *cobra.Command {
 			}
 			err = a.withExcelProgress(label, commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.Trace(cfg, excel.TraceOptions{Action: traceAction, Workbook: workbook, Force: force, Session: session}, commandOpts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).Trace(cfg, excel.TraceOptions{Action: traceAction, Workbook: workbook, Force: force, Session: session}, commandOpts)
 				return runErr
 			})
 			if err != nil {
@@ -2863,7 +2865,7 @@ func (a *app) testCommand() *cobra.Command {
 			}
 			err = a.withExcelProgress("Running VBA tests", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = excel.Runner{RootDir: a.cwd}.TestWithOptions(cfg, filter, excel.TestOptions{Session: session, Keepalive: commandOpts, RuntimeMode: runtime.Mode, RuntimeSource: runtime.Source, UIResponses: excel.UIResponses{MsgBox: msgBoxResponses, Input: inputResponses, FileDialog: fileDialogResponses}, DebugStream: excel.DebugStreamOptions{Enabled: true}, UIStream: excel.UIStreamOptions{Enabled: uiStream, RedactInput: true}, ModuleFilter: moduleFilter, TagFilter: tagFilter})
+				env, code, runErr = a.excelRunnerForConfig(cfg).TestWithOptions(cfg, filter, excel.TestOptions{Session: session, Keepalive: commandOpts, RuntimeMode: runtime.Mode, RuntimeSource: runtime.Source, UIResponses: excel.UIResponses{MsgBox: msgBoxResponses, Input: inputResponses, FileDialog: fileDialogResponses}, DebugStream: excel.DebugStreamOptions{Enabled: true}, UIStream: excel.UIStreamOptions{Enabled: uiStream, RedactInput: true}, ModuleFilter: moduleFilter, TagFilter: tagFilter})
 				return runErr
 			})
 			if err != nil {
@@ -2898,7 +2900,7 @@ func (a *app) processListCommand() *cobra.Command {
 		Short: "List all local Excel processes",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			env, code, err := excel.Runner{RootDir: a.cwd}.ProcessList(excel.ProcessListOptions{Action: "list"})
+			env, code, err := a.excelRunner().ProcessList(excel.ProcessListOptions{Action: "list"})
 			if err != nil {
 				return err
 			}
@@ -2948,7 +2950,7 @@ unsaved workbooks or active work. Use with extreme caution.`,
 				}
 				opts.PID = pidInt
 			}
-			env, code, err := excel.Runner{RootDir: a.cwd}.ProcessCleanup(opts)
+			env, code, err := a.excelRunner().ProcessCleanup(opts)
 			if err != nil {
 				return err
 			}
@@ -3205,7 +3207,7 @@ func (a *app) inspectFormCommand(flags *inspectSharedFlags) *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Inspecting workbook form", opts.Keepalive, func() error {
 				var runErr error
-				scriptEnv, code, runErr = excel.Runner{RootDir: a.cwd}.InspectForm(cfg, opts)
+				scriptEnv, code, runErr = a.excelRunnerForConfig(cfg).InspectForm(cfg, opts)
 				return runErr
 			})
 			if err != nil {
@@ -3635,7 +3637,7 @@ func (a *app) runSessionInspect(cfg config.Config, opts excel.InspectOptions, fo
 	var code int
 	err := a.withExcelProgress("Inspecting live workbook", opts.Keepalive, func() error {
 		var runErr error
-		scriptEnv, code, runErr = excel.Runner{RootDir: a.cwd}.Inspect(cfg, opts)
+		scriptEnv, code, runErr = a.excelRunnerForConfig(cfg).Inspect(cfg, opts)
 		return runErr
 	})
 	if err != nil {
@@ -3734,7 +3736,7 @@ func (a *app) inspectStateForWorkbook(cfg config.Config, workbookPath string) (m
 }
 
 func (a *app) inspectSessionStatus(cfg config.Config) (map[string]any, bool) {
-	env, _, err := excel.Runner{RootDir: a.cwd}.Session(cfg, "status")
+	env, _, err := a.excelRunnerForConfig(cfg).Session(cfg, "status")
 	if err == nil {
 		if status := cliObjectMap(env.Session); len(status) > 0 {
 			return status, true
@@ -4350,7 +4352,7 @@ func (a *app) checkCommand() *cobra.Command {
 			var doctorCode int
 			err = a.withExcelProgress("Checking Excel automation", commandOpts, func() error {
 				var runErr error
-				doctor, doctorCode, runErr = excel.Runner{RootDir: a.cwd}.Doctor(cfg, commandOpts)
+				doctor, doctorCode, runErr = a.excelRunnerForConfig(cfg).Doctor(cfg, commandOpts)
 				return runErr
 			})
 			if err != nil {
@@ -4877,6 +4879,14 @@ func (a *app) loadConfig(command string) (config.Config, error) {
 		return cfg, a.writeFailure(command, output.ExitConfig, "config_error", err)
 	}
 	return cfg, nil
+}
+
+func (a *app) excelRunner() excel.Runner {
+	return excel.Runner{RootDir: a.cwd, BridgeMode: a.bridge}
+}
+
+func (a *app) excelRunnerForConfig(cfg config.Config) excel.Runner {
+	return excel.Runner{RootDir: a.cwd, BridgeMode: a.bridge, ConfigBridgeMode: cfg.Excel.Bridge}
 }
 
 func (a *app) writeScaffoldWelcome(command string, skipUpdateCheck bool) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -129,6 +129,28 @@ func TestRootCommandIncludesBridgeFlag(t *testing.T) {
 	}
 }
 
+func TestLoadConfigAllowsValidBridgeOverrideWhenConfigBridgeIsInvalid(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+bridge = "broken"
+`)
+	if err := os.WriteFile(filepath.Join(dir, config.FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := &app{cwd: dir, bridge: "powershell"}
+	cfg, err := a.loadConfig("fmt")
+	if err != nil {
+		t.Fatalf("loadConfig returned error: %v", err)
+	}
+	if cfg.Excel.Bridge != "broken" {
+		t.Fatalf("excel.bridge = %q, want broken", cfg.Excel.Bridge)
+	}
+}
+
 func TestRootCommandIncludesBackupAndRollbackCommands(t *testing.T) {
 	a := &app{}
 	root := a.rootCommand()

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -119,6 +119,16 @@ func TestRootCommandIncludesVersionCommand(t *testing.T) {
 	}
 }
 
+func TestRootCommandIncludesBridgeFlag(t *testing.T) {
+	a := &app{}
+	root := a.rootCommand()
+
+	flag := root.PersistentFlags().Lookup("bridge")
+	if flag == nil {
+		t.Fatal("expected persistent --bridge flag")
+	}
+}
+
 func TestRootCommandIncludesBackupAndRollbackCommands(t *testing.T) {
 	a := &app{}
 	root := a.rootCommand()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,9 +7,12 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
 )
 
 const FileName = "xlflow.toml"
+
+var ErrInvalidExcelBridge = errors.New("excel.bridge must be one of auto, powershell, dotnet")
 
 type Config struct {
 	Project  ProjectConfig  `toml:"project"`
@@ -98,6 +101,14 @@ func Default() Config {
 }
 
 func Load(cwd string) (Config, error) {
+	return load(cwd, false)
+}
+
+func LoadAllowInvalidExcelBridge(cwd string) (Config, error) {
+	return load(cwd, true)
+}
+
+func load(cwd string, allowInvalidExcelBridge bool) (Config, error) {
 	cfg := Default()
 	path := filepath.Join(cwd, FileName)
 	if _, err := os.Stat(path); err != nil {
@@ -110,6 +121,9 @@ func Load(cwd string) (Config, error) {
 		return cfg, err
 	}
 	applyDefaults(&cfg)
+	if err := normalizeExcelBridge(&cfg, allowInvalidExcelBridge); err != nil {
+		return cfg, err
+	}
 	return cfg, validate(cfg)
 }
 
@@ -151,11 +165,6 @@ func validate(cfg Config) error {
 	if cfg.Excel.Path == "" {
 		return errors.New("excel.path is required")
 	}
-	switch cfg.Excel.Bridge {
-	case "auto", "powershell", "dotnet":
-	default:
-		return fmt.Errorf("excel.bridge must be one of auto, powershell, dotnet")
-	}
 	switch cfg.VBA.FolderAnnotation {
 	case "update", "preserve", "ignore":
 	default:
@@ -166,6 +175,21 @@ func validate(cfg Config) error {
 	default:
 		return fmt.Errorf("userform.code_source must be one of frm, sidecar")
 	}
+	return nil
+}
+
+func normalizeExcelBridge(cfg *Config, allowInvalid bool) error {
+	mode, err := excelbridge.ParseMode(cfg.Excel.Bridge)
+	if err != nil {
+		if allowInvalid {
+			return nil
+		}
+		if errors.Is(err, excelbridge.ErrInvalidMode) {
+			return ErrInvalidExcelBridge
+		}
+		return err
+	}
+	cfg.Excel.Bridge = string(mode)
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type ExcelConfig struct {
 	Path          string `toml:"path"`
 	Visible       bool   `toml:"visible"`
 	DisplayAlerts bool   `toml:"display_alerts"`
+	Bridge        string `toml:"bridge"`
 }
 
 type SourceConfig struct {
@@ -68,6 +69,7 @@ func Default() Config {
 			Path:          filepath.ToSlash(filepath.Join("build", "Book.xlsm")),
 			Visible:       false,
 			DisplayAlerts: false,
+			Bridge:        "auto",
 		},
 		Src: SourceConfig{
 			Modules:  filepath.ToSlash(filepath.Join("src", "modules")),
@@ -119,6 +121,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Excel.Path == "" {
 		cfg.Excel.Path = defaults.Excel.Path
 	}
+	if cfg.Excel.Bridge == "" {
+		cfg.Excel.Bridge = defaults.Excel.Bridge
+	}
 	if cfg.Src.Modules == "" {
 		cfg.Src.Modules = defaults.Src.Modules
 	}
@@ -145,6 +150,11 @@ func validate(cfg Config) error {
 	}
 	if cfg.Excel.Path == "" {
 		return errors.New("excel.path is required")
+	}
+	switch cfg.Excel.Bridge {
+	case "auto", "powershell", "dotnet":
+	default:
+		return fmt.Errorf("excel.bridge must be one of auto, powershell, dotnet")
 	}
 	switch cfg.VBA.FolderAnnotation {
 	case "update", "preserve", "ignore":
@@ -185,6 +195,8 @@ path = %q
 visible = %t
 # Suppress Excel alert dialogs (e.g. overwrite confirmations).
 display_alerts = %t
+# Excel bridge mode. Valid values: "auto", "powershell", "dotnet".
+bridge = %q
 
 # Source tree directories.
 [src]
@@ -237,7 +249,7 @@ forbid_interactive_input = %t
 `
 	_, err = fmt.Fprintf(f, tmpl,
 		cfg.Project.Name, cfg.Project.Entry,
-		cfg.Excel.Path, cfg.Excel.Visible, cfg.Excel.DisplayAlerts,
+		cfg.Excel.Path, cfg.Excel.Visible, cfg.Excel.DisplayAlerts, cfg.Excel.Bridge,
 		cfg.Src.Modules, cfg.Src.Classes, cfg.Src.Forms, cfg.Src.Workbook,
 		cfg.VBA.Folders, cfg.VBA.FolderAnnotation, cfg.VBA.DefaultComponentFolders,
 		cfg.UserForm.CodeSource,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -136,6 +136,27 @@ bridge = "broken"
 	}
 }
 
+func TestLoadNormalizesExcelBridgeValue(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+bridge = " PowerShell "
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Excel.Bridge != "powershell" {
+		t.Fatalf("excel.bridge = %q, want powershell", cfg.Excel.Bridge)
+	}
+}
+
 func TestWriteProducesReadableConfig(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Default()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,9 @@ path = "build/Sales.xlsm"
 	if !cfg.Lint.RequireOptionExplicit {
 		t.Fatalf("lint defaults were not applied")
 	}
+	if cfg.Excel.Bridge != "auto" {
+		t.Fatalf("unexpected excel bridge default: %q", cfg.Excel.Bridge)
+	}
 	if !cfg.Lint.ForbidInteractiveInput {
 		t.Fatalf("interactive input lint default was not applied")
 	}
@@ -115,10 +118,29 @@ code_source = "broken"
 	}
 }
 
+func TestLoadRejectsInvalidExcelBridge(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+bridge = "broken"
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected invalid excel bridge error")
+	}
+}
+
 func TestWriteProducesReadableConfig(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Default()
 	cfg.Project.Name = "write-test"
+	cfg.Excel.Bridge = "powershell"
 	cfg.UserForm.CodeSource = "frm"
 	cfg.Lint.ForbidInteractiveInput = false
 
@@ -136,6 +158,9 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	}
 	if loaded.UserForm.CodeSource != "frm" {
 		t.Fatalf("userform.code_source mismatch: got %q, want frm", loaded.UserForm.CodeSource)
+	}
+	if loaded.Excel.Bridge != "powershell" {
+		t.Fatalf("excel.bridge mismatch: got %q, want powershell", loaded.Excel.Bridge)
 	}
 	if loaded.Lint.ForbidInteractiveInput {
 		t.Fatal("expected forbid_interactive_input=false")

--- a/internal/excel/bridge.go
+++ b/internal/excel/bridge.go
@@ -9,22 +9,22 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
 	"github.com/harumiWeb/xlflow/internal/excel/forms"
-	bundledscripts "github.com/harumiWeb/xlflow/internal/excel/scripts"
 	"github.com/harumiWeb/xlflow/internal/output"
 )
 
 type Runner struct {
-	RootDir string
+	RootDir          string
+	BridgeMode       string
+	ConfigBridgeMode string
 }
 
 type WorkbookRef struct {
@@ -1355,10 +1355,6 @@ type commandRunOptions struct {
 func (r Runner) runWithOptions(commandName string, args map[string]string, opts commandRunOptions) (output.Envelope, int, error) {
 	env := output.New(commandName)
 	var err error
-	if !scriptExecutionSupported(r.RootDir, commandName) {
-		env = output.Failure(commandName, output.Error{Code: "environment", Message: fmt.Sprintf("Excel automation is only supported on Windows in the MVP unless a script override is provided at scripts/%s.ps1", commandName)})
-		return env, output.ExitEnvironment, nil
-	}
 
 	var uiSession *uiStreamSession
 	var debugSession *debugStreamSession
@@ -1389,9 +1385,30 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 		args["DebugStreamPipeName"] = debugSession.PipePath()
 	}
 
-	script, cleanup, err := scriptPath(r.RootDir, commandName)
+	mode, _, err := excelbridge.ResolveMode(r.BridgeMode, os.Getenv(excelbridge.EnvBridge), r.ConfigBridgeMode)
 	if err != nil {
-		env = output.Failure(commandName, output.Error{Code: "script_not_found", Message: err.Error(), Source: "xlflow"})
+		env = output.Failure(commandName, output.Error{Code: "bridge_mode_invalid", Message: err.Error(), Source: "xlflow", Phase: "bridge.resolve"})
+		if debugResult, debugStreamErr := closeDebugStreamSession(debugSession); debugResult != nil || debugStreamErr != nil {
+			env.Debug = mergeDebugResult(nil, debugResult)
+			if debugStreamErr != nil {
+				env.Logs = append(env.Logs, "Debug stream closed with an error: "+debugStreamErr.Error())
+			}
+		}
+		if uiEvents, uiStreamErr := closeUIStreamSession(uiSession); len(uiEvents) > 0 || uiStreamErr != nil {
+			env.UI = mergeUIResult(nil, uiEvents)
+			if uiStreamErr != nil {
+				env.Logs = append(env.Logs, "UI stream closed with an error: "+uiStreamErr.Error())
+			}
+		}
+		return env, output.ExitConfig, nil
+	}
+	if mode == excelbridge.ModeDotNet {
+		env = output.Failure(commandName, output.Error{
+			Code:    "bridge_not_available",
+			Message: ".NET Excel bridge is not available in this build yet; use --bridge powershell or --bridge auto.",
+			Source:  "xlflow",
+			Phase:   "bridge.resolve",
+		})
 		if debugResult, debugStreamErr := closeDebugStreamSession(debugSession); debugResult != nil || debugStreamErr != nil {
 			env.Debug = mergeDebugResult(nil, debugResult)
 			if debugStreamErr != nil {
@@ -1406,13 +1423,7 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 		}
 		return env, output.ExitEnvironment, nil
 	}
-	if cleanup != nil {
-		defer cleanup()
-	}
-	cmdArgs := []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script}
-	for k, v := range args {
-		cmdArgs = append(cmdArgs, "-"+k, v)
-	}
+
 	var ctx context.Context
 	var cancel context.CancelFunc
 	if opts.Timeout > 0 {
@@ -1421,35 +1432,13 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 		ctx, cancel = context.WithCancel(context.Background())
 	}
 	defer cancel()
-	powershellExe, err := powerShellExecutable()
-	if err != nil {
-		env = output.Failure(commandName, output.Error{Code: "environment", Message: err.Error(), Source: "xlflow"})
-		if debugResult, debugStreamErr := closeDebugStreamSession(debugSession); debugResult != nil || debugStreamErr != nil {
-			env.Debug = mergeDebugResult(nil, debugResult)
-			if debugStreamErr != nil {
-				env.Logs = append(env.Logs, "Debug stream closed with an error: "+debugStreamErr.Error())
-			}
-		}
-		if uiEvents, uiStreamErr := closeUIStreamSession(uiSession); len(uiEvents) > 0 || uiStreamErr != nil {
-			env.UI = mergeUIResult(nil, uiEvents)
-			if uiStreamErr != nil {
-				env.Logs = append(env.Logs, "UI stream closed with an error: "+uiStreamErr.Error())
-			}
-		}
-		return env, output.ExitEnvironment, nil
-	}
-	cmd := exec.CommandContext(ctx, powershellExe, cmdArgs...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err = cmd.Start()
-	if err == nil {
-		err = cmd.Wait()
-	}
+
+	provider := excelbridge.PowerShellProvider{RootDir: r.RootDir}
+	response, err := provider.Execute(ctx, excelbridge.Request{Command: commandName, Args: args})
 	debugResult, debugStreamErr := closeDebugStreamSession(debugSession)
 	uiEvents, uiStreamErr := closeUIStreamSession(uiSession)
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded && commandName == "run" {
+		if response.TimedOut && commandName == "run" {
 			env = output.Failure(commandName, output.Error{
 				Code:    "macro_timeout",
 				Message: fmt.Sprintf("Macro did not complete within %s. Possible causes: a file picker, MsgBox, UserForm, or long-running loop is still waiting.", opts.Timeout.String()),
@@ -1470,11 +1459,20 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 			env.UI = mergeUIResult(nil, uiEvents)
 			return env, output.ExitValidation, nil
 		}
+		code := "script_failed"
+		source := "powershell"
 		message := err.Error()
-		if stderr.Len() > 0 {
-			message = stderr.String()
+		if len(response.Stderr) > 0 {
+			message = string(response.Stderr)
 		}
-		env = output.Failure(commandName, output.Error{Code: "script_failed", Message: message, Source: "powershell"})
+		if strings.Contains(message, "Excel automation is only supported on Windows in the MVP") || strings.Contains(message, "PowerShell executable not found") {
+			code = "environment"
+			source = "xlflow"
+		} else if strings.Contains(message, "script ") && strings.Contains(message, "was not available from on-disk script locations or embedded runtime assets") {
+			code = "script_not_found"
+			source = "xlflow"
+		}
+		env = output.Failure(commandName, output.Error{Code: code, Message: message, Source: source})
 		if debugStreamErr != nil {
 			env.Logs = append(env.Logs, "Debug stream closed with an error: "+debugStreamErr.Error())
 		}
@@ -1487,9 +1485,9 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 	}
 
 	var result ScriptResult
-	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+	if err := json.Unmarshal(response.Stdout, &result); err != nil {
 		env = output.Failure(commandName, output.Error{Code: "invalid_script_json", Message: fmt.Sprintf("failed to parse script JSON: %v", err), Source: "powershell"})
-		env.Logs = []string{stdout.String()}
+		env.Logs = []string{string(response.Stdout)}
 		if uiStreamErr != nil {
 			env.Logs = append(env.Logs, "UI stream closed with an error: "+uiStreamErr.Error())
 		}
@@ -1731,77 +1729,21 @@ func workbookPath(root, path string) string {
 }
 
 func scriptPath(root, commandName string) (string, func(), error) {
-	if path, ok := externalScriptPath(root, commandName); ok {
-		return path, nil, nil
-	}
-	return materializeBundledScript(commandName)
+	return excelbridge.ScriptPath(root, commandName)
 }
 
 func materializeBundledScript(commandName string) (string, func(), error) {
-	name := commandName + ".ps1"
-	path, cleanup, err := bundledscripts.Materialize(commandName)
-	if err != nil {
-		return "", nil, fmt.Errorf("script %s was not available from on-disk script locations or embedded runtime assets: %w", name, err)
-	}
-	return path, cleanup, nil
+	return excelbridge.MaterializeBundledScript(commandName)
 }
 
 func externalScriptPath(root, commandName string) (string, bool) {
-	name := commandName + ".ps1"
-	candidates := []string{}
-	if path, ok := rootScriptOverridePath(root, commandName); ok {
-		candidates = append(candidates, path)
-	}
-	if _, file, _, ok := runtime.Caller(0); ok {
-		candidates = append(candidates, filepath.Join(filepath.Dir(file), "scripts", name))
-	}
-	if exe, err := os.Executable(); err == nil {
-		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "scripts", name))
-	}
-	for _, candidate := range candidates {
-		clean := filepath.Clean(candidate)
-		if _, err := os.Stat(clean); err == nil {
-			return clean, true
-		}
-	}
-	return "", false
+	return excelbridge.ExternalScriptPath(root, commandName)
 }
 
 func hasExternalScriptOverride(root, commandName string) bool {
-	_, ok := rootScriptOverridePath(root, commandName)
-	return ok
-}
-
-func scriptExecutionSupported(root, commandName string) bool {
-	return runtime.GOOS == "windows" || hasExternalScriptOverride(root, commandName)
-}
-
-func powerShellExecutable() (string, error) {
-	return powerShellExecutableFor(runtime.GOOS, exec.LookPath)
+	return excelbridge.HasExternalScriptOverride(root, commandName)
 }
 
 func powerShellExecutableFor(goos string, lookPath func(file string) (string, error)) (string, error) {
-	var candidates []string
-	if goos == "windows" {
-		candidates = []string{"powershell"}
-	} else {
-		candidates = []string{"pwsh", "powershell"}
-	}
-	for _, candidate := range candidates {
-		if _, err := lookPath(candidate); err == nil {
-			return candidate, nil
-		}
-	}
-	return "", fmt.Errorf("PowerShell executable not found on %s (searched: %s)", goos, strings.Join(candidates, ", "))
-}
-
-func rootScriptOverridePath(root, commandName string) (string, bool) {
-	if root == "" {
-		return "", false
-	}
-	candidate := filepath.Clean(filepath.Join(root, "scripts", commandName+".ps1"))
-	if _, err := os.Stat(candidate); err == nil {
-		return candidate, true
-	}
-	return "", false
+	return excelbridge.PowerShellExecutableFor(goos, lookPath)
 }

--- a/internal/excel/bridge.go
+++ b/internal/excel/bridge.go
@@ -1465,12 +1465,16 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 		if len(response.Stderr) > 0 {
 			message = string(response.Stderr)
 		}
-		if strings.Contains(message, "Excel automation is only supported on Windows in the MVP") || strings.Contains(message, "PowerShell executable not found") {
-			code = "environment"
-			source = "xlflow"
-		} else if strings.Contains(message, "script ") && strings.Contains(message, "was not available from on-disk script locations or embedded runtime assets") {
-			code = "script_not_found"
-			source = "xlflow"
+		var bridgeErr *excelbridge.Error
+		if errors.As(err, &bridgeErr) {
+			switch bridgeErr.Kind {
+			case excelbridge.ErrorUnsupportedHost, excelbridge.ErrorPowerShellMissing:
+				code = "environment"
+				source = "xlflow"
+			case excelbridge.ErrorScriptNotFound:
+				code = "script_not_found"
+				source = "xlflow"
+			}
 		}
 		env = output.Failure(commandName, output.Error{Code: code, Message: message, Source: source})
 		if debugStreamErr != nil {

--- a/internal/excel/bridge/bridge.go
+++ b/internal/excel/bridge/bridge.go
@@ -1,0 +1,74 @@
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const EnvBridge = "XLFLOW_EXCEL_BRIDGE"
+
+type Mode string
+
+const (
+	ModeAuto       Mode = "auto"
+	ModePowerShell Mode = "powershell"
+	ModeDotNet     Mode = "dotnet"
+)
+
+type Request struct {
+	Command string
+	Args    map[string]string
+}
+
+type Response struct {
+	Stdout   []byte
+	Stderr   []byte
+	TimedOut bool
+}
+
+type Info struct {
+	Name    string
+	Version string
+}
+
+type Provider interface {
+	Name() string
+	Supports(command string) bool
+	Info(context.Context) (Info, error)
+	Execute(context.Context, Request) (Response, error)
+}
+
+func ParseMode(raw string) (Mode, error) {
+	mode := Mode(strings.ToLower(strings.TrimSpace(raw)))
+	if mode == "" {
+		return "", fmt.Errorf("bridge mode must be one of auto, powershell, dotnet")
+	}
+	switch mode {
+	case ModeAuto, ModePowerShell, ModeDotNet:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("bridge mode must be one of auto, powershell, dotnet")
+	}
+}
+
+func ResolveMode(cli, env, cfg string) (Mode, string, error) {
+	for _, candidate := range []struct {
+		value  string
+		source string
+	}{
+		{value: cli, source: "cli"},
+		{value: env, source: "env"},
+		{value: cfg, source: "config"},
+	} {
+		if strings.TrimSpace(candidate.value) == "" {
+			continue
+		}
+		mode, err := ParseMode(candidate.value)
+		if err != nil {
+			return "", candidate.source, err
+		}
+		return mode, candidate.source, nil
+	}
+	return ModeAuto, "default", nil
+}

--- a/internal/excel/bridge/bridge.go
+++ b/internal/excel/bridge/bridge.go
@@ -2,11 +2,13 @@ package bridge
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 )
 
 const EnvBridge = "XLFLOW_EXCEL_BRIDGE"
+
+var ErrInvalidMode = errors.New("bridge mode must be one of auto, powershell, dotnet")
 
 type Mode string
 
@@ -39,16 +41,44 @@ type Provider interface {
 	Execute(context.Context, Request) (Response, error)
 }
 
+type ErrorKind string
+
+const (
+	ErrorUnsupportedHost   ErrorKind = "unsupported_host"
+	ErrorPowerShellMissing ErrorKind = "powershell_missing"
+	ErrorScriptNotFound    ErrorKind = "script_not_found"
+)
+
+type Error struct {
+	Kind    ErrorKind
+	Message string
+	Err     error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 func ParseMode(raw string) (Mode, error) {
 	mode := Mode(strings.ToLower(strings.TrimSpace(raw)))
 	if mode == "" {
-		return "", fmt.Errorf("bridge mode must be one of auto, powershell, dotnet")
+		return "", ErrInvalidMode
 	}
 	switch mode {
 	case ModeAuto, ModePowerShell, ModeDotNet:
 		return mode, nil
 	default:
-		return "", fmt.Errorf("bridge mode must be one of auto, powershell, dotnet")
+		return "", ErrInvalidMode
 	}
 }
 

--- a/internal/excel/bridge/powershell.go
+++ b/internal/excel/bridge/powershell.go
@@ -31,7 +31,10 @@ func (p PowerShellProvider) Info(context.Context) (Info, error) {
 
 func (p PowerShellProvider) Execute(ctx context.Context, req Request) (Response, error) {
 	if !ScriptExecutionSupported(p.RootDir, req.Command) {
-		return Response{}, fmt.Errorf("excel automation is only supported on Windows in the MVP unless a script override is provided at scripts/%s.ps1", req.Command)
+		return Response{}, &Error{
+			Kind:    ErrorUnsupportedHost,
+			Message: fmt.Sprintf("excel automation is only supported on Windows in the MVP unless a script override is provided at scripts/%s.ps1", req.Command),
+		}
 	}
 
 	script, cleanup, err := ScriptPath(p.RootDir, req.Command)
@@ -78,7 +81,11 @@ func MaterializeBundledScript(commandName string) (string, func(), error) {
 	name := commandName + ".ps1"
 	path, cleanup, err := bundledscripts.Materialize(commandName)
 	if err != nil {
-		return "", nil, fmt.Errorf("script %s was not available from on-disk script locations or embedded runtime assets: %w", name, err)
+		return "", nil, &Error{
+			Kind:    ErrorScriptNotFound,
+			Message: fmt.Sprintf("script %s was not available from on-disk script locations or embedded runtime assets", name),
+			Err:     err,
+		}
 	}
 	return path, cleanup, nil
 }
@@ -129,7 +136,10 @@ func PowerShellExecutableFor(goos string, lookPath func(file string) (string, er
 			return candidate, nil
 		}
 	}
-	return "", fmt.Errorf("PowerShell executable not found on %s (searched: %s)", goos, strings.Join(candidates, ", "))
+	return "", &Error{
+		Kind:    ErrorPowerShellMissing,
+		Message: fmt.Sprintf("PowerShell executable not found on %s (searched: %s)", goos, strings.Join(candidates, ", ")),
+	}
 }
 
 func RootScriptOverridePath(root, commandName string) (string, bool) {

--- a/internal/excel/bridge/powershell.go
+++ b/internal/excel/bridge/powershell.go
@@ -1,0 +1,144 @@
+package bridge
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	bundledscripts "github.com/harumiWeb/xlflow/internal/excel/scripts"
+)
+
+type PowerShellProvider struct {
+	RootDir string
+}
+
+func (p PowerShellProvider) Name() string {
+	return string(ModePowerShell)
+}
+
+func (p PowerShellProvider) Supports(string) bool {
+	return true
+}
+
+func (p PowerShellProvider) Info(context.Context) (Info, error) {
+	return Info{Name: p.Name()}, nil
+}
+
+func (p PowerShellProvider) Execute(ctx context.Context, req Request) (Response, error) {
+	if !ScriptExecutionSupported(p.RootDir, req.Command) {
+		return Response{}, fmt.Errorf("excel automation is only supported on Windows in the MVP unless a script override is provided at scripts/%s.ps1", req.Command)
+	}
+
+	script, cleanup, err := ScriptPath(p.RootDir, req.Command)
+	if err != nil {
+		return Response{}, err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	powershellExe, err := PowerShellExecutable()
+	if err != nil {
+		return Response{}, err
+	}
+
+	cmdArgs := []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script}
+	for k, v := range req.Args {
+		cmdArgs = append(cmdArgs, "-"+k, v)
+	}
+
+	cmd := exec.CommandContext(ctx, powershellExe, cmdArgs...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Start()
+	if err == nil {
+		err = cmd.Wait()
+	}
+	return Response{
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+		TimedOut: ctx.Err() == context.DeadlineExceeded,
+	}, err
+}
+
+func ScriptPath(root, commandName string) (string, func(), error) {
+	if path, ok := ExternalScriptPath(root, commandName); ok {
+		return path, nil, nil
+	}
+	return MaterializeBundledScript(commandName)
+}
+
+func MaterializeBundledScript(commandName string) (string, func(), error) {
+	name := commandName + ".ps1"
+	path, cleanup, err := bundledscripts.Materialize(commandName)
+	if err != nil {
+		return "", nil, fmt.Errorf("script %s was not available from on-disk script locations or embedded runtime assets: %w", name, err)
+	}
+	return path, cleanup, nil
+}
+
+func ExternalScriptPath(root, commandName string) (string, bool) {
+	name := commandName + ".ps1"
+	candidates := []string{}
+	if path, ok := RootScriptOverridePath(root, commandName); ok {
+		candidates = append(candidates, path)
+	}
+	if _, file, _, ok := runtime.Caller(0); ok {
+		candidates = append(candidates, filepath.Join(filepath.Dir(filepath.Dir(file)), "scripts", name))
+	}
+	if exe, err := os.Executable(); err == nil {
+		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "scripts", name))
+	}
+	for _, candidate := range candidates {
+		clean := filepath.Clean(candidate)
+		if _, err := os.Stat(clean); err == nil {
+			return clean, true
+		}
+	}
+	return "", false
+}
+
+func HasExternalScriptOverride(root, commandName string) bool {
+	_, ok := RootScriptOverridePath(root, commandName)
+	return ok
+}
+
+func ScriptExecutionSupported(root, commandName string) bool {
+	return runtime.GOOS == "windows" || HasExternalScriptOverride(root, commandName)
+}
+
+func PowerShellExecutable() (string, error) {
+	return PowerShellExecutableFor(runtime.GOOS, exec.LookPath)
+}
+
+func PowerShellExecutableFor(goos string, lookPath func(file string) (string, error)) (string, error) {
+	var candidates []string
+	if goos == "windows" {
+		candidates = []string{"powershell"}
+	} else {
+		candidates = []string{"pwsh", "powershell"}
+	}
+	for _, candidate := range candidates {
+		if _, err := lookPath(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("PowerShell executable not found on %s (searched: %s)", goos, strings.Join(candidates, ", "))
+}
+
+func RootScriptOverridePath(root, commandName string) (string, bool) {
+	if root == "" {
+		return "", false
+	}
+	candidate := filepath.Clean(filepath.Join(root, "scripts", commandName+".ps1"))
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate, true
+	}
+	return "", false
+}

--- a/internal/excel/bridge_test.go
+++ b/internal/excel/bridge_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
 	"github.com/harumiWeb/xlflow/internal/excel/forms"
 	"github.com/harumiWeb/xlflow/internal/output"
 )
@@ -163,6 +164,47 @@ func TestPowerShellExecutableForReturnsErrorWhenUnavailable(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected missing PowerShell error")
+	}
+}
+
+func TestResolveBridgeModePrecedence(t *testing.T) {
+	mode, source, err := excelbridge.ResolveMode("", "powershell", "dotnet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != excelbridge.ModePowerShell || source != "env" {
+		t.Fatalf("ResolveMode env precedence = (%q, %q), want (powershell, env)", mode, source)
+	}
+
+	mode, source, err = excelbridge.ResolveMode("dotnet", "powershell", "auto")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != excelbridge.ModeDotNet || source != "cli" {
+		t.Fatalf("ResolveMode cli precedence = (%q, %q), want (dotnet, cli)", mode, source)
+	}
+}
+
+func TestRunnerRejectsDotNetBridgeWithoutFallback(t *testing.T) {
+	root := t.TempDir()
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := `@{ status = "ok"; command = "run"; logs = @("unexpected powershell execution") } | ConvertTo-Json -Compress`
+	if err := os.WriteFile(filepath.Join(scriptsDir, "run.ps1"), []byte(script), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	env, code, err := Runner{RootDir: root, BridgeMode: "dotnet"}.Run(config.Default(), RunOptions{Macro: "Main.Run"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitEnvironment {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitEnvironment)
+	}
+	if env.Error == nil || env.Error.Code != "bridge_not_available" {
+		t.Fatalf("unexpected error: %+v", env.Error)
 	}
 }
 


### PR DESCRIPTION
- Added an abstraction for Excel bridge providers in Go, allowing for selection between PowerShell and .NET bridges.
- Implemented persistent `--bridge` flag for commands, with support for `auto`, `powershell`, and `dotnet` options.
- Updated command documentation to reflect new bridge options and their precedence.
- Enhanced error handling for unsupported bridge modes and added tests for bridge resolution logic.
- Refactored existing Excel command execution to utilize the new bridge provider structure.