### PR TITLE
feat: Implement Excel process management and inspection services in .NET bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added native `.NET` bridge support for runner-backed `xlflow inspect workbook|sheets|range --session --bridge dotnet --json` and `xlflow process list|cleanup --bridge dotnet --json`, including `--bridge auto` fallback from unsupported/runtime/protocol `.NET` failures back to PowerShell for supported commands.
 - Added native `.NET` `xlflow doctor --bridge dotnet --json` diagnostics for runtime and Excel COM probing, plus documentation clarifying that top-level `bridge` metadata remains provider-specific between PowerShell and `.NET` bridges.
 - Added structured COM error fields (`h_result`, `details`) to `xlflow doctor --bridge dotnet --json` error output. COM activation failures now include the HRESULT hex code and exception details alongside the error message.
 - Added an Excel bridge provider abstraction in Go, moved PowerShell invocation behind `PowerShellProvider`, and added bridge selection via persistent `--bridge`, `XLFLOW_EXCEL_BRIDGE`, and `[excel].bridge` while keeping `auto` on the existing PowerShell behavior for now.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,7 @@ tasks:
     desc: Install xlflow to local environment
     cmds:
       - go install ./cmd/xlflow
+      - powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\build-dotnet-bridge.ps1' -InstallToGoBin
 
   run:
     desc: Run xlflow without install

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs
@@ -1,4 +1,5 @@
 using Xlflow.ExcelBridge.Diagnostics;
+using Xlflow.ExcelBridge.Services;
 
 namespace Xlflow.ExcelBridge.Commands;
 
@@ -21,14 +22,18 @@ public sealed class CommandRegistry
         return new CommandRegistry(new ICommandHandler[]
         {
             new DoctorCommand(),
+            new InspectCommand(),
+            new ProcessCommand(),
         });
     }
 
-    public static CommandRegistry Create(Func<ExcelDiagnosticsResult>? probeExcel)
+    public static CommandRegistry Create(Func<ExcelDiagnosticsResult>? probeExcel, IInspectService? inspectService = null, IProcessService? processService = null)
     {
         return new CommandRegistry(new ICommandHandler[]
         {
             new DoctorCommand(probeExcel),
+            new InspectCommand(inspectService),
+            new ProcessCommand(processService),
         });
     }
 

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/InspectCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/InspectCommand.cs
@@ -1,0 +1,46 @@
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Commands;
+
+public sealed class InspectCommand : ICommandHandler
+{
+    private readonly IInspectService _service;
+
+    public InspectCommand(IInspectService? service = null)
+    {
+        _service = service ?? new ExcelInspectionService();
+    }
+
+    public string CommandName => "inspect";
+
+    public bool Supports(BridgeRequest request)
+    {
+        return string.Equals(request.Command, CommandName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
+    {
+        var args = new InspectCommandArguments(
+            Target: BridgePayload.GetString(request.Payload, "Target") ?? "",
+            Sheet: BridgePayload.GetString(request.Payload, "Sheet") ?? "",
+            Address: BridgePayload.GetString(request.Payload, "Address") ?? "",
+            WorkbookPath: BridgePayload.GetString(request.Payload, "WorkbookPath") ?? "",
+            MetadataPath: BridgePayload.GetString(request.Payload, "MetadataPath") ?? "",
+            UseSession: BridgePayload.GetBool(request.Payload, "UseSession"),
+            IncludeStyle: BridgePayload.GetBool(request.Payload, "IncludeStyle"),
+            MaxRows: BridgePayload.GetInt(request.Payload, "MaxRows"),
+            MaxCols: BridgePayload.GetInt(request.Payload, "MaxCols"));
+
+        if (string.IsNullOrWhiteSpace(args.Target))
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                Code: "inspect_args_invalid",
+                Message: "Target is required",
+                Phase: "inspect",
+                Source: "xlflow"));
+        }
+
+        return _service.Execute(request, args, cancellationToken);
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/ProcessCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/ProcessCommand.cs
@@ -1,0 +1,44 @@
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Commands;
+
+public sealed class ProcessCommand : ICommandHandler
+{
+    private readonly IProcessService _service;
+
+    public ProcessCommand(IProcessService? service = null)
+    {
+        _service = service ?? new ExcelProcessService();
+    }
+
+    public string CommandName => "process";
+
+    public bool Supports(BridgeRequest request)
+    {
+        return string.Equals(request.Command, CommandName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
+    {
+        var action = BridgePayload.GetString(request.Payload, "Action");
+        action = string.IsNullOrWhiteSpace(action) ? "list" : action.Trim().ToLowerInvariant();
+
+        if (action is not ("list" or "cleanup"))
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                Code: "process_args_invalid",
+                Message: "Action must be list or cleanup",
+                Phase: "process",
+                Source: "xlflow"));
+        }
+
+        var args = new ProcessCommandArguments(
+            Action: action,
+            TargetPid: BridgePayload.GetNullableInt(request.Payload, "TargetPid"),
+            Auto: BridgePayload.GetBool(request.Payload, "Auto"),
+            All: BridgePayload.GetBool(request.Payload, "All"));
+
+        return _service.Execute(request, args, cancellationToken);
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -1,0 +1,675 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace Xlflow.ExcelBridge.Services;
+
+internal static class BridgePayload
+{
+    public static string? GetString(JsonElement payload, string name)
+    {
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        foreach (var property in payload.EnumerateObject())
+        {
+            if (!string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            return property.Value.ValueKind switch
+            {
+                JsonValueKind.Null => null,
+                JsonValueKind.String => property.Value.GetString(),
+                _ => property.Value.ToString(),
+            };
+        }
+
+        return null;
+    }
+
+    public static bool GetBool(JsonElement payload, string name, bool defaultValue = false)
+    {
+        var value = GetString(payload, name);
+        return bool.TryParse(value, out var parsed) ? parsed : defaultValue;
+    }
+
+    public static int GetInt(JsonElement payload, string name, int defaultValue = 0)
+    {
+        var value = GetString(payload, name);
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : defaultValue;
+    }
+
+    public static int? GetNullableInt(JsonElement payload, string name)
+    {
+        var value = GetString(payload, name);
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+    }
+}
+
+internal sealed record SessionMetadata(long Hwnd, int Pid, string WorkbookPath);
+
+internal sealed record ExcelSessionAttachment(object Excel, object Workbook, string SessionMode);
+
+internal sealed record ExcelProcessInfo(int ProcessId, bool? HasWorkbook);
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The .NET bridge only runs on Windows with Excel COM automation.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Bridge support intentionally treats COM inspection as best-effort and normalizes failures to null/false or structured bridge errors.")]
+[SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "These helpers favor simple iteration-focused signatures.")]
+internal static class ExcelBridgeSupport
+{
+    private const int ObjIdNativeOm = unchecked((int)0xFFFFFFF0);
+    private static readonly Guid DispatchGuid = new("00020400-0000-0000-C000-000000000046");
+
+    public static string NormalizePath(string path)
+    {
+        return Path.GetFullPath(path);
+    }
+
+    public static bool PathsEqual(string left, string right)
+    {
+        return string.Equals(NormalizePath(left), NormalizePath(right), StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static SessionMetadata? ReadSessionMetadata(string metadataPath)
+    {
+        if (string.IsNullOrWhiteSpace(metadataPath) || !File.Exists(metadataPath))
+        {
+            return null;
+        }
+
+        using var json = JsonDocument.Parse(File.ReadAllText(metadataPath));
+        var root = json.RootElement;
+        var hwnd = TryGetInt64(root, "hwnd");
+        var pid = TryGetInt32(root, "pid");
+        var workbookPath = BridgePayload.GetString(root, "workbook_path") ?? "";
+        return new SessionMetadata(hwnd, pid, workbookPath);
+    }
+
+    public static bool SessionMetadataMatchesWorkbook(string metadataPath, string workbookPath)
+    {
+        var metadata = ReadSessionMetadata(metadataPath);
+        if (metadata is null || string.IsNullOrWhiteSpace(metadata.WorkbookPath))
+        {
+            return false;
+        }
+
+        return PathsEqual(metadata.WorkbookPath, workbookPath);
+    }
+
+    public static ExcelSessionAttachment AttachToSessionWorkbook(string workbookPath, string metadataPath, bool useSession)
+    {
+        workbookPath = NormalizePath(workbookPath);
+
+        if (useSession)
+        {
+            var excel = GetSessionExcel(metadataPath)
+                ?? throw new InvalidOperationException("xlflow session is not running");
+            var workbook = GetOpenWorkbook(excel, workbookPath);
+            return new ExcelSessionAttachment(excel, workbook, "explicit");
+        }
+
+        if (SessionMetadataMatchesWorkbook(metadataPath, workbookPath))
+        {
+            var excel = GetExcelFromSessionMetadata(metadataPath);
+            if (excel is not null)
+            {
+                try
+                {
+                    var workbook = GetOpenWorkbook(excel, workbookPath);
+                    return new ExcelSessionAttachment(excel, workbook, "auto");
+                }
+                catch
+                {
+                    ReleaseComObject(excel);
+                }
+            }
+        }
+
+        throw new InvalidOperationException("no matching xlflow session workbook is running; run xlflow session start or use the configured workbook session");
+    }
+
+    public static object? GetSessionExcel(string metadataPath)
+    {
+        var excel = GetExcelFromSessionMetadata(metadataPath);
+        if (excel is not null)
+        {
+            return excel;
+        }
+        return null;
+    }
+
+    public static object? GetExcelFromSessionMetadata(string metadataPath)
+    {
+        var metadata = ReadSessionMetadata(metadataPath);
+        if (metadata is null)
+        {
+            return null;
+        }
+
+        if (metadata.Hwnd != 0)
+        {
+            var excel = TryGetExcelByHwnd(metadata.Hwnd);
+            if (excel is not null)
+            {
+                return excel;
+            }
+        }
+
+        if (metadata.Pid > 0)
+        {
+            return TryGetExcelByProcessId(metadata.Pid);
+        }
+
+        return null;
+    }
+
+    public static object GetOpenWorkbook(object excel, string workbookPath)
+    {
+        workbookPath = NormalizePath(workbookPath);
+        object? workbooks = null;
+        try
+        {
+            workbooks = Get(excel, "Workbooks");
+            var count = ToInt(Get(workbooks!, "Count"));
+            for (var index = 1; index <= count; index++)
+            {
+                object? candidate = null;
+                var matched = false;
+                try
+                {
+                    candidate = Get(workbooks!, "Item", index);
+                    var fullName = GetString(candidate!, "FullName");
+                    if (!string.IsNullOrWhiteSpace(fullName) && PathsEqual(fullName, workbookPath))
+                    {
+                        matched = true;
+                        return candidate!;
+                    }
+                }
+                finally
+                {
+                    if (!matched)
+                    {
+                        ReleaseComObject(candidate);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ReleaseComObject(workbooks);
+        }
+
+        throw new InvalidOperationException($"xlflow session workbook is not open: {workbookPath}");
+    }
+
+    public static bool TryGetWorkbookDirtyState(object workbook, out bool dirty)
+    {
+        try
+        {
+            dirty = !ToBool(Get(workbook, "Saved"));
+            return true;
+        }
+        catch
+        {
+            dirty = false;
+            return false;
+        }
+    }
+
+    public static bool? GetWorkbookStateByProcessId(int processId)
+    {
+        if (processId <= 0)
+        {
+            return null;
+        }
+
+        var sawWorkbookFreeState = false;
+        foreach (var hwnd in GetWindowsForProcess(processId))
+        {
+            foreach (var candidateHwnd in EnumerateWindowAndChildren(hwnd))
+            {
+                var excel = TryGetExcelFromWindow(candidateHwnd);
+                if (excel is null)
+                {
+                    continue;
+                }
+
+                object? workbooks = null;
+                try
+                {
+                    workbooks = Get(excel, "Workbooks");
+                    if (ToInt(Get(workbooks!, "Count")) > 0)
+                    {
+                        return true;
+                    }
+
+                    sawWorkbookFreeState = true;
+                }
+                catch
+                {
+                    // ignore inaccessible candidate
+                }
+                finally
+                {
+                    ReleaseComObject(workbooks);
+                    ReleaseComObject(excel);
+                }
+            }
+        }
+
+        return sawWorkbookFreeState ? false : null;
+    }
+
+    public static List<ExcelProcessInfo> GetExcelProcesses()
+    {
+        return Process.GetProcessesByName("EXCEL")
+            .Select(process =>
+            {
+                try
+                {
+                    return new ExcelProcessInfo(process.Id, GetWorkbookStateByProcessId(process.Id));
+                }
+                finally
+                {
+                    process.Dispose();
+                }
+            })
+            .OrderBy(process => process.ProcessId)
+            .ToList();
+    }
+
+    public static object? TryGetExcelByProcessId(int processId)
+    {
+        if (processId <= 0)
+        {
+            return null;
+        }
+
+        foreach (var hwnd in GetWindowsForProcess(processId))
+        {
+            foreach (var candidateHwnd in EnumerateWindowAndChildren(hwnd))
+            {
+                var excel = TryGetExcelFromWindow(candidateHwnd);
+                if (excel is not null)
+                {
+                    return excel;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static object? TryGetExcelByHwnd(long hwnd)
+    {
+        if (hwnd == 0)
+        {
+            return null;
+        }
+
+        foreach (var candidateHwnd in EnumerateWindowAndChildren(new IntPtr(hwnd)))
+        {
+            var excel = TryGetExcelFromWindow(candidateHwnd);
+            if (excel is not null)
+            {
+                return excel;
+            }
+        }
+
+        return null;
+    }
+
+    public static string GetRangeAddress(object range)
+    {
+        try
+        {
+            return GetString(range, "Address", false, false, 1, false) ?? "";
+        }
+        catch
+        {
+            return "";
+        }
+    }
+
+    public static string? TryGetCellText(object? cell)
+    {
+        if (cell is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var text = GetString(cell, "Text");
+            return string.IsNullOrWhiteSpace(text) ? null : text;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static string? TryGetFormula(object? cell)
+    {
+        if (cell is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var formula = GetString(cell, "Formula");
+            if (string.IsNullOrWhiteSpace(formula) || !formula.StartsWith('='))
+            {
+                return null;
+            }
+
+            return formula;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static bool VisibleToBool(object? value)
+    {
+        try
+        {
+            return Convert.ToInt32(value, CultureInfo.InvariantCulture) == -1;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static string? ColorToHex(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var color = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+            if (color < 0)
+            {
+                return null;
+            }
+
+            var red = color & 255;
+            var green = (color >> 8) & 255;
+            var blue = (color >> 16) & 255;
+            return $"#{red:X2}{green:X2}{blue:X2}";
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static string BorderStyleName(object? lineStyle, object? weight)
+    {
+        try
+        {
+            var line = Convert.ToInt32(lineStyle, CultureInfo.InvariantCulture);
+            if (line == -4142)
+            {
+                return "none";
+            }
+
+            return line switch
+            {
+                -4119 => "double",
+                -4115 => "dashed",
+                -4118 => "dotted",
+                4 => "dashDot",
+                5 => "dashDotDot",
+                13 => "slantDashDot",
+                _ => Convert.ToInt32(weight, CultureInfo.InvariantCulture) switch
+                {
+                    1 => "hair",
+                    2 => "thin",
+                    -4138 => "medium",
+                    4 => "thick",
+                    _ => "thin",
+                },
+            };
+        }
+        catch
+        {
+            return "none";
+        }
+    }
+
+    public static string? AlignmentName(object? value, string axis)
+    {
+        try
+        {
+            var alignment = Convert.ToInt32(value, CultureInfo.InvariantCulture);
+            return alignment switch
+            {
+                -4131 => "left",
+                -4108 => "center",
+                -4152 => "right",
+                -4130 => "justify",
+                -4117 => "distributed",
+                -4160 when axis == "vertical" => "top",
+                -4107 when axis == "vertical" => "bottom",
+                _ => null,
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static string FillType(object? pattern)
+    {
+        try
+        {
+            var fill = Convert.ToInt32(pattern, CultureInfo.InvariantCulture);
+            return fill switch
+            {
+                -4142 => "none",
+                1 => "solid",
+                _ => $"pattern:{fill}",
+            };
+        }
+        catch
+        {
+            return "none";
+        }
+    }
+
+    public static object? Get(object comObject, string memberName, params object?[] args)
+    {
+        return comObject.GetType().InvokeMember(
+            memberName,
+            System.Reflection.BindingFlags.GetProperty | System.Reflection.BindingFlags.InvokeMethod,
+            null,
+            comObject,
+            args,
+            CultureInfo.InvariantCulture);
+    }
+
+    public static void Set(object comObject, string memberName, object? value)
+    {
+        comObject.GetType().InvokeMember(
+            memberName,
+            System.Reflection.BindingFlags.SetProperty,
+            null,
+            comObject,
+            [value],
+            CultureInfo.InvariantCulture);
+    }
+
+    public static string? GetString(object comObject, string memberName, params object?[] args)
+    {
+        var value = Get(comObject, memberName, args);
+        return value?.ToString();
+    }
+
+    public static int ToInt(object? value)
+    {
+        return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+    }
+
+    public static bool ToBool(object? value)
+    {
+        return Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+    }
+
+    public static void ReleaseComObject(object? value)
+    {
+        if (value is null || !Marshal.IsComObject(value))
+        {
+            return;
+        }
+
+        try
+        {
+            Marshal.ReleaseComObject(value);
+        }
+        catch
+        {
+            // best-effort COM cleanup
+        }
+    }
+
+    private static List<IntPtr> GetWindowsForProcess(int processId)
+    {
+        var windows = new List<IntPtr>();
+        NativeMethods.EnumWindows((hwnd, _) =>
+        {
+            var threadId = NativeMethods.GetWindowThreadProcessId(hwnd, out var candidatePid);
+            if (threadId == 0)
+            {
+                return true;
+            }
+            if (candidatePid == processId)
+            {
+                windows.Add(hwnd);
+            }
+
+            return true;
+        }, IntPtr.Zero);
+        return windows;
+    }
+
+    private static IEnumerable<IntPtr> EnumerateWindowAndChildren(IntPtr hwnd)
+    {
+        yield return hwnd;
+
+        var children = new List<IntPtr>();
+        NativeMethods.EnumChildWindows(hwnd, (childHwnd, _) =>
+        {
+            children.Add(childHwnd);
+            return true;
+        }, IntPtr.Zero);
+
+        foreach (var child in children)
+        {
+            yield return child;
+        }
+    }
+
+    private static object? TryGetExcelFromWindow(IntPtr hwnd)
+    {
+        object? dispatch = null;
+        try
+        {
+            var dispatchGuid = DispatchGuid;
+            var hr = NativeMethods.AccessibleObjectFromWindow(hwnd, ObjIdNativeOm, ref dispatchGuid, out dispatch);
+            if (hr != 0 || dispatch is null)
+            {
+                return null;
+            }
+
+            object? candidate = dispatch;
+            try
+            {
+                var application = Get(dispatch, "Application");
+                if (application is not null)
+                {
+                    candidate = application;
+                }
+            }
+            catch
+            {
+                candidate = dispatch;
+            }
+
+            object? workbooks = null;
+            try
+            {
+                workbooks = Get(candidate!, "Workbooks");
+                _ = ToInt(Get(workbooks!, "Count"));
+                if (!ReferenceEquals(candidate, dispatch))
+                {
+                    ReleaseComObject(dispatch);
+                }
+
+                return candidate;
+            }
+            catch
+            {
+                ReleaseComObject(workbooks);
+                if (!ReferenceEquals(candidate, dispatch))
+                {
+                    ReleaseComObject(candidate);
+                }
+
+                ReleaseComObject(dispatch);
+                return null;
+            }
+        }
+        catch
+        {
+            ReleaseComObject(dispatch);
+            return null;
+        }
+    }
+
+    private static int TryGetInt32(JsonElement element, string name)
+    {
+        var value = BridgePayload.GetString(element, name);
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0;
+    }
+
+    private static long TryGetInt64(JsonElement element, string name)
+    {
+        var value = BridgePayload.GetString(element, name);
+        return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0L;
+    }
+
+    private static class NativeMethods
+    {
+        public delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern bool EnumChildWindows(IntPtr hwndParent, EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out int processId);
+
+        [DllImport("oleacc.dll")]
+        public static extern int AccessibleObjectFromWindow(
+            IntPtr hwnd,
+            int dwId,
+            ref Guid riid,
+            [MarshalAs(UnmanagedType.Interface)] out object? ppvObject);
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -614,6 +614,8 @@ internal static class ExcelBridgeSupport
             {
                 workbooks = Get(candidate!, "Workbooks");
                 _ = ToInt(Get(workbooks!, "Count"));
+                ReleaseComObject(workbooks);
+                workbooks = null;
                 if (!ReferenceEquals(candidate, dispatch))
                 {
                     ReleaseComObject(dispatch);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelInspectionService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelInspectionService.cs
@@ -1,0 +1,719 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The .NET bridge only runs on Windows with Excel COM automation.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Inspect snapshots intentionally degrade best-effort COM reads into structured bridge responses.")]
+public sealed class ExcelInspectionService : IInspectService
+{
+    public BridgeResponse Execute(BridgeRequest request, InspectCommandArguments args, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        object? excel = null;
+        object? workbook = null;
+
+        try
+        {
+            var attachment = ExcelBridgeSupport.AttachToSessionWorkbook(args.WorkbookPath, args.MetadataPath, args.UseSession);
+            excel = attachment.Excel;
+            workbook = attachment.Workbook;
+
+            var workbookPath = ExcelBridgeSupport.NormalizePath(args.WorkbookPath);
+            var dirtyKnown = ExcelBridgeSupport.TryGetWorkbookDirtyState(workbook, out var dirtyState);
+            var dirty = attachment.SessionMode == "none" ? false : dirtyKnown ? dirtyState : true;
+            var needsSave = attachment.SessionMode == "none" ? false : dirty;
+
+            var target = NewTargetResult("live_session", workbookPath);
+            var session = NewSessionResult(workbookPath, attachment.SessionMode, dirty, needsSave);
+            var workbookResult = NewWorkbookResult(workbookPath, attachment.SessionMode, dirty, needsSave);
+
+            Dictionary<string, object?> inspect;
+            IReadOnlyList<string> logs;
+
+            switch (args.Target)
+            {
+                case "workbook":
+                    {
+                        var sheets = ReadSheetSummaries(workbook);
+                        var workbookSummary = new Dictionary<string, object?>
+                        {
+                            ["path"] = workbookPath,
+                            ["name"] = Path.GetFileName(workbookPath),
+                            ["sheets"] = sheets,
+                        };
+
+                        object? activeSheet = null;
+                        try
+                        {
+                            activeSheet = ExcelBridgeSupport.Get(workbook, "ActiveSheet");
+                            var activeSheetName = ExcelBridgeSupport.GetString(activeSheet!, "Name");
+                            if (!string.IsNullOrWhiteSpace(activeSheetName))
+                            {
+                                workbookSummary["active_sheet"] = activeSheetName;
+                            }
+                        }
+                        catch
+                        {
+                            // best-effort active sheet inspection
+                        }
+                        finally
+                        {
+                            ExcelBridgeSupport.ReleaseComObject(activeSheet);
+                        }
+
+                        inspect = new Dictionary<string, object?>
+                        {
+                            ["target"] = "workbook",
+                            ["source"] = "excel_com",
+                            ["target_info"] = NewLiveInspectTargetInfo(workbookPath),
+                            ["workbook"] = workbookSummary,
+                        };
+                        logs = [$"inspected live workbook {workbookPath}"];
+                        break;
+                    }
+                case "sheets":
+                    {
+                        inspect = new Dictionary<string, object?>
+                        {
+                            ["target"] = "sheets",
+                            ["source"] = "excel_com",
+                            ["target_info"] = NewLiveInspectTargetInfo(workbookPath),
+                            ["sheets"] = ReadSheetSummaries(workbook),
+                        };
+                        logs = ["inspected live workbook worksheets"];
+                        break;
+                    }
+                case "range":
+                    {
+                        object? worksheet = null;
+                        object? range = null;
+                        try
+                        {
+                            worksheet = GetWorksheetByName(workbook, args.Sheet);
+                            range = ExcelBridgeSupport.Get(worksheet!, "Range", args.Address)
+                                ?? throw new InvalidOperationException($"failed to resolve range {args.Sheet}!{args.Address}");
+                            var normalizedAddress = ExcelBridgeSupport.GetRangeAddress(range);
+                            target["sheet"] = args.Sheet;
+                            target["range"] = normalizedAddress;
+
+                            inspect = new Dictionary<string, object?>
+                            {
+                                ["target"] = "range",
+                                ["source"] = "excel_com",
+                                ["target_info"] = NewLiveInspectTargetInfo(workbookPath),
+                                ["range"] = ReadRangeSnapshot(worksheet!, range, normalizedAddress, "", args.MaxRows, args.MaxCols, args.IncludeStyle),
+                            };
+                            logs = [$"inspected live range {args.Sheet}!{normalizedAddress}"];
+                        }
+                        finally
+                        {
+                            ExcelBridgeSupport.ReleaseComObject(range);
+                            ExcelBridgeSupport.ReleaseComObject(worksheet);
+                        }
+
+                        break;
+                    }
+                default:
+                    return BridgeResponse.Failed(
+                        request,
+                        BridgeError.Create("BRIDGE_COMMAND_UNSUPPORTED", $"Inspect target '{args.Target}' is not supported by the .NET bridge.", "bridge.capability"));
+            }
+
+            return new BridgeResponse
+            {
+                RequestId = request.RequestId,
+                Command = request.Command,
+                Logs = logs,
+                Extensions = new Dictionary<string, object?>
+                {
+                    ["target"] = target,
+                    ["session"] = session,
+                    ["workbook"] = workbookResult,
+                    ["inspect"] = inspect,
+                },
+            };
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("xlflow session", StringComparison.OrdinalIgnoreCase))
+        {
+            return Failure(request, "session_required", ex.Message, "xlflow");
+        }
+        catch (InvalidOperationException ex) when (ex.Message.StartsWith("sheet '", StringComparison.OrdinalIgnoreCase) && ex.Message.EndsWith("' not found", StringComparison.OrdinalIgnoreCase))
+        {
+            return Failure(request, "sheet_not_found", ex.Message, "xlflow");
+        }
+        catch (COMException ex)
+        {
+            return Failure(request, "inspect_failed", ex.Message, "xlflow-excel-bridge", ex.ErrorCode);
+        }
+        catch (Exception ex)
+        {
+            return Failure(request, "inspect_failed", ex.Message, "xlflow-excel-bridge");
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(workbook);
+            ExcelBridgeSupport.ReleaseComObject(excel);
+        }
+    }
+
+    private static BridgeResponse Failure(BridgeRequest request, string code, string message, string source, int? number = null)
+    {
+        return new BridgeResponse
+        {
+            RequestId = request.RequestId,
+            Command = request.Command,
+            Status = BridgeStatus.Failed,
+            Error = new BridgeError(code, message, "inspect", source, number),
+        };
+    }
+
+    private static Dictionary<string, object?> NewTargetResult(string kind, string path)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["kind"] = kind,
+            ["path"] = path,
+            ["description"] = "Workbook currently open through xlflow session",
+        };
+    }
+
+    private static Dictionary<string, object?> NewSessionResult(string workbookPath, string sessionMode, bool dirty, bool needsSave)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["active"] = true,
+            ["workbook_path"] = workbookPath,
+            ["dirty"] = dirty,
+            ["save_required"] = needsSave,
+            ["live_newer_than_disk"] = needsSave,
+            ["mode"] = sessionMode,
+            ["source_of_truth"] = needsSave ? "live_workbook" : "saved_workbook",
+        };
+    }
+
+    private static Dictionary<string, object?> NewWorkbookResult(string workbookPath, string sessionMode, bool dirty, bool needsSave)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["path"] = workbookPath,
+            ["session"] = true,
+            ["session_mode"] = sessionMode,
+            ["session_requested"] = sessionMode == "explicit",
+            ["auto_session"] = sessionMode == "auto",
+            ["dirty"] = dirty,
+            ["needs_save"] = needsSave,
+        };
+    }
+
+    private static Dictionary<string, object?> NewLiveInspectTargetInfo(string workbookPath)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["kind"] = "live_session",
+            ["path"] = workbookPath,
+            ["note"] = "This command inspected the live workbook currently open in Excel through xlflow session.",
+        };
+    }
+
+    private static List<Dictionary<string, object?>> ReadSheetSummaries(object workbook)
+    {
+        var sheets = new List<Dictionary<string, object?>>();
+        object? worksheets = null;
+        try
+        {
+            worksheets = ExcelBridgeSupport.Get(workbook, "Worksheets");
+            var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(worksheets!, "Count"));
+            for (var index = 1; index <= count; index++)
+            {
+                object? worksheet = null;
+                try
+                {
+                    worksheet = ExcelBridgeSupport.Get(worksheets!, "Item", index);
+                    sheets.Add(NewSheetSummary(worksheet!));
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(worksheet);
+                }
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(worksheets);
+        }
+
+        return sheets;
+    }
+
+    private static Dictionary<string, object?> NewSheetSummary(object worksheet)
+    {
+        var usedInfo = GetUsedRangeInfo(worksheet);
+        try
+        {
+            return new Dictionary<string, object?>
+            {
+                ["name"] = ExcelBridgeSupport.GetString(worksheet, "Name") ?? "",
+                ["index"] = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(worksheet, "Index")),
+                ["visible"] = ExcelBridgeSupport.VisibleToBool(ExcelBridgeSupport.Get(worksheet, "Visible")),
+                ["used_range"] = usedInfo.Address,
+                ["row_count"] = usedInfo.RowCount,
+                ["column_count"] = usedInfo.ColumnCount,
+            };
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(usedInfo.Range);
+        }
+    }
+
+    private static object GetWorksheetByName(object workbook, string sheetName)
+    {
+        object? worksheets = null;
+        try
+        {
+            worksheets = ExcelBridgeSupport.Get(workbook, "Worksheets");
+            var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(worksheets!, "Count"));
+            for (var index = 1; index <= count; index++)
+            {
+                object? worksheet = null;
+                var matched = false;
+                try
+                {
+                    worksheet = ExcelBridgeSupport.Get(worksheets!, "Item", index);
+                    var name = ExcelBridgeSupport.GetString(worksheet!, "Name");
+                    if (string.Equals(name, sheetName, StringComparison.Ordinal))
+                    {
+                        matched = true;
+                        return worksheet!;
+                    }
+                }
+                finally
+                {
+                    if (!matched)
+                    {
+                        ExcelBridgeSupport.ReleaseComObject(worksheet);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(worksheets);
+        }
+
+        throw new InvalidOperationException($"sheet '{sheetName}' not found");
+    }
+
+    private static UsedRangeInfo GetUsedRangeInfo(object worksheet)
+    {
+        object? usedRange = null;
+        try
+        {
+            usedRange = ExcelBridgeSupport.Get(worksheet, "UsedRange");
+            if (usedRange is null)
+            {
+                return new UsedRangeInfo(null, "", 0, 0);
+            }
+
+            object? rows = null;
+            object? columns = null;
+            try
+            {
+                rows = ExcelBridgeSupport.Get(usedRange, "Rows");
+                columns = ExcelBridgeSupport.Get(usedRange, "Columns");
+                var address = ExcelBridgeSupport.GetRangeAddress(usedRange);
+                var rowCount = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(rows!, "Count"));
+                var columnCount = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(columns!, "Count"));
+                if (rowCount == 1 && columnCount == 1)
+                {
+                    object? probe = null;
+                    try
+                    {
+                        var cells = ExcelBridgeSupport.Get(usedRange, "Cells");
+                        try
+                        {
+                            probe = ExcelBridgeSupport.Get(cells!, "Item", 1, 1);
+                        }
+                        finally
+                        {
+                            ExcelBridgeSupport.ReleaseComObject(cells);
+                        }
+
+                        if (ExcelBridgeSupport.TryGetCellText(probe) is null && ExcelBridgeSupport.TryGetFormula(probe) is null)
+                        {
+                            ExcelBridgeSupport.ReleaseComObject(usedRange);
+                            return new UsedRangeInfo(null, "", 0, 0);
+                        }
+                    }
+                    finally
+                    {
+                        ExcelBridgeSupport.ReleaseComObject(probe);
+                    }
+                }
+
+                return new UsedRangeInfo(usedRange, address, rowCount, columnCount);
+            }
+            finally
+            {
+                ExcelBridgeSupport.ReleaseComObject(rows);
+                ExcelBridgeSupport.ReleaseComObject(columns);
+            }
+        }
+        catch (Exception ex)
+        {
+            ExcelBridgeSupport.ReleaseComObject(usedRange);
+            throw new InvalidOperationException($"failed to inspect used range: {ex.Message}");
+        }
+    }
+
+    private static Dictionary<string, object?> ReadRangeSnapshot(object worksheet, object range, string rangeAddress, string usedRangeAddress, int maxRows, int maxCols, bool withStyle)
+    {
+        object? rows = null;
+        object? columns = null;
+        object? worksheetCells = null;
+        try
+        {
+            rows = ExcelBridgeSupport.Get(range, "Rows");
+            columns = ExcelBridgeSupport.Get(range, "Columns");
+            worksheetCells = ExcelBridgeSupport.Get(worksheet, "Cells");
+
+            var rowCount = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(rows!, "Count"));
+            var columnCount = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(columns!, "Count"));
+            var returnRows = rowCount;
+            var returnCols = columnCount;
+            var truncated = false;
+            if (maxRows > 0 && rowCount > maxRows)
+            {
+                returnRows = maxRows;
+                truncated = true;
+            }
+
+            if (maxCols > 0 && columnCount > maxCols)
+            {
+                returnCols = maxCols;
+                truncated = true;
+            }
+
+            var values = new List<List<object?>>();
+            var cells = new List<Dictionary<string, object?>>();
+            var rowSnapshots = new List<Dictionary<string, object?>>();
+            var columnSnapshots = new List<Dictionary<string, object?>>();
+            var warnings = new List<string>();
+            var mergedRanges = new List<string>();
+            var mergedSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var startRow = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(range, "Row"));
+            var startCol = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(range, "Column"));
+
+            for (var rowOffset = 0; rowOffset < returnRows; rowOffset++)
+            {
+                var line = new List<object?>();
+                for (var colOffset = 0; colOffset < returnCols; colOffset++)
+                {
+                    object? cell = null;
+                    try
+                    {
+                        cell = ExcelBridgeSupport.Get(worksheetCells!, "Item", startRow + rowOffset, startCol + colOffset);
+                        var cellText = ExcelBridgeSupport.TryGetCellText(cell);
+                        line.Add(cellText);
+                        if (withStyle)
+                        {
+                            var cellAddress = ExcelBridgeSupport.GetRangeAddress(cell!);
+                            string? mergeAddress = null;
+                            try
+                            {
+                                if (ExcelBridgeSupport.ToBool(ExcelBridgeSupport.Get(cell!, "MergeCells")))
+                                {
+                                    var mergeArea = ExcelBridgeSupport.Get(cell!, "MergeArea");
+                                    try
+                                    {
+                                        mergeAddress = ExcelBridgeSupport.GetRangeAddress(mergeArea!);
+                                        if (!string.IsNullOrWhiteSpace(mergeAddress) && mergedSeen.Add(mergeAddress))
+                                        {
+                                            mergedRanges.Add(mergeAddress);
+                                        }
+                                    }
+                                    finally
+                                    {
+                                        ExcelBridgeSupport.ReleaseComObject(mergeArea);
+                                    }
+                                }
+                            }
+                            catch
+                            {
+                                mergeAddress = null;
+                            }
+
+                            var style = NewStyleSnapshot(cell!);
+                            cells.Add(new Dictionary<string, object?>
+                            {
+                                ["address"] = cellAddress,
+                                ["row"] = startRow + rowOffset,
+                                ["column"] = startCol + colOffset,
+                                ["value"] = cellText,
+                                ["formula"] = ExcelBridgeSupport.TryGetFormula(cell),
+                                ["fill"] = style["fill"],
+                                ["font"] = style["font"],
+                                ["border"] = style["border"],
+                                ["number_format"] = style["number_format"],
+                                ["horizontal_alignment"] = style["horizontal_alignment"],
+                                ["vertical_alignment"] = style["vertical_alignment"],
+                                ["merged"] = mergeAddress is not null,
+                                ["merge_range"] = mergeAddress,
+                            });
+                        }
+                    }
+                    finally
+                    {
+                        ExcelBridgeSupport.ReleaseComObject(cell);
+                    }
+                }
+
+                values.Add(line);
+            }
+
+            if (withStyle)
+            {
+                object? worksheetRows = null;
+                object? worksheetColumns = null;
+                try
+                {
+                    worksheetRows = ExcelBridgeSupport.Get(worksheet, "Rows");
+                    worksheetColumns = ExcelBridgeSupport.Get(worksheet, "Columns");
+                    for (var rowOffset = 0; rowOffset < returnRows; rowOffset++)
+                    {
+                        object? rowRef = null;
+                        try
+                        {
+                            var rowIndex = startRow + rowOffset;
+                            rowRef = ExcelBridgeSupport.Get(worksheetRows!, "Item", rowIndex);
+                            rowSnapshots.Add(new Dictionary<string, object?>
+                            {
+                                ["row"] = rowIndex,
+                                ["height"] = Convert.ToDouble(ExcelBridgeSupport.Get(rowRef!, "RowHeight"), CultureInfo.InvariantCulture),
+                                ["hidden"] = ExcelBridgeSupport.ToBool(ExcelBridgeSupport.Get(rowRef!, "Hidden")),
+                            });
+                        }
+                        finally
+                        {
+                            ExcelBridgeSupport.ReleaseComObject(rowRef);
+                        }
+                    }
+
+                    for (var colOffset = 0; colOffset < returnCols; colOffset++)
+                    {
+                        object? columnRef = null;
+                        try
+                        {
+                            var colIndex = startCol + colOffset;
+                            columnRef = ExcelBridgeSupport.Get(worksheetColumns!, "Item", colIndex);
+                            var columnName = ColumnIndexToLetter(colIndex);
+                            columnSnapshots.Add(new Dictionary<string, object?>
+                            {
+                                ["column"] = columnName,
+                                ["index"] = colIndex,
+                                ["width"] = Convert.ToDouble(ExcelBridgeSupport.Get(columnRef!, "ColumnWidth"), CultureInfo.InvariantCulture),
+                                ["hidden"] = ExcelBridgeSupport.ToBool(ExcelBridgeSupport.Get(columnRef!, "Hidden")),
+                            });
+                        }
+                        finally
+                        {
+                            ExcelBridgeSupport.ReleaseComObject(columnRef);
+                        }
+                    }
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(worksheetRows);
+                    ExcelBridgeSupport.ReleaseComObject(worksheetColumns);
+                }
+            }
+
+            var returnedRange = "";
+            if (returnRows > 0 && returnCols > 0)
+            {
+                object? topLeft = null;
+                object? bottomRight = null;
+                object? returned = null;
+                try
+                {
+                    topLeft = ExcelBridgeSupport.Get(worksheetCells!, "Item", startRow, startCol);
+                    bottomRight = ExcelBridgeSupport.Get(worksheetCells!, "Item", startRow + returnRows - 1, startCol + returnCols - 1);
+                    returned = ExcelBridgeSupport.Get(worksheet, "Range", topLeft!, bottomRight!);
+                    returnedRange = ExcelBridgeSupport.GetRangeAddress(returned!);
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(returned);
+                    ExcelBridgeSupport.ReleaseComObject(topLeft);
+                    ExcelBridgeSupport.ReleaseComObject(bottomRight);
+                }
+            }
+
+            if (truncated)
+            {
+                warnings.Add($"Output was truncated: selection has {rowCount} row(s) x {columnCount} column(s), returned {returnRows} row(s) x {returnCols} column(s).");
+            }
+
+            var snapshot = new Dictionary<string, object?>
+            {
+                ["sheet"] = ExcelBridgeSupport.GetString(worksheet, "Name") ?? "",
+                ["row_count"] = rowCount,
+                ["column_count"] = columnCount,
+                ["values"] = values,
+                ["truncated"] = truncated,
+                ["max_rows"] = maxRows,
+                ["max_cols"] = maxCols,
+                ["returned_range"] = returnedRange,
+            };
+
+            if (!string.IsNullOrWhiteSpace(rangeAddress))
+            {
+                snapshot["range"] = rangeAddress;
+            }
+
+            if (!string.IsNullOrWhiteSpace(usedRangeAddress))
+            {
+                snapshot["used_range"] = usedRangeAddress;
+            }
+
+            if (warnings.Count > 0)
+            {
+                snapshot["warnings"] = warnings;
+            }
+
+            if (withStyle)
+            {
+                snapshot["style_included"] = true;
+                snapshot["cells"] = cells;
+                snapshot["columns"] = columnSnapshots;
+                snapshot["rows"] = rowSnapshots;
+                snapshot["merged_ranges"] = mergedRanges;
+            }
+
+            return snapshot;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(worksheetCells);
+            ExcelBridgeSupport.ReleaseComObject(columns);
+            ExcelBridgeSupport.ReleaseComObject(rows);
+        }
+    }
+
+    private static Dictionary<string, object?> NewStyleSnapshot(object cell)
+    {
+        object? interior = null;
+        object? font = null;
+        object? borders = null;
+        try
+        {
+            interior = ExcelBridgeSupport.Get(cell, "Interior");
+            font = ExcelBridgeSupport.Get(cell, "Font");
+            borders = ExcelBridgeSupport.Get(cell, "Borders");
+
+            var fillType = ExcelBridgeSupport.FillType(ExcelBridgeSupport.Get(interior!, "Pattern"));
+            var fillColor = fillType == "none" ? null : ExcelBridgeSupport.ColorToHex(ExcelBridgeSupport.Get(interior!, "Color"));
+
+            Dictionary<string, object?>? fontSnapshot = null;
+            try
+            {
+                fontSnapshot = new Dictionary<string, object?>
+                {
+                    ["name"] = ExcelBridgeSupport.GetString(font!, "Name") ?? "",
+                    ["size"] = Convert.ToDouble(ExcelBridgeSupport.Get(font!, "Size"), CultureInfo.InvariantCulture),
+                    ["bold"] = ExcelBridgeSupport.ToBool(ExcelBridgeSupport.Get(font!, "Bold")),
+                    ["italic"] = ExcelBridgeSupport.ToBool(ExcelBridgeSupport.Get(font!, "Italic")),
+                    ["color"] = ExcelBridgeSupport.ColorToHex(ExcelBridgeSupport.Get(font!, "Color")),
+                };
+            }
+            catch
+            {
+                fontSnapshot = null;
+            }
+
+            var numberFormat = ExcelBridgeSupport.GetString(cell, "NumberFormat");
+            if (string.IsNullOrWhiteSpace(numberFormat))
+            {
+                numberFormat = null;
+            }
+
+            var border = new Dictionary<string, object?>
+            {
+                ["top"] = NewBorderEdgeSnapshot(borders!, 8),
+                ["right"] = NewBorderEdgeSnapshot(borders!, 10),
+                ["bottom"] = NewBorderEdgeSnapshot(borders!, 9),
+                ["left"] = NewBorderEdgeSnapshot(borders!, 7),
+            };
+
+            return new Dictionary<string, object?>
+            {
+                ["fill"] = fillType == "none" && fillColor is null
+                    ? null
+                    : new Dictionary<string, object?> { ["type"] = fillType, ["color"] = fillColor },
+                ["font"] = fontSnapshot,
+                ["border"] = border,
+                ["number_format"] = numberFormat,
+                ["horizontal_alignment"] = ExcelBridgeSupport.AlignmentName(ExcelBridgeSupport.Get(cell, "HorizontalAlignment"), "horizontal"),
+                ["vertical_alignment"] = ExcelBridgeSupport.AlignmentName(ExcelBridgeSupport.Get(cell, "VerticalAlignment"), "vertical"),
+            };
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(borders);
+            ExcelBridgeSupport.ReleaseComObject(font);
+            ExcelBridgeSupport.ReleaseComObject(interior);
+        }
+    }
+
+    private static Dictionary<string, object?> NewBorderEdgeSnapshot(object borders, int index)
+    {
+        object? border = null;
+        try
+        {
+            border = ExcelBridgeSupport.Get(borders, "Item", index);
+            string? color = null;
+            try
+            {
+                if (ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(border!, "LineStyle")) != -4142)
+                {
+                    color = ExcelBridgeSupport.ColorToHex(ExcelBridgeSupport.Get(border!, "Color"));
+                }
+            }
+            catch
+            {
+                color = null;
+            }
+
+            return new Dictionary<string, object?>
+            {
+                ["style"] = ExcelBridgeSupport.BorderStyleName(
+                    ExcelBridgeSupport.Get(border!, "LineStyle"),
+                    ExcelBridgeSupport.Get(border!, "Weight")),
+                ["color"] = color,
+            };
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(border);
+        }
+    }
+
+    private sealed record UsedRangeInfo(object? Range, string Address, int RowCount, int ColumnCount);
+
+    private static string ColumnIndexToLetter(int colIndex)
+    {
+        var result = "";
+        while (colIndex > 0)
+        {
+            colIndex--;
+            result = (char)('A' + colIndex % 26) + result;
+            colIndex /= 26;
+        }
+        return result;
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelProcessService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelProcessService.cs
@@ -1,0 +1,305 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The .NET bridge only runs on Windows with Excel COM automation.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Process cleanup/list normalize OS and COM failures into structured bridge responses.")]
+[SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "The current signatures favor testability and concise cleanup logic.")]
+public sealed class ExcelProcessService : IProcessService
+{
+    public BridgeResponse Execute(BridgeRequest request, ProcessCommandArguments args, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            return args.Action switch
+            {
+                "list" => List(request),
+                "cleanup" => Cleanup(request, args),
+                _ => BridgeResponse.Failed(request, new BridgeError("process_args_invalid", "Action must be list or cleanup", "process", "xlflow")),
+            };
+        }
+        catch (Exception ex)
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                Code: "process_enumeration_failed",
+                Message: ex.Message,
+                Phase: "process",
+                Source: "xlflow-excel-bridge"));
+        }
+    }
+
+    private static BridgeResponse List(BridgeRequest request)
+    {
+        var processes = ExcelBridgeSupport.GetExcelProcesses()
+            .OrderBy(item => item.ProcessId)
+            .Select(item => new Dictionary<string, object?>
+            {
+                ["pid"] = item.ProcessId,
+                ["has_workbook"] = item.HasWorkbook,
+            })
+            .ToArray();
+
+        var logs = processes.Length == 0
+            ? new[] { "0 Excel processes found" }
+            : new[] { $"found {processes.Length} Excel process(es)" };
+
+        return new BridgeResponse
+        {
+            RequestId = request.RequestId,
+            Command = request.Command,
+            Logs = logs,
+            Extensions = new Dictionary<string, object?>
+            {
+                ["process"] = processes,
+            },
+        };
+    }
+
+    private static BridgeResponse Cleanup(BridgeRequest request, ProcessCommandArguments args)
+    {
+        var mode = "";
+        var targetPids = new List<int>();
+        var targetProcesses = new Dictionary<int, Process>();
+
+        try
+        {
+            if (args.TargetPid is > 0)
+            {
+                mode = "pid";
+                Process? process = null;
+                try
+                {
+                    process = Process.GetProcessById(args.TargetPid.Value);
+                    if (!string.Equals(process.ProcessName, "EXCEL", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ProcessNotFound(request, args.TargetPid.Value);
+                    }
+
+                    targetPids.Add(args.TargetPid.Value);
+                }
+                catch (ArgumentException)
+                {
+                    process?.Dispose();
+                    return ProcessNotFound(request, args.TargetPid.Value);
+                }
+                finally
+                {
+                    process?.Dispose();
+                }
+            }
+            else if (args.Auto)
+            {
+                mode = "auto";
+                foreach (var process in ExcelBridgeSupport.GetExcelProcesses())
+                {
+                    if (process.HasWorkbook == false)
+                    {
+                        targetPids.Add(process.ProcessId);
+                    }
+                }
+            }
+            else if (args.All)
+            {
+                mode = "all";
+                foreach (var process in Process.GetProcessesByName("EXCEL"))
+                {
+                    targetPids.Add(process.Id);
+                    targetProcesses[process.Id] = process;
+                }
+            }
+            else
+            {
+                return BridgeResponse.Failed(request, new BridgeError(
+                    Code: "process_args_invalid",
+                    Message: "process cleanup requires a PID, --auto, or --all",
+                    Phase: "process",
+                    Source: "xlflow"));
+            }
+
+            if (targetPids.Count == 0)
+            {
+                return new BridgeResponse
+                {
+                    RequestId = request.RequestId,
+                    Command = request.Command,
+                    Logs = ["0 Excel processes to clean up"],
+                    Extensions = new Dictionary<string, object?>
+                    {
+                        ["process"] = new Dictionary<string, object?>
+                        {
+                            ["action"] = "cleanup",
+                            ["mode"] = mode,
+                            ["total"] = 0,
+                            ["results"] = Array.Empty<object>(),
+                        },
+                    },
+                };
+            }
+
+            var cleanupResults = new List<Dictionary<string, object?>>();
+            foreach (var targetPid in targetPids)
+            {
+                cleanupResults.Add(args.All
+                    ? StopAllTarget(targetProcesses, targetPid)
+                    : StopProcessTarget(targetPid));
+            }
+
+            var terminatedCount = cleanupResults.Count(item => item.TryGetValue("terminated", out var value) && value is true);
+            var failedCount = cleanupResults.Count - terminatedCount;
+            var processPayload = new Dictionary<string, object?>
+            {
+                ["action"] = "cleanup",
+                ["mode"] = mode,
+                ["total"] = cleanupResults.Count,
+                ["results"] = cleanupResults,
+            };
+
+            if (failedCount > 0)
+            {
+                return new BridgeResponse
+                {
+                    RequestId = request.RequestId,
+                    Command = request.Command,
+                    Status = BridgeStatus.Failed,
+                    Error = new BridgeError(
+                        Code: "process_termination_failed",
+                        Message: $"{failedCount} of {cleanupResults.Count} Excel process(es) failed to terminate",
+                        Phase: "process",
+                        Source: "xlflow"),
+                    Extensions = new Dictionary<string, object?>
+                    {
+                        ["process"] = processPayload,
+                    },
+                };
+            }
+
+            return new BridgeResponse
+            {
+                RequestId = request.RequestId,
+                Command = request.Command,
+                Logs = [$"terminated {terminatedCount} Excel process(es)"],
+                Extensions = new Dictionary<string, object?>
+                {
+                    ["process"] = processPayload,
+                },
+            };
+        }
+        finally
+        {
+            foreach (var process in targetProcesses.Values)
+            {
+                process.Dispose();
+            }
+        }
+    }
+
+    private static BridgeResponse ProcessNotFound(BridgeRequest request, int pid)
+    {
+        return BridgeResponse.Failed(request, new BridgeError(
+            Code: "process_not_found",
+            Message: $"no Excel process found with PID {pid}",
+            Phase: "process",
+            Source: "xlflow"));
+    }
+
+    private static Dictionary<string, object?> StopAllTarget(Dictionary<int, Process> targetProcesses, int targetPid)
+    {
+        if (!targetProcesses.TryGetValue(targetPid, out var process))
+        {
+            return NewCleanupResult(targetPid, true, "unknown");
+        }
+
+        try
+        {
+            process.Refresh();
+            if (process.HasExited)
+            {
+                return NewCleanupResult(targetPid, true, "unknown");
+            }
+
+            process.Kill(true);
+            var exited = process.WaitForExit(3000);
+            process.Refresh();
+            if (!exited && !process.HasExited)
+            {
+                return NewCleanupResult(targetPid, false, "force");
+            }
+            return NewCleanupResult(targetPid, true, "force");
+        }
+        catch
+        {
+            return NewCleanupResult(targetPid, false, "none");
+        }
+    }
+
+    private static Dictionary<string, object?> StopProcessTarget(int targetPid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(targetPid);
+            return StopProcess(process);
+        }
+        catch (ArgumentException)
+        {
+            return NewCleanupResult(targetPid, true, "unknown");
+        }
+        catch
+        {
+            return NewCleanupResult(targetPid, false, "none");
+        }
+    }
+
+    private static Dictionary<string, object?> StopProcess(Process process)
+    {
+        try
+        {
+            try
+            {
+                if (process.CloseMainWindow())
+                {
+                    if (process.WaitForExit(3000))
+                    {
+                        return NewCleanupResult(process.Id, true, "graceful");
+                    }
+                }
+            }
+            catch
+            {
+                // fall through to force termination
+            }
+
+            process.Refresh();
+            if (process.HasExited)
+            {
+                return NewCleanupResult(process.Id, true, "unknown");
+            }
+
+            process.Kill(true);
+            var exited = process.WaitForExit(3000);
+            process.Refresh();
+            if (!exited && !process.HasExited)
+            {
+                return NewCleanupResult(process.Id, false, "force");
+            }
+            return NewCleanupResult(process.Id, true, "force");
+        }
+        catch
+        {
+            return NewCleanupResult(process.Id, false, "none");
+        }
+    }
+
+    private static Dictionary<string, object?> NewCleanupResult(int pid, bool terminated, string method)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["pid"] = pid,
+            ["terminated"] = terminated,
+            ["method"] = method,
+        };
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IInspectService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IInspectService.cs
@@ -1,0 +1,8 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+public interface IInspectService
+{
+    BridgeResponse Execute(BridgeRequest request, InspectCommandArguments args, CancellationToken cancellationToken);
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IProcessService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IProcessService.cs
@@ -1,0 +1,8 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+public interface IProcessService
+{
+    BridgeResponse Execute(BridgeRequest request, ProcessCommandArguments args, CancellationToken cancellationToken);
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/InspectCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/InspectCommandArguments.cs
@@ -1,0 +1,12 @@
+namespace Xlflow.ExcelBridge.Services;
+
+public sealed record InspectCommandArguments(
+    string Target,
+    string Sheet,
+    string Address,
+    string WorkbookPath,
+    string MetadataPath,
+    bool UseSession,
+    bool IncludeStyle,
+    int MaxRows,
+    int MaxCols);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ProcessCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ProcessCommandArguments.cs
@@ -1,0 +1,7 @@
+namespace Xlflow.ExcelBridge.Services;
+
+public sealed record ProcessCommandArguments(
+    string Action,
+    int? TargetPid,
+    bool Auto,
+    bool All);

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeHostTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeHostTests.cs
@@ -22,7 +22,7 @@ public sealed class BridgeHostTests
     }
 
     [Fact]
-    public void CapabilitiesJsonIncludesDoctor()
+    public void CapabilitiesJsonIncludesSupportedCommands()
     {
         using var stdout = new StringWriter();
         using var stderr = new StringWriter();
@@ -33,6 +33,8 @@ public sealed class BridgeHostTests
         using var json = JsonDocument.Parse(stdout.ToString());
         var commands = json.RootElement.GetProperty("commands").EnumerateArray().Select(item => item.GetString()).ToArray();
         Assert.Contains("doctor", commands);
+        Assert.Contains("inspect", commands);
+        Assert.Contains("process", commands);
     }
 
     [Fact]

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/InspectCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/InspectCommandTests.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+using Xlflow.ExcelBridge.Commands;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Serialization;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class InspectCommandTests
+{
+    [Fact]
+    public void HandleParsesPayloadAndReturnsExpectedExtensions()
+    {
+        var service = new FakeInspectService((request, args) =>
+        {
+            Assert.Equal("inspect", request.Command);
+            Assert.Equal("range", args.Target);
+            Assert.Equal("Sheet1", args.Sheet);
+            Assert.Equal("A1:B2", args.Address);
+            Assert.Equal(@"C:\work\book.xlsm", args.WorkbookPath);
+            Assert.Equal(@"C:\work\.xlflow\session.json", args.MetadataPath);
+            Assert.True(args.UseSession);
+            Assert.True(args.IncludeStyle);
+            Assert.Equal(25, args.MaxRows);
+            Assert.Equal(8, args.MaxCols);
+
+            return BridgeResponse.Ok(request, new Dictionary<string, object?>
+            {
+                ["target"] = new Dictionary<string, object?>
+                {
+                    ["kind"] = "live_session",
+                    ["path"] = args.WorkbookPath,
+                },
+                ["session"] = new Dictionary<string, object?>
+                {
+                    ["active"] = true,
+                    ["workbook_path"] = args.WorkbookPath,
+                },
+                ["workbook"] = new Dictionary<string, object?>
+                {
+                    ["path"] = args.WorkbookPath,
+                    ["session"] = true,
+                },
+                ["inspect"] = new Dictionary<string, object?>
+                {
+                    ["target"] = args.Target,
+                    ["source"] = "excel_com",
+                    ["range"] = new Dictionary<string, object?>
+                    {
+                        ["sheet"] = args.Sheet,
+                        ["range"] = "$A$1:$B$2",
+                        ["returned_range"] = "$A$1:$B$2",
+                        ["row_count"] = 2,
+                        ["column_count"] = 2,
+                        ["values"] = new object?[][]
+                        {
+                            ["a", "b"],
+                            ["c", "d"],
+                        },
+                        ["style_included"] = true,
+                        ["merged_ranges"] = Array.Empty<string>(),
+                    },
+                },
+            });
+        });
+        var command = new InspectCommand(service);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-inspect",
+            Command = "inspect",
+            Payload = JsonDocument.Parse("""
+                {
+                  "Target": "range",
+                  "Sheet": "Sheet1",
+                  "Address": "A1:B2",
+                  "WorkbookPath": "C:\\work\\book.xlsm",
+                  "MetadataPath": "C:\\work\\.xlflow\\session.json",
+                  "UseSession": "true",
+                  "IncludeStyle": "true",
+                  "MaxRows": "25",
+                  "MaxCols": "8"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("range", json.RootElement.GetProperty("inspect").GetProperty("target").GetString());
+        Assert.Equal("excel_com", json.RootElement.GetProperty("inspect").GetProperty("source").GetString());
+        Assert.Equal("$A$1:$B$2", json.RootElement.GetProperty("inspect").GetProperty("range").GetProperty("returned_range").GetString());
+        Assert.True(json.RootElement.GetProperty("inspect").GetProperty("range").GetProperty("style_included").GetBoolean());
+    }
+
+    [Fact]
+    public void HandleRejectsMissingTarget()
+    {
+        var command = new InspectCommand(new FakeInspectService((request, _) => BridgeResponse.Ok(request)));
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-inspect-missing-target",
+            Command = "inspect",
+            Payload = JsonDocument.Parse("""{"WorkbookPath":"C:\\work\\book.xlsm"}""").RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("inspect_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    private sealed class FakeInspectService(Func<BridgeRequest, InspectCommandArguments, BridgeResponse> handler) : IInspectService
+    {
+        public BridgeResponse Execute(BridgeRequest request, InspectCommandArguments args, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request, args);
+        }
+    }
+}

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ProcessCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ProcessCommandTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using Xlflow.ExcelBridge.Commands;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Serialization;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class ProcessCommandTests
+{
+    [Fact]
+    public void HandleParsesCleanupPayloadAndReturnsExpectedExtensions()
+    {
+        var service = new FakeProcessService((request, args) =>
+        {
+            Assert.Equal("cleanup", args.Action);
+            Assert.Equal(1234, args.TargetPid);
+            Assert.False(args.Auto);
+            Assert.False(args.All);
+
+            return new BridgeResponse
+            {
+                RequestId = request.RequestId,
+                Command = request.Command,
+                Extensions = new Dictionary<string, object?>
+                {
+                    ["process"] = new Dictionary<string, object?>
+                    {
+                        ["action"] = "cleanup",
+                        ["mode"] = "pid",
+                        ["total"] = 1,
+                        ["results"] = new[]
+                        {
+                            new Dictionary<string, object?>
+                            {
+                                ["pid"] = 1234,
+                                ["terminated"] = true,
+                                ["method"] = "graceful",
+                            },
+                        },
+                    },
+                },
+            };
+        });
+        var command = new ProcessCommand(service);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-process-cleanup",
+            Command = "process",
+            Payload = JsonDocument.Parse("""
+                {
+                  "Action": "cleanup",
+                  "TargetPid": "1234",
+                  "Auto": "false",
+                  "All": "false"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("cleanup", json.RootElement.GetProperty("process").GetProperty("action").GetString());
+        Assert.Equal("pid", json.RootElement.GetProperty("process").GetProperty("mode").GetString());
+        Assert.Equal(1, json.RootElement.GetProperty("process").GetProperty("total").GetInt32());
+    }
+
+    [Fact]
+    public void HandleDefaultsMissingActionToList()
+    {
+        var service = new FakeProcessService((request, args) =>
+        {
+            Assert.Equal("list", args.Action);
+            return BridgeResponse.Ok(request, new Dictionary<string, object?>
+            {
+                ["process"] = new[]
+                {
+                    new Dictionary<string, object?>
+                    {
+                        ["pid"] = 1234,
+                        ["has_workbook"] = true,
+                    },
+                },
+            });
+        });
+        var command = new ProcessCommand(service);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-process-list",
+            Command = "process",
+            Payload = JsonDocument.Parse("""{}""").RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal(1234, json.RootElement.GetProperty("process")[0].GetProperty("pid").GetInt32());
+        Assert.True(json.RootElement.GetProperty("process")[0].GetProperty("has_workbook").GetBoolean());
+    }
+
+    [Fact]
+    public void HandleRejectsUnsupportedAction()
+    {
+        var command = new ProcessCommand(new FakeProcessService((request, _) => BridgeResponse.Ok(request)));
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-process-invalid",
+            Command = "process",
+            Payload = JsonDocument.Parse("""{"Action":"unknown"}""").RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("process_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    private sealed class FakeProcessService(Func<BridgeRequest, ProcessCommandArguments, BridgeResponse> handler) : IProcessService
+    {
+        public BridgeResponse Execute(BridgeRequest request, ProcessCommandArguments args, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request, args);
+        }
+    }
+}

--- a/docs/bridge/dotnet-bridge.md
+++ b/docs/bridge/dotnet-bridge.md
@@ -67,6 +67,38 @@ Fields:
 - `excel.trust_vba_access` — observed Trust access state; `null` when not determinable.
 - `excel.error` — present only when a non-fatal diagnostic warning occurred.
 
+### `inspect`
+
+The .NET bridge now supports the session-backed read-only inspection targets used by the Excel runner:
+
+- `xlflow inspect workbook --session --bridge dotnet --json`
+- `xlflow inspect sheets --session --bridge dotnet --json`
+- `xlflow inspect range --session --bridge dotnet --json`
+
+These commands preserve the existing top-level envelope fields produced by the Go CLI:
+
+- `target`
+- `session`
+- `workbook`
+- `inspect`
+- `logs`
+
+The `.NET` implementation intentionally stays limited to the live/session-backed runner path for now. Saved-file inspect flows still use the existing non-bridge workbook reader.
+
+### `process`
+
+The .NET bridge now supports:
+
+- `xlflow process list --bridge dotnet --json`
+- `xlflow process cleanup --bridge dotnet --json`
+
+Behavior matches the PowerShell contract:
+
+- `process list` returns `process: [{ pid, has_workbook }]`
+- `process cleanup --auto` targets only workbook-free Excel processes
+- `process cleanup --all` force-stops the selected Excel processes
+- partial cleanup failures return structured `process_termination_failed` errors while preserving the `process` result payload
+
 ## Process Model
 
 The bridge is a separate executable named `xlflow-excel-bridge.exe`.
@@ -96,6 +128,8 @@ xlflow-excel-bridge.exe --capabilities-json
 
 The Go resolver must check capabilities before selecting .NET in `auto` mode.
 
+For issue #76, `auto` may select `.NET` for `doctor`, `inspect`, and `process`. If `.NET` reports capability/runtime/protocol failures for one of these commands, the Go side may fall back to PowerShell only in `auto` mode. Explicit `--bridge dotnet` remains strict.
+
 ## Selection
 
 Users will be able to select the bridge through:
@@ -112,14 +146,13 @@ When `--bridge dotnet` is selected explicitly, xlflow must not fallback to Power
 The planned migration order is:
 
 1. `doctor`
-2. `inspect` and `process`
-3. `pull` and `push`
-4. `macros` and `run`
-5. dialog watcher
-6. `test`, `trace`, and runtime injection
-7. `form` and `export-image`
-8. release packaging
-9. default bridge switch
+2. `pull` and `push`
+3. `macros` and `run`
+4. dialog watcher
+5. `test`, `trace`, and runtime injection
+6. `form` and `export-image`
+7. release packaging
+8. default bridge switch
 
 `run` is intentionally not first because it combines macro invocation, runtime injection, compile checks, dialog capture, timeout behavior, and session handling.
 

--- a/internal/excel/bridge.go
+++ b/internal/excel/bridge.go
@@ -80,7 +80,7 @@ func shouldAutoFallbackToPowerShell(execution providerExecution) bool {
 	if execution.result == nil {
 		return false
 	}
-	if execution.result.ProtocolVersion != 0 && execution.result.ProtocolVersion != excelbridge.ProtocolVersion {
+	if execution.result.ProtocolVersion != excelbridge.ProtocolVersion {
 		return true
 	}
 	return execution.result.Error != nil && strings.EqualFold(execution.result.Error.Code, "BRIDGE_COMMAND_UNSUPPORTED")

--- a/internal/excel/bridge.go
+++ b/internal/excel/bridge.go
@@ -36,6 +36,56 @@ var bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge
 	}
 }
 
+type providerExecution struct {
+	provider  excelbridge.Provider
+	response  excelbridge.Response
+	execErr   error
+	decodeErr error
+	result    *ScriptResult
+}
+
+func executeBridgeProvider(ctx context.Context, provider excelbridge.Provider, commandName string, args map[string]string) providerExecution {
+	execution := providerExecution{provider: provider}
+	execution.response, execution.execErr = provider.Execute(ctx, excelbridge.Request{Command: commandName, Args: args})
+	if execution.execErr != nil {
+		return execution
+	}
+
+	var result ScriptResult
+	if err := json.Unmarshal(execution.response.Stdout, &result); err != nil {
+		execution.decodeErr = err
+		return execution
+	}
+	execution.result = &result
+	return execution
+}
+
+func shouldAutoFallbackToPowerShell(execution providerExecution) bool {
+	if execution.provider == nil || execution.provider.Name() != string(excelbridge.ModeDotNet) {
+		return false
+	}
+	if execution.execErr != nil {
+		var bridgeErr *excelbridge.Error
+		if errors.As(execution.execErr, &bridgeErr) {
+			switch bridgeErr.Kind {
+			case excelbridge.ErrorDotNetMissing, excelbridge.ErrorDotNetRuntime:
+				return true
+			}
+		}
+		return false
+	}
+	if execution.decodeErr != nil {
+		return true
+	}
+	if execution.result == nil {
+		return false
+	}
+	if execution.result.ProtocolVersion != 0 && execution.result.ProtocolVersion != excelbridge.ProtocolVersion {
+		return true
+	}
+	return execution.result.Error != nil && strings.EqualFold(execution.result.Error.Code, "BRIDGE_COMMAND_UNSUPPORTED")
+}
+
 type WorkbookRef struct {
 	Path string `json:"path"`
 }
@@ -1421,8 +1471,25 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 	}
 	defer cancel()
 
-	provider := bridgeProviderForMode(r.RootDir, mode)
-	response, err := provider.Execute(ctx, excelbridge.Request{Command: commandName, Args: args})
+	var execution providerExecution
+	switch mode {
+	case excelbridge.ModeAuto:
+		dotNetProvider := bridgeProviderForMode(r.RootDir, excelbridge.ModeDotNet)
+		if dotNetProvider.Supports(commandName) {
+			execution = executeBridgeProvider(ctx, dotNetProvider, commandName, args)
+			if shouldAutoFallbackToPowerShell(execution) {
+				execution = executeBridgeProvider(ctx, bridgeProviderForMode(r.RootDir, excelbridge.ModePowerShell), commandName, args)
+			}
+		} else {
+			execution = executeBridgeProvider(ctx, bridgeProviderForMode(r.RootDir, excelbridge.ModePowerShell), commandName, args)
+		}
+	default:
+		execution = executeBridgeProvider(ctx, bridgeProviderForMode(r.RootDir, mode), commandName, args)
+	}
+
+	provider := execution.provider
+	response := execution.response
+	err = execution.execErr
 	debugResult, debugStreamErr := closeDebugStreamSession(debugSession)
 	uiEvents, uiStreamErr := closeUIStreamSession(uiSession)
 	if err != nil {
@@ -1481,9 +1548,8 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 		return env, output.ExitEnvironment, nil
 	}
 
-	var result ScriptResult
-	if err := json.Unmarshal(response.Stdout, &result); err != nil {
-		env = output.Failure(commandName, output.Error{Code: "invalid_script_json", Message: fmt.Sprintf("failed to parse script JSON: %v", err), Source: provider.Name()})
+	if execution.decodeErr != nil {
+		env = output.Failure(commandName, output.Error{Code: "invalid_script_json", Message: fmt.Sprintf("failed to parse script JSON: %v", execution.decodeErr), Source: provider.Name()})
 		env.Logs = []string{string(response.Stdout)}
 		if uiStreamErr != nil {
 			env.Logs = append(env.Logs, "UI stream closed with an error: "+uiStreamErr.Error())
@@ -1491,6 +1557,7 @@ func (r Runner) runWithOptions(commandName string, args map[string]string, opts 
 		env.UI = mergeUIResult(nil, uiEvents)
 		return env, output.ExitEnvironment, nil
 	}
+	result := *execution.result
 	if provider.Name() == string(excelbridge.ModeDotNet) && result.ProtocolVersion != excelbridge.ProtocolVersion {
 		env = output.Failure(commandName, output.Error{
 			Code:    "bridge_protocol_mismatch",

--- a/internal/excel/bridge/dotnet.go
+++ b/internal/excel/bridge/dotnet.go
@@ -20,8 +20,16 @@ var dotNetLookPath = exec.LookPath
 var dotNetBridgeCandidatesFunc = dotNetBridgeCandidates
 var repoLocalDotNetBridgeProjectPathFunc = repoLocalDotNetBridgeProjectPath
 
+// dotNetSupportedCommands is the Go-side source of truth for auto-mode provider selection.
+// It controls whether --bridge auto will attempt the .NET bridge before falling back to
+// PowerShell. This list MUST be kept in sync with the commands advertised by the .NET
+// bridge's --capabilities-json response (see bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs).
+// When adding a command to the .NET bridge, update this map and the corresponding
+// capabilities test in BridgeHostTests.cs.
 var dotNetSupportedCommands = map[string]struct{}{
-	"doctor": {},
+	"doctor":  {},
+	"inspect": {},
+	"process": {},
 }
 
 type DotNetProvider struct {

--- a/internal/excel/bridge_test.go
+++ b/internal/excel/bridge_test.go
@@ -728,6 +728,53 @@ func TestRunnerAutoModeFallsBackToPowerShellOnDecodeError(t *testing.T) {
 	}
 }
 
+func TestRunnerAutoModeFallsBackToPowerShellWhenDotNetProtocolVersionMissing(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+
+	var dotNetCalls, powerShellCalls int
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		switch mode {
+		case excelbridge.ModeDotNet:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModeDotNet),
+				supports:  true,
+				callCount: &dotNetCalls,
+				response:  excelbridge.Response{Stdout: []byte(`{"status":"ok","command":"process","logs":[],"process":[]}`)},
+			}
+		default:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModePowerShell),
+				supports:  true,
+				callCount: &powerShellCalls,
+				response:  excelbridge.Response{Stdout: []byte(`{"status":"ok","command":"process","logs":[],"process":[{"pid":7777,"has_workbook":true}]}`)},
+			}
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "auto"}.ProcessList(ProcessListOptions{Action: "list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if dotNetCalls != 1 {
+		t.Fatalf("dotnet calls = %d, want 1", dotNetCalls)
+	}
+	if powerShellCalls != 1 {
+		t.Fatalf("powershell calls = %d, want 1 (fallback expected)", powerShellCalls)
+	}
+	processes, ok := env.Process.([]interface{})
+	if !ok || len(processes) != 1 {
+		t.Fatalf("expected powershell result with one process, got %v", env.Process)
+	}
+	first, ok := processes[0].(map[string]interface{})
+	if !ok || first["pid"] != float64(7777) {
+		t.Fatalf("unexpected process payload: %+v", processes[0])
+	}
+}
+
 func TestBuildUIButtonAddScriptArgs(t *testing.T) {
 	root := t.TempDir()
 	cfg := config.Default()
@@ -1823,7 +1870,7 @@ $result | ConvertTo-Json -Compress
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, _, err := Runner{RootDir: root}.ProcessList(ProcessListOptions{Action: "list"})
+	env, _, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessList(ProcessListOptions{Action: "list"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1853,7 +1900,7 @@ $result | ConvertTo-Json -Compress
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, _, err := Runner{RootDir: root}.ProcessList(ProcessListOptions{})
+	env, _, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessList(ProcessListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1880,7 +1927,7 @@ $result | ConvertTo-Json -Compress
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, _, err := Runner{RootDir: root}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", PID: 1234})
+	env, _, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", PID: 1234})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1922,7 +1969,7 @@ $result | ConvertTo-Json -Compress
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, _, err := Runner{RootDir: root}.ProcessCleanup(ProcessCleanupOptions{PID: 1234})
+	env, _, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessCleanup(ProcessCleanupOptions{PID: 1234})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1955,7 +2002,7 @@ $result | ConvertTo-Json -Compress
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, _, err := Runner{RootDir: root}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", Auto: true})
+	env, _, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", Auto: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1991,7 +2038,7 @@ $result | ConvertTo-Json -Compress
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, _, err := Runner{RootDir: root}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", All: true})
+	env, _, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", All: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2034,7 +2081,7 @@ $result | ConvertTo-Json -Compress
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, code, err := Runner{RootDir: root}.ProcessList(ProcessListOptions{Action: "list"})
+	env, code, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessList(ProcessListOptions{Action: "list"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2078,7 +2125,7 @@ func TestProcessCleanupDecodesCleanupResult(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, code, err := Runner{RootDir: root}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", PID: 5678})
+	env, code, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", PID: 5678})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2129,7 +2176,7 @@ func TestProcessCleanupDecodesTerminationFailedResult(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(scriptsDir, "process.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env, code, err := Runner{RootDir: root}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", All: true})
+	env, code, err := Runner{RootDir: root, BridgeMode: "powershell"}.ProcessCleanup(ProcessCleanupOptions{Action: "cleanup", All: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/excel/bridge_test.go
+++ b/internal/excel/bridge_test.go
@@ -40,6 +40,37 @@ func (f fakeBridgeProvider) Execute(_ context.Context, req excelbridge.Request) 
 	return f.response, f.err
 }
 
+type trackingBridgeProvider struct {
+	name      string
+	supports  bool
+	response  excelbridge.Response
+	err       error
+	callCount *int
+	requests  *[]excelbridge.Request
+}
+
+func (p trackingBridgeProvider) Name() string {
+	return p.name
+}
+
+func (p trackingBridgeProvider) Supports(string) bool {
+	return p.supports
+}
+
+func (p trackingBridgeProvider) Info(context.Context) (excelbridge.Info, error) {
+	return excelbridge.Info{Name: p.name, Version: "test"}, nil
+}
+
+func (p trackingBridgeProvider) Execute(_ context.Context, req excelbridge.Request) (excelbridge.Response, error) {
+	if p.callCount != nil {
+		*p.callCount = *p.callCount + 1
+	}
+	if p.requests != nil {
+		*p.requests = append(*p.requests, req)
+	}
+	return p.response, p.err
+}
+
 func TestExternalScriptPathFindsRepositoryScripts(t *testing.T) {
 	path, ok := externalScriptPath(t.TempDir(), "run")
 	if !ok {
@@ -245,6 +276,179 @@ func TestRunnerRejectsDotNetBridgeWithoutFallback(t *testing.T) {
 	}
 }
 
+func TestRunnerAutoBridgeUsesDotNetWhenSupported(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+
+	var dotNetCalls int
+	var powerShellCalls int
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		switch mode {
+		case excelbridge.ModeDotNet:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModeDotNet),
+				supports:  true,
+				callCount: &dotNetCalls,
+				response:  excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"process","logs":[],"process":[{"pid":1234,"has_workbook":true}]}`)},
+			}
+		default:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModePowerShell),
+				supports:  true,
+				callCount: &powerShellCalls,
+				response:  excelbridge.Response{Stdout: []byte(`{"status":"ok","command":"process","logs":[],"process":[{"pid":9999,"has_workbook":false}]}`)},
+			}
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "auto"}.ProcessList(ProcessListOptions{Action: "list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if dotNetCalls != 1 {
+		t.Fatalf("dotnet calls = %d, want 1", dotNetCalls)
+	}
+	if powerShellCalls != 0 {
+		t.Fatalf("powershell calls = %d, want 0", powerShellCalls)
+	}
+	processes, ok := env.Process.([]interface{})
+	if !ok || len(processes) != 1 {
+		t.Fatalf("Process = %v, want one-element array", env.Process)
+	}
+	first, ok := processes[0].(map[string]interface{})
+	if !ok || first["pid"] != float64(1234) {
+		t.Fatalf("unexpected process payload: %+v", processes[0])
+	}
+}
+
+func TestRunnerAutoBridgeFallsBackToPowerShellForUnsupportedDotNetInspectTarget(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+
+	var dotNetCalls int
+	var powerShellCalls int
+	var dotNetRequests []excelbridge.Request
+	var powerShellRequests []excelbridge.Request
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		switch mode {
+		case excelbridge.ModeDotNet:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModeDotNet),
+				supports:  true,
+				callCount: &dotNetCalls,
+				requests:  &dotNetRequests,
+				response:  excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"failed","command":"inspect","logs":[],"error":{"code":"BRIDGE_COMMAND_UNSUPPORTED","message":"Inspect target 'used-range' is not supported by the .NET bridge.","source":"xlflow-excel-bridge","phase":"bridge.capability"}}`)},
+			}
+		default:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModePowerShell),
+				supports:  true,
+				callCount: &powerShellCalls,
+				requests:  &powerShellRequests,
+				response:  excelbridge.Response{Stdout: []byte(`{"status":"ok","command":"inspect","logs":["inspected live used range for Sheet1"],"target":{"kind":"live_session","path":"C:\\temp\\Book.xlsm","sheet":"Sheet1","description":"Workbook currently open through xlflow session"},"session":{"active":true,"workbook_path":"C:\\temp\\Book.xlsm","dirty":false,"save_required":false,"live_newer_than_disk":false,"mode":"explicit","source_of_truth":"saved_workbook"},"workbook":{"path":"C:\\temp\\Book.xlsm","session":true,"session_mode":"explicit","session_requested":true,"auto_session":false,"dirty":false,"needs_save":false},"inspect":{"target":"used-range","source":"excel_com","target_info":{"kind":"live_session","path":"C:\\temp\\Book.xlsm"},"range":{"sheet":"Sheet1","used_range":"A1","row_count":1,"column_count":1,"values":[["value"]],"truncated":false,"max_rows":100,"max_cols":30,"returned_range":"A1"}}}`)},
+			}
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "auto"}.Inspect(config.Default(), InspectOptions{
+		Target:    "used-range",
+		Sheet:     "Sheet1",
+		Limits:    map[string]int{"max_rows": 100, "max_cols": 30},
+		Session:   true,
+		Keepalive: CommandOptions{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if dotNetCalls != 1 || powerShellCalls != 1 {
+		t.Fatalf("dotnet calls = %d, powershell calls = %d, want 1 each", dotNetCalls, powerShellCalls)
+	}
+	if len(dotNetRequests) != 1 || len(powerShellRequests) != 1 {
+		t.Fatalf("unexpected request counts: dotnet=%d powershell=%d", len(dotNetRequests), len(powerShellRequests))
+	}
+	if got := dotNetRequests[0].Args["Target"]; got != "used-range" {
+		t.Fatalf("dotnet target = %q, want used-range", got)
+	}
+	if got := powerShellRequests[0].Args["Target"]; got != "used-range" {
+		t.Fatalf("powershell target = %q, want used-range", got)
+	}
+	if env.Command != "inspect" {
+		t.Fatalf("Command = %q, want inspect", env.Command)
+	}
+	payload, ok := env.Inspect.(map[string]interface{})
+	if !ok || payload["target"] != "used-range" {
+		t.Fatalf("unexpected inspect payload: %+v", env.Inspect)
+	}
+}
+
+func TestRunnerDotNetInspectResponsePreservesEnvelopeFields(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		return trackingBridgeProvider{
+			name:     string(mode),
+			supports: true,
+			response: excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"inspect","logs":["inspected live workbook C:\\temp\\Book.xlsm"],"target":{"kind":"live_session","path":"C:\\temp\\Book.xlsm","description":"Workbook currently open through xlflow session"},"session":{"active":true,"workbook_path":"C:\\temp\\Book.xlsm","dirty":false,"save_required":false,"live_newer_than_disk":false,"mode":"explicit","source_of_truth":"saved_workbook"},"workbook":{"path":"C:\\temp\\Book.xlsm","session":true,"session_mode":"explicit","session_requested":true,"auto_session":false,"dirty":false,"needs_save":false},"inspect":{"target":"workbook","source":"excel_com","target_info":{"kind":"live_session","path":"C:\\temp\\Book.xlsm","note":"This command inspected the live workbook currently open in Excel through xlflow session."},"workbook":{"path":"C:\\temp\\Book.xlsm","name":"Book.xlsm","sheets":[{"name":"Sheet1","index":1,"visible":true,"used_range":"$A$1","row_count":1,"column_count":1}]}}}`)},
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "dotnet"}.Inspect(config.Default(), InspectOptions{
+		Target:    "workbook",
+		Session:   true,
+		Limits:    map[string]int{"max_rows": 100, "max_cols": 30},
+		Keepalive: CommandOptions{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if env.Target == nil || env.Session == nil || env.Workbook == nil || env.Inspect == nil {
+		t.Fatalf("expected inspect envelope fields to be populated: %+v", env)
+	}
+	inspectPayload, ok := env.Inspect.(map[string]interface{})
+	if !ok || inspectPayload["target"] != "workbook" {
+		t.Fatalf("unexpected inspect payload: %+v", env.Inspect)
+	}
+}
+
+func TestRunnerDotNetProcessCleanupResponsePreservesEnvelopeFields(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		return trackingBridgeProvider{
+			name:     string(mode),
+			supports: true,
+			response: excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"process","logs":["terminated 1 Excel process(es)"],"process":{"action":"cleanup","mode":"pid","total":1,"results":[{"pid":1234,"terminated":true,"method":"graceful"}]}}`)},
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "dotnet"}.ProcessCleanup(ProcessCleanupOptions{
+		Action: "cleanup",
+		PID:    1234,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	processPayload, ok := env.Process.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected process cleanup payload map, got %#v", env.Process)
+	}
+	if processPayload["action"] != "cleanup" || processPayload["mode"] != "pid" {
+		t.Fatalf("unexpected process cleanup payload: %+v", processPayload)
+	}
+}
+
 func TestRunnerRejectsDotNetProtocolMismatch(t *testing.T) {
 	original := bridgeProviderForMode
 	t.Cleanup(func() { bridgeProviderForMode = original })
@@ -391,6 +595,136 @@ func TestRunnerDoctorPreservesDotNetBridgeStructuredErrorMetadata(t *testing.T) 
 	}
 	if bridge["name"] != "xlflow-excel-bridge" {
 		t.Fatalf("Bridge.name = %v, want xlflow-excel-bridge", bridge["name"])
+	}
+}
+
+func TestRunnerDotNetExplicitModeDoesNotFallBackOnDecodeError(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+
+	var dotNetCalls, powerShellCalls int
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		switch mode {
+		case excelbridge.ModeDotNet:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModeDotNet),
+				supports:  true,
+				callCount: &dotNetCalls,
+				response:  excelbridge.Response{Stdout: []byte(`not valid json {{{`)},
+			}
+		default:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModePowerShell),
+				supports:  true,
+				callCount: &powerShellCalls,
+				response:  excelbridge.Response{Stdout: []byte(`{"status":"ok","command":"process","logs":[],"process":[]}`)},
+			}
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "dotnet"}.ProcessList(ProcessListOptions{Action: "list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code == output.ExitSuccess {
+		t.Fatalf("expected error exit, got ExitSuccess")
+	}
+	if dotNetCalls != 1 {
+		t.Fatalf("dotnet calls = %d, want 1", dotNetCalls)
+	}
+	if powerShellCalls != 0 {
+		t.Fatalf("powershell must not be called in explicit --bridge dotnet mode, got %d calls", powerShellCalls)
+	}
+	if env.Error == nil || env.Error.Code != "invalid_script_json" {
+		t.Fatalf("expected invalid_script_json error, got %+v", env.Error)
+	}
+}
+
+func TestRunnerAutoModeDoesNotFallBackForUnsupportedCommand(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+
+	var dotNetCalls, powerShellCalls int
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		switch mode {
+		case excelbridge.ModeDotNet:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModeDotNet),
+				supports:  false,
+				callCount: &dotNetCalls,
+				response:  excelbridge.Response{Stdout: []byte(`{}`)},
+			}
+		default:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModePowerShell),
+				supports:  true,
+				callCount: &powerShellCalls,
+				response:  excelbridge.Response{Stdout: []byte(`{"status":"ok","command":"run","logs":[],"result":{"stdout":"","stderr":"","exit_code":0,"duration_ms":1}}`)},
+			}
+		}
+	}
+
+	_, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "auto"}.Run(config.Default(), RunOptions{
+		Macro: "Module1.Main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dotNetCalls != 0 {
+		t.Fatalf(".NET must not be called for commands it does not support, got %d calls", dotNetCalls)
+	}
+	if powerShellCalls != 1 {
+		t.Fatalf("powershell calls = %d, want 1", powerShellCalls)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+}
+
+func TestRunnerAutoModeFallsBackToPowerShellOnDecodeError(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+
+	var dotNetCalls, powerShellCalls int
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		switch mode {
+		case excelbridge.ModeDotNet:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModeDotNet),
+				supports:  true,
+				callCount: &dotNetCalls,
+				response:  excelbridge.Response{Stdout: []byte(`not valid json {{{`)},
+			}
+		default:
+			return trackingBridgeProvider{
+				name:      string(excelbridge.ModePowerShell),
+				supports:  true,
+				callCount: &powerShellCalls,
+				response:  excelbridge.Response{Stdout: []byte(`{"status":"ok","command":"process","logs":[],"process":[{"pid":9999,"has_workbook":false}]}`)},
+			}
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "auto"}.ProcessList(ProcessListOptions{Action: "list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if dotNetCalls != 1 {
+		t.Fatalf("dotnet calls = %d, want 1", dotNetCalls)
+	}
+	if powerShellCalls != 1 {
+		t.Fatalf("powershell calls = %d, want 1 (fallback expected)", powerShellCalls)
+	}
+	processes, ok := env.Process.([]interface{})
+	if !ok || len(processes) != 1 {
+		t.Fatalf("expected powershell result with one process, got %v", env.Process)
+	}
+	first, ok := processes[0].(map[string]interface{})
+	if !ok || first["pid"] != float64(9999) {
+		t.Fatalf("unexpected process payload: %+v", processes[0])
 	}
 }
 

--- a/scripts/build-dotnet-bridge.ps1
+++ b/scripts/build-dotnet-bridge.ps1
@@ -1,7 +1,36 @@
+param(
+	[switch]$InstallToGoBin
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $root = Split-Path -Parent $PSScriptRoot
-$solution = Join-Path $root 'bridge/dotnet/Xlflow.ExcelBridge.sln'
+$project = Join-Path $root 'bridge/dotnet/src/Xlflow.ExcelBridge/Xlflow.ExcelBridge.csproj'
+$bridgeExe = Join-Path $root 'bridge/dotnet/src/Xlflow.ExcelBridge/bin/Release/net8.0/xlflow-excel-bridge.exe'
 
-dotnet build $solution --configuration Release
+dotnet build $project --configuration Release
+
+if (-not $InstallToGoBin) {
+	return
+}
+
+if (-not (Test-Path $bridgeExe)) {
+	throw "Bridge executable was not produced: $bridgeExe"
+}
+
+$goBin = (go env GOBIN).Trim()
+if ([string]::IsNullOrWhiteSpace($goBin)) {
+	$goPath = (go env GOPATH).Trim()
+	if ([string]::IsNullOrWhiteSpace($goPath)) {
+		throw 'Unable to resolve GOBIN/GOPATH from go env.'
+	}
+
+	$primaryGoPath = $goPath.Split([IO.Path]::PathSeparator)[0]
+	$goBin = Join-Path $primaryGoPath 'bin'
+}
+
+New-Item -ItemType Directory -Path $goBin -Force | Out-Null
+$destination = Join-Path $goBin 'xlflow-excel-bridge.exe'
+Copy-Item -Path $bridgeExe -Destination $destination -Force
+Write-Output "Installed xlflow-excel-bridge.exe to $destination"


### PR DESCRIPTION
- Add ExcelProcessService for managing Excel processes, including listing and cleanup functionalities.
- Introduce IProcessService and IInspectService interfaces for service abstraction.
- Create command argument classes: ProcessCommandArguments and InspectCommandArguments for structured input handling.
- Implement InspectCommand to handle inspection requests and return structured responses.
- Add tests for ProcessCommand and InspectCommand to ensure correct behavior and response formatting.
- Update documentation to reflect new inspect and process commands in the .NET bridge.
- Enhance the Go bridge to support automatic fallback to PowerShell for unsupported commands and handle errors gracefully.

Closes #76