### PR TITLE
Add support for image export and form inspection commands

### DIFF
--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs
@@ -22,7 +22,11 @@ public sealed class CommandRegistry
         return new CommandRegistry(new ICommandHandler[]
         {
             new DoctorCommand(),
+            new ExportImageCommand(),
+            new FormExportImageCommand(),
+            new FormWriteCommand(),
             new InspectCommand(),
+            new InspectFormCommand(),
             new MacrosCommand(),
             new ProcessCommand(),
             new PullCommand(),
@@ -35,7 +39,11 @@ public sealed class CommandRegistry
 
     public static CommandRegistry Create(
         Func<ExcelDiagnosticsResult>? probeExcel,
+        IExportImageService? exportImageService = null,
+        IFormExportImageService? formExportImageService = null,
         IInspectService? inspectService = null,
+        IFormWriteService? formWriteService = null,
+        IInspectFormService? inspectFormService = null,
         IMacrosService? macrosService = null,
         IProcessService? processService = null,
         IPullService? pullService = null,
@@ -47,7 +55,11 @@ public sealed class CommandRegistry
         return new CommandRegistry(new ICommandHandler[]
         {
             new DoctorCommand(probeExcel),
+            new ExportImageCommand(exportImageService),
+            new FormExportImageCommand(formExportImageService),
+            new FormWriteCommand(formWriteService),
             new InspectCommand(inspectService),
+            new InspectFormCommand(inspectFormService),
             new MacrosCommand(macrosService),
             new ProcessCommand(processService),
             new PullCommand(pullService),

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/ExportImageCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/ExportImageCommand.cs
@@ -1,0 +1,64 @@
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Commands;
+
+public sealed class ExportImageCommand : ICommandHandler
+{
+    private readonly IExportImageService _service;
+
+    public ExportImageCommand(IExportImageService? service = null)
+    {
+        _service = service ?? new ExcelExportImageService();
+    }
+
+    public string CommandName => "export-image";
+
+    public bool Supports(BridgeRequest request)
+    {
+        return string.Equals(request.Command, CommandName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
+    {
+        var args = new ExportImageCommandArguments(
+            WorkbookPath: BridgePayload.GetString(request.Payload, "WorkbookPath") ?? "",
+            Sheet: BridgePayload.GetString(request.Payload, "Sheet") ?? "",
+            RangeAddress: BridgePayload.GetString(request.Payload, "RangeAddress") ?? "",
+            OutputPath: BridgePayload.GetString(request.Payload, "OutputPath") ?? "",
+            OutputIsDefault: BridgePayload.GetBool(request.Payload, "OutputIsDefault"),
+            ImageFormat: BridgePayload.GetString(request.Payload, "ImageFormat") ?? "png",
+            Overwrite: BridgePayload.GetBool(request.Payload, "Overwrite"),
+            Visible: BridgePayload.GetBool(request.Payload, "Visible"),
+            UseSession: BridgePayload.GetBool(request.Payload, "UseSession"),
+            MetadataPath: BridgePayload.GetString(request.Payload, "MetadataPath") ?? "");
+
+        if (string.IsNullOrWhiteSpace(args.WorkbookPath))
+        {
+            return Failure(request, "export_image_args_invalid", "WorkbookPath is required");
+        }
+        if (string.IsNullOrWhiteSpace(args.Sheet))
+        {
+            return Failure(request, "export_image_args_invalid", "Sheet is required");
+        }
+        if (string.IsNullOrWhiteSpace(args.RangeAddress))
+        {
+            return Failure(request, "export_image_args_invalid", "RangeAddress is required");
+        }
+        if (string.IsNullOrWhiteSpace(args.OutputPath))
+        {
+            return Failure(request, "export_image_args_invalid", "OutputPath is required");
+        }
+
+        return _service.Execute(request, args, cancellationToken);
+    }
+
+    private static BridgeResponse Failure(BridgeRequest request, string code, string message)
+    {
+        return BridgeResponse.Failed(request, new BridgeError(
+            Code: code,
+            Message: message,
+            Phase: "export-image",
+            Source: "xlflow"));
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/FormExportImageCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/FormExportImageCommand.cs
@@ -1,0 +1,58 @@
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Commands;
+
+public sealed class FormExportImageCommand : ICommandHandler
+{
+    private readonly IFormExportImageService _service;
+
+    public FormExportImageCommand(IFormExportImageService? service = null)
+    {
+        _service = service ?? new ExcelFormExportImageService();
+    }
+
+    public string CommandName => "form-export-image";
+
+    public bool Supports(BridgeRequest request)
+    {
+        return string.Equals(request.Command, CommandName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
+    {
+        var args = new FormExportImageCommandArguments(
+            WorkbookPath: BridgePayload.GetString(request.Payload, "WorkbookPath") ?? "",
+            FormName: BridgePayload.GetString(request.Payload, "FormName") ?? "",
+            OutputPath: BridgePayload.GetString(request.Payload, "OutputPath") ?? "",
+            Initializer: BridgePayload.GetString(request.Payload, "Initializer") ?? "",
+            Overwrite: BridgePayload.GetBool(request.Payload, "Overwrite"),
+            Visible: BridgePayload.GetBool(request.Payload, "Visible"),
+            UseSession: BridgePayload.GetBool(request.Payload, "UseSession"),
+            MetadataPath: BridgePayload.GetString(request.Payload, "MetadataPath") ?? "");
+
+        if (string.IsNullOrWhiteSpace(args.WorkbookPath))
+        {
+            return Failure(request, "form_export_image_args_invalid", "WorkbookPath is required");
+        }
+        if (string.IsNullOrWhiteSpace(args.FormName))
+        {
+            return Failure(request, "form_export_image_args_invalid", "FormName is required");
+        }
+        if (string.IsNullOrWhiteSpace(args.OutputPath))
+        {
+            return Failure(request, "form_export_image_args_invalid", "OutputPath is required");
+        }
+
+        return _service.Execute(request, args, cancellationToken);
+    }
+
+    private static BridgeResponse Failure(BridgeRequest request, string code, string message)
+    {
+        return BridgeResponse.Failed(request, new BridgeError(
+            Code: code,
+            Message: message,
+            Phase: "form-export-image",
+            Source: "xlflow"));
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/FormWriteCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/FormWriteCommand.cs
@@ -1,0 +1,79 @@
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Commands;
+
+public sealed class FormWriteCommand : ICommandHandler
+{
+    private readonly IFormWriteService _service;
+
+    public FormWriteCommand(IFormWriteService? service = null)
+    {
+        _service = service ?? new ExcelFormWriteService();
+    }
+
+    public string CommandName => "form-write";
+
+    public bool Supports(BridgeRequest request)
+    {
+        return string.Equals(request.Command, CommandName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
+    {
+        var args = new FormWriteCommandArguments(
+            Action: BridgePayload.GetString(request.Payload, "Action") ?? "",
+            WorkbookPath: BridgePayload.GetString(request.Payload, "WorkbookPath") ?? "",
+            SpecPath: BridgePayload.GetString(request.Payload, "SpecPath") ?? "",
+            FormsDir: BridgePayload.GetString(request.Payload, "FormsDir") ?? "",
+            CodeSource: BridgePayload.GetString(request.Payload, "CodeSource") ?? "frm",
+            Folders: BridgePayload.GetBool(request.Payload, "Folders"),
+            FolderAnnotation: BridgePayload.GetString(request.Payload, "FolderAnnotation") ?? "update",
+            DefaultComponentFolders: BridgePayload.GetBool(request.Payload, "DefaultComponentFolders"),
+            SpecJson64: BridgePayload.GetString(request.Payload, "SpecJson64") ?? "",
+            Overwrite: BridgePayload.GetBool(request.Payload, "Overwrite"),
+            NoSave: BridgePayload.GetBool(request.Payload, "NoSave"),
+            Visible: BridgePayload.GetBool(request.Payload, "Visible"),
+            UseSession: BridgePayload.GetBool(request.Payload, "UseSession"),
+            MetadataPath: BridgePayload.GetString(request.Payload, "MetadataPath") ?? "");
+
+        var action = args.Action.Trim().ToLowerInvariant();
+        var validationCode = action == "apply" ? "form_apply_args_invalid" : "form_build_args_invalid";
+
+        if (action is not ("build" or "apply"))
+        {
+            return Failed(request, validationCode, $"unsupported form action: {args.Action}");
+        }
+        if (string.IsNullOrWhiteSpace(args.WorkbookPath))
+        {
+            return Failed(request, validationCode, "WorkbookPath is required.");
+        }
+        if (string.IsNullOrWhiteSpace(args.SpecJson64))
+        {
+            return Failed(request, validationCode, "SpecJson64 is required.");
+        }
+        if (string.IsNullOrWhiteSpace(args.FormsDir))
+        {
+            return Failed(request, validationCode, "FormsDir is required.");
+        }
+        if (args.NoSave && !args.UseSession)
+        {
+            return Failed(request, validationCode, "--NoSave requires --UseSession.");
+        }
+        if (action == "build" && args.Overwrite && args.NoSave)
+        {
+            return Failed(request, validationCode, "--overwrite cannot be combined with --NoSave because Excel requires an intermediate save before recreating the UserForm.");
+        }
+
+        return _service.Execute(request, args with { Action = action }, cancellationToken);
+    }
+
+    private static BridgeResponse Failed(BridgeRequest request, string code, string message)
+    {
+        return BridgeResponse.Failed(request, new BridgeError(
+            Code: code,
+            Message: message,
+            Phase: "validate_args",
+            Source: "xlflow"));
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/InspectFormCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/InspectFormCommand.cs
@@ -1,0 +1,54 @@
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Commands;
+
+public sealed class InspectFormCommand : ICommandHandler
+{
+    private readonly IInspectFormService _service;
+
+    public InspectFormCommand(IInspectFormService? service = null)
+    {
+        _service = service ?? new ExcelFormInspectionService();
+    }
+
+    public string CommandName => "inspect-form";
+
+    public bool Supports(BridgeRequest request)
+    {
+        return string.Equals(request.Command, CommandName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
+    {
+        var args = new InspectFormCommandArguments(
+            WorkbookPath: BridgePayload.GetString(request.Payload, "WorkbookPath") ?? "",
+            FormName: BridgePayload.GetString(request.Payload, "FormName") ?? "",
+            Basis: BridgePayload.GetString(request.Payload, "Basis") ?? "runtime",
+            Initializer: BridgePayload.GetString(request.Payload, "Initializer") ?? "",
+            StrictDesigner: BridgePayload.GetBool(request.Payload, "StrictDesigner"),
+            Visible: BridgePayload.GetBool(request.Payload, "Visible"),
+            UseSession: BridgePayload.GetBool(request.Payload, "UseSession"),
+            MetadataPath: BridgePayload.GetString(request.Payload, "MetadataPath") ?? "");
+
+        if (string.IsNullOrWhiteSpace(args.WorkbookPath))
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                Code: "inspect_form_args_invalid",
+                Message: "WorkbookPath is required",
+                Phase: "inspect-form",
+                Source: "xlflow"));
+        }
+
+        if (string.IsNullOrWhiteSpace(args.FormName))
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                Code: "inspect_form_args_invalid",
+                Message: "FormName is required",
+                Phase: "inspect-form",
+                Source: "xlflow"));
+        }
+
+        return _service.Execute(request, args, cancellationToken);
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -601,18 +601,44 @@ internal static class ExcelBridgeSupport
         dynamic dyn = comObject;
         return memberName switch
         {
+            "CopyPicture" => InvokeCopyPicture(dyn, args),
             "Open" => dyn.Open(args[0]),
             "Save" => dyn.Save(),
             "SaveCopyAs" => dyn.SaveCopyAs(args[0]),
             "Import" => dyn.Import(args[0]),
             "Export" => dyn.Export(args[0]),
             "Remove" => dyn.Remove(args[0]),
+            "Paste" => InvokePaste(dyn),
             "Close" => args.Length > 0 ? dyn.Close(args[0]) : dyn.Close(),
             "Quit" => dyn.Quit(),
             "DeleteLines" => dyn.DeleteLines(args[0], args[1]),
             "InsertLines" => dyn.InsertLines(args[0], args[1]),
             _ => throw new InvalidOperationException($"Unsupported COM method for dynamic dispatch: {memberName}"),
         };
+    }
+
+    private static object? InvokeCopyPicture(dynamic dyn, object?[] args)
+    {
+        switch (args.Length)
+        {
+            case 0:
+                dyn.CopyPicture();
+                return null;
+            case 1:
+                dyn.CopyPicture(args[0]);
+                return null;
+            case 2:
+                dyn.CopyPicture(args[0], args[1]);
+                return null;
+            default:
+                throw new InvalidOperationException("CopyPicture currently supports up to 2 arguments.");
+        }
+    }
+
+    private static object? InvokePaste(dynamic dyn)
+    {
+        dyn.Paste();
+        return null;
     }
 
     public static T RunPhase<T>(string phase, Func<T> action)
@@ -666,6 +692,126 @@ internal static class ExcelBridgeSupport
     {
         var value = Get(comObject, memberName, args);
         return value?.ToString();
+    }
+
+    public static object? TryGetWorkbookVbProject(object? workbook)
+    {
+        if (workbook is null)
+        {
+            return null;
+        }
+        try
+        {
+            dynamic wb = workbook;
+            return (object?)wb.VBProject;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static string? TryGetWorkbookName(object? workbook)
+    {
+        if (workbook is null)
+        {
+            return null;
+        }
+        try
+        {
+            dynamic wb = workbook;
+            return Convert.ToString(wb.Name, CultureInfo.InvariantCulture);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static string? TryGetWorkbookFullName(object? workbook)
+    {
+        if (workbook is null)
+        {
+            return null;
+        }
+        try
+        {
+            dynamic wb = workbook;
+            return Convert.ToString(wb.FullName, CultureInfo.InvariantCulture);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static object? TryGetActiveSheet(object? excel)
+    {
+        if (excel is null)
+        {
+            return null;
+        }
+        try
+        {
+            dynamic app = excel;
+            return (object?)app.ActiveSheet;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static object? TryGetSelection(object? excel)
+    {
+        if (excel is null)
+        {
+            return null;
+        }
+        try
+        {
+            dynamic app = excel;
+            return (object?)app.Selection;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static bool TryGetVisible(object? excel, out bool visible)
+    {
+        if (excel is null)
+        {
+            visible = false;
+            return false;
+        }
+        try
+        {
+            dynamic app = excel;
+            visible = Convert.ToBoolean(app.Visible, CultureInfo.InvariantCulture);
+            return true;
+        }
+        catch
+        {
+            visible = false;
+            return false;
+        }
+    }
+
+    public static object? RunExcelMacro(object excel, string macroName, params object?[] args)
+    {
+        dynamic app = excel;
+        return args.Length switch
+        {
+            0 => app.Run(macroName),
+            1 => app.Run(macroName, args[0]),
+            2 => app.Run(macroName, args[0], args[1]),
+            3 => app.Run(macroName, args[0], args[1], args[2]),
+            4 => app.Run(macroName, args[0], args[1], args[2], args[3]),
+            5 => app.Run(macroName, args[0], args[1], args[2], args[3], args[4]),
+            _ => throw new InvalidOperationException("RunExcelMacro currently supports up to 5 macro arguments."),
+        };
     }
 
     public static int ToInt(object? value)

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelExportImageService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelExportImageService.cs
@@ -1,0 +1,671 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Globalization;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Windows;
+
+namespace Xlflow.ExcelBridge.Services;
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The .NET bridge only runs on Windows with Excel COM automation.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Bridge services intentionally normalize COM failures into structured bridge responses.")]
+public sealed class ExcelExportImageService : IExportImageService
+{
+    public BridgeResponse Execute(BridgeRequest request, ExportImageCommandArguments args, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        object? excel = null;
+        object? workbook = null;
+        object? worksheet = null;
+        object? range = null;
+        object? chartObjects = null;
+        object? chartObject = null;
+        object? chart = null;
+        object? activeSheet = null;
+        object? selection = null;
+        var phase = "validate_args";
+        var createdParentDirs = false;
+        var sessionAttached = false;
+        var sessionMode = "none";
+        var originalVisible = false;
+        var restoreVisible = false;
+        var savedSheetName = "";
+        var savedSelectionAddress = "";
+        var outputPath = "";
+        var temporaryExportPath = "";
+        var dirty = false;
+        var needsSave = false;
+        var resolvedRangeAddress = "";
+
+        try
+        {
+            phase = "validate_args";
+            var normalizedFormat = NormalizeFormat(args.ImageFormat);
+            outputPath = PrepareOutputPath(args.OutputPath, args.Overwrite, out createdParentDirs, out temporaryExportPath);
+
+            phase = "open_workbook";
+            var open = OpenWorkbook(args.WorkbookPath, args.MetadataPath, args.UseSession, args.Visible);
+            excel = open.Excel;
+            workbook = open.Workbook;
+            sessionAttached = open.SessionAttached;
+            sessionMode = open.SessionMode;
+
+            if (sessionAttached && ExcelBridgeSupport.TryGetWorkbookDirtyState(workbook, out dirty))
+            {
+                needsSave = dirty;
+            }
+
+            originalVisible = ReadExcelVisible(excel);
+            if (sessionAttached)
+            {
+                activeSheet = ExcelBridgeSupport.TryGetActiveSheet(excel);
+                if (activeSheet is not null)
+                {
+                    savedSheetName = ExcelBridgeSupport.GetString(activeSheet, "Name") ?? "";
+                }
+                selection = ExcelBridgeSupport.TryGetSelection(excel);
+                if (selection is not null)
+                {
+                    savedSelectionAddress = ExcelBridgeSupport.GetRangeAddress(selection);
+                }
+            }
+
+            phase = "resolve_sheet";
+            worksheet = GetWorksheet(workbook, args.Sheet);
+            if (worksheet is null)
+            {
+                return Failure(request, "sheet_not_found", $"Sheet '{args.Sheet}' was not found.", "Excel", phase, args, sessionAttached, sessionMode, dirty, needsSave);
+            }
+
+            phase = "resolve_range";
+            range = ExcelBridgeSupport.Get(worksheet, "Range", args.RangeAddress)
+                ?? throw new InvalidOperationException($"invalid_range: Range '{args.RangeAddress}' is invalid for sheet '{args.Sheet}'.");
+            resolvedRangeAddress = ExcelBridgeSupport.GetRangeAddress(range);
+            if (string.IsNullOrWhiteSpace(resolvedRangeAddress))
+            {
+                resolvedRangeAddress = args.RangeAddress;
+            }
+
+            phase = "activate_window";
+            ActivateWorkbookWindow(excel, worksheet, range, originalVisible, ref restoreVisible);
+
+            phase = "create_chart_host";
+            dynamic ws = worksheet;
+            dynamic rg = range;
+            dynamic chartObjectsDynamic = ws.ChartObjects();
+            chartObjects = (object)chartObjectsDynamic;
+            chartObject = (object)chartObjectsDynamic.Add(
+                Convert.ToDouble(rg.Left, CultureInfo.InvariantCulture),
+                Convert.ToDouble(rg.Top, CultureInfo.InvariantCulture),
+                Math.Max(Convert.ToDouble(rg.Width, CultureInfo.InvariantCulture), 1.0),
+                Math.Max(Convert.ToDouble(rg.Height, CultureInfo.InvariantCulture), 1.0));
+            ((dynamic)chartObject).Name = $"xlflow.export.{Guid.NewGuid():N}";
+            chart = (object)((dynamic)chartObject).Chart;
+
+            phase = "copy_picture";
+            var clipboardResult = CopyRangeToChartWithRetry(range, chart!, excel, worksheet, cancellationToken);
+
+            phase = "export_chart";
+            var exportOk = ExcelBridgeSupport.InvokeMethod(chart!, "Export", outputPath, "PNG");
+            if (!(exportOk is bool exported && exported) && !File.Exists(outputPath))
+            {
+                throw new InvalidOperationException("export_image_failed: Excel did not create the requested image file.");
+            }
+            if (!string.IsNullOrWhiteSpace(temporaryExportPath))
+            {
+                File.Move(outputPath, args.OutputPath, true);
+                outputPath = args.OutputPath;
+                temporaryExportPath = "";
+            }
+
+            var output = new Dictionary<string, object?>
+            {
+                ["path"] = outputPath,
+                ["format"] = normalizedFormat,
+                ["default"] = args.OutputIsDefault,
+            };
+            if (createdParentDirs)
+            {
+                output["created_parent_dirs"] = true;
+            }
+
+            var dimensions = TryGetImageDimensions(outputPath);
+            if (dimensions is not null)
+            {
+                output["width_px"] = dimensions.Value.Width;
+                output["height_px"] = dimensions.Value.Height;
+            }
+
+            var targetPath = ExcelBridgeSupport.NormalizePath(args.WorkbookPath);
+            var extensions = new Dictionary<string, object?>
+            {
+                ["target"] = new Dictionary<string, object?>
+                {
+                    ["kind"] = sessionAttached ? "live_session" : "file",
+                    ["path"] = targetPath,
+                    ["sheet"] = ExcelBridgeSupport.GetString(worksheet, "Name") ?? args.Sheet,
+                    ["range"] = resolvedRangeAddress,
+                },
+                ["session"] = SessionPayload(targetPath, sessionAttached, sessionMode, dirty, needsSave),
+                ["workbook"] = WorkbookPayload(targetPath, sessionAttached, sessionMode, dirty, needsSave),
+                ["output"] = output,
+            };
+
+            var warnings = new List<Dictionary<string, object?>>();
+            if (clipboardResult.Warning is not null)
+            {
+                warnings.Add(clipboardResult.Warning);
+            }
+            if (needsSave)
+            {
+                warnings.Add(new Dictionary<string, object?>
+                {
+                    ["code"] = "save_required",
+                    ["message"] = "The live workbook is newer than disk. `export-image` used the live workbook state, not the saved workbook file.",
+                });
+            }
+            if (warnings.Count > 0)
+            {
+                extensions["warnings"] = warnings;
+            }
+
+            return new BridgeResponse
+            {
+                RequestId = request.RequestId,
+                Command = request.Command,
+                Logs =
+                [
+                    sessionAttached ? $"attached to xlflow session ({sessionMode})" : $"opened workbook {targetPath}",
+                    $"exported {(ExcelBridgeSupport.GetString(worksheet, "Name") ?? args.Sheet)}!{resolvedRangeAddress} to {outputPath}",
+                ],
+                Extensions = extensions,
+            };
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Failure(request, ClassifyErrorCode(ex.Message), ex.Message, "xlflow-excel-bridge", phase, args, sessionAttached, sessionMode, dirty, needsSave);
+        }
+        catch (Exception ex)
+        {
+            return Failure(request, "export_image_failed", ExcelBridgeSupport.FormatExceptionDetail(ex), "xlflow-excel-bridge", phase, args, sessionAttached, sessionMode, dirty, needsSave);
+        }
+        finally
+        {
+            if (restoreVisible && excel is not null)
+            {
+                TrySetVisible(excel, originalVisible);
+            }
+
+            if (sessionAttached && workbook is not null && excel is not null)
+            {
+                RestoreSelection(workbook, savedSheetName, savedSelectionAddress);
+            }
+
+            if (chartObject is not null)
+            {
+                try
+                {
+                    ExcelBridgeSupport.InvokeMethod(chartObject, "Delete");
+                }
+                catch
+                {
+                    // best-effort cleanup
+                }
+            }
+
+            ExcelBridgeSupport.ReleaseComObject(chart);
+            ExcelBridgeSupport.ReleaseComObject(chartObject);
+            ExcelBridgeSupport.ReleaseComObject(chartObjects);
+            ExcelBridgeSupport.ReleaseComObject(range);
+            ExcelBridgeSupport.ReleaseComObject(worksheet);
+            ExcelBridgeSupport.ReleaseComObject(selection);
+            ExcelBridgeSupport.ReleaseComObject(activeSheet);
+
+            if (!string.IsNullOrWhiteSpace(temporaryExportPath) && File.Exists(temporaryExportPath))
+            {
+                try
+                {
+                    File.Delete(temporaryExportPath);
+                }
+                catch
+                {
+                    // best-effort cleanup
+                }
+            }
+
+            CloseWorkbook(excel, workbook, sessionAttached);
+        }
+    }
+
+    private static string NormalizeFormat(string imageFormat)
+    {
+        var normalized = string.IsNullOrWhiteSpace(imageFormat) ? "png" : imageFormat.Trim().ToLowerInvariant();
+        if (!string.Equals(normalized, "png", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"unsupported_image_format: Image format '{imageFormat}' is not supported. Supported formats: png.");
+        }
+        return normalized;
+    }
+
+    private static string PrepareOutputPath(string outputPath, bool overwrite, out bool createdParentDirs, out string temporaryExportPath)
+    {
+        createdParentDirs = false;
+        temporaryExportPath = "";
+        var resolved = Path.GetFullPath(outputPath);
+        if (Directory.Exists(resolved))
+        {
+            throw new InvalidOperationException($"export_image_args_invalid: Output path '{resolved}' is a directory.");
+        }
+
+        var extension = Path.GetExtension(resolved);
+        if (!string.IsNullOrWhiteSpace(extension) && !string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"unsupported_image_format: Image format '{extension.TrimStart('.')}' is not supported. Supported formats: png.");
+        }
+
+        var parent = Path.GetDirectoryName(resolved);
+        if (!string.IsNullOrWhiteSpace(parent) && !Directory.Exists(parent))
+        {
+            Directory.CreateDirectory(parent);
+            createdParentDirs = true;
+        }
+
+        if (File.Exists(resolved) && !overwrite)
+        {
+            throw new InvalidOperationException($"output_file_exists: Output file '{resolved}' already exists. Use --overwrite to replace it.");
+        }
+
+        if (File.Exists(resolved) && overwrite)
+        {
+            temporaryExportPath = Path.Combine(parent ?? Path.GetTempPath(), $"xlflow-export-{Guid.NewGuid():N}.png");
+            return temporaryExportPath;
+        }
+
+        return resolved;
+    }
+
+    private static (object Excel, object Workbook, bool SessionAttached, string SessionMode) OpenWorkbook(string workbookPath, string metadataPath, bool useSession, bool visible)
+    {
+        if (useSession)
+        {
+            var attached = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, true);
+            return (attached.Excel, attached.Workbook, true, attached.SessionMode);
+        }
+        if (ExcelBridgeSupport.SessionMetadataMatchesWorkbook(metadataPath, workbookPath))
+        {
+            try
+            {
+                var attached = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, false);
+                return (attached.Excel, attached.Workbook, true, attached.SessionMode);
+            }
+            catch
+            {
+                // fall through to direct open
+            }
+        }
+
+        var direct = ExcelBridgeSupport.OpenWorkbookDirect(workbookPath, visible);
+        return (direct.Excel, direct.Workbook, false, direct.SessionMode);
+    }
+
+    private static object? GetWorksheet(object workbook, string sheet)
+    {
+        object? worksheets = null;
+        try
+        {
+            worksheets = ExcelBridgeSupport.Get(workbook, "Worksheets");
+            return ExcelBridgeSupport.Get(worksheets!, "Item", sheet);
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(worksheets);
+        }
+    }
+
+    private static bool ReadExcelVisible(object excel)
+    {
+        return ExcelBridgeSupport.TryGetVisible(excel, out var visible) && visible;
+    }
+
+    private static void TrySetVisible(object excel, bool visible)
+    {
+        try
+        {
+            ExcelBridgeSupport.Set(excel, "Visible", visible);
+        }
+        catch
+        {
+            // best-effort visibility restore
+        }
+    }
+
+    private static void ActivateWorkbookWindow(object excel, object worksheet, object range, bool originalVisible, ref bool restoreVisible)
+    {
+        var hwnd = ExcelBridgeSupport.GetExcelMainHwnd(excel);
+        if (!originalVisible)
+        {
+            TrySetVisible(excel, true);
+            restoreVisible = true;
+        }
+        if (hwnd != 0)
+        {
+            _ = WindowCapture.MoveWindowIntoCaptureBounds(WindowCapture.GetWindowInfo(new IntPtr(hwnd)));
+        }
+        try
+        {
+            ExcelBridgeSupport.InvokeMethod(worksheet, "Activate");
+        }
+        catch
+        {
+            // best-effort activation
+        }
+        try
+        {
+            ExcelBridgeSupport.InvokeMethod(range, "Select");
+        }
+        catch
+        {
+            // best-effort selection
+        }
+        Thread.Sleep(300);
+    }
+
+    private static ClipboardPasteResult CopyRangeToChartWithRetry(object range, object chart, object excel, object worksheet, CancellationToken cancellationToken)
+    {
+        Exception? lastFailure = null;
+        var attempts = new List<Dictionary<string, object?>>();
+        for (var attempt = 1; attempt <= 4; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(range, "CopyPicture", 2, -4147);
+                var clipboardReady = WaitForClipboardPicture(TimeSpan.FromMilliseconds(900), TimeSpan.FromMilliseconds(100), cancellationToken);
+                attempts.Add(new Dictionary<string, object?>
+                {
+                    ["attempt"] = attempt,
+                    ["clipboard_ready"] = clipboardReady,
+                });
+                if (!clipboardReady)
+                {
+                    lastFailure = new InvalidOperationException("clipboard_timeout: Excel did not publish an image to the clipboard after CopyPicture.");
+                    ReActivate(worksheet, range, excel);
+                    continue;
+                }
+
+                ExcelBridgeSupport.InvokeViaDynamic(chart, "Paste");
+                if (attempt > 1)
+                {
+                    return new ClipboardPasteResult(new Dictionary<string, object?>
+                    {
+                        ["code"] = "clipboard_retry_succeeded",
+                        ["message"] = $"Clipboard image export succeeded after {attempt} attempts.",
+                        ["attempts"] = attempts,
+                    });
+                }
+                return new ClipboardPasteResult(null);
+            }
+            catch (Exception ex)
+            {
+                lastFailure = ex;
+                attempts.Add(new Dictionary<string, object?>
+                {
+                    ["attempt"] = attempt,
+                    ["error"] = ExcelBridgeSupport.FormatExceptionDetail(ex),
+                });
+                ReActivate(worksheet, range, excel);
+                Thread.Sleep(150 * attempt);
+            }
+        }
+
+        var detail = lastFailure is null ? "clipboard_unavailable: clipboard image data was not available." : ExcelBridgeSupport.FormatExceptionDetail(lastFailure);
+        if (!detail.Contains(':'))
+        {
+            detail = $"clipboard_unavailable: {detail}";
+        }
+        throw new InvalidOperationException(detail);
+    }
+
+    private static void ReActivate(object worksheet, object range, object excel)
+    {
+        try
+        {
+            ExcelBridgeSupport.InvokeMethod(worksheet, "Activate");
+        }
+        catch
+        {
+        }
+        try
+        {
+            ExcelBridgeSupport.InvokeMethod(range, "Select");
+        }
+        catch
+        {
+        }
+        var hwnd = ExcelBridgeSupport.GetExcelMainHwnd(excel);
+        if (hwnd != 0)
+        {
+            _ = WindowCapture.MoveWindowIntoCaptureBounds(WindowCapture.GetWindowInfo(new IntPtr(hwnd)));
+        }
+    }
+
+    private static bool WaitForClipboardPicture(TimeSpan timeout, TimeSpan pollInterval, CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (ClipboardNative.HasPicture())
+            {
+                return true;
+            }
+            Thread.Sleep(pollInterval);
+        }
+        return ClipboardNative.HasPicture();
+    }
+
+    private static (int Width, int Height)? TryGetImageDimensions(string path)
+    {
+        try
+        {
+            using var image = Image.FromFile(path);
+            return (image.Width, image.Height);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void RestoreSelection(object workbook, string savedSheetName, string savedSelectionAddress)
+    {
+        if (string.IsNullOrWhiteSpace(savedSheetName))
+        {
+            return;
+        }
+
+        object? savedSheet = null;
+        object? savedSelectionRange = null;
+        try
+        {
+            savedSheet = GetWorksheet(workbook, savedSheetName);
+            if (savedSheet is null)
+            {
+                return;
+            }
+            ExcelBridgeSupport.InvokeMethod(savedSheet, "Activate");
+            if (!string.IsNullOrWhiteSpace(savedSelectionAddress))
+            {
+                savedSelectionRange = ExcelBridgeSupport.Get(savedSheet, "Range", savedSelectionAddress);
+                if (savedSelectionRange is not null)
+                {
+                    ExcelBridgeSupport.InvokeMethod(savedSelectionRange, "Select");
+                }
+            }
+        }
+        catch
+        {
+            // best-effort selection restore
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(savedSelectionRange);
+            ExcelBridgeSupport.ReleaseComObject(savedSheet);
+        }
+    }
+
+    private static Dictionary<string, object?> SessionPayload(string path, bool sessionAttached, string sessionMode, bool dirty, bool needsSave)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["active"] = sessionAttached,
+            ["workbook_path"] = path,
+            ["dirty"] = dirty,
+            ["save_required"] = needsSave,
+            ["live_newer_than_disk"] = needsSave,
+            ["mode"] = sessionMode,
+            ["source_of_truth"] = needsSave ? "live_workbook" : "saved_workbook",
+        };
+    }
+
+    private static Dictionary<string, object?> WorkbookPayload(string path, bool sessionAttached, string sessionMode, bool dirty, bool needsSave)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["path"] = path,
+            ["session"] = sessionAttached,
+            ["session_mode"] = sessionMode,
+            ["session_requested"] = sessionAttached,
+            ["auto_session"] = sessionAttached && string.Equals(sessionMode, "auto", StringComparison.OrdinalIgnoreCase),
+            ["dirty"] = dirty,
+            ["needs_save"] = needsSave,
+        };
+    }
+
+    private static BridgeResponse Failure(BridgeRequest request, string code, string message, string source, string phase, ExportImageCommandArguments args, bool sessionAttached, string sessionMode, bool dirty, bool needsSave)
+    {
+        var path = string.IsNullOrWhiteSpace(args.WorkbookPath) ? null : ExcelBridgeSupport.NormalizePath(args.WorkbookPath);
+        var extensions = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            extensions["target"] = new Dictionary<string, object?>
+            {
+                ["kind"] = sessionAttached ? "live_session" : "file",
+                ["path"] = path,
+            };
+            extensions["session"] = SessionPayload(path, sessionAttached, sessionMode, dirty, needsSave);
+            extensions["workbook"] = WorkbookPayload(path, sessionAttached, sessionMode, dirty, needsSave);
+        }
+
+        return new BridgeResponse
+        {
+            RequestId = request.RequestId,
+            Command = request.Command,
+            Status = BridgeStatus.Failed,
+            Error = new BridgeError(code, message, phase, source),
+            Extensions = extensions,
+        };
+    }
+
+    private static string ClassifyErrorCode(string message)
+    {
+        if (message.Contains("clipboard_timeout", StringComparison.OrdinalIgnoreCase))
+        {
+            return "clipboard_timeout";
+        }
+        if (message.Contains("clipboard_unavailable", StringComparison.OrdinalIgnoreCase))
+        {
+            return "clipboard_unavailable";
+        }
+        if (message.Contains("invalid_range", StringComparison.OrdinalIgnoreCase))
+        {
+            return "invalid_range";
+        }
+        if (message.Contains("sheet_not_found", StringComparison.OrdinalIgnoreCase))
+        {
+            return "sheet_not_found";
+        }
+        if (message.Contains("output_file_exists", StringComparison.OrdinalIgnoreCase))
+        {
+            return "output_file_exists";
+        }
+        if (message.Contains("unsupported_image_format", StringComparison.OrdinalIgnoreCase))
+        {
+            return "unsupported_image_format";
+        }
+        return "export_image_failed";
+    }
+
+    private static void CloseWorkbook(object? excel, object? workbook, bool sessionAttached)
+    {
+        if (sessionAttached)
+        {
+            ExcelBridgeSupport.ReleaseComObject(workbook);
+            ExcelBridgeSupport.ReleaseComObject(excel);
+            return;
+        }
+
+        if (workbook is not null)
+        {
+            try
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(workbook, "Close", false);
+            }
+            catch
+            {
+            }
+            ExcelBridgeSupport.ReleaseComObject(workbook);
+        }
+        if (excel is not null)
+        {
+            try
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(excel, "Quit");
+            }
+            catch
+            {
+            }
+            ExcelBridgeSupport.ReleaseComObject(excel);
+        }
+    }
+
+    private sealed record ClipboardPasteResult(Dictionary<string, object?>? Warning);
+
+    private static class ClipboardNative
+    {
+        private const uint CfBitmap = 2;
+        private const uint CfDib = 8;
+        private const uint CfEnhMetaFile = 14;
+
+        public static bool HasPicture()
+        {
+            if (!OpenClipboard(IntPtr.Zero))
+            {
+                return false;
+            }
+            try
+            {
+                return IsClipboardFormatAvailable(CfEnhMetaFile) ||
+                       IsClipboardFormatAvailable(CfDib) ||
+                       IsClipboardFormatAvailable(CfBitmap);
+            }
+            finally
+            {
+                _ = CloseClipboard();
+            }
+        }
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern bool OpenClipboard(IntPtr hwndNewOwner);
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern bool CloseClipboard();
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern bool IsClipboardFormatAvailable(uint format);
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormExportImageService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormExportImageService.cs
@@ -1,0 +1,740 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Globalization;
+using System.Text.Json;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Windows;
+
+namespace Xlflow.ExcelBridge.Services;
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The .NET bridge only runs on Windows with Excel COM automation.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Bridge services intentionally normalize COM failures into structured bridge responses.")]
+public sealed class ExcelFormExportImageService : IFormExportImageService
+{
+    public BridgeResponse Execute(BridgeRequest request, FormExportImageCommandArguments args, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        object? excel = null;
+        object? workbook = null;
+        object? vbProject = null;
+        object? runtimeExcel = null;
+        object? runtimeWorkbook = null;
+        object? runtimeVbProject = null;
+        object? helperComponent = null;
+        var runtimeWorkbookPath = "";
+        var outputPath = "";
+        var temporaryOutputPath = "";
+        var createdParentDirs = false;
+        var sessionAttached = false;
+        var sessionMode = "none";
+        var dirty = false;
+        var needsSave = false;
+        var phase = "validate_args";
+
+        try
+        {
+            outputPath = PrepareOutputPath(args.OutputPath, args.Overwrite, out createdParentDirs, out temporaryOutputPath);
+
+            phase = "open_source_workbook";
+            var open = OpenWorkbook(args.WorkbookPath, args.MetadataPath, args.UseSession, args.Visible);
+            excel = open.Excel;
+            workbook = open.Workbook;
+            sessionAttached = open.SessionAttached;
+            sessionMode = open.SessionMode;
+            if (sessionAttached && ExcelBridgeSupport.TryGetWorkbookDirtyState(workbook, out dirty))
+            {
+                needsSave = dirty;
+            }
+
+            phase = "read_vbproject";
+            vbProject = ExcelBridgeSupport.TryGetWorkbookVbProject(workbook);
+            if (vbProject is null)
+            {
+                return Failure(request, "vbproject_access_denied", "VBProject access is denied. Enable 'Trust access to the VBA project object model' in Excel Trust Center.", "Excel", phase, args, sessionAttached, sessionMode, dirty, needsSave);
+            }
+            if (!HasUserForm(vbProject, args.FormName))
+            {
+                return Failure(request, "form_not_found", $"UserForm '{args.FormName}' was not found in the workbook.", "xlflow", phase, args, sessionAttached, sessionMode, dirty, needsSave);
+            }
+
+            phase = "open_runtime_copy";
+            var runtimeOpen = OpenRuntimeWorkbookCopy(workbook);
+            runtimeExcel = runtimeOpen.Excel;
+            runtimeWorkbook = runtimeOpen.Workbook;
+            runtimeWorkbookPath = runtimeOpen.Path;
+            runtimeVbProject = ExcelBridgeSupport.TryGetWorkbookVbProject(runtimeWorkbook)
+                ?? throw new InvalidOperationException("vbproject_access_denied: runtime VBProject is unavailable");
+            helperComponent = InstallHelper(runtimeVbProject);
+
+            var processId = ExcelBridgeSupport.GetExcelProcessId(runtimeExcel);
+            var sourceCaption = GetDesignerCaption(workbook, args.FormName);
+            var token = $"xlflow-capture-{Guid.NewGuid():N}";
+
+            phase = "schedule_form_capture";
+            InvokePrepareCapture(runtimeExcel, runtimeWorkbook, args.FormName, token, args.Initializer, sourceCaption);
+
+            phase = "find_form_window";
+            var capture = WaitForCaptureWindow(runtimeExcel, runtimeWorkbook, processId, token, cancellationToken);
+            var window = WindowCapture.MoveWindowIntoCaptureBounds(capture)
+                ?? throw new InvalidOperationException($"window_not_found: could not find a visible UserForm window for capture token {token}");
+
+            phase = "capture_window_image";
+            var imageInfo = WindowCapture.CaptureWindowImage(window.Hwnd, outputPath);
+            if (!string.IsNullOrWhiteSpace(temporaryOutputPath))
+            {
+                File.Move(outputPath, args.OutputPath, true);
+                outputPath = args.OutputPath;
+                temporaryOutputPath = "";
+            }
+
+            var targetPath = ExcelBridgeSupport.NormalizePath(args.WorkbookPath);
+            var output = new Dictionary<string, object?>
+            {
+                ["path"] = outputPath,
+                ["format"] = "png",
+                ["width_px"] = imageInfo.WidthPx,
+                ["height_px"] = imageInfo.HeightPx,
+            };
+            if (createdParentDirs)
+            {
+                output["created_parent_dirs"] = true;
+            }
+
+            var target = new Dictionary<string, object?>
+            {
+                ["kind"] = sessionAttached ? "live_session" : "file",
+                ["path"] = targetPath,
+                ["form"] = args.FormName,
+                ["capture_state"] = "temporary_copy",
+                ["note"] = "Runtime export used a temporary workbook copy.",
+                ["capture_window"] = new Dictionary<string, object?>
+                {
+                    ["hwnd"] = window.Hwnd,
+                    ["title"] = window.Title,
+                    ["class_name"] = window.ClassName,
+                    ["left"] = window.Left,
+                    ["top"] = window.Top,
+                    ["width"] = window.Width,
+                    ["height"] = window.Height,
+                },
+            };
+
+            var warnings = new List<Dictionary<string, object?>>
+            {
+                new()
+                {
+                    ["code"] = "runtime_form_loads_initialize",
+                    ["message"] = "Form image export loads the form at runtime and executes UserForm_Initialize.",
+                },
+                new()
+                {
+                    ["code"] = "runtime_form_temp_copy",
+                    ["message"] = "Form image export executed against a temporary workbook copy so the source workbook and live session are not mutated.",
+                },
+                new()
+                {
+                    ["code"] = "userform_image_export_experimental",
+                    ["message"] = "UserForm image export is experimental and currently supports Windows desktop Excel only.",
+                },
+            };
+            if (!string.IsNullOrWhiteSpace(args.Initializer))
+            {
+                warnings.Add(new Dictionary<string, object?>
+                {
+                    ["code"] = "runtime_form_initializer_invoked",
+                    ["message"] = $"Form image export also invoked {args.Initializer}(ThisWorkbook).",
+                });
+            }
+            if (needsSave)
+            {
+                warnings.Add(new Dictionary<string, object?>
+                {
+                    ["code"] = "save_required",
+                    ["message"] = "The live workbook is newer than disk. `form export-image` used the live workbook state, not the saved workbook file.",
+                });
+            }
+
+            return new BridgeResponse
+            {
+                RequestId = request.RequestId,
+                Command = request.Command,
+                Logs =
+                [
+                    sessionAttached ? $"attached to xlflow session ({sessionMode})" : $"opened workbook {targetPath}",
+                    $"exported runtime UserForm {args.FormName} to {outputPath}",
+                ],
+                Extensions = new Dictionary<string, object?>
+                {
+                    ["target"] = target,
+                    ["session"] = SessionPayload(targetPath, sessionAttached, sessionMode, dirty, needsSave),
+                    ["workbook"] = WorkbookPayload(targetPath, sessionAttached, sessionMode, dirty, needsSave),
+                    ["forms"] = new Dictionary<string, object?>
+                    {
+                        ["name"] = args.FormName,
+                        ["basis"] = "runtime",
+                        ["initializer"] = string.IsNullOrWhiteSpace(args.Initializer) ? null : args.Initializer,
+                    },
+                    ["output"] = output,
+                    ["warnings"] = warnings,
+                },
+            };
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Failure(request, ClassifyErrorCode(ex.Message), ex.Message, "xlflow-excel-bridge", phase, args, sessionAttached, sessionMode, dirty, needsSave);
+        }
+        catch (Exception ex)
+        {
+            return Failure(request, "form_export_image_failed", ExcelBridgeSupport.FormatExceptionDetail(ex), "xlflow-excel-bridge", phase, args, sessionAttached, sessionMode, dirty, needsSave);
+        }
+        finally
+        {
+            CleanupCapture(runtimeExcel, runtimeWorkbook);
+            RemoveTemporaryComponent(runtimeVbProject, helperComponent);
+            CloseWorkbook(runtimeExcel, runtimeWorkbook, false);
+            if (!string.IsNullOrWhiteSpace(runtimeWorkbookPath) && File.Exists(runtimeWorkbookPath))
+            {
+                try
+                {
+                    File.Delete(runtimeWorkbookPath);
+                }
+                catch
+                {
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(temporaryOutputPath) && File.Exists(temporaryOutputPath))
+            {
+                try
+                {
+                    File.Delete(temporaryOutputPath);
+                }
+                catch
+                {
+                }
+            }
+            ExcelBridgeSupport.ReleaseComObject(runtimeVbProject);
+            ExcelBridgeSupport.ReleaseComObject(vbProject);
+            CloseWorkbook(excel, workbook, sessionAttached);
+        }
+    }
+
+    private static string PrepareOutputPath(string outputPath, bool overwrite, out bool createdParentDirs, out string temporaryOutputPath)
+    {
+        createdParentDirs = false;
+        temporaryOutputPath = "";
+        var resolved = Path.GetFullPath(outputPath);
+        if (Directory.Exists(resolved))
+        {
+            throw new InvalidOperationException($"form_export_image_args_invalid: Output path '{resolved}' is a directory.");
+        }
+        var extension = Path.GetExtension(resolved);
+        if (string.IsNullOrWhiteSpace(extension) || !string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"unsupported_image_format: Image format '{extension.TrimStart('.')}' is not supported. Supported formats: png.");
+        }
+        var parent = Path.GetDirectoryName(resolved);
+        if (!string.IsNullOrWhiteSpace(parent) && !Directory.Exists(parent))
+        {
+            Directory.CreateDirectory(parent);
+            createdParentDirs = true;
+        }
+        if (File.Exists(resolved) && !overwrite)
+        {
+            throw new InvalidOperationException($"output_file_exists: Output file '{resolved}' already exists. Use --overwrite to replace it.");
+        }
+        if (File.Exists(resolved) && overwrite)
+        {
+            temporaryOutputPath = Path.Combine(parent ?? Path.GetTempPath(), $"xlflow-form-export-{Guid.NewGuid():N}.png");
+            return temporaryOutputPath;
+        }
+        return resolved;
+    }
+
+    private static (object Excel, object Workbook, bool SessionAttached, string SessionMode) OpenWorkbook(string workbookPath, string metadataPath, bool useSession, bool visible)
+    {
+        if (useSession)
+        {
+            var attached = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, true);
+            return (attached.Excel, attached.Workbook, true, attached.SessionMode);
+        }
+        if (ExcelBridgeSupport.SessionMetadataMatchesWorkbook(metadataPath, workbookPath))
+        {
+            try
+            {
+                var attached = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, false);
+                return (attached.Excel, attached.Workbook, true, attached.SessionMode);
+            }
+            catch
+            {
+            }
+        }
+        var direct = ExcelBridgeSupport.OpenWorkbookDirect(workbookPath, visible);
+        return (direct.Excel, direct.Workbook, false, direct.SessionMode);
+    }
+
+    private static bool HasUserForm(object vbProject, string formName)
+    {
+        object? components = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(components!, "Count"));
+            for (var index = 1; index <= count; index++)
+            {
+                object? component = null;
+                try
+                {
+                    component = ExcelBridgeSupport.Get(components!, "Item", index);
+                    var type = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(component!, "Type"));
+                    var name = ExcelBridgeSupport.GetString(component!, "Name") ?? "";
+                    if (type == 3 && string.Equals(name, formName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(component);
+                }
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+        return false;
+    }
+
+    private static (object Excel, object Workbook, string Path) OpenRuntimeWorkbookCopy(object workbook)
+    {
+        var fullName = ExcelBridgeSupport.TryGetWorkbookFullName(workbook) ?? "";
+        var extension = Path.GetExtension(fullName);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            extension = ".xlsm";
+        }
+        var tempPath = Path.Combine(Path.GetTempPath(), $"xlflow-form-export-image-{Guid.NewGuid():N}{extension}");
+        ExcelBridgeSupport.InvokeViaDynamic(workbook, "SaveCopyAs", tempPath);
+        var direct = ExcelBridgeSupport.OpenWorkbookDirect(tempPath, true);
+        return (direct.Excel, direct.Workbook, tempPath);
+    }
+
+    private static string GetDesignerCaption(object workbook, string formName)
+    {
+        object? component = null;
+        object? designer = null;
+        try
+        {
+            var vbProject = ExcelBridgeSupport.TryGetWorkbookVbProject(workbook);
+            var components = ExcelBridgeSupport.Get(vbProject!, "VBComponents");
+            component = ExcelBridgeSupport.Get(components!, "Item", formName);
+            designer = ExcelBridgeSupport.Get(component!, "Designer");
+            return ExcelBridgeSupport.GetString(designer!, "Caption") ?? "";
+        }
+        catch
+        {
+            return "";
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(designer);
+            ExcelBridgeSupport.ReleaseComObject(component);
+        }
+    }
+
+    private static object InstallHelper(object runtimeVbProject)
+    {
+        object? components = null;
+        object? component = null;
+        object? codeModule = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(runtimeVbProject, "VBComponents")
+                ?? throw new InvalidOperationException("vbproject_access_denied: VBComponents is unavailable.");
+            component = ExcelBridgeSupport.InvokeMethod(components, "Add", 1)
+                ?? throw new InvalidOperationException("vba_compile_failed: could not add helper module.");
+            ExcelBridgeSupport.Set(component, "Name", "XlflowCap_" + Guid.NewGuid().ToString("N")[..20]);
+            codeModule = ExcelBridgeSupport.Get(component, "CodeModule")
+                ?? throw new InvalidOperationException("vba_compile_failed: helper CodeModule is unavailable.");
+            ExcelBridgeSupport.InvokeMethod(codeModule, "AddFromString", BuildHelperCode());
+            return component;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(codeModule);
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static void InvokePrepareCapture(object runtimeExcel, object runtimeWorkbook, string formName, string token, string initializer, string expectedCaption)
+    {
+        var workbookName = (ExcelBridgeSupport.TryGetWorkbookName(runtimeWorkbook) ?? "").Replace("'", "''", StringComparison.Ordinal);
+        var macroName = $"'{workbookName}'!XlflowPrepareFormImageCapture";
+        ExcelBridgeSupport.RunExcelMacro(runtimeExcel, macroName, formName, token, initializer, expectedCaption);
+    }
+
+    private static WindowInfo WaitForCaptureWindow(object runtimeExcel, object runtimeWorkbook, int processId, string token, CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(7);
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var status = ReadCaptureStatus(runtimeExcel, runtimeWorkbook);
+            if (!string.IsNullOrWhiteSpace(status.Source) || !string.IsNullOrWhiteSpace(status.Message))
+            {
+                var source = string.IsNullOrWhiteSpace(status.Source) ? "XlflowFormImageCapture.capture_prepare" : status.Source;
+                throw new InvalidOperationException($"{source}: {status.Message}");
+            }
+
+            WindowInfo? window = null;
+            if (status.Hwnd != 0)
+            {
+                window = WindowCapture.WaitForStableWindow(new IntPtr(status.Hwnd), TimeSpan.FromMilliseconds(1200), TimeSpan.FromMilliseconds(100), 2);
+                if (WindowCapture.IsLikelyUserFormWindow(window))
+                {
+                    return window!;
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(status.Caption))
+            {
+                window = WindowCapture.FindWindowByTitle(processId, status.Caption, exactMatch: true);
+                if (WindowCapture.IsLikelyUserFormWindow(window))
+                {
+                    return WindowCapture.WaitForStableWindow(new IntPtr(window!.Hwnd), TimeSpan.FromMilliseconds(1200), TimeSpan.FromMilliseconds(100), 2) ?? window;
+                }
+            }
+            window = WindowCapture.FindWindowByTitle(processId, token, exactMatch: false);
+            if (WindowCapture.IsLikelyUserFormWindow(window))
+            {
+                return WindowCapture.WaitForStableWindow(new IntPtr(window!.Hwnd), TimeSpan.FromMilliseconds(1200), TimeSpan.FromMilliseconds(100), 2) ?? window;
+            }
+            Thread.Sleep(100);
+        }
+        throw new InvalidOperationException($"window_not_found: could not find a visible UserForm window for capture token {token}");
+    }
+
+    private static CaptureStatus ReadCaptureStatus(object runtimeExcel, object runtimeWorkbook)
+    {
+        var workbookName = (ExcelBridgeSupport.TryGetWorkbookName(runtimeWorkbook) ?? "").Replace("'", "''", StringComparison.Ordinal);
+        var macroName = $"'{workbookName}'!XlflowReadFormImageCaptureStatus";
+        var value = Convert.ToString(ExcelBridgeSupport.RunExcelMacro(runtimeExcel, macroName), CultureInfo.InvariantCulture) ?? "";
+        var parts = value.Split('\t');
+        long hwnd = 0;
+        _ = parts.Length >= 5 && long.TryParse(parts[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out hwnd);
+        return new CaptureStatus(
+            parts.Length >= 1 ? parts[0] : "",
+            parts.Length >= 2 ? parts[1] : "",
+            parts.Length >= 3 && string.Equals(parts[2], "True", StringComparison.OrdinalIgnoreCase),
+            parts.Length >= 4 ? parts[3] : "",
+            hwnd);
+    }
+
+    private static void CleanupCapture(object? runtimeExcel, object? runtimeWorkbook)
+    {
+        if (runtimeExcel is null || runtimeWorkbook is null)
+        {
+            return;
+        }
+        try
+        {
+            var workbookName = (ExcelBridgeSupport.TryGetWorkbookName(runtimeWorkbook) ?? "").Replace("'", "''", StringComparison.Ordinal);
+            var macroName = $"'{workbookName}'!XlflowCleanupFormImageCapture";
+            ExcelBridgeSupport.RunExcelMacro(runtimeExcel, macroName);
+        }
+        catch
+        {
+        }
+    }
+
+    private static Dictionary<string, object?> SessionPayload(string path, bool sessionAttached, string sessionMode, bool dirty, bool needsSave)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["active"] = sessionAttached,
+            ["workbook_path"] = path,
+            ["dirty"] = dirty,
+            ["save_required"] = needsSave,
+            ["live_newer_than_disk"] = needsSave,
+            ["mode"] = sessionMode,
+            ["source_of_truth"] = needsSave ? "live_workbook" : "saved_workbook",
+        };
+    }
+
+    private static Dictionary<string, object?> WorkbookPayload(string path, bool sessionAttached, string sessionMode, bool dirty, bool needsSave)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["path"] = path,
+            ["session"] = sessionAttached,
+            ["session_mode"] = sessionMode,
+            ["session_requested"] = sessionAttached,
+            ["auto_session"] = sessionAttached && string.Equals(sessionMode, "auto", StringComparison.OrdinalIgnoreCase),
+            ["saved"] = false,
+            ["dirty"] = dirty,
+            ["needs_save"] = needsSave,
+        };
+    }
+
+    private static BridgeResponse Failure(BridgeRequest request, string code, string message, string source, string phase, FormExportImageCommandArguments args, bool sessionAttached, string sessionMode, bool dirty, bool needsSave)
+    {
+        var path = string.IsNullOrWhiteSpace(args.WorkbookPath) ? null : ExcelBridgeSupport.NormalizePath(args.WorkbookPath);
+        var extensions = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            extensions["target"] = new Dictionary<string, object?>
+            {
+                ["kind"] = sessionAttached ? "live_session" : "file",
+                ["path"] = path,
+                ["form"] = args.FormName,
+                ["capture_state"] = "temporary_copy",
+                ["note"] = "Runtime export used a temporary workbook copy.",
+            };
+            extensions["session"] = SessionPayload(path, sessionAttached, sessionMode, dirty, needsSave);
+            extensions["workbook"] = WorkbookPayload(path, sessionAttached, sessionMode, dirty, needsSave);
+        }
+        return new BridgeResponse
+        {
+            RequestId = request.RequestId,
+            Command = request.Command,
+            Status = BridgeStatus.Failed,
+            Error = new BridgeError(code, message, phase, source),
+            Extensions = extensions,
+        };
+    }
+
+    private static string ClassifyErrorCode(string message)
+    {
+        if (message.Contains("initializer", StringComparison.OrdinalIgnoreCase))
+        {
+            return "form_initializer_failed";
+        }
+        if (message.Contains("runtime_load", StringComparison.OrdinalIgnoreCase))
+        {
+            return "runtime_form_load_failed";
+        }
+        if (message.Contains("compile", StringComparison.OrdinalIgnoreCase))
+        {
+            return "vba_compile_failed";
+        }
+        if (message.Contains("window_not_found", StringComparison.OrdinalIgnoreCase))
+        {
+            return "window_not_found";
+        }
+        if (message.Contains("image_capture_failed", StringComparison.OrdinalIgnoreCase))
+        {
+            return "image_capture_failed";
+        }
+        if (message.Contains("output_file_exists", StringComparison.OrdinalIgnoreCase))
+        {
+            return "output_file_exists";
+        }
+        if (message.Contains("unsupported_image_format", StringComparison.OrdinalIgnoreCase))
+        {
+            return "unsupported_image_format";
+        }
+        if (message.Contains("vbproject_access_denied", StringComparison.OrdinalIgnoreCase))
+        {
+            return "vbproject_access_denied";
+        }
+        if (message.Contains("form_not_found", StringComparison.OrdinalIgnoreCase))
+        {
+            return "form_not_found";
+        }
+        return "form_export_image_failed";
+    }
+
+    private static void RemoveTemporaryComponent(object? vbProject, object? component)
+    {
+        object? components = null;
+        try
+        {
+            if (vbProject is null || component is null)
+            {
+                return;
+            }
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            if (components is not null)
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(components, "Remove", component);
+            }
+        }
+        catch
+        {
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(component);
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static void CloseWorkbook(object? excel, object? workbook, bool sessionAttached)
+    {
+        if (sessionAttached)
+        {
+            ExcelBridgeSupport.ReleaseComObject(workbook);
+            ExcelBridgeSupport.ReleaseComObject(excel);
+            return;
+        }
+        if (workbook is not null)
+        {
+            try
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(workbook, "Close", false);
+            }
+            catch
+            {
+            }
+            ExcelBridgeSupport.ReleaseComObject(workbook);
+        }
+        if (excel is not null)
+        {
+            try
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(excel, "Quit");
+            }
+            catch
+            {
+            }
+            ExcelBridgeSupport.ReleaseComObject(excel);
+        }
+    }
+
+    private static void TrySetVisible(object excel, bool visible)
+    {
+        try
+        {
+            ExcelBridgeSupport.Set(excel, "Visible", visible);
+        }
+        catch
+        {
+        }
+    }
+
+    private static string BuildHelperCode()
+    {
+        return """""
+Option Explicit
+
+#If VBA7 Then
+Private Declare PtrSafe Function FindWindowW Lib "user32" (ByVal lpClassName As LongPtr, ByVal lpWindowName As LongPtr) As LongPtr
+#Else
+Private Declare Function FindWindowW Lib "user32" (ByVal lpClassName As Long, ByVal lpWindowName As Long) As Long
+#End If
+
+Private xlflowCapturedForm As Object
+Private xlflowCaptureFormName As String
+Private xlflowCaptureToken As String
+Private xlflowCaptureInitializer As String
+Private xlflowCaptureScheduledAt As Date
+Private xlflowLastErrorSource As String
+Private xlflowLastErrorMessage As String
+Private xlflowCaptureReady As Boolean
+Private xlflowCaptureWindowCaption As String
+Private xlflowCaptureWindowHandle As String
+Private xlflowExpectedCaption As String
+
+Private Function XlflowFindFormWindowHandle(ByVal caption As String) As String
+#If VBA7 Then
+  Dim hwnd As LongPtr
+#Else
+  Dim hwnd As Long
+#End If
+
+  hwnd = 0
+  If Len(caption) > 0 Then
+    hwnd = FindWindowW(0, StrPtr(caption))
+  End If
+  XlflowFindFormWindowHandle = CStr(hwnd)
+End Function
+
+Public Sub XlflowPrepareFormImageCapture(ByVal formName As String, ByVal token As String, Optional ByVal initializer As String = "", Optional ByVal expectedCaption As String = "")
+  xlflowCaptureFormName = formName
+  xlflowCaptureToken = token
+  xlflowCaptureInitializer = Trim$(initializer)
+  xlflowExpectedCaption = Trim$(expectedCaption)
+  xlflowLastErrorSource = ""
+  xlflowLastErrorMessage = ""
+  xlflowCaptureReady = False
+  xlflowCaptureWindowCaption = ""
+  xlflowCaptureWindowHandle = "0"
+  xlflowCaptureScheduledAt = Now + TimeSerial(0, 0, 1)
+  Application.OnTime xlflowCaptureScheduledAt, "'" & Replace(ThisWorkbook.Name, "'", "''") & "'!XlflowExecuteFormImageCapture"
+End Sub
+
+Public Sub XlflowExecuteFormImageCapture()
+  Dim loaded As Boolean
+  Dim initializerRan As Boolean
+  Dim caption As String
+  On Error GoTo ErrHandler
+
+  Set xlflowCapturedForm = UserForms.Add(xlflowCaptureFormName)
+  loaded = True
+
+  If Len(xlflowCaptureInitializer) > 0 Then
+    CallByName xlflowCapturedForm, xlflowCaptureInitializer, VbMethod, ThisWorkbook
+    initializerRan = True
+  End If
+
+  caption = ""
+  On Error Resume Next
+  caption = CStr(xlflowCapturedForm.Caption)
+  On Error GoTo ErrHandler
+  If Len(xlflowExpectedCaption) > 0 Then
+    If Len(caption) = 0 _
+      Or StrComp(caption, xlflowCaptureFormName, vbTextCompare) = 0 _
+      Or LCase$(Left$(caption, 8)) = "userform" Then
+      caption = xlflowExpectedCaption
+    End If
+  End If
+  If Len(caption) = 0 Then
+    caption = xlflowCaptureFormName
+  End If
+
+  xlflowCapturedForm.Caption = caption & " [xlflow-capture-" & xlflowCaptureToken & "]"
+  xlflowCapturedForm.Show vbModeless
+  DoEvents
+  xlflowCaptureWindowCaption = CStr(xlflowCapturedForm.Caption)
+  xlflowCaptureWindowHandle = XlflowFindFormWindowHandle(xlflowCaptureWindowCaption)
+  xlflowCaptureReady = True
+  Exit Sub
+
+ErrHandler:
+  If Not loaded Then
+    xlflowLastErrorSource = "XlflowFormImageCapture.runtime_load"
+  ElseIf Len(xlflowCaptureInitializer) > 0 And Not initializerRan Then
+    xlflowLastErrorSource = "XlflowFormImageCapture.initializer"
+  Else
+    xlflowLastErrorSource = "XlflowFormImageCapture.capture_prepare"
+  End If
+  xlflowLastErrorMessage = Err.Description
+End Sub
+
+Public Sub XlflowCleanupFormImageCapture()
+  On Error Resume Next
+  If xlflowCaptureScheduledAt <> 0 Then
+    Application.OnTime xlflowCaptureScheduledAt, "'" & Replace(ThisWorkbook.Name, "'", "''") & "'!XlflowExecuteFormImageCapture", , False
+  End If
+  If Not xlflowCapturedForm Is Nothing Then
+    Unload xlflowCapturedForm
+  End If
+  Set xlflowCapturedForm = Nothing
+  xlflowCaptureScheduledAt = 0
+  xlflowCaptureReady = False
+  xlflowCaptureWindowCaption = ""
+  xlflowCaptureWindowHandle = "0"
+  xlflowExpectedCaption = ""
+  xlflowLastErrorSource = ""
+  xlflowLastErrorMessage = ""
+  On Error GoTo 0
+End Sub
+
+Public Function XlflowReadFormImageCaptureStatus() As String
+  XlflowReadFormImageCaptureStatus = xlflowLastErrorSource & vbTab & xlflowLastErrorMessage & vbTab & CStr(xlflowCaptureReady) & vbTab & Replace(xlflowCaptureWindowCaption, vbTab, " ") & vbTab & xlflowCaptureWindowHandle
+End Function
+""""";
+    }
+
+    private sealed record CaptureStatus(string Source, string Message, bool Ready, string Caption, long Hwnd);
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormInspectionService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormInspectionService.cs
@@ -476,13 +476,17 @@ public sealed class ExcelFormInspectionService : IInspectFormService
 
     private static Dictionary<string, object?> SerializeControl(object control)
     {
+        var progId = ExcelBridgeSupport.GetString(control, "ProgId") ?? "";
         var result = new Dictionary<string, object?>
         {
             ["name"] = ExcelBridgeSupport.GetString(control, "Name") ?? "",
-            ["type"] = control.GetType().Name,
+            ["type"] = ResolveDesignerControlType(progId, control.GetType().Name),
         };
 
-        AddStringMember(control, result, "ProgId", "prog_id");
+        if (!string.IsNullOrWhiteSpace(progId))
+        {
+            result["prog_id"] = progId;
+        }
         AddStringMember(control, result, "Caption", "caption");
         AddStringMember(control, result, "Text", "text");
         AddStringMember(control, result, "Value", "value");
@@ -512,6 +516,20 @@ public sealed class ExcelFormInspectionService : IInspectFormService
         }
 
         return result;
+    }
+
+    internal static string ResolveDesignerControlType(string? progId, string? fallbackTypeName)
+    {
+        if (!string.IsNullOrWhiteSpace(progId))
+        {
+            var segments = progId.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (segments.Length >= 2 && !string.IsNullOrWhiteSpace(segments[1]))
+            {
+                return segments[1];
+            }
+        }
+
+        return string.IsNullOrWhiteSpace(fallbackTypeName) ? "Control" : fallbackTypeName;
     }
 
     private static bool HasExpectedParent(object control, string expectedParentName)

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormInspectionService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormInspectionService.cs
@@ -1,0 +1,1131 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The .NET bridge only runs on Windows with Excel COM automation.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Bridge services intentionally normalize COM failures into structured bridge responses.")]
+public sealed class ExcelFormInspectionService : IInspectFormService
+{
+    public BridgeResponse Execute(BridgeRequest request, InspectFormCommandArguments args, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        object? excel = null;
+        object? workbook = null;
+        object? vbProject = null;
+        object? runtimeExcel = null;
+        object? runtimeWorkbook = null;
+        object? runtimeVBProject = null;
+        object? helperComponent = null;
+        string? runtimeWorkbookPath = null;
+        var sessionAttached = false;
+        var sessionMode = "none";
+
+        try
+        {
+            var basis = NormalizeBasis(args.Basis);
+            if (basis is null)
+            {
+                return Failure(request, "inspect_form_args_invalid", $"unsupported inspect form basis: {args.Basis}", "xlflow");
+            }
+            if (basis == "designer" && !string.IsNullOrWhiteSpace(args.Initializer))
+            {
+                return Failure(request, "inspect_form_args_invalid", "--initializer can only be used with runtime or both inspection", "xlflow");
+            }
+
+            var openResult = OpenWorkbookForInspect(args.WorkbookPath, args.MetadataPath, args.UseSession, args.Visible);
+            excel = openResult.Excel;
+            workbook = openResult.Workbook;
+            sessionAttached = openResult.SessionAttached;
+            sessionMode = openResult.SessionMode;
+
+            vbProject = ExcelBridgeSupport.TryGetWorkbookVbProject(workbook);
+            if (vbProject is null)
+            {
+                return Failure(request, "vbproject_access_denied", "VBProject access is denied. Enable 'Trust access to the VBA project object model' in Excel Trust Center.", "Excel");
+            }
+
+            if (!HasUserForm(vbProject, args.FormName))
+            {
+                return Failure(request, "form_not_found", $"UserForm '{args.FormName}' was not found in the workbook.", "xlflow");
+            }
+
+            var targetKind = sessionAttached ? "live_session" : "file";
+            var workbookPath = ExcelBridgeSupport.NormalizePath(args.WorkbookPath);
+            var saveStateKnown = ExcelBridgeSupport.TryGetWorkbookDirtyState(workbook, out var dirtyState);
+            var dirty = sessionAttached ? saveStateKnown ? dirtyState : true : false;
+            var needsSave = sessionAttached ? dirty : false;
+
+            object formsPayload;
+            if (basis == "runtime")
+            {
+                var runtimeOpen = OpenRuntimeWorkbookCopy(workbook, args.Visible);
+                runtimeExcel = runtimeOpen.Excel;
+                runtimeWorkbook = runtimeOpen.Workbook;
+                runtimeWorkbookPath = runtimeOpen.Path;
+                runtimeVBProject = ExcelBridgeSupport.TryGetWorkbookVbProject(runtimeWorkbook)
+                    ?? throw new InvalidOperationException("runtime VBProject is unavailable");
+                helperComponent = InstallInspectHelper(runtimeVBProject);
+                formsPayload = InvokeInspectHelper(runtimeExcel, runtimeWorkbook, args.FormName, "runtime", args.Initializer);
+            }
+            else if (basis == "both")
+            {
+                var runtimeOpen = OpenRuntimeWorkbookCopy(workbook, args.Visible);
+                runtimeExcel = runtimeOpen.Excel;
+                runtimeWorkbook = runtimeOpen.Workbook;
+                runtimeWorkbookPath = runtimeOpen.Path;
+                runtimeVBProject = ExcelBridgeSupport.TryGetWorkbookVbProject(runtimeWorkbook)
+                    ?? throw new InvalidOperationException("runtime VBProject is unavailable");
+                helperComponent = InstallInspectHelper(runtimeVBProject);
+                var runtimeForm = InvokeInspectHelper(runtimeExcel, runtimeWorkbook, args.FormName, "runtime", args.Initializer);
+                var designerForm = args.StrictDesigner
+                    ? InvokeInspectHelper(runtimeExcel, runtimeWorkbook, args.FormName, "designer", "")
+                    : ReadDesignerFormSnapshot(vbProject, args.FormName);
+                formsPayload = new Dictionary<string, object?>
+                {
+                    ["runtime"] = runtimeForm,
+                    ["designer"] = designerForm,
+                };
+            }
+            else
+            {
+                if (args.StrictDesigner)
+                {
+                    var runtimeOpen = OpenRuntimeWorkbookCopy(workbook, args.Visible);
+                    runtimeExcel = runtimeOpen.Excel;
+                    runtimeWorkbook = runtimeOpen.Workbook;
+                    runtimeWorkbookPath = runtimeOpen.Path;
+                    runtimeVBProject = ExcelBridgeSupport.TryGetWorkbookVbProject(runtimeWorkbook)
+                        ?? throw new InvalidOperationException("runtime VBProject is unavailable");
+                    helperComponent = InstallInspectHelper(runtimeVBProject);
+                    formsPayload = InvokeInspectHelper(runtimeExcel, runtimeWorkbook, args.FormName, "designer", "");
+                }
+                else
+                {
+                    formsPayload = ReadDesignerFormSnapshot(vbProject, args.FormName);
+                }
+            }
+
+            var warnings = new List<Dictionary<string, string>>();
+            if (basis is "runtime" or "both")
+            {
+                warnings.Add(new Dictionary<string, string>
+                {
+                    ["code"] = "runtime_form_loads_initialize",
+                    ["message"] = "Runtime inspection loads the form and executes UserForm_Initialize.",
+                });
+                warnings.Add(new Dictionary<string, string>
+                {
+                    ["code"] = "runtime_form_temp_copy",
+                    ["message"] = "Runtime inspection executed against a temporary workbook copy so the source workbook and live session are not mutated.",
+                });
+                if (!string.IsNullOrWhiteSpace(args.Initializer))
+                {
+                    warnings.Add(new Dictionary<string, string>
+                    {
+                        ["code"] = "runtime_form_initializer_invoked",
+                        ["message"] = $"Runtime inspection also invoked {args.Initializer}(ThisWorkbook).",
+                    });
+                }
+            }
+            if (needsSave)
+            {
+                warnings.Add(new Dictionary<string, string>
+                {
+                    ["code"] = "save_required",
+                    ["message"] = "The live workbook is newer than disk. Run `xlflow save --session` to persist workbook changes.",
+                });
+            }
+
+            var target = new Dictionary<string, object?>
+            {
+                ["kind"] = targetKind,
+                ["path"] = workbookPath,
+            };
+            if (basis is "runtime" or "both")
+            {
+                target["note"] = "Runtime inspection used a temporary workbook copy.";
+            }
+            else if (args.StrictDesigner)
+            {
+                target["note"] = "Strict designer inspection used a temporary workbook copy plus helper module to recover concrete control types.";
+            }
+
+            var extensions = new Dictionary<string, object?>
+            {
+                ["target"] = target,
+                ["session"] = new Dictionary<string, object?>
+                {
+                    ["active"] = sessionAttached,
+                    ["workbook_path"] = workbookPath,
+                    ["dirty"] = dirty,
+                    ["save_required"] = needsSave,
+                    ["live_newer_than_disk"] = needsSave,
+                    ["mode"] = sessionMode,
+                    ["source_of_truth"] = needsSave ? "live_workbook" : "saved_workbook",
+                },
+                ["workbook"] = new Dictionary<string, object?>
+                {
+                    ["path"] = workbookPath,
+                    ["session"] = sessionAttached,
+                    ["session_mode"] = sessionMode,
+                    ["session_requested"] = sessionAttached && args.UseSession,
+                    ["auto_session"] = sessionAttached && !args.UseSession,
+                    ["saved"] = false,
+                    ["dirty"] = dirty,
+                    ["needs_save"] = needsSave,
+                },
+                ["forms"] = formsPayload,
+            };
+            if (warnings.Count > 0)
+            {
+                extensions["warnings"] = warnings;
+            }
+
+            return new BridgeResponse
+            {
+                RequestId = request.RequestId,
+                Command = request.Command,
+                Logs = [sessionAttached ? $"attached to xlflow session ({sessionMode})" : $"inspected {basis} UserForm {args.FormName}"],
+                Extensions = extensions,
+            };
+        }
+        catch (JsonException ex)
+        {
+            return Failure(request, "inspect_form_failed", ex.Message, "xlflow-excel-bridge");
+        }
+        catch (InvalidOperationException ex)
+        {
+            var code = ClassifyInspectErrorCode(ex.Message);
+            return Failure(request, code, ex.Message, "xlflow-excel-bridge");
+        }
+        catch (Exception ex)
+        {
+            return Failure(request, "inspect_form_failed", ExcelBridgeSupport.FormatExceptionDetail(ex), "xlflow-excel-bridge");
+        }
+        finally
+        {
+            RemoveTemporaryComponent(runtimeVBProject, helperComponent);
+            CloseWorkbook(runtimeWorkbook, runtimeExcel);
+            if (!string.IsNullOrWhiteSpace(runtimeWorkbookPath) && File.Exists(runtimeWorkbookPath))
+            {
+                try
+                {
+                    File.Delete(runtimeWorkbookPath);
+                }
+                catch
+                {
+                    // best-effort cleanup
+                }
+            }
+
+            ExcelBridgeSupport.ReleaseComObject(runtimeVBProject);
+            ExcelBridgeSupport.ReleaseComObject(vbProject);
+            if (sessionAttached)
+            {
+                ExcelBridgeSupport.ReleaseComObject(workbook);
+                ExcelBridgeSupport.ReleaseComObject(excel);
+            }
+            else
+            {
+                CloseWorkbook(workbook, excel);
+            }
+        }
+    }
+
+    private static string? NormalizeBasis(string basis)
+    {
+        var normalized = (basis ?? "").Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "runtime" => "runtime",
+            "designer" => "designer",
+            "both" => "both",
+            _ => null,
+        };
+    }
+
+    private static BridgeResponse Failure(BridgeRequest request, string code, string message, string source)
+    {
+        return BridgeResponse.Failed(request, new BridgeError(
+            Code: code,
+            Message: message,
+            Phase: "inspect-form",
+            Source: source));
+    }
+
+    private static string ClassifyInspectErrorCode(string message)
+    {
+        if (message.Contains("runtime_load", StringComparison.OrdinalIgnoreCase))
+        {
+            return "runtime_form_load_failed";
+        }
+        if (message.Contains("initializer", StringComparison.OrdinalIgnoreCase))
+        {
+            return "form_initializer_failed";
+        }
+        if (message.Contains("enumerate", StringComparison.OrdinalIgnoreCase))
+        {
+            return "control_enumeration_failed";
+        }
+        if (message.Contains("designer", StringComparison.OrdinalIgnoreCase))
+        {
+            return "designer_access_failed";
+        }
+        if (message.Contains("xlflow session", StringComparison.OrdinalIgnoreCase))
+        {
+            return "session_required";
+        }
+        return "inspect_form_failed";
+    }
+
+    private static (object Excel, object Workbook, bool SessionAttached, string SessionMode) OpenWorkbookForInspect(
+        string workbookPath, string metadataPath, bool useSession, bool visible)
+    {
+        if (useSession)
+        {
+            var attachment = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, true);
+            return (attachment.Excel, attachment.Workbook, true, attachment.SessionMode);
+        }
+
+        if (ExcelBridgeSupport.SessionMetadataMatchesWorkbook(metadataPath, workbookPath))
+        {
+            try
+            {
+                var attachment = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, false);
+                return (attachment.Excel, attachment.Workbook, true, attachment.SessionMode);
+            }
+            catch
+            {
+                // fall through to direct open
+            }
+        }
+
+        var direct = ExcelBridgeSupport.OpenWorkbookDirect(workbookPath, visible);
+        return (direct.Excel, direct.Workbook, false, "none");
+    }
+
+    private static (object Excel, object Workbook, string Path) OpenRuntimeWorkbookCopy(object sourceWorkbook, bool visible)
+    {
+        var sourceFullName = ExcelBridgeSupport.TryGetWorkbookFullName(sourceWorkbook) ?? "";
+        var extension = Path.GetExtension(sourceFullName);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            extension = ".xlsm";
+        }
+
+        var tempPath = Path.Combine(Path.GetTempPath(), $"xlflow-inspect-form-{Guid.NewGuid():N}{extension}");
+        ExcelBridgeSupport.InvokeViaDynamic(sourceWorkbook, "SaveCopyAs", tempPath);
+        var direct = ExcelBridgeSupport.OpenWorkbookDirect(tempPath, visible);
+        return (direct.Excel, direct.Workbook, tempPath);
+    }
+
+    private static bool HasUserForm(object vbProject, string formName)
+    {
+        object? components = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(components!, "Count"));
+            for (var index = 1; index <= count; index++)
+            {
+                object? component = null;
+                try
+                {
+                    component = ExcelBridgeSupport.Get(components!, "Item", index);
+                    var type = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(component!, "Type"));
+                    var name = ExcelBridgeSupport.GetString(component!, "Name") ?? "";
+                    if (type == 3 && string.Equals(name, formName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(component);
+                }
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+
+        return false;
+    }
+
+    private static Dictionary<string, object?> ReadDesignerFormSnapshot(object vbProject, string formName)
+    {
+        object? components = null;
+        object? component = null;
+        object? designer = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            component = ExcelBridgeSupport.Get(components!, "Item", formName)
+                ?? throw new InvalidOperationException($"XlflowInspectFormJson.designer: UserForm '{formName}' was not found.");
+            designer = ExcelBridgeSupport.Get(component!, "Designer")
+                ?? throw new InvalidOperationException($"XlflowInspectFormJson.designer: failed to access Designer for '{formName}'.");
+
+            var rootControls = GetChildControls(designer, formName);
+            return new Dictionary<string, object?>
+            {
+                ["name"] = formName,
+                ["basis"] = "designer",
+                ["caption"] = ExcelBridgeSupport.GetString(designer, "Caption") ?? "",
+                ["width"] = TryGetDouble(designer, "Width"),
+                ["height"] = TryGetDouble(designer, "Height"),
+                ["coordinate_system"] = "parent-relative",
+                ["controls"] = rootControls,
+            };
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(designer);
+            ExcelBridgeSupport.ReleaseComObject(component);
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static object InstallInspectHelper(object runtimeVBProject)
+    {
+        object? components = null;
+        object? component = null;
+        object? codeModule = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(runtimeVBProject, "VBComponents")
+                ?? throw new InvalidOperationException("VBComponents is unavailable.");
+            component = ExcelBridgeSupport.InvokeMethod(components, "Add", 1)
+                ?? throw new InvalidOperationException("could not add inspect helper module.");
+            SetProperty(component, "Name", "XlflowForm_" + Guid.NewGuid().ToString("N")[..20]);
+            codeModule = ExcelBridgeSupport.Get(component, "CodeModule")
+                ?? throw new InvalidOperationException("inspect helper CodeModule is unavailable.");
+            ExcelBridgeSupport.InvokeMethod(codeModule, "AddFromString", BuildInspectHelperCode());
+            return component;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(codeModule);
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static object InvokeInspectHelper(object runtimeExcel, object runtimeWorkbook, string formName, string basis, string initializer)
+    {
+        var workbookName = (ExcelBridgeSupport.TryGetWorkbookName(runtimeWorkbook) ?? "").Replace("'", "''", StringComparison.Ordinal);
+        var macroName = $"'{workbookName}'!XlflowInspectFormJson";
+        try
+        {
+            var json = Convert.ToString(ExcelBridgeSupport.RunExcelMacro(runtimeExcel, macroName, formName, basis, initializer), CultureInfo.InvariantCulture);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                throw new InvalidOperationException("inspect form helper returned no JSON");
+            }
+
+            using var document = JsonDocument.Parse(json);
+            return JsonSerializer.Deserialize<object>(document.RootElement.GetRawText()) ?? new Dictionary<string, object?>();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(ExcelBridgeSupport.FormatExceptionDetail(ex), ex);
+        }
+    }
+
+    private static List<Dictionary<string, object?>> GetChildControls(object parent, string expectedParentName)
+    {
+        var controls = new List<Dictionary<string, object?>>();
+        object? children = null;
+        try
+        {
+            children = ExcelBridgeSupport.Get(parent, "Controls");
+            if (children is null)
+            {
+                return controls;
+            }
+
+            var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(children, "Count"));
+            for (var index = 0; index < count; index++)
+            {
+                object? control = null;
+                try
+                {
+                    control = ExcelBridgeSupport.Get(children, "Item", index);
+                    if (control is null || !HasExpectedParent(control, expectedParentName))
+                    {
+                        continue;
+                    }
+                    controls.Add(SerializeControl(control));
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(control);
+                }
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(children);
+        }
+
+        return controls;
+    }
+
+    private static Dictionary<string, object?> SerializeControl(object control)
+    {
+        var result = new Dictionary<string, object?>
+        {
+            ["name"] = ExcelBridgeSupport.GetString(control, "Name") ?? "",
+            ["type"] = control.GetType().Name,
+        };
+
+        AddStringMember(control, result, "ProgId", "prog_id");
+        AddStringMember(control, result, "Caption", "caption");
+        AddStringMember(control, result, "Text", "text");
+        AddStringMember(control, result, "Value", "value");
+        AddDoubleMember(control, result, "Left", "left");
+        AddDoubleMember(control, result, "Top", "top");
+        AddDoubleMember(control, result, "Width", "width");
+        AddDoubleMember(control, result, "Height", "height");
+        AddIntMember(control, result, "TabIndex", "tab_index");
+        AddBoolMember(control, result, "Enabled", "enabled");
+        AddBoolMember(control, result, "Visible", "visible");
+        AddIntMember(control, result, "ListIndex", "selected_index");
+
+        var list = TryGetList(control);
+        if (list.Count > 0)
+        {
+            result["list"] = list;
+        }
+
+        if (ControlCanContainChildren(Convert.ToString(result["type"], CultureInfo.InvariantCulture) ?? ""))
+        {
+            var name = Convert.ToString(result["name"], CultureInfo.InvariantCulture) ?? "";
+            var children = GetChildControls(control, name);
+            if (children.Count > 0)
+            {
+                result["controls"] = children;
+            }
+        }
+
+        return result;
+    }
+
+    private static bool HasExpectedParent(object control, string expectedParentName)
+    {
+        object? parent = null;
+        try
+        {
+            parent = ExcelBridgeSupport.Get(control, "Parent");
+            var parentName = ExcelBridgeSupport.GetString(parent!, "Name") ?? "";
+            return string.Equals(parentName.Trim(), expectedParentName.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(parent);
+        }
+    }
+
+    private static bool ControlCanContainChildren(string controlType)
+    {
+        return controlType.Trim().ToLowerInvariant() is "frame" or "multipage" or "page" or "tabstrip";
+    }
+
+    private static List<string> TryGetList(object control)
+    {
+        var items = new List<string>();
+        int listCount;
+        try
+        {
+            listCount = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(control, "ListCount"));
+        }
+        catch
+        {
+            return items;
+        }
+
+        for (var index = 0; index < listCount; index++)
+        {
+            try
+            {
+                var item = ExcelBridgeSupport.Get(control, "List", index);
+                items.Add(item?.ToString() ?? "");
+            }
+            catch
+            {
+                break;
+            }
+        }
+
+        return items;
+    }
+
+    private static void AddStringMember(object source, Dictionary<string, object?> target, string memberName, string jsonKey)
+    {
+        try
+        {
+            var value = ExcelBridgeSupport.Get(source, memberName);
+            if (value is null)
+            {
+                return;
+            }
+            target[jsonKey] = Convert.ToString(value, CultureInfo.InvariantCulture) ?? "";
+        }
+        catch
+        {
+            // best-effort read
+        }
+    }
+
+    private static void AddDoubleMember(object source, Dictionary<string, object?> target, string memberName, string jsonKey)
+    {
+        var value = TryGetDouble(source, memberName);
+        if (value is not null)
+        {
+            target[jsonKey] = value.Value;
+        }
+    }
+
+    private static void AddIntMember(object source, Dictionary<string, object?> target, string memberName, string jsonKey)
+    {
+        try
+        {
+            var raw = ExcelBridgeSupport.Get(source, memberName);
+            if (raw is null)
+            {
+                return;
+            }
+            target[jsonKey] = Convert.ToInt32(raw, CultureInfo.InvariantCulture);
+        }
+        catch
+        {
+            // best-effort read
+        }
+    }
+
+    private static void AddBoolMember(object source, Dictionary<string, object?> target, string memberName, string jsonKey)
+    {
+        try
+        {
+            var raw = ExcelBridgeSupport.Get(source, memberName);
+            if (raw is null)
+            {
+                return;
+            }
+            target[jsonKey] = Convert.ToBoolean(raw, CultureInfo.InvariantCulture);
+        }
+        catch
+        {
+            // best-effort read
+        }
+    }
+
+    private static double? TryGetDouble(object source, string memberName)
+    {
+        try
+        {
+            var raw = ExcelBridgeSupport.Get(source, memberName);
+            if (raw is null)
+            {
+                return null;
+            }
+            return Convert.ToDouble(raw, CultureInfo.InvariantCulture);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void SetProperty(object comObject, string name, object value)
+    {
+        comObject.GetType().InvokeMember(
+            name,
+            System.Reflection.BindingFlags.SetProperty,
+            null,
+            comObject,
+            [value],
+            CultureInfo.InvariantCulture);
+    }
+
+    private static void RemoveTemporaryComponent(object? vbProject, object? component)
+    {
+        object? components = null;
+        try
+        {
+            if (vbProject is null || component is null)
+            {
+                return;
+            }
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            if (components is not null)
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(components, "Remove", component);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(component);
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static void CloseWorkbook(object? workbook, object? excel)
+    {
+        if (workbook is not null)
+        {
+            try
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(workbook, "Close", false);
+            }
+            catch
+            {
+                // best-effort close
+            }
+            ExcelBridgeSupport.ReleaseComObject(workbook);
+        }
+
+        if (excel is not null)
+        {
+            try
+            {
+                dynamic app = excel;
+                app.Quit();
+            }
+            catch
+            {
+                // best-effort quit
+            }
+            ExcelBridgeSupport.ReleaseComObject(excel);
+        }
+    }
+
+    private static string BuildInspectHelperCode()
+    {
+        return """""
+Option Explicit
+
+Private Const xlflowBasisDesigner As String = "designer"
+Private Const xlflowBasisRuntime As String = "runtime"
+Private Const xlflowCoordinateSystem As String = "parent-relative"
+
+Public Function XlflowInspectFormJson(ByVal formName As String, ByVal basis As String, Optional ByVal initializer As String = "") As String
+  Dim normalizedBasis As String
+  normalizedBasis = LCase$(Trim$(basis))
+
+  Select Case normalizedBasis
+    Case xlflowBasisDesigner
+      XlflowInspectFormJson = InspectDesignerFormJson(formName)
+    Case xlflowBasisRuntime
+      XlflowInspectFormJson = InspectRuntimeFormJson(formName, initializer)
+    Case Else
+      Err.Raise vbObjectError + 7300, "XlflowInspectFormJson.args", "Unsupported inspect basis: " & basis
+  End Select
+End Function
+
+Private Function InspectDesignerFormJson(ByVal formName As String) As String
+  On Error GoTo ErrHandler
+
+  Dim component As Object
+  Dim designer As Object
+
+  Set component = ThisWorkbook.VBProject.VBComponents.Item(formName)
+  Set designer = component.Designer
+  InspectDesignerFormJson = SerializeFormSnapshot(formName, xlflowBasisDesigner, designer)
+  Exit Function
+
+ErrHandler:
+  Err.Raise Err.Number, "XlflowInspectFormJson.designer", Err.Description
+End Function
+
+Private Function InspectRuntimeFormJson(ByVal formName As String, ByVal initializer As String) As String
+  Dim formInstance As Object
+  Dim loaded As Boolean
+  Dim initializerRan As Boolean
+  Dim errorNumber As Long
+  Dim errorDescription As String
+  Dim errorSource As String
+
+  On Error GoTo ErrHandler
+
+  Set formInstance = UserForms.Add(formName)
+  loaded = True
+
+  If Len(Trim$(initializer)) > 0 Then
+    CallByName formInstance, Trim$(initializer), VbMethod, ThisWorkbook
+    initializerRan = True
+  End If
+
+  InspectRuntimeFormJson = SerializeFormSnapshot(formName, xlflowBasisRuntime, formInstance)
+
+Cleanup:
+  On Error Resume Next
+  If loaded Then
+    Unload formInstance
+  End If
+  Set formInstance = Nothing
+  On Error GoTo 0
+
+  If errorNumber <> 0 Then
+    Err.Raise errorNumber, errorSource, errorDescription
+  End If
+  Exit Function
+
+ErrHandler:
+  errorNumber = Err.Number
+  errorDescription = Err.Description
+  If Not loaded Then
+    errorSource = "XlflowInspectFormJson.runtime_load"
+  ElseIf Len(Trim$(initializer)) > 0 And Not initializerRan Then
+    errorSource = "XlflowInspectFormJson.initializer"
+  Else
+    errorSource = "XlflowInspectFormJson.enumerate"
+  End If
+  Resume Cleanup
+End Function
+
+Private Function SerializeFormSnapshot(ByVal formName As String, ByVal basis As String, ByVal formObject As Object) As String
+  Dim json As String
+  Dim hasFields As Boolean
+  Dim controls As Object
+
+  json = "{"
+
+  JsonAddString json, "name", formName, hasFields
+  JsonAddString json, "basis", basis, hasFields
+  JsonAddStringFromMember json, formObject, "Caption", "caption", hasFields
+  JsonAddNumberFromMember json, formObject, "Width", "width", hasFields
+  JsonAddNumberFromMember json, formObject, "Height", "height", hasFields
+  JsonAddString json, "coordinate_system", xlflowCoordinateSystem, hasFields
+
+  Set controls = GetObjectControls(formObject)
+  JsonAddRaw json, "controls", SerializeControls(controls, formName), hasFields
+
+  json = json & "}"
+  SerializeFormSnapshot = json
+End Function
+
+Private Function SerializeControls(ByVal controls As Object, ByVal expectedParentName As String) As String
+  Dim json As String
+  Dim first As Boolean
+  Dim control As Object
+
+  json = "["
+  first = True
+
+  If Not controls Is Nothing Then
+    For Each control In controls
+      If Not ControlHasExpectedParent(control, expectedParentName) Then
+        GoTo ContinueLoop
+      End If
+      If Not first Then
+        json = json & ","
+      End If
+      json = json & SerializeControl(control)
+      first = False
+ContinueLoop:
+    Next control
+  End If
+
+  json = json & "]"
+  SerializeControls = json
+End Function
+
+Private Function SerializeControl(ByVal control As Object) As String
+  Dim json As String
+  Dim hasFields As Boolean
+  Dim children As Object
+  Dim listCount As Long
+  Dim selectedIndex As Long
+  Dim typeNameValue As String
+
+  json = "{"
+
+  JsonAddStringFromMember json, control, "Name", "name", hasFields
+  typeNameValue = TypeName(control)
+  JsonAddString json, "type", typeNameValue, hasFields
+  JsonAddStringFromMember json, control, "ProgId", "prog_id", hasFields
+  JsonAddStringFromMember json, control, "Caption", "caption", hasFields
+  JsonAddStringFromMember json, control, "Text", "text", hasFields
+  JsonAddStringFromMember json, control, "Value", "value", hasFields
+  JsonAddNumberFromMember json, control, "Left", "left", hasFields
+  JsonAddNumberFromMember json, control, "Top", "top", hasFields
+  JsonAddNumberFromMember json, control, "Width", "width", hasFields
+  JsonAddNumberFromMember json, control, "Height", "height", hasFields
+  JsonAddLongFromMember json, control, "TabIndex", "tab_index", hasFields
+  JsonAddBoolFromMember json, control, "Enabled", "enabled", hasFields
+  JsonAddBoolFromMember json, control, "Visible", "visible", hasFields
+
+  If TryGetLongMember(control, "ListIndex", selectedIndex) Then
+    JsonAddLong json, "selected_index", selectedIndex, hasFields
+  End If
+  If TryGetLongMember(control, "ListCount", listCount) Then
+    JsonAddRaw json, "list", SerializeControlList(control, listCount), hasFields
+  End If
+
+  If ControlCanContainChildren(typeNameValue) Then
+    Set children = GetObjectControls(control)
+  End If
+  If Not children Is Nothing Then
+    JsonAddRaw json, "controls", SerializeControls(children, SafeControlName(control)), hasFields
+  End If
+
+  json = json & "}"
+  SerializeControl = json
+End Function
+
+Private Function ControlHasExpectedParent(ByVal control As Object, ByVal expectedParentName As String) As Boolean
+  On Error GoTo Missing
+
+  Dim parentObject As Object
+  Dim parentName As String
+  Set parentObject = CallByName(control, "Parent", VbGet)
+  If parentObject Is Nothing Then
+    GoTo Missing
+  End If
+
+  parentName = CallByName(parentObject, "Name", VbGet)
+  ControlHasExpectedParent = (StrComp(Trim$(parentName), Trim$(expectedParentName), vbTextCompare) = 0)
+  Exit Function
+
+Missing:
+  ControlHasExpectedParent = False
+End Function
+
+Private Function SafeControlName(ByVal control As Object) As String
+  On Error GoTo Missing
+
+  SafeControlName = CStr(CallByName(control, "Name", VbGet))
+  Exit Function
+
+Missing:
+  SafeControlName = vbNullString
+End Function
+
+Private Function ControlCanContainChildren(ByVal controlType As String) As Boolean
+  Select Case LCase$(Trim$(controlType))
+    Case "frame", "multipage", "page", "tabstrip"
+      ControlCanContainChildren = True
+    Case Else
+      ControlCanContainChildren = False
+  End Select
+End Function
+
+Private Function SerializeControlList(ByVal control As Object, ByVal listCount As Long) As String
+  Dim json As String
+  Dim i As Long
+  Dim first As Boolean
+  Dim itemValue As String
+
+  json = "["
+  first = True
+
+  If listCount > 0 Then
+    For i = 0 To listCount - 1
+      If TryGetListItem(control, i, itemValue) Then
+        If Not first Then
+          json = json & ","
+        End If
+        json = json & JsonQuote(itemValue)
+        first = False
+      End If
+    Next i
+  End If
+
+  json = json & "]"
+  SerializeControlList = json
+End Function
+
+Private Function TryGetListItem(ByVal control As Object, ByVal index As Long, ByRef valueOut As String) As Boolean
+  On Error GoTo Missing
+
+  Dim itemValue As Variant
+  itemValue = control.List(index)
+  If IsNull(itemValue) Or IsEmpty(itemValue) Then
+    valueOut = vbNullString
+  Else
+    valueOut = CStr(itemValue)
+  End If
+  TryGetListItem = True
+  Exit Function
+
+Missing:
+  valueOut = vbNullString
+  TryGetListItem = False
+End Function
+
+Private Function GetObjectControls(ByVal target As Object) As Object
+  On Error Resume Next
+  Set GetObjectControls = target.Controls
+  On Error GoTo 0
+End Function
+
+Private Sub JsonAddStringFromMember(ByRef json As String, ByVal target As Object, ByVal memberName As String, ByVal jsonKey As String, ByRef hasFields As Boolean)
+  Dim value As String
+  If TryGetStringMember(target, memberName, value) Then
+    JsonAddString json, jsonKey, value, hasFields
+  End If
+End Sub
+
+Private Sub JsonAddNumberFromMember(ByRef json As String, ByVal target As Object, ByVal memberName As String, ByVal jsonKey As String, ByRef hasFields As Boolean)
+  Dim value As Double
+  If TryGetNumberMember(target, memberName, value) Then
+    JsonAddNumber json, jsonKey, value, hasFields
+  End If
+End Sub
+
+Private Sub JsonAddLongFromMember(ByRef json As String, ByVal target As Object, ByVal memberName As String, ByVal jsonKey As String, ByRef hasFields As Boolean)
+  Dim value As Long
+  If TryGetLongMember(target, memberName, value) Then
+    JsonAddLong json, jsonKey, value, hasFields
+  End If
+End Sub
+
+Private Sub JsonAddBoolFromMember(ByRef json As String, ByVal target As Object, ByVal memberName As String, ByVal jsonKey As String, ByRef hasFields As Boolean)
+  Dim value As Boolean
+  If TryGetBoolMember(target, memberName, value) Then
+    JsonAddBool json, jsonKey, value, hasFields
+  End If
+End Sub
+
+Private Function TryGetStringMember(ByVal target As Object, ByVal memberName As String, ByRef valueOut As String) As Boolean
+  On Error GoTo Missing
+
+  Dim rawValue As Variant
+  rawValue = CallByName(target, memberName, VbGet)
+  If IsObject(rawValue) Or IsNull(rawValue) Or IsEmpty(rawValue) Then
+    GoTo Missing
+  End If
+
+  valueOut = CStr(rawValue)
+  TryGetStringMember = True
+  Exit Function
+
+Missing:
+  valueOut = vbNullString
+  TryGetStringMember = False
+End Function
+
+Private Function TryGetNumberMember(ByVal target As Object, ByVal memberName As String, ByRef valueOut As Double) As Boolean
+  On Error GoTo Missing
+
+  Dim rawValue As Variant
+  rawValue = CallByName(target, memberName, VbGet)
+  If IsObject(rawValue) Or IsNull(rawValue) Or IsEmpty(rawValue) Then
+    GoTo Missing
+  End If
+
+  valueOut = CDbl(rawValue)
+  TryGetNumberMember = True
+  Exit Function
+
+Missing:
+  valueOut = 0
+  TryGetNumberMember = False
+End Function
+
+Private Function TryGetLongMember(ByVal target As Object, ByVal memberName As String, ByRef valueOut As Long) As Boolean
+  On Error GoTo Missing
+
+  Dim rawValue As Variant
+  rawValue = CallByName(target, memberName, VbGet)
+  If IsObject(rawValue) Or IsNull(rawValue) Or IsEmpty(rawValue) Then
+    GoTo Missing
+  End If
+
+  valueOut = CLng(rawValue)
+  TryGetLongMember = True
+  Exit Function
+
+Missing:
+  valueOut = 0
+  TryGetLongMember = False
+End Function
+
+Private Function TryGetBoolMember(ByVal target As Object, ByVal memberName As String, ByRef valueOut As Boolean) As Boolean
+  On Error GoTo Missing
+
+  Dim rawValue As Variant
+  rawValue = CallByName(target, memberName, VbGet)
+  If IsObject(rawValue) Or IsNull(rawValue) Or IsEmpty(rawValue) Then
+    GoTo Missing
+  End If
+
+  valueOut = CBool(rawValue)
+  TryGetBoolMember = True
+  Exit Function
+
+Missing:
+  valueOut = False
+  TryGetBoolMember = False
+End Function
+
+Private Sub JsonAddRaw(ByRef json As String, ByVal key As String, ByVal rawValue As String, ByRef hasFields As Boolean)
+  If hasFields Then
+    json = json & ","
+  End If
+  json = json & JsonQuote(key) & ":" & rawValue
+  hasFields = True
+End Sub
+
+Private Sub JsonAddString(ByRef json As String, ByVal key As String, ByVal value As String, ByRef hasFields As Boolean)
+  If hasFields Then
+    json = json & ","
+  End If
+  json = json & JsonQuote(key) & ":" & JsonQuote(value)
+  hasFields = True
+End Sub
+
+Private Sub JsonAddNumber(ByRef json As String, ByVal key As String, ByVal value As Double, ByRef hasFields As Boolean)
+  If hasFields Then
+    json = json & ","
+  End If
+  json = json & JsonQuote(key) & ":" & Trim$(Str$(value))
+  hasFields = True
+End Sub
+
+Private Sub JsonAddLong(ByRef json As String, ByVal key As String, ByVal value As Long, ByRef hasFields As Boolean)
+  If hasFields Then
+    json = json & ","
+  End If
+  json = json & JsonQuote(key) & ":" & CStr(value)
+  hasFields = True
+End Sub
+
+Private Sub JsonAddBool(ByRef json As String, ByVal key As String, ByVal value As Boolean, ByRef hasFields As Boolean)
+  If hasFields Then
+    json = json & ","
+  End If
+  json = json & JsonQuote(key) & ":" & IIf(value, "true", "false")
+  hasFields = True
+End Sub
+
+Private Function JsonQuote(ByVal value As String) As String
+  JsonQuote = """" & JsonEscape(value) & """"
+End Function
+
+Private Function JsonEscape(ByVal value As String) As String
+  Dim text As String
+  text = value
+  text = Replace(text, "\", "\\")
+  text = Replace(text, """", Chr$(92) & Chr$(34))
+  text = Replace(text, vbCrLf, "\n")
+  text = Replace(text, vbCr, "\n")
+  text = Replace(text, vbLf, "\n")
+  text = Replace(text, vbTab, "\t")
+  JsonEscape = text
+End Function
+""""";
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormWriteService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormWriteService.cs
@@ -1,0 +1,1250 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The .NET bridge only runs on Windows with Excel COM automation.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Bridge services intentionally normalize COM failures into structured bridge responses.")]
+public sealed class ExcelFormWriteService : IFormWriteService
+{
+    private const int ComponentTypeForm = 3;
+
+    private static readonly Dictionary<string, string> TypeProgIdMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["label"] = "Forms.Label.1",
+        ["textbox"] = "Forms.TextBox.1",
+        ["combobox"] = "Forms.ComboBox.1",
+        ["listbox"] = "Forms.ListBox.1",
+        ["commandbutton"] = "Forms.CommandButton.1",
+        ["checkbox"] = "Forms.CheckBox.1",
+        ["optionbutton"] = "Forms.OptionButton.1",
+        ["frame"] = "Forms.Frame.1",
+    };
+
+    public BridgeResponse Execute(BridgeRequest request, FormWriteCommandArguments args, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        object? excel = null;
+        object? workbook = null;
+        var sessionAttached = false;
+        var sessionMode = "none";
+
+        try
+        {
+            var spec = DecodeSpec(args.SpecJson64);
+            var warnings = CollectContractWarnings(spec);
+
+            var openResult = OpenWorkbookForWrite(args.WorkbookPath, args.MetadataPath, args.UseSession, args.Visible);
+            excel = openResult.Excel;
+            workbook = openResult.Workbook;
+            sessionAttached = openResult.SessionAttached;
+            sessionMode = openResult.SessionMode;
+
+            var workbookPath = ExcelBridgeSupport.NormalizePath(args.WorkbookPath);
+            object vbProject;
+            try
+            {
+                vbProject = ExcelBridgeSupport.Get(workbook, "VBProject")
+                    ?? throw new InvalidOperationException("VBProject access is denied.");
+            }
+            catch
+            {
+                return Failed(request, "vbproject_access_denied", "VBProject access is denied. Enable 'Trust access to the VBA project object model' in Excel Trust Center.", "open_workbook", "Excel");
+            }
+
+            object? builtComponent = null;
+            try
+            {
+                builtComponent = args.Action == "build"
+                    ? BuildForm(vbProject, workbook, spec, args)
+                    : ApplyForm(vbProject, spec, args);
+
+                var saved = false;
+                if (sessionAttached)
+                {
+                    if (!args.NoSave)
+                    {
+                        ExcelBridgeSupport.InvokeViaDynamic(workbook, "Save");
+                        saved = true;
+                    }
+                }
+                else
+                {
+                    ExcelBridgeSupport.InvokeViaDynamic(workbook, "Save");
+                    saved = true;
+                }
+
+                var sourceArtifacts = ExportBuiltUserFormArtifacts(builtComponent!, args);
+                var dirtyKnown = ExcelBridgeSupport.TryGetWorkbookDirtyState(workbook, out var dirtyState);
+                var dirty = sessionAttached ? dirtyKnown ? dirtyState : true : false;
+                var needsSave = sessionAttached && !saved ? dirty : false;
+
+                if (needsSave)
+                {
+                    warnings.Add(NewMessage("save_required", $"The live workbook is newer than disk after `form {args.Action}`. Run `xlflow save --session` before relying on disk-backed inspect, pull, or source review."));
+                }
+
+                return new BridgeResponse
+                {
+                    RequestId = request.RequestId,
+                    Command = request.Command,
+                    Logs =
+                    [
+                        sessionAttached ? $"attached to xlflow session ({sessionMode})" : $"opened workbook {workbookPath}",
+                        $"{args.Action} form {spec.Form.Name} from {args.SpecPath}",
+                        $"synchronized UserForm source artifacts for {spec.Form.Name}",
+                    ],
+                    Extensions = BuildResponseExtensions(spec, args, sourceArtifacts, workbookPath, sessionAttached, sessionMode, saved, dirty, needsSave, warnings),
+                };
+            }
+            catch (InvalidOperationException ex)
+            {
+                var (code, message) = ClassifyFormWriteError(args.Action, ex.Message);
+                return Failed(request, code, message, "write_designer", "xlflow-excel-bridge");
+            }
+            finally
+            {
+                ExcelBridgeSupport.ReleaseComObject(builtComponent);
+                ExcelBridgeSupport.ReleaseComObject(vbProject);
+            }
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("xlflow session", StringComparison.OrdinalIgnoreCase))
+        {
+            return Failed(request, "session_required", ex.Message, "open_workbook", "xlflow");
+        }
+        catch (Exception ex)
+        {
+            return Failed(request, args.Action == "apply" ? "form_apply_failed" : "form_build_failed", ExcelBridgeSupport.FormatExceptionDetail(ex), "write_designer", "xlflow-excel-bridge");
+        }
+        finally
+        {
+            if (sessionAttached)
+            {
+                ExcelBridgeSupport.ReleaseComObject(workbook);
+                ExcelBridgeSupport.ReleaseComObject(excel);
+            }
+            else
+            {
+                CloseComInstance(workbook, excel);
+            }
+        }
+    }
+
+    private static Dictionary<string, object?> BuildResponseExtensions(
+        FormWriteSpec spec,
+        FormWriteCommandArguments args,
+        SourceArtifacts sourceArtifacts,
+        string workbookPath,
+        bool sessionAttached,
+        string sessionMode,
+        bool saved,
+        bool dirty,
+        bool needsSave,
+        List<Dictionary<string, string>> warnings)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["target"] = new Dictionary<string, object?>
+            {
+                ["kind"] = sessionAttached ? "live_session" : "file",
+                ["path"] = workbookPath,
+            },
+            ["session"] = new Dictionary<string, object?>
+            {
+                ["active"] = sessionAttached,
+                ["workbook_path"] = workbookPath,
+                ["dirty"] = dirty,
+                ["save_required"] = needsSave,
+                ["live_newer_than_disk"] = needsSave,
+                ["mode"] = sessionMode,
+                ["source_of_truth"] = needsSave ? "live_workbook" : "saved_workbook",
+            },
+            ["workbook"] = new Dictionary<string, object?>
+            {
+                ["path"] = workbookPath,
+                ["session"] = sessionAttached,
+                ["session_mode"] = sessionMode,
+                ["session_requested"] = sessionAttached && args.UseSession,
+                ["auto_session"] = sessionAttached && !args.UseSession,
+                ["saved"] = saved,
+                ["dirty"] = dirty,
+                ["needs_save"] = needsSave,
+            },
+            ["forms"] = new Dictionary<string, object?>
+            {
+                ["name"] = spec.Form.Name,
+                ["basis"] = spec.Basis,
+                ["action"] = args.Action,
+                ["coordinate_system"] = spec.CoordinateSystem ?? "",
+                ["control_count"] = spec.Controls?.Count ?? 0,
+                ["spec_path"] = args.SpecPath,
+                ["overwrite"] = args.Overwrite,
+                ["source_synced"] = true,
+                ["caption"] = spec.Form.Caption ?? "",
+                ["source_artifacts"] = new Dictionary<string, object?>
+                {
+                    ["form_path"] = sourceArtifacts.FormPath,
+                    ["frx_path"] = sourceArtifacts.FrxPath,
+                    ["code_path"] = sourceArtifacts.CodePath ?? "",
+                },
+            },
+            ["warnings"] = warnings,
+            ["hints"] = new List<Dictionary<string, string>>
+            {
+                NewMessage("userform_review_commands", $"Review the result with `xlflow inspect form {spec.Form.Name} --designer --json` or `xlflow form export-image {spec.Form.Name} --out <path>`.")
+            },
+        };
+    }
+
+    private static BridgeResponse Failed(BridgeRequest request, string code, string message, string phase, string source)
+    {
+        return BridgeResponse.Failed(request, new BridgeError(
+            Code: code,
+            Message: message,
+            Phase: phase,
+            Source: source));
+    }
+
+    private static (object Excel, object Workbook, bool SessionAttached, string SessionMode) OpenWorkbookForWrite(string workbookPath, string metadataPath, bool useSession, bool visible)
+    {
+        if (useSession)
+        {
+            var attachment = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, true);
+            return (attachment.Excel, attachment.Workbook, true, attachment.SessionMode);
+        }
+
+        if (ExcelBridgeSupport.SessionMetadataMatchesWorkbook(metadataPath, workbookPath))
+        {
+            try
+            {
+                var attachment = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, false);
+                return (attachment.Excel, attachment.Workbook, true, attachment.SessionMode);
+            }
+            catch
+            {
+                // fall through
+            }
+        }
+
+        var direct = ExcelBridgeSupport.OpenWorkbookDirect(workbookPath, visible);
+        return (direct.Excel, direct.Workbook, false, "none");
+    }
+
+    private static FormWriteSpec DecodeSpec(string encoded)
+    {
+        try
+        {
+            var bytes = Convert.FromBase64String(encoded);
+            var json = Encoding.UTF8.GetString(bytes);
+            var spec = JsonSerializer.Deserialize<FormWriteSpec>(json);
+            if (spec is null)
+            {
+                throw new InvalidOperationException("decoded form spec was empty");
+            }
+            return spec;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("invalid form spec payload: " + ex.Message, ex);
+        }
+    }
+
+    private static List<Dictionary<string, string>> CollectContractWarnings(FormWriteSpec spec)
+    {
+        var warnings = new List<Dictionary<string, string>>();
+        var hasFormSizeExpectation =
+            spec.Form.Width is not null ||
+            spec.Form.Height is not null ||
+            spec.Form.Build?.Width is not null ||
+            spec.Form.Build?.Height is not null ||
+            spec.Form.Observed?.Width is not null ||
+            spec.Form.Observed?.Height is not null;
+        if (hasFormSizeExpectation)
+        {
+            warnings.Add(NewMessage("best_effort_form_size", "Form-level width/height are best-effort in Designer build and may not round-trip through Excel VBIDE Designer APIs. Field scope: form.observed.width, form.observed.height, form.build.width, form.build.height.", "form.observed.width"));
+        }
+
+        var listStateControls = spec.Controls
+            .Where(control => control.Type is not null &&
+                (control.Type.Equals("combobox", StringComparison.OrdinalIgnoreCase) || control.Type.Equals("listbox", StringComparison.OrdinalIgnoreCase)) &&
+                ((control.List?.Count ?? 0) > 0 || control.SelectedIndex is not null || (control.Observed?.List?.Count ?? 0) > 0 || control.Observed?.SelectedIndex is not null))
+            .Select(control => control.Name)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (listStateControls.Length > 0)
+        {
+            warnings.Add(NewMessage("best_effort_list_state", "Design-time ComboBox/ListBox list and selectedIndex are best-effort during build and should be treated as observed-only for round-trip expectations. Field scope includes controls[*].list and controls[*].selectedIndex. Controls: " + string.Join(", ", listStateControls) + ".", "controls[*].selectedIndex"));
+        }
+        return warnings;
+    }
+
+    private static object BuildForm(object vbProject, object workbook, FormWriteSpec spec, FormWriteCommandArguments args)
+    {
+        object? existing = null;
+        object? component = null;
+        string? existingCodeText = null;
+        string? restoreDir = null;
+        string? restorePath = null;
+        var removedExisting = false;
+
+        try
+        {
+            existing = GetComponentByName(vbProject, spec.Form.Name);
+            if (existing is not null)
+            {
+                if (ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(existing, "Type")) != ComponentTypeForm)
+                {
+                    throw new InvalidOperationException($"form_already_exists: component '{spec.Form.Name}' exists but is not a UserForm.");
+                }
+                if (!args.Overwrite)
+                {
+                    throw new InvalidOperationException($"form_already_exists: UserForm '{spec.Form.Name}' already exists.");
+                }
+
+                restoreDir = NewRestoreDirectory();
+                existingCodeText = ReadCodeModuleText(existing);
+                restorePath = ExportComponentBackup(existing, restoreDir);
+                RemoveComponentByName(vbProject, spec.Form.Name);
+                removedExisting = true;
+                if (args.NoSave)
+                {
+                    throw new InvalidOperationException("designer_write_failed: overwrite requires an intermediate workbook save, but save is disabled for this command.");
+                }
+                ExcelBridgeSupport.InvokeViaDynamic(workbook, "Save");
+            }
+
+            component = NewUserFormComponent(vbProject, spec.Form.Name);
+            PopulateFormComponent(component, spec);
+            if (VbaSourceHelper.IsSidecarMode(args.CodeSource))
+            {
+                SyncUserFormCodeBehind(component, args.FormsDir, existingCodeText);
+            }
+            else if (!string.IsNullOrWhiteSpace(existingCodeText))
+            {
+                WriteCodeModuleText(component, existingCodeText);
+            }
+            return component;
+        }
+        catch
+        {
+            if (removedExisting)
+            {
+                try { RemoveComponentInstance(vbProject, component); } catch { }
+                if (!string.IsNullOrWhiteSpace(restorePath))
+                {
+                    ImportComponentBackup(vbProject, restorePath, spec.Form.Name);
+                    ExcelBridgeSupport.InvokeViaDynamic(workbook, "Save");
+                }
+            }
+            throw;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(existing);
+            if (!string.IsNullOrWhiteSpace(restoreDir) && Directory.Exists(restoreDir))
+            {
+                try { Directory.Delete(restoreDir, true); } catch { }
+            }
+        }
+    }
+
+    private static object ApplyForm(object vbProject, FormWriteSpec spec, FormWriteCommandArguments args)
+    {
+        var component = GetComponentByName(vbProject, spec.Form.Name);
+        if (component is null || ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(component, "Type")) != ComponentTypeForm)
+        {
+            ExcelBridgeSupport.ReleaseComObject(component);
+            throw new InvalidOperationException($"form_not_found: UserForm '{spec.Form.Name}' was not found in the workbook.");
+        }
+
+        try
+        {
+            object? designer = null;
+            try
+            {
+                designer = ExcelBridgeSupport.Get(component, "Designer");
+                if (designer is null)
+                {
+                    throw new InvalidOperationException($"designer_write_failed: failed to access Designer for '{spec.Form.Name}'.");
+                }
+                ClearDesignerControls(designer);
+            }
+            finally
+            {
+                ExcelBridgeSupport.ReleaseComObject(designer);
+            }
+            PopulateFormComponent(component, spec);
+            if (VbaSourceHelper.IsSidecarMode(args.CodeSource))
+            {
+                SyncUserFormCodeBehind(component, args.FormsDir, null);
+            }
+            return component;
+        }
+        catch
+        {
+            ExcelBridgeSupport.ReleaseComObject(component);
+            throw;
+        }
+    }
+
+    private static void PopulateFormComponent(object component, FormWriteSpec spec)
+    {
+        object? designer = null;
+        try
+        {
+            designer = ExcelBridgeSupport.Get(component, "Designer");
+            if (designer is null)
+            {
+                throw new InvalidOperationException($"designer_write_failed: failed to access Designer for '{spec.Form.Name}'.");
+            }
+            SetDesignerFormProperties(designer, component, spec.Form);
+            foreach (var root in GetRootControls(spec))
+            {
+                AddDesignerControl(designer, root, spec.Controls);
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(designer);
+        }
+    }
+
+    private static List<FormWriteControlSpec> GetRootControls(FormWriteSpec spec)
+    {
+        var roots = spec.Controls.Where(control => string.IsNullOrWhiteSpace(control.ParentId)).ToList();
+        if (roots.Count == 0)
+        {
+            roots = spec.Controls.ToList();
+        }
+        roots.Sort((left, right) => (left.ZIndex ?? int.MaxValue).CompareTo(right.ZIndex ?? int.MaxValue));
+        return roots;
+    }
+
+    private static FormWriteControlSpec[] GetChildControls(IEnumerable<FormWriteControlSpec> allControls, FormWriteControlSpec parent)
+    {
+        var id = string.IsNullOrWhiteSpace(parent.Id) ? parent.Name : parent.Id;
+        var explicitChildren = allControls
+            .Where(control => !string.IsNullOrWhiteSpace(control.ParentId) && string.Equals(control.ParentId, id, StringComparison.Ordinal))
+            .OrderBy(control => control.ZIndex ?? int.MaxValue)
+            .ToArray();
+        return explicitChildren.Length > 0
+            ? explicitChildren
+            : (parent.Controls ?? []).OrderBy(control => control.ZIndex ?? int.MaxValue).ToArray();
+    }
+
+    private static void AddDesignerControl(object parent, FormWriteControlSpec controlSpec, IReadOnlyList<FormWriteControlSpec> allControls)
+    {
+        object? controls = null;
+        object? control = null;
+        try
+        {
+            controls = ExcelBridgeSupport.Get(parent, "Controls");
+            if (controls is null)
+            {
+                throw new InvalidOperationException("designer_write_failed: failed to access Controls collection.");
+            }
+            control = ExcelBridgeSupport.InvokeMethod(controls, "Add", ResolveProgId(controlSpec), controlSpec.Name, true)
+                ?? throw new InvalidOperationException($"designer_write_failed: failed to add control '{controlSpec.Name}'.");
+            SetDesignerControlProperties(control, controlSpec);
+            foreach (var child in GetChildControls(allControls, controlSpec))
+            {
+                AddDesignerControl(control, child, allControls);
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(control);
+            ExcelBridgeSupport.ReleaseComObject(controls);
+        }
+    }
+
+    private static void ClearDesignerControls(object designer)
+    {
+        object? controls = null;
+        try
+        {
+            controls = ExcelBridgeSupport.Get(designer, "Controls");
+            if (controls is null)
+            {
+                return;
+            }
+            while (ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(controls, "Count")) > 0)
+            {
+                var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(controls, "Count"));
+                object? control = null;
+                try
+                {
+                    control = ExcelBridgeSupport.Get(controls, "Item", count - 1);
+                    var name = ExcelBridgeSupport.GetString(control!, "Name") ?? "";
+                    ExcelBridgeSupport.InvokeMethod(controls, "Remove", name);
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(control);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("designer_write_failed: failed to clear existing controls. " + ex.Message, ex);
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(controls);
+        }
+    }
+
+    private static void SetDesignerFormProperties(object designer, object component, FormWriteFormSpec form)
+    {
+        var caption = form.Build?.Caption ?? form.Caption ?? form.Observed?.Caption;
+        if (!string.IsNullOrWhiteSpace(caption))
+        {
+            TrySetProperty(designer, "Caption", caption);
+        }
+        var width = form.Build?.Width ?? form.Width ?? form.Observed?.Width;
+        if (width is not null)
+        {
+            if (!SetVBComponentProperty(component, "Width", width.Value))
+            {
+                TrySetProperty(designer, "Width", width.Value);
+            }
+        }
+        var height = form.Build?.Height ?? form.Height ?? form.Observed?.Height;
+        if (height is not null)
+        {
+            if (!SetVBComponentProperty(component, "Height", height.Value))
+            {
+                TrySetProperty(designer, "Height", height.Value);
+            }
+        }
+    }
+
+    private static void SetDesignerControlProperties(object control, FormWriteControlSpec spec)
+    {
+        var caption = spec.Caption ?? spec.Observed?.Caption;
+        if (!string.IsNullOrWhiteSpace(caption))
+        {
+            TrySetProperty(control, "Caption", caption);
+        }
+        var left = spec.Left ?? spec.Observed?.Left;
+        if (left is not null)
+        {
+            TrySetProperty(control, "Left", left.Value);
+        }
+        var top = spec.Top ?? spec.Observed?.Top;
+        if (top is not null)
+        {
+            TrySetProperty(control, "Top", top.Value);
+        }
+        var width = spec.Width ?? spec.Observed?.Width;
+        if (width is not null)
+        {
+            TrySetProperty(control, "Width", width.Value);
+        }
+        var height = spec.Height ?? spec.Observed?.Height;
+        if (height is not null)
+        {
+            TrySetProperty(control, "Height", height.Value);
+        }
+        var tabIndex = spec.TabIndex ?? spec.Observed?.TabIndex;
+        if (tabIndex is not null)
+        {
+            TrySetProperty(control, "TabIndex", tabIndex.Value);
+        }
+        var enabled = spec.Enabled ?? spec.Observed?.Enabled;
+        if (enabled is not null)
+        {
+            TrySetProperty(control, "Enabled", enabled.Value);
+        }
+        var visible = spec.Visible ?? spec.Observed?.Visible;
+        if (visible is not null)
+        {
+            TrySetProperty(control, "Visible", visible.Value);
+        }
+        if (spec.Value.ValueKind != JsonValueKind.Undefined)
+        {
+            var value = JsonSerializer.Deserialize<object>(spec.Value.GetRawText());
+            if (value is not null)
+            {
+                TrySetProperty(control, "Value", value);
+            }
+        }
+        else if (spec.Observed?.Value.ValueKind != JsonValueKind.Undefined)
+        {
+            var observedValue = JsonSerializer.Deserialize<object>(spec.Observed!.Value.GetRawText());
+            if (observedValue is not null)
+            {
+                TrySetProperty(control, "Value", observedValue);
+            }
+        }
+        var text = spec.Text ?? spec.Observed?.Text;
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            TrySetProperty(control, "Text", text);
+        }
+        SetControlListItems(control, spec.List ?? spec.Observed?.List);
+        var selectedIndex = spec.SelectedIndex ?? spec.Observed?.SelectedIndex;
+        if (selectedIndex is not null)
+        {
+            TrySetProperty(control, "ListIndex", selectedIndex.Value);
+        }
+    }
+
+    private static void SetControlListItems(object control, IReadOnlyList<string>? items)
+    {
+        if (items is null)
+        {
+            return;
+        }
+        try
+        {
+            var listCount = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(control, "ListCount"));
+            if (listCount > 0)
+            {
+                ExcelBridgeSupport.InvokeMethod(control, "Clear");
+            }
+        }
+        catch
+        {
+            return;
+        }
+        foreach (var item in items)
+        {
+            try
+            {
+                ExcelBridgeSupport.InvokeMethod(control, "AddItem", item ?? "");
+            }
+            catch
+            {
+                return;
+            }
+        }
+    }
+
+    private static bool TrySetProperty(object target, string propertyName, object value)
+    {
+        try
+        {
+            ExcelBridgeSupport.Set(target, propertyName, value);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool SetVBComponentProperty(object component, string propertyName, double value)
+    {
+        object? properties = null;
+        try
+        {
+            properties = ExcelBridgeSupport.Get(component, "Properties");
+            if (properties is null)
+            {
+                return false;
+            }
+            var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(properties, "Count"));
+            for (var index = 0; index < count; index++)
+            {
+                object? property = null;
+                try
+                {
+                    property = ExcelBridgeSupport.Get(properties, "Item", index);
+                    var name = ExcelBridgeSupport.GetString(property!, "Name") ?? "";
+                    if (string.Equals(name, propertyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        ExcelBridgeSupport.Set(property!, "Value", value);
+                        return true;
+                    }
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(property);
+                }
+            }
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(properties);
+        }
+        return false;
+    }
+
+    private static object? GetComponentByName(object vbProject, string name)
+    {
+        object? components = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            return ExcelBridgeSupport.Get(components!, "Item", name);
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static object NewUserFormComponent(object vbProject, string name)
+    {
+        object? components = null;
+        object? component = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            component = ExcelBridgeSupport.InvokeMethod(components!, "Add", ComponentTypeForm)
+                ?? throw new InvalidOperationException($"designer_write_failed: failed to create UserForm '{name}'.");
+            ExcelBridgeSupport.Set(component, "Name", name);
+            return component;
+        }
+        catch (Exception ex)
+        {
+            if (components is not null && component is not null)
+            {
+                try { ExcelBridgeSupport.InvokeMethod(components, "Remove", component); } catch { }
+            }
+            throw new InvalidOperationException($"designer_write_failed: failed to create UserForm '{name}'. {ex.Message}", ex);
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static void RemoveComponentByName(object vbProject, string name)
+    {
+        object? components = null;
+        object? component = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            component = ExcelBridgeSupport.Get(components!, "Item", name);
+            if (component is null)
+            {
+                return;
+            }
+            ExcelBridgeSupport.InvokeMethod(components!, "Remove", component);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"designer_write_failed: failed to remove existing component '{name}'. {ex.Message}", ex);
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(component);
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static void RemoveComponentInstance(object vbProject, object? component)
+    {
+        object? components = null;
+        try
+        {
+            if (component is null)
+            {
+                return;
+            }
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            if (components is not null)
+            {
+                ExcelBridgeSupport.InvokeMethod(components, "Remove", component);
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static string NewRestoreDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "xlflow-form-restore-" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string ExportComponentBackup(object component, string directory)
+    {
+        var name = ExcelBridgeSupport.GetString(component, "Name") ?? "UserForm";
+        var exportPath = Path.Combine(directory, name + ".frm");
+        ExcelBridgeSupport.InvokeViaDynamic(component, "Export", exportPath);
+        return exportPath;
+    }
+
+    private static void ImportComponentBackup(object vbProject, string exportPath, string expectedName)
+    {
+        object? components = null;
+        object? restored = null;
+        try
+        {
+            components = ExcelBridgeSupport.Get(vbProject, "VBComponents");
+            restored = ExcelBridgeSupport.InvokeMethod(components!, "Import", exportPath);
+            if (restored is not null)
+            {
+                var restoredName = ExcelBridgeSupport.GetString(restored, "Name") ?? "";
+                if (!string.Equals(restoredName, expectedName, StringComparison.OrdinalIgnoreCase))
+                {
+                    ExcelBridgeSupport.Set(restored, "Name", expectedName);
+                }
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(restored);
+            ExcelBridgeSupport.ReleaseComObject(components);
+        }
+    }
+
+    private static string? ReadCodeModuleText(object component)
+    {
+        object? codeModule = null;
+        try
+        {
+            codeModule = ExcelBridgeSupport.Get(component, "CodeModule");
+            return codeModule is null ? null : VbaSourceHelper.GetCodeModuleText(codeModule);
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(codeModule);
+        }
+    }
+
+    private static void WriteCodeModuleText(object component, string text)
+    {
+        object? codeModule = null;
+        try
+        {
+            codeModule = ExcelBridgeSupport.Get(component, "CodeModule");
+            if (codeModule is not null)
+            {
+                VbaSourceHelper.SetCodeModuleText(codeModule, text);
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(codeModule);
+        }
+    }
+
+    private static void SyncUserFormCodeBehind(object component, string formsDir, string? fallbackText)
+    {
+        var formName = ExcelBridgeSupport.GetString(component, "Name") ?? "";
+        var codePath = VbaSourceHelper.GetUserFormCodePath(formsDir, formName);
+        if (!string.IsNullOrWhiteSpace(codePath) && File.Exists(codePath))
+        {
+            WriteCodeModuleText(component, File.ReadAllText(codePath, Encoding.UTF8));
+            return;
+        }
+        if (!string.IsNullOrWhiteSpace(fallbackText))
+        {
+            WriteCodeModuleText(component, fallbackText);
+        }
+    }
+
+    private static SourceArtifacts ExportBuiltUserFormArtifacts(object component, FormWriteCommandArguments args)
+    {
+        var exportPath = VbaSourceHelper.GetComponentPath(component, "", "", args.FormsDir, "", args.Folders, args.FolderAnnotation, args.DefaultComponentFolders)
+            ?? throw new InvalidOperationException($"designer_write_failed: failed to resolve the source artifact path for built UserForm '{ExcelBridgeSupport.GetString(component, "Name")}'.");
+        var parent = Path.GetDirectoryName(exportPath);
+        if (!string.IsNullOrWhiteSpace(parent))
+        {
+            Directory.CreateDirectory(parent);
+        }
+        RemoveExportArtifacts(exportPath);
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "xlflow-form-write-" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(tmpDir);
+        try
+        {
+            var name = ExcelBridgeSupport.GetString(component, "Name") ?? "UserForm";
+            var tmpFile = Path.Combine(tmpDir, name + ".frm");
+            ExcelBridgeSupport.InvokeViaDynamic(component, "Export", tmpFile);
+            foreach (var exportedFile in Directory.GetFiles(tmpDir))
+            {
+                var ext = Path.GetExtension(exportedFile).ToLowerInvariant();
+                if (ext is ".bas" or ".cls" or ".frm")
+                {
+                    var content = File.ReadAllText(exportedFile, Encoding.Default);
+                    content = VbaSourceHelper.ConvertToUtf8(content);
+                    content = NormalizeUserFormArtifact(content, component);
+                    if (args.FolderAnnotation == "update")
+                    {
+                        var desiredAnnotation = VbaSourceHelper.GetFolderAnnotationForPath(args.FormsDir, exportPath);
+                        content = VbaSourceHelper.UpdateFolderAnnotationText(content, args.FolderAnnotation, desiredAnnotation);
+                    }
+                    File.WriteAllText(exportPath, content, new UTF8Encoding(false));
+                }
+                else
+                {
+                    File.Copy(exportedFile, Path.ChangeExtension(exportPath, ext), true);
+                }
+            }
+
+            string? codePath = null;
+            if (VbaSourceHelper.IsSidecarMode(args.CodeSource))
+            {
+                codePath = ExportUserFormCodeBehind(component, args.FormsDir);
+            }
+
+            return new SourceArtifacts(exportPath, Path.ChangeExtension(exportPath, ".frx"), codePath);
+        }
+        finally
+        {
+            if (Directory.Exists(tmpDir))
+            {
+                try { Directory.Delete(tmpDir, true); } catch { }
+            }
+        }
+    }
+
+    private static string? ExportUserFormCodeBehind(object component, string formsDir)
+    {
+        var name = ExcelBridgeSupport.GetString(component, "Name") ?? "";
+        var codePath = VbaSourceHelper.GetUserFormCodePath(formsDir, name);
+        if (string.IsNullOrWhiteSpace(codePath))
+        {
+            return null;
+        }
+        object? codeModule = null;
+        try
+        {
+            codeModule = ExcelBridgeSupport.Get(component, "CodeModule");
+            if (codeModule is null)
+            {
+                return null;
+            }
+            var text = VbaSourceHelper.GetCodeModuleText(codeModule);
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return File.Exists(codePath) ? codePath : null;
+            }
+            var dir = Path.GetDirectoryName(codePath);
+            if (!string.IsNullOrWhiteSpace(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            File.WriteAllText(codePath, text, new UTF8Encoding(false));
+            return codePath;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(codeModule);
+        }
+    }
+
+    private static void RemoveExportArtifacts(string exportPath)
+    {
+        foreach (var path in new[] { exportPath, Path.ChangeExtension(exportPath, ".frx") })
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string NormalizeUserFormArtifact(string content, object component)
+    {
+        try
+        {
+            object? designer = null;
+            try
+            {
+                designer = ExcelBridgeSupport.Get(component, "Designer");
+                var caption = designer is null ? null : ExcelBridgeSupport.GetString(designer, "Caption");
+                if (!string.IsNullOrWhiteSpace(caption))
+                {
+                    content = InjectOrUpdateCaption(content, caption);
+                }
+            }
+            finally
+            {
+                ExcelBridgeSupport.ReleaseComObject(designer);
+            }
+        }
+        catch
+        {
+        }
+        return content;
+    }
+
+    private static string InjectOrUpdateCaption(string content, string caption)
+    {
+        var lines = new List<string>(content.Split(["\r\n", "\n", "\r"], StringSplitOptions.None));
+        var beginIndex = lines.FindIndex(line => line.Trim() == "Begin");
+        var endIndex = beginIndex >= 0 ? lines.FindIndex(beginIndex + 1, line => line.Trim() == "End") : -1;
+        if (beginIndex >= 0 && endIndex > beginIndex)
+        {
+            for (var index = beginIndex + 1; index < endIndex; index++)
+            {
+                var trimmed = lines[index].Trim();
+                if (trimmed.StartsWith("Caption", StringComparison.OrdinalIgnoreCase) && trimmed.Contains('='))
+                {
+                    lines[index] = $"   Caption = \"{caption}\"";
+                    return string.Join(Environment.NewLine, lines);
+                }
+            }
+            lines.Insert(beginIndex + 1, $"   Caption = \"{caption}\"");
+        }
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static string ResolveProgId(FormWriteControlSpec spec)
+    {
+        if (!string.IsNullOrWhiteSpace(spec.ProgId))
+        {
+            return spec.ProgId;
+        }
+        if (TypeProgIdMap.TryGetValue(spec.Type ?? "", out var progId))
+        {
+            return progId;
+        }
+        throw new InvalidOperationException($"unsupported_form_control: unsupported control type '{spec.Type}'.");
+    }
+
+    private static Dictionary<string, string> NewMessage(string code, string message, string? fieldPath = null)
+    {
+        var result = new Dictionary<string, string>
+        {
+            ["code"] = code,
+            ["message"] = message,
+        };
+        if (!string.IsNullOrWhiteSpace(fieldPath))
+        {
+            result["field_path"] = fieldPath;
+        }
+        return result;
+    }
+
+    private static (string Code, string Message) ClassifyFormWriteError(string action, string message)
+    {
+        if (message.StartsWith("form_already_exists: ", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("form_already_exists", message["form_already_exists: ".Length..]);
+        }
+        if (message.StartsWith("form_not_found: ", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("form_not_found", message["form_not_found: ".Length..]);
+        }
+        if (message.StartsWith("unsupported_form_control: ", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("unsupported_form_control", message["unsupported_form_control: ".Length..]);
+        }
+        if (message.StartsWith("designer_write_failed: ", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("designer_write_failed", message["designer_write_failed: ".Length..]);
+        }
+        return (action == "apply" ? "form_apply_failed" : "form_build_failed", message);
+    }
+
+    private static void CloseComInstance(object? workbook, object? excel)
+    {
+        try
+        {
+            if (workbook is not null)
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(workbook, "Close", false);
+            }
+        }
+        catch
+        {
+        }
+        try
+        {
+            if (excel is not null)
+            {
+                ExcelBridgeSupport.InvokeViaDynamic(excel, "Quit");
+            }
+        }
+        catch
+        {
+        }
+        ExcelBridgeSupport.ReleaseComObject(workbook);
+        ExcelBridgeSupport.ReleaseComObject(excel);
+    }
+
+    private sealed record SourceArtifacts(string FormPath, string FrxPath, string? CodePath);
+
+    private sealed class FormWriteSpec
+    {
+        [JsonPropertyName("basis")]
+        public string Basis { get; init; } = "";
+
+        [JsonPropertyName("coordinateSystem")]
+        public string? CoordinateSystem { get; init; }
+
+        [JsonPropertyName("form")]
+        public FormWriteFormSpec Form { get; init; } = new();
+
+        [JsonPropertyName("controls")]
+        public List<FormWriteControlSpec> Controls { get; init; } = [];
+    }
+
+    private sealed class FormWriteFormSpec
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = "";
+
+        [JsonPropertyName("caption")]
+        public string? Caption { get; init; }
+
+        [JsonPropertyName("width")]
+        public double? Width { get; init; }
+
+        [JsonPropertyName("height")]
+        public double? Height { get; init; }
+
+        [JsonPropertyName("observed")]
+        public FormWriteObservedFormSpec? Observed { get; init; }
+
+        [JsonPropertyName("build")]
+        public FormWriteBuildFormSpec? Build { get; init; }
+    }
+
+    private sealed class FormWriteObservedFormSpec
+    {
+        [JsonPropertyName("caption")]
+        public string? Caption { get; init; }
+
+        [JsonPropertyName("width")]
+        public double? Width { get; init; }
+
+        [JsonPropertyName("height")]
+        public double? Height { get; init; }
+    }
+
+    private sealed class FormWriteBuildFormSpec
+    {
+        [JsonPropertyName("caption")]
+        public string? Caption { get; init; }
+
+        [JsonPropertyName("width")]
+        public double? Width { get; init; }
+
+        [JsonPropertyName("height")]
+        public double? Height { get; init; }
+    }
+
+    private sealed class FormWriteControlSpec
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = "";
+
+        [JsonPropertyName("parentId")]
+        public string ParentId { get; init; } = "";
+
+        [JsonPropertyName("zIndex")]
+        public int? ZIndex { get; init; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; init; } = "";
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = "";
+
+        [JsonPropertyName("progId")]
+        public string? ProgId { get; init; }
+
+        [JsonPropertyName("caption")]
+        public string? Caption { get; init; }
+
+        [JsonPropertyName("text")]
+        public string? Text { get; init; }
+
+        [JsonPropertyName("value")]
+        public JsonElement Value { get; init; }
+
+        [JsonPropertyName("left")]
+        public double? Left { get; init; }
+
+        [JsonPropertyName("top")]
+        public double? Top { get; init; }
+
+        [JsonPropertyName("width")]
+        public double? Width { get; init; }
+
+        [JsonPropertyName("height")]
+        public double? Height { get; init; }
+
+        [JsonPropertyName("tabIndex")]
+        public int? TabIndex { get; init; }
+
+        [JsonPropertyName("selectedIndex")]
+        public int? SelectedIndex { get; init; }
+
+        [JsonPropertyName("enabled")]
+        public bool? Enabled { get; init; }
+
+        [JsonPropertyName("visible")]
+        public bool? Visible { get; init; }
+
+        [JsonPropertyName("list")]
+        public List<string>? List { get; init; }
+
+        [JsonPropertyName("controls")]
+        public List<FormWriteControlSpec>? Controls { get; init; }
+
+        [JsonPropertyName("observed")]
+        public FormWriteObservedControlSpec? Observed { get; init; }
+    }
+
+    private sealed class FormWriteObservedControlSpec
+    {
+        [JsonPropertyName("caption")]
+        public string? Caption { get; init; }
+
+        [JsonPropertyName("text")]
+        public string? Text { get; init; }
+
+        [JsonPropertyName("value")]
+        public JsonElement Value { get; init; }
+
+        [JsonPropertyName("left")]
+        public double? Left { get; init; }
+
+        [JsonPropertyName("top")]
+        public double? Top { get; init; }
+
+        [JsonPropertyName("width")]
+        public double? Width { get; init; }
+
+        [JsonPropertyName("height")]
+        public double? Height { get; init; }
+
+        [JsonPropertyName("tabIndex")]
+        public int? TabIndex { get; init; }
+
+        [JsonPropertyName("selectedIndex")]
+        public int? SelectedIndex { get; init; }
+
+        [JsonPropertyName("enabled")]
+        public bool? Enabled { get; init; }
+
+        [JsonPropertyName("visible")]
+        public bool? Visible { get; init; }
+
+        [JsonPropertyName("list")]
+        public List<string>? List { get; init; }
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExportImageCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExportImageCommandArguments.cs
@@ -1,0 +1,13 @@
+namespace Xlflow.ExcelBridge.Services;
+
+public sealed record ExportImageCommandArguments(
+    string WorkbookPath,
+    string Sheet,
+    string RangeAddress,
+    string OutputPath,
+    bool OutputIsDefault,
+    string ImageFormat,
+    bool Overwrite,
+    bool Visible,
+    bool UseSession,
+    string MetadataPath);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/FormExportImageCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/FormExportImageCommandArguments.cs
@@ -1,0 +1,11 @@
+namespace Xlflow.ExcelBridge.Services;
+
+public sealed record FormExportImageCommandArguments(
+    string WorkbookPath,
+    string FormName,
+    string OutputPath,
+    string Initializer,
+    bool Overwrite,
+    bool Visible,
+    bool UseSession,
+    string MetadataPath);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/FormWriteCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/FormWriteCommandArguments.cs
@@ -1,0 +1,17 @@
+namespace Xlflow.ExcelBridge.Services;
+
+public sealed record FormWriteCommandArguments(
+    string Action,
+    string WorkbookPath,
+    string SpecPath,
+    string FormsDir,
+    string CodeSource,
+    bool Folders,
+    string FolderAnnotation,
+    bool DefaultComponentFolders,
+    string SpecJson64,
+    bool Overwrite,
+    bool NoSave,
+    bool Visible,
+    bool UseSession,
+    string MetadataPath);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IExportImageService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IExportImageService.cs
@@ -1,0 +1,8 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+public interface IExportImageService
+{
+    BridgeResponse Execute(BridgeRequest request, ExportImageCommandArguments args, CancellationToken cancellationToken);
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IFormExportImageService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IFormExportImageService.cs
@@ -1,0 +1,8 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+public interface IFormExportImageService
+{
+    BridgeResponse Execute(BridgeRequest request, FormExportImageCommandArguments args, CancellationToken cancellationToken);
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IFormWriteService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IFormWriteService.cs
@@ -1,0 +1,8 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+public interface IFormWriteService
+{
+    BridgeResponse Execute(BridgeRequest request, FormWriteCommandArguments args, CancellationToken cancellationToken);
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IInspectFormService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IInspectFormService.cs
@@ -1,0 +1,8 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+public interface IInspectFormService
+{
+    BridgeResponse Execute(BridgeRequest request, InspectFormCommandArguments args, CancellationToken cancellationToken);
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/InspectFormCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/InspectFormCommandArguments.cs
@@ -1,0 +1,11 @@
+namespace Xlflow.ExcelBridge.Services;
+
+public sealed record InspectFormCommandArguments(
+    string WorkbookPath,
+    string FormName,
+    string Basis,
+    string Initializer,
+    bool StrictDesigner,
+    bool Visible,
+    bool UseSession,
+    string MetadataPath);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Windows/WindowCapture.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Windows/WindowCapture.cs
@@ -1,0 +1,439 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Xlflow.ExcelBridge.Windows;
+
+internal sealed record WindowInfo(long Hwnd, string Title, string ClassName, int Left, int Top, int Width, int Height);
+
+internal sealed record WindowImageInfo(int WidthPx, int HeightPx, double Scale);
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Window capture is Windows-only bridge behavior.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Window capture falls back from optional DPI and screen-copy APIs.")]
+[SuppressMessage("Performance", "CA1838:Avoid StringBuilder parameters for P/Invokes", Justification = "The bounded text helpers mirror the existing DialogWatcher implementation.")]
+[SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "The helper returns iteration-friendly collections for simple call sites.")]
+internal static class WindowCapture
+{
+    private const int SwRestore = 9;
+    private const uint SwpNoSize = 0x0001;
+    private const uint SwpNoZOrder = 0x0004;
+    private const uint SwpNoActivate = 0x0010;
+    private const uint MonitorDefaultToNearest = 2;
+
+    public static WindowInfo? GetWindowInfo(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero || !NativeMethods.IsWindowVisible(hwnd))
+        {
+            return null;
+        }
+
+        if (!NativeMethods.GetWindowRect(hwnd, out var rect))
+        {
+            return null;
+        }
+
+        var width = rect.Right - rect.Left;
+        var height = rect.Bottom - rect.Top;
+        if (width <= 0 || height <= 0)
+        {
+            return null;
+        }
+
+        return new WindowInfo(
+            hwnd.ToInt64(),
+            NativeMethods.GetWindowText(hwnd),
+            NativeMethods.GetClassName(hwnd),
+            rect.Left,
+            rect.Top,
+            width,
+            height);
+    }
+
+    public static WindowInfo? WaitForStableWindow(IntPtr hwnd, TimeSpan timeout, TimeSpan pollInterval, int stableSamples)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        var lastSignature = "";
+        var stableCount = 0;
+        WindowInfo? last = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            var window = GetWindowInfo(hwnd);
+            if (window is null)
+            {
+                Thread.Sleep(pollInterval);
+                continue;
+            }
+
+            var signature = $"{window.Left}:{window.Top}:{window.Width}:{window.Height}";
+            if (string.Equals(signature, lastSignature, StringComparison.Ordinal))
+            {
+                stableCount++;
+            }
+            else
+            {
+                lastSignature = signature;
+                stableCount = 1;
+            }
+
+            last = window;
+            if (stableCount >= stableSamples)
+            {
+                return window;
+            }
+            Thread.Sleep(pollInterval);
+        }
+
+        return last;
+    }
+
+    public static bool IsLikelyUserFormWindow(WindowInfo? window)
+    {
+        if (window is null)
+        {
+            return false;
+        }
+
+        if (string.Equals(window.ClassName.Trim(), "XLMAIN", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return window.ClassName.StartsWith("Thunder", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static WindowInfo? FindWindowByTitle(int processId, string title, bool exactMatch)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return null;
+        }
+
+        foreach (var hwnd in EnumerateTopLevelWindows(processId))
+        {
+            var info = GetWindowInfo(hwnd);
+            if (info is null)
+            {
+                continue;
+            }
+
+            if (exactMatch)
+            {
+                if (string.Equals(info.Title, title, StringComparison.Ordinal))
+                {
+                    return info;
+                }
+                continue;
+            }
+
+            if (info.Title.Contains(title, StringComparison.OrdinalIgnoreCase))
+            {
+                return info;
+            }
+        }
+
+        return null;
+    }
+
+    public static WindowInfo? MoveWindowIntoCaptureBounds(WindowInfo? window)
+    {
+        if (window is null)
+        {
+            return null;
+        }
+
+        var hwnd = new IntPtr(window.Hwnd);
+        if (NativeMethods.IsIconic(hwnd))
+        {
+            _ = NativeMethods.ShowWindow(hwnd, SwRestore);
+        }
+        _ = NativeMethods.SetForegroundWindow(hwnd);
+
+        var targetRect = GetWorkingArea(hwnd);
+        if (targetRect is null)
+        {
+            return WaitForStableWindow(hwnd, TimeSpan.FromMilliseconds(1200), TimeSpan.FromMilliseconds(100), 2) ?? window;
+        }
+
+        var margin = 16;
+        var minLeft = targetRect.Value.Left + margin;
+        var maxLeft = targetRect.Value.Right - window.Width - margin;
+        if (maxLeft < minLeft)
+        {
+            minLeft = targetRect.Value.Left;
+            maxLeft = Math.Max(minLeft, targetRect.Value.Right - window.Width);
+        }
+
+        var minTop = targetRect.Value.Top + margin;
+        var maxTop = targetRect.Value.Bottom - window.Height - margin;
+        if (maxTop < minTop)
+        {
+            minTop = targetRect.Value.Top;
+            maxTop = Math.Max(minTop, targetRect.Value.Bottom - window.Height);
+        }
+
+        var left = Math.Min(Math.Max(window.Left, minLeft), maxLeft);
+        var top = Math.Min(Math.Max(window.Top, minTop), maxTop);
+        _ = NativeMethods.SetWindowPos(hwnd, IntPtr.Zero, left, top, 0, 0, SwpNoSize | SwpNoZOrder | SwpNoActivate);
+        return WaitForStableWindow(hwnd, TimeSpan.FromMilliseconds(1200), TimeSpan.FromMilliseconds(100), 2)
+            ?? GetWindowInfo(hwnd)
+            ?? window;
+    }
+
+    public static WindowImageInfo CaptureWindowImage(long hwndValue, string path)
+    {
+        var hwnd = new IntPtr(hwndValue);
+        if (!NativeMethods.GetWindowRect(hwnd, out var rect))
+        {
+            throw new InvalidOperationException("window_not_found: failed to resolve window bounds");
+        }
+
+        var width = rect.Right - rect.Left;
+        var height = rect.Bottom - rect.Top;
+        if (width <= 0 || height <= 0)
+        {
+            throw new InvalidOperationException("image_capture_failed: target window has non-positive bounds");
+        }
+
+        var scale = GetWindowCaptureScale(hwnd);
+        var captureWidth = (int)Math.Ceiling(width * scale);
+        var captureHeight = (int)Math.Ceiling(height * scale);
+
+        using var bitmap = new Bitmap(captureWidth, captureHeight);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(Color.White);
+
+        var printOk = false;
+        var hdc = IntPtr.Zero;
+        try
+        {
+            hdc = graphics.GetHdc();
+            printOk = NativeMethods.PrintWindow(hwnd, hdc, 2) || NativeMethods.PrintWindow(hwnd, hdc, 0);
+        }
+        finally
+        {
+            if (hdc != IntPtr.Zero)
+            {
+                graphics.ReleaseHdc(hdc);
+            }
+        }
+
+        if (!printOk)
+        {
+            try
+            {
+                graphics.CopyFromScreen(rect.Left, rect.Top, 0, 0, new Size(captureWidth, captureHeight));
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"image_capture_failed: failed to capture the target window ({ex.Message})", ex);
+            }
+        }
+
+        using var trimmed = TrimBlackEdges(bitmap);
+        trimmed.Save(path, ImageFormat.Png);
+        return new WindowImageInfo(trimmed.Width, trimmed.Height, scale);
+    }
+
+    private static List<IntPtr> EnumerateTopLevelWindows(int processId)
+    {
+        var handles = new List<IntPtr>();
+        NativeMethods.EnumWindows((hwnd, lParam) =>
+        {
+            _ = NativeMethods.GetWindowThreadProcessId(hwnd, out var pid);
+            if (processId <= 0 || pid == processId)
+            {
+                handles.Add(hwnd);
+            }
+            return true;
+        }, IntPtr.Zero);
+        return handles;
+    }
+
+    private static NativeMethods.Rect? GetWorkingArea(IntPtr hwnd)
+    {
+        var monitor = NativeMethods.MonitorFromWindow(hwnd, MonitorDefaultToNearest);
+        if (monitor == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        var info = new NativeMethods.MonitorInfo();
+        info.CbSize = Marshal.SizeOf<NativeMethods.MonitorInfo>();
+        if (!NativeMethods.GetMonitorInfo(monitor, ref info))
+        {
+            return null;
+        }
+
+        return info.RcWork;
+    }
+
+    private static double GetWindowCaptureScale(IntPtr hwnd)
+    {
+        try
+        {
+            var dpi = NativeMethods.GetDpiForWindow(hwnd);
+            if (dpi < 96)
+            {
+                return 1.0;
+            }
+            return Math.Clamp(dpi / 96.0, 1.0, 4.0);
+        }
+        catch
+        {
+            return 1.0;
+        }
+    }
+
+    private static Bitmap TrimBlackEdges(Bitmap bitmap)
+    {
+        var left = 0;
+        var right = bitmap.Width - 1;
+        var top = 0;
+        var bottom = bitmap.Height - 1;
+
+        while (left < right && EdgeIsBlack(bitmap, "left", left))
+        {
+            left++;
+        }
+        while (right > left && EdgeIsBlack(bitmap, "right", right))
+        {
+            right--;
+        }
+        while (top < bottom && EdgeIsBlack(bitmap, "top", top))
+        {
+            top++;
+        }
+        while (bottom > top && EdgeIsBlack(bitmap, "bottom", bottom))
+        {
+            bottom--;
+        }
+
+        var width = right - left + 1;
+        var height = bottom - top + 1;
+        if (width <= 0 || height <= 0 || (width == bitmap.Width && height == bitmap.Height))
+        {
+            return new Bitmap(bitmap);
+        }
+
+        var trimmed = new Bitmap(width, height, bitmap.PixelFormat);
+        using var graphics = Graphics.FromImage(trimmed);
+        graphics.DrawImage(bitmap, new Rectangle(0, 0, width, height), new Rectangle(left, top, width, height), GraphicsUnit.Pixel);
+        return trimmed;
+    }
+
+    private static bool EdgeIsBlack(Bitmap bitmap, string edge, int index, int threshold = 64, int step = 2, double minimumDarkRatio = 0.75, int ignoreTopPixels = 32)
+    {
+        var samples = 0;
+        var darkSamples = 0;
+        switch (edge)
+        {
+            case "left":
+            case "right":
+                for (var y = Math.Min(ignoreTopPixels, Math.Max(0, bitmap.Height - 1)); y < bitmap.Height; y += step)
+                {
+                    var pixel = bitmap.GetPixel(index, y);
+                    samples++;
+                    if (pixel.R <= threshold && pixel.G <= threshold && pixel.B <= threshold)
+                    {
+                        darkSamples++;
+                    }
+                }
+                break;
+            case "top":
+            case "bottom":
+                for (var x = 0; x < bitmap.Width; x += step)
+                {
+                    var pixel = bitmap.GetPixel(x, index);
+                    samples++;
+                    if (pixel.R <= threshold && pixel.G <= threshold && pixel.B <= threshold)
+                    {
+                        darkSamples++;
+                    }
+                }
+                break;
+        }
+
+        return samples > 0 && (double)darkSamples / samples >= minimumDarkRatio;
+    }
+
+    private static class NativeMethods
+    {
+        public delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Rect
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MonitorInfo
+        {
+            public int CbSize;
+            public Rect RcMonitor;
+            public Rect RcWork;
+            public uint DwFlags;
+        }
+
+        [DllImport("user32.dll")]
+        public static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern bool IsWindowVisible(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        public static extern bool GetWindowRect(IntPtr hwnd, out Rect rect);
+
+        [DllImport("user32.dll")]
+        public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out int processId);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetWindowTextW(IntPtr hwnd, StringBuilder text, int maxCount);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetClassNameW(IntPtr hwnd, StringBuilder className, int maxCount);
+
+        [DllImport("user32.dll")]
+        public static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint flags);
+
+        [DllImport("user32.dll")]
+        public static extern uint GetDpiForWindow(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint flags);
+
+        [DllImport("user32.dll")]
+        public static extern bool GetMonitorInfo(IntPtr monitor, ref MonitorInfo monitorInfo);
+
+        [DllImport("user32.dll")]
+        public static extern bool SetWindowPos(IntPtr hwnd, IntPtr hwndInsertAfter, int x, int y, int cx, int cy, uint flags);
+
+        [DllImport("user32.dll")]
+        public static extern bool SetForegroundWindow(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        public static extern bool ShowWindow(IntPtr hwnd, int command);
+
+        [DllImport("user32.dll")]
+        public static extern bool IsIconic(IntPtr hwnd);
+
+        public static string GetWindowText(IntPtr hwnd)
+        {
+            var text = new StringBuilder(1024);
+            _ = GetWindowTextW(hwnd, text, text.Capacity);
+            return text.ToString();
+        }
+
+        public static string GetClassName(IntPtr hwnd)
+        {
+            var text = new StringBuilder(256);
+            _ = GetClassNameW(hwnd, text, text.Capacity);
+            return text.ToString();
+        }
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Xlflow.ExcelBridge.csproj
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Xlflow.ExcelBridge.csproj
@@ -18,4 +18,8 @@
     <InternalsVisibleTo Include="Xlflow.ExcelBridge.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeHostTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeHostTests.cs
@@ -33,7 +33,11 @@ public sealed class BridgeHostTests
         using var json = JsonDocument.Parse(stdout.ToString());
         var commands = json.RootElement.GetProperty("commands").EnumerateArray().Select(item => item.GetString()).ToArray();
         Assert.Contains("doctor", commands);
+        Assert.Contains("export-image", commands);
+        Assert.Contains("form-export-image", commands);
+        Assert.Contains("form-write", commands);
         Assert.Contains("inspect", commands);
+        Assert.Contains("inspect-form", commands);
         Assert.Contains("macros", commands);
         Assert.Contains("pull", commands);
         Assert.Contains("process", commands);

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ExcelBridgeSupportTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ExcelBridgeSupportTests.cs
@@ -92,6 +92,19 @@ public sealed class ExcelBridgeSupportTests
         Assert.Equal(2, excel.Workbooks.ItemCalls);
     }
 
+    [Fact]
+    public void InvokeViaDynamic_SupportsCopyPictureAndPaste()
+    {
+        var range = new FakeRange();
+        var chart = new FakeChart();
+
+        ExcelBridgeSupport.InvokeViaDynamic(range, "CopyPicture", 2, -4147);
+        ExcelBridgeSupport.InvokeViaDynamic(chart, "Paste");
+
+        Assert.Equal((2, -4147), range.LastCopyPictureArgs);
+        Assert.True(chart.PasteCalled);
+    }
+
     public sealed class FakeExcel(params FakeWorkbook[] workbooks)
     {
         public FakeWorkbookCollection Workbooks { get; } = new(workbooks);
@@ -113,5 +126,25 @@ public sealed class ExcelBridgeSupportTests
     public sealed class FakeWorkbook(string fullName)
     {
         public string FullName { get; } = fullName;
+    }
+
+    public sealed class FakeRange
+    {
+        public (object? Appearance, object? Format)? LastCopyPictureArgs { get; private set; }
+
+        public void CopyPicture(object? appearance, object? format)
+        {
+            LastCopyPictureArgs = (appearance, format);
+        }
+    }
+
+    public sealed class FakeChart
+    {
+        public bool PasteCalled { get; private set; }
+
+        public void Paste()
+        {
+            PasteCalled = true;
+        }
     }
 }

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ExportImageCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ExportImageCommandTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using Xlflow.ExcelBridge.Commands;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Serialization;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class ExportImageCommandTests
+{
+    [Fact]
+    public void HandleParsesPayloadAndReturnsExpectedExtensions()
+    {
+        var service = new FakeExportImageService((request, args) =>
+        {
+            Assert.Equal("export-image", request.Command);
+            Assert.Equal(@"C:\work\book.xlsm", args.WorkbookPath);
+            Assert.Equal("Sheet1", args.Sheet);
+            Assert.Equal("A1:C10", args.RangeAddress);
+            Assert.Equal(@"C:\work\out\sheet.png", args.OutputPath);
+            Assert.True(args.OutputIsDefault);
+            Assert.Equal("png", args.ImageFormat);
+            Assert.True(args.Overwrite);
+            Assert.False(args.Visible);
+            Assert.True(args.UseSession);
+            Assert.Equal(@"C:\work\.xlflow\session.json", args.MetadataPath);
+
+            return BridgeResponse.Ok(request, new Dictionary<string, object?>
+            {
+                ["target"] = new Dictionary<string, object?> { ["kind"] = "live_session", ["path"] = args.WorkbookPath, ["sheet"] = args.Sheet, ["range"] = args.RangeAddress },
+                ["session"] = new Dictionary<string, object?> { ["active"] = true, ["workbook_path"] = args.WorkbookPath },
+                ["workbook"] = new Dictionary<string, object?> { ["path"] = args.WorkbookPath, ["session"] = true },
+                ["output"] = new Dictionary<string, object?> { ["path"] = args.OutputPath, ["format"] = "png", ["default"] = args.OutputIsDefault },
+            });
+        });
+        var command = new ExportImageCommand(service);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-export-image",
+            Command = "export-image",
+            Payload = JsonDocument.Parse("""
+                {
+                  "WorkbookPath": "C:\\work\\book.xlsm",
+                  "Sheet": "Sheet1",
+                  "RangeAddress": "A1:C10",
+                  "OutputPath": "C:\\work\\out\\sheet.png",
+                  "OutputIsDefault": "true",
+                  "ImageFormat": "png",
+                  "Overwrite": "true",
+                  "Visible": "false",
+                  "UseSession": "true",
+                  "MetadataPath": "C:\\work\\.xlflow\\session.json"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal(@"C:\work\out\sheet.png", json.RootElement.GetProperty("output").GetProperty("path").GetString());
+    }
+
+    [Fact]
+    public void HandleRejectsMissingRangeAddressBeforeService()
+    {
+        var command = new ExportImageCommand(new FakeExportImageService((request, _) => BridgeResponse.Ok(request)));
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-export-image-invalid",
+            Command = "export-image",
+            Payload = JsonDocument.Parse("""
+                {
+                  "WorkbookPath": "C:\\work\\book.xlsm",
+                  "Sheet": "Sheet1",
+                  "OutputPath": "C:\\work\\out\\sheet.png"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("export_image_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    private sealed class FakeExportImageService(Func<BridgeRequest, ExportImageCommandArguments, BridgeResponse> handler) : IExportImageService
+    {
+        public BridgeResponse Execute(BridgeRequest request, ExportImageCommandArguments args, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request, args);
+        }
+    }
+}

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormExportImageCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormExportImageCommandTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using Xlflow.ExcelBridge.Commands;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Serialization;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class FormExportImageCommandTests
+{
+    [Fact]
+    public void HandleParsesPayloadAndReturnsExpectedExtensions()
+    {
+        var service = new FakeFormExportImageService((request, args) =>
+        {
+            Assert.Equal("form-export-image", request.Command);
+            Assert.Equal(@"C:\work\book.xlsm", args.WorkbookPath);
+            Assert.Equal("UserForm1", args.FormName);
+            Assert.Equal(@"C:\work\out\UserForm1.png", args.OutputPath);
+            Assert.Equal("InitializePreview", args.Initializer);
+            Assert.True(args.Overwrite);
+            Assert.False(args.Visible);
+            Assert.True(args.UseSession);
+            Assert.Equal(@"C:\work\.xlflow\session.json", args.MetadataPath);
+
+            return BridgeResponse.Ok(request, new Dictionary<string, object?>
+            {
+                ["target"] = new Dictionary<string, object?> { ["kind"] = "live_session", ["path"] = args.WorkbookPath, ["form"] = args.FormName },
+                ["session"] = new Dictionary<string, object?> { ["active"] = true, ["workbook_path"] = args.WorkbookPath },
+                ["workbook"] = new Dictionary<string, object?> { ["path"] = args.WorkbookPath, ["session"] = true },
+                ["forms"] = new Dictionary<string, object?> { ["name"] = args.FormName, ["basis"] = "runtime" },
+                ["output"] = new Dictionary<string, object?> { ["path"] = args.OutputPath, ["format"] = "png" },
+            });
+        });
+        var command = new FormExportImageCommand(service);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-form-export-image",
+            Command = "form-export-image",
+            Payload = JsonDocument.Parse("""
+                {
+                  "WorkbookPath": "C:\\work\\book.xlsm",
+                  "FormName": "UserForm1",
+                  "OutputPath": "C:\\work\\out\\UserForm1.png",
+                  "Initializer": "InitializePreview",
+                  "Overwrite": "true",
+                  "Visible": "false",
+                  "UseSession": "true",
+                  "MetadataPath": "C:\\work\\.xlflow\\session.json"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("runtime", json.RootElement.GetProperty("forms").GetProperty("basis").GetString());
+    }
+
+    [Fact]
+    public void HandleRejectsMissingFormNameBeforeService()
+    {
+        var command = new FormExportImageCommand(new FakeFormExportImageService((request, _) => BridgeResponse.Ok(request)));
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-form-export-image-invalid",
+            Command = "form-export-image",
+            Payload = JsonDocument.Parse("""
+                {
+                  "WorkbookPath": "C:\\work\\book.xlsm",
+                  "OutputPath": "C:\\work\\out\\UserForm1.png"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("form_export_image_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    private sealed class FakeFormExportImageService(Func<BridgeRequest, FormExportImageCommandArguments, BridgeResponse> handler) : IFormExportImageService
+    {
+        public BridgeResponse Execute(BridgeRequest request, FormExportImageCommandArguments args, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request, args);
+        }
+    }
+}

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormWriteCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormWriteCommandTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using Xlflow.ExcelBridge.Commands;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Serialization;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class FormWriteCommandTests
+{
+    [Fact]
+    public void HandleParsesPayloadAndReturnsExpectedExtensions()
+    {
+        var service = new FakeFormWriteService((request, args) =>
+        {
+            Assert.Equal("form-write", request.Command);
+            Assert.Equal("build", args.Action);
+            Assert.Equal(@"C:\work\book.xlsm", args.WorkbookPath);
+            Assert.Equal(@"src\forms\specs\UserForm1.yaml", args.SpecPath);
+            Assert.Equal(@"C:\work\src\forms", args.FormsDir);
+            Assert.Equal("sidecar", args.CodeSource);
+            Assert.True(args.Folders);
+            Assert.Equal("update", args.FolderAnnotation);
+            Assert.True(args.DefaultComponentFolders);
+            Assert.Equal("eyJmb28iOiJiYXIifQ==", args.SpecJson64);
+            Assert.True(args.Overwrite);
+            Assert.False(args.NoSave);
+            Assert.False(args.Visible);
+            Assert.True(args.UseSession);
+            Assert.Equal(@"C:\work\.xlflow\session.json", args.MetadataPath);
+
+            return BridgeResponse.Ok(request, new Dictionary<string, object?>
+            {
+                ["target"] = new Dictionary<string, object?> { ["kind"] = "live_session", ["path"] = args.WorkbookPath },
+                ["session"] = new Dictionary<string, object?> { ["active"] = true, ["workbook_path"] = args.WorkbookPath },
+                ["workbook"] = new Dictionary<string, object?> { ["path"] = args.WorkbookPath, ["session"] = true },
+                ["forms"] = new Dictionary<string, object?>
+                {
+                    ["name"] = "UserForm1",
+                    ["action"] = args.Action,
+                    ["source_synced"] = true,
+                },
+            });
+        });
+        var command = new FormWriteCommand(service);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-form-write",
+            Command = "form-write",
+            Payload = JsonDocument.Parse("""
+                {
+                  "Action": "build",
+                  "WorkbookPath": "C:\\work\\book.xlsm",
+                  "SpecPath": "src\\forms\\specs\\UserForm1.yaml",
+                  "FormsDir": "C:\\work\\src\\forms",
+                  "CodeSource": "sidecar",
+                  "Folders": "true",
+                  "FolderAnnotation": "update",
+                  "DefaultComponentFolders": "true",
+                  "SpecJson64": "eyJmb28iOiJiYXIifQ==",
+                  "Overwrite": "true",
+                  "NoSave": "false",
+                  "Visible": "false",
+                  "UseSession": "true",
+                  "MetadataPath": "C:\\work\\.xlflow\\session.json"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("UserForm1", json.RootElement.GetProperty("forms").GetProperty("name").GetString());
+        Assert.Equal("build", json.RootElement.GetProperty("forms").GetProperty("action").GetString());
+    }
+
+    [Fact]
+    public void HandleRejectsInvalidNoSaveUsageBeforeService()
+    {
+        var command = new FormWriteCommand(new FakeFormWriteService((request, _) => BridgeResponse.Ok(request)));
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-form-write-invalid",
+            Command = "form-write",
+            Payload = JsonDocument.Parse("""
+                {
+                  "Action": "build",
+                  "WorkbookPath": "C:\\work\\book.xlsm",
+                  "FormsDir": "C:\\work\\src\\forms",
+                  "SpecJson64": "eyJmb28iOiJiYXIifQ==",
+                  "NoSave": "true",
+                  "UseSession": "false"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("form_build_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    private sealed class FakeFormWriteService(Func<BridgeRequest, FormWriteCommandArguments, BridgeResponse> handler) : IFormWriteService
+    {
+        public BridgeResponse Execute(BridgeRequest request, FormWriteCommandArguments args, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request, args);
+        }
+    }
+}

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/InspectFormCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/InspectFormCommandTests.cs
@@ -8,6 +8,17 @@ namespace Xlflow.ExcelBridge.Tests;
 
 public sealed class InspectFormCommandTests
 {
+    [Theory]
+    [InlineData("Forms.Label.1", "__ComObject", "Label")]
+    [InlineData("Forms.TextBox.1", "__ComObject", "TextBox")]
+    [InlineData("", "__ComObject", "__ComObject")]
+    [InlineData(null, "Frame", "Frame")]
+    public void ResolveDesignerControlType_PrefersProgIdSegment(string? progId, string fallbackTypeName, string expected)
+    {
+        var actual = ExcelFormInspectionService.ResolveDesignerControlType(progId, fallbackTypeName);
+        Assert.Equal(expected, actual);
+    }
+
     [Fact]
     public void HandleParsesPayloadAndReturnsExpectedExtensions()
     {

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/InspectFormCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/InspectFormCommandTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using Xlflow.ExcelBridge.Commands;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Serialization;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class InspectFormCommandTests
+{
+    [Fact]
+    public void HandleParsesPayloadAndReturnsExpectedExtensions()
+    {
+        var service = new FakeInspectFormService((request, args) =>
+        {
+            Assert.Equal("inspect-form", request.Command);
+            Assert.Equal(@"C:\work\book.xlsm", args.WorkbookPath);
+            Assert.Equal("UserForm1", args.FormName);
+            Assert.Equal("both", args.Basis);
+            Assert.Equal("InitializeRuntime", args.Initializer);
+            Assert.True(args.StrictDesigner);
+            Assert.False(args.Visible);
+            Assert.True(args.UseSession);
+            Assert.Equal(@"C:\work\.xlflow\session.json", args.MetadataPath);
+
+            return BridgeResponse.Ok(request, new Dictionary<string, object?>
+            {
+                ["target"] = new Dictionary<string, object?>
+                {
+                    ["kind"] = "live_session",
+                    ["path"] = args.WorkbookPath,
+                    ["note"] = "Runtime inspection used a temporary workbook copy.",
+                },
+                ["session"] = new Dictionary<string, object?>
+                {
+                    ["active"] = true,
+                    ["workbook_path"] = args.WorkbookPath,
+                    ["dirty"] = false,
+                    ["save_required"] = false,
+                    ["mode"] = "explicit",
+                },
+                ["workbook"] = new Dictionary<string, object?>
+                {
+                    ["path"] = args.WorkbookPath,
+                    ["session"] = true,
+                    ["session_mode"] = "explicit",
+                },
+                ["forms"] = new Dictionary<string, object?>
+                {
+                    ["runtime"] = new Dictionary<string, object?>
+                    {
+                        ["name"] = args.FormName,
+                        ["basis"] = "runtime",
+                    },
+                    ["designer"] = new Dictionary<string, object?>
+                    {
+                        ["name"] = args.FormName,
+                        ["basis"] = "designer",
+                    },
+                },
+                ["warnings"] = new List<Dictionary<string, string>>
+                {
+                    new() { ["code"] = "runtime_form_temp_copy", ["message"] = "Runtime inspection executed against a temporary workbook copy so the source workbook and live session are not mutated." },
+                },
+            });
+        });
+        var command = new InspectFormCommand(service);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-inspect-form",
+            Command = "inspect-form",
+            Payload = JsonDocument.Parse("""
+                {
+                  "WorkbookPath": "C:\\work\\book.xlsm",
+                  "FormName": "UserForm1",
+                  "Basis": "both",
+                  "Initializer": "InitializeRuntime",
+                  "StrictDesigner": "true",
+                  "Visible": "false",
+                  "UseSession": "true",
+                  "MetadataPath": "C:\\work\\.xlflow\\session.json"
+                }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("live_session", json.RootElement.GetProperty("target").GetProperty("kind").GetString());
+        Assert.Equal("runtime", json.RootElement.GetProperty("forms").GetProperty("runtime").GetProperty("basis").GetString());
+        Assert.Equal("designer", json.RootElement.GetProperty("forms").GetProperty("designer").GetProperty("basis").GetString());
+        Assert.Equal("runtime_form_temp_copy", json.RootElement.GetProperty("warnings")[0].GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public void HandleRejectsMissingWorkbookPath()
+    {
+        var command = new InspectFormCommand(new FakeInspectFormService((request, _) => BridgeResponse.Ok(request)));
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-inspect-form-missing-workbook",
+            Command = "inspect-form",
+            Payload = JsonDocument.Parse("""{"FormName":"UserForm1"}""").RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("inspect_form_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public void HandleRejectsMissingFormName()
+    {
+        var command = new InspectFormCommand(new FakeInspectFormService((request, _) => BridgeResponse.Ok(request)));
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-inspect-form-missing-form",
+            Command = "inspect-form",
+            Payload = JsonDocument.Parse("""{"WorkbookPath":"C:\\work\\book.xlsm"}""").RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("inspect_form_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    private sealed class FakeInspectFormService(Func<BridgeRequest, InspectFormCommandArguments, BridgeResponse> handler) : IInspectFormService
+    {
+        public BridgeResponse Execute(BridgeRequest request, InspectFormCommandArguments args, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request, args);
+        }
+    }
+}

--- a/internal/excel/bridge_test.go
+++ b/internal/excel/bridge_test.go
@@ -424,6 +424,159 @@ func TestRunnerDotNetInspectResponsePreservesEnvelopeFields(t *testing.T) {
 	}
 }
 
+func TestRunnerDotNetInspectFormResponsePreservesEnvelopeFields(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		return trackingBridgeProvider{
+			name:     string(mode),
+			supports: true,
+			response: excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"inspect-form","logs":["inspected both UserForm UserForm1"],"target":{"kind":"live_session","path":"C:\\temp\\Book.xlsm","note":"Runtime inspection used a temporary workbook copy."},"session":{"active":true,"workbook_path":"C:\\temp\\Book.xlsm","dirty":false,"save_required":false,"live_newer_than_disk":false,"mode":"explicit","source_of_truth":"saved_workbook"},"workbook":{"path":"C:\\temp\\Book.xlsm","session":true,"session_mode":"explicit","session_requested":true,"auto_session":false,"saved":false,"dirty":false,"needs_save":false},"forms":{"runtime":{"name":"UserForm1","basis":"runtime","controls":[]},"designer":{"name":"UserForm1","basis":"designer","controls":[]}},"warnings":[{"code":"runtime_form_temp_copy","message":"Runtime inspection executed against a temporary workbook copy so the source workbook and live session are not mutated."}]}`)},
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "dotnet"}.InspectForm(config.Default(), InspectFormOptions{
+		Name:           "UserForm1",
+		Basis:          "both",
+		StrictDesigner: true,
+		Session:        true,
+		Keepalive:      CommandOptions{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if env.Target == nil || env.Session == nil || env.Workbook == nil || env.Forms == nil || env.Warnings == nil {
+		t.Fatalf("expected inspect-form envelope fields to be populated: %+v", env)
+	}
+	formsPayload, ok := env.Forms.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected forms payload map, got %#v", env.Forms)
+	}
+	runtimeForm, ok := formsPayload["runtime"].(map[string]interface{})
+	if !ok || runtimeForm["basis"] != "runtime" {
+		t.Fatalf("unexpected runtime form payload: %+v", formsPayload["runtime"])
+	}
+	designerForm, ok := formsPayload["designer"].(map[string]interface{})
+	if !ok || designerForm["basis"] != "designer" {
+		t.Fatalf("unexpected designer form payload: %+v", formsPayload["designer"])
+	}
+}
+
+func TestRunnerDotNetFormWriteResponsePreservesEnvelopeFields(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		return trackingBridgeProvider{
+			name:     string(mode),
+			supports: true,
+			response: excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"form-write","logs":["build form UserForm1 from src/forms/specs/UserForm1.yaml"],"target":{"kind":"live_session","path":"C:\\temp\\Book.xlsm"},"session":{"active":true,"workbook_path":"C:\\temp\\Book.xlsm","dirty":false,"save_required":false,"live_newer_than_disk":false,"mode":"explicit","source_of_truth":"saved_workbook"},"workbook":{"path":"C:\\temp\\Book.xlsm","session":true,"session_mode":"explicit","session_requested":true,"auto_session":false,"saved":true,"dirty":false,"needs_save":false},"forms":{"name":"UserForm1","basis":"designer","action":"build","coordinate_system":"parent-relative","control_count":2,"spec_path":"src/forms/specs/UserForm1.yaml","overwrite":true,"source_synced":true,"source_artifacts":{"form_path":"C:\\temp\\src\\forms\\UserForm1.frm","frx_path":"C:\\temp\\src\\forms\\UserForm1.frx","code_path":"C:\\temp\\src\\forms\\code\\UserForm1.bas"}},"warnings":[],"hints":[{"code":"userform_review_commands","message":"review"}]}`)},
+		}
+	}
+
+	spec := forms.FormSpec{
+		SchemaVersion: 1,
+		Kind:          "xlflow.userform",
+		Basis:         "designer",
+		Form:          forms.FormSpecForm{Name: "UserForm1"},
+		Controls:      []forms.FormSpecControl{{ID: "label1", Name: "Label1", Type: "label"}},
+	}
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "dotnet"}.FormWrite(config.Default(), FormWriteOptions{
+		Action:    "build",
+		SpecPath:  "src/forms/specs/UserForm1.yaml",
+		Spec:      spec,
+		Overwrite: true,
+		Session:   true,
+		Keepalive: CommandOptions{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if env.Command != "form build" {
+		t.Fatalf("Command = %q, want form build", env.Command)
+	}
+	if env.Target == nil || env.Session == nil || env.Workbook == nil || env.Forms == nil {
+		t.Fatalf("expected form-write envelope fields to be populated: %+v", env)
+	}
+	formsPayload, ok := env.Forms.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected forms payload map, got %#v", env.Forms)
+	}
+	if formsPayload["action"] != "build" || formsPayload["name"] != "UserForm1" {
+		t.Fatalf("unexpected forms payload: %+v", formsPayload)
+	}
+}
+
+func TestRunnerDotNetFormExportImageResponsePreservesEnvelopeFields(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		return trackingBridgeProvider{
+			name:     string(mode),
+			supports: true,
+			response: excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"form-export-image","logs":["exported runtime UserForm UserForm1 to C:\\temp\\UserForm1.png"],"target":{"kind":"live_session","path":"C:\\temp\\Book.xlsm","form":"UserForm1","capture_state":"temporary_copy","note":"Runtime export used a temporary workbook copy."},"session":{"active":true,"workbook_path":"C:\\temp\\Book.xlsm","dirty":false,"save_required":false,"live_newer_than_disk":false,"mode":"explicit","source_of_truth":"saved_workbook"},"workbook":{"path":"C:\\temp\\Book.xlsm","session":true,"session_mode":"explicit","session_requested":true,"auto_session":false,"saved":false,"dirty":false,"needs_save":false},"forms":{"name":"UserForm1","basis":"runtime"},"output":{"path":"C:\\temp\\UserForm1.png","format":"png","width_px":320,"height_px":240},"warnings":[{"code":"runtime_form_temp_copy","message":"Runtime export executed against a temporary workbook copy so the source workbook and live session are not mutated."}]}`)},
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "dotnet"}.FormExportImage(config.Default(), FormExportImageOptions{
+		Name:      "UserForm1",
+		OutPath:   `C:\temp\UserForm1.png`,
+		Session:   true,
+		Keepalive: CommandOptions{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if env.Target == nil || env.Session == nil || env.Workbook == nil || env.Forms == nil || env.Output == nil {
+		t.Fatalf("expected form-export-image envelope fields to be populated: %+v", env)
+	}
+	formsPayload, ok := env.Forms.(map[string]interface{})
+	if !ok || formsPayload["basis"] != "runtime" {
+		t.Fatalf("unexpected forms payload: %+v", env.Forms)
+	}
+}
+
+func TestRunnerDotNetExportImageResponsePreservesEnvelopeFields(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		return trackingBridgeProvider{
+			name:     string(mode),
+			supports: true,
+			response: excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"export-image","logs":["exported Sheet1!A1:C10 to C:\\temp\\sheet.png"],"target":{"kind":"live_session","path":"C:\\temp\\Book.xlsm","sheet":"Sheet1","range":"A1:C10"},"session":{"active":true,"workbook_path":"C:\\temp\\Book.xlsm","dirty":false,"save_required":false,"live_newer_than_disk":false,"mode":"explicit","source_of_truth":"saved_workbook"},"workbook":{"path":"C:\\temp\\Book.xlsm","session":true,"session_mode":"explicit","session_requested":true,"auto_session":false,"dirty":false,"needs_save":false},"output":{"path":"C:\\temp\\sheet.png","format":"png","default":true,"width_px":320,"height_px":240},"warnings":[{"code":"clipboard_retry_succeeded","message":"Clipboard image export succeeded after 2 attempts."}]}`)},
+		}
+	}
+
+	env, code, err := Runner{RootDir: t.TempDir(), BridgeMode: "dotnet"}.ExportImage(config.Default(), ExportImageOptions{
+		Sheet:     "Sheet1",
+		Range:     "A1:C10",
+		OutPath:   `C:\temp\sheet.png`,
+		Session:   true,
+		Keepalive: CommandOptions{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitSuccess)
+	}
+	if env.Target == nil || env.Session == nil || env.Workbook == nil || env.Output == nil {
+		t.Fatalf("expected export-image envelope fields to be populated: %+v", env)
+	}
+	outputPayload, ok := env.Output.(map[string]interface{})
+	if !ok || outputPayload["format"] != "png" {
+		t.Fatalf("unexpected output payload: %+v", env.Output)
+	}
+}
+
 func TestRunnerDotNetProcessCleanupResponsePreservesEnvelopeFields(t *testing.T) {
 	original := bridgeProviderForMode
 	t.Cleanup(func() { bridgeProviderForMode = original })


### PR DESCRIPTION
Closes #81 

## Summary

Implements issue #81 by moving UserForm inspect/build/image export and worksheet range image export onto the `.NET bridge`.

This adds explicit `--bridge dotnet` support for the following flows:

- `xlflow inspect form ... --bridge dotnet --json`
- `xlflow form build ... --bridge dotnet --json`
- `xlflow form export-image ... --bridge dotnet --json`
- `xlflow export-image ... --bridge dotnet --json`

## Changes

- add `.NET bridge` commands and registry entries for:
  - `inspect-form`
  - `form-write`
  - `form-export-image`
  - `export-image`
- implement `.NET` UserForm inspection service
  - designer inspect
  - runtime inspect via temporary workbook copy
  - initializer invocation support
- implement `.NET` UserForm build/import service
  - spec-driven build
  - source artifact sync for `.frm` / `.frx`
  - sidecar code-behind sync
- implement `.NET` UserForm image export service
  - runtime temp-copy workflow
  - UserForm window discovery
  - `PrintWindow` + screen capture fallback
- implement `.NET` worksheet/range image export service
  - `Range.CopyPicture` -> chart paste -> PNG export
  - clipboard retry / structured error classification
  - Excel activation / minimized or offscreen window handling
- harden `.NET` COM access paths
  - reduce fragile reflection-based access on workbook/session/VBProject paths
  - add dynamic dispatch helpers for COM methods such as `CopyPicture` / `Paste`
- preserve UserForm sidecar code artifact during build/export sync

## Validation

### Automated tests

- `dotnet test bridge/dotnet/Xlflow.ExcelBridge.sln`
- `go test ./internal/excel ./internal/cli`

### Windows + Excel E2E

Workspaces used:

- `C:\dev\go\xlflow\tmp_workspaces\issue81-dotnet-bridge-e2e-r3`
- `C:\dev\go\xlflow\tmp_workspaces\issue81-dotnet-bridge-init-r3`

Verified:

- blank workbook flow
  - `xlflow new --json`
  - `xlflow doctor --json`
  - `xlflow pull --json`
  - `xlflow lint --json`
- standard module round-trip
  - `xlflow session start --json`
  - `xlflow push --fast --session --no-save --json`
  - `xlflow run Main.Run --session --json`
  - `xlflow save --session --json`
  - `xlflow session stop --json`
  - Excel COM check confirmed `A1 = status:ok`
- class module round-trip
  - `src/classes/StatusWriter.cls`
- UserForm round-trip
  - `xlflow form build src/forms/specs/CaptureForm.yaml --bridge dotnet --session --json`
  - `xlflow pull --json`
  - confirmed:
    - `src/forms/CaptureForm.frm`
    - `src/forms/CaptureForm.frx`
    - `src/forms/code/CaptureForm.bas`
- `init` flow
  - `xlflow init <workbook> --json`
  - `xlflow pull --json`

Explicit `.NET bridge` command checks:

- `xlflow inspect form CaptureForm --both --initializer InitializePreview --bridge dotnet --json`
- `xlflow form export-image CaptureForm --initializer InitializePreview --out .xlflow/artifacts/CaptureForm-dotnet.png --overwrite --bridge dotnet --session --json`
- `xlflow export-image --sheet Sheet1 --range A1:B2 --out .xlflow/artifacts/Sheet1-dotnet.png --overwrite --bridge dotnet --session --json`
- `xlflow export-image --sheet Sheet1 --range A1:B2 --out .xlflow/artifacts/Sheet1-dotnet-nosession.png --overwrite --bridge dotnet --json`

## Notes

- During verification, a stale repo-local bridge executable caused old capabilities to be selected. Rebuilding the Release bridge artifacts resolved that mismatch.
- One non-blocking observation remains: runtime inspect may report `caption = "UserForm1"` in some cases even though export/capture and round-trip behavior are correct.