### PR TITLE
Restore spinner progress for `xlflow test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.11.0
+
 - Added native `.NET` bridge support for the remaining Windows workbook commands: `xlflow new`, `session start|status|save|stop`, `attach --active`, `runner install|status|remove`, `list forms`, `ui button add|list|remove`, and `edit cell|range|rows|columns` with explicit `--bridge dotnet --json`.
 - Packaged the `.NET` Excel bridge into Windows release ZIPs as `xlflow-excel-bridge.exe` beside `xlflow.exe`, while documenting AppLocker, WDAC, AV, and unsigned-executable caveats for managed Windows environments.
 - Added native `.NET` bridge support for `xlflow test --bridge dotnet --json`, enabling VBA test discovery and execution through the .NET bridge. Supports `Test*`/`*_Test` naming, `@Tag("...")` annotations, `BeforeAll`/`AfterAll`/`BeforeEach`/`AfterEach` hooks, inconclusive detection (`vbObjectError + 516`), runtime injection, UI/debug stream helpers, and session-aware workflow. Auto mode keeps the existing PowerShell behavior; use `--bridge dotnet` explicitly to route through the .NET bridge.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2856,7 +2856,6 @@ func (a *app) testCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			commandOpts := buildCommandOptions(a.stderrWriter())
-			commandOpts.Progress = false
 			cfg, err := a.loadConfig("test")
 			if err != nil {
 				return err

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -106,6 +106,42 @@ func TestRootCommandIncludesTestCommand(t *testing.T) {
 	}
 }
 
+func TestTestCommandWritesProgressToStderrForNonInteractiveJSONRuns(t *testing.T) {
+	skipWindowsPowerShellOnlyTest(t)
+
+	dir := t.TempDir()
+	cfg := config.Default()
+	if err := config.Write(filepath.Join(dir, config.FileName), cfg); err != nil {
+		t.Fatal(err)
+	}
+	writeTestTestScript(t, dir)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	a := &app{
+		cwd:            dir,
+		stdout:         &stdout,
+		stderr:         &stderr,
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs(withPowerShellBridge("--json", "test"))
+	if err := root.Execute(); err != nil {
+		t.Fatalf("test command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+	if got := stderr.String(); got != "xlflow: Running VBA tests...\n" {
+		t.Fatalf("stderr progress = %q", got)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("json output should be valid: %v\n%s", err, stdout.String())
+	}
+	if env["command"] != "test" {
+		t.Fatalf("expected command=test, got %v", env["command"])
+	}
+}
+
 func TestRootCommandIncludesVersionCommand(t *testing.T) {
 	a := &app{}
 	root := a.rootCommand()
@@ -4049,6 +4085,44 @@ Set-Content -LiteralPath $markerPath -Value ($names -join [Environment]::NewLine
 } | ConvertTo-Json -Compress
 `
 	if err := os.WriteFile(filepath.Join(scriptsDir, "push.ps1"), []byte(script), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTestTestScript(t *testing.T, root string) {
+	t.Helper()
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := `param(
+  [string]$WorkbookPath,
+  [string]$Filter = "",
+  [string]$ModuleFilter = "",
+  [string]$TagFilter = "",
+  [string]$Visible = "false",
+  [string]$RuntimeMode = "test",
+  [string]$RuntimeSource = "command",
+  [string]$MsgBoxResponsesJSON = "",
+  [string]$InputResponsesJSON = "",
+  [string]$FileDialogResponsesJSON = "",
+  [string]$DebugStreamEnabled = "false",
+  [string]$DebugStreamPipeName = "",
+  [string]$UIStreamEnabled = "false",
+  [string]$UIStreamRedactInput = "true",
+  [string]$UIStreamPipeName = "",
+  [string]$UseSession = "false",
+  [string]$MetadataPath = ""
+)
+@{
+  status = 'ok'
+  command = 'test'
+  logs = @('stub test ok')
+  workbook = @{ path = $WorkbookPath }
+  tests = @()
+} | ConvertTo-Json -Compress -Depth 5
+`
+	if err := os.WriteFile(filepath.Join(scriptsDir, "test.ps1"), []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/vitepress/commands/test.md
+++ b/vitepress/commands/test.md
@@ -78,6 +78,7 @@ xlflow test --filedialog folder:export-dir=@cancel --ui-stream --json
 
 > [!IMPORTANT]
 > `test` executes VBA. Use a controlled workbook state before running tests that mutate sheets or files.
+> `test` reports progress on stderr. Interactive terminals show a spinner, while non-interactive or `--json` runs emit a single progress line so stdout stays parseable.
 
 ::: tip
 Keep VBA assertions simple and scalar so failures are easy for agents to parse.


### PR DESCRIPTION
Closes #69 

## Summary
- Re-enabled shared Excel progress handling for `xlflow test` so it now reports stderr progress like the other COM-backed commands.
- Added a regression test that runs `test` through the CLI with a PowerShell script override and verifies the non-interactive JSON path still emits `xlflow: Running VBA tests...` on stderr.
- Documented the stderr progress behavior in the `test` command docs.

## Testing
- `go test ./internal/cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress output is now enabled for the `test` command.

* **Documentation**
  * Clarified how progress reporting works in different modes—spinners in interactive terminals and single-line output in non-interactive or JSON modes.

* **Tests**
  * Added integration test for progress output behavior in non-interactive JSON runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->