### PR TITLE
Fix debug stream pipe handling in non-Windows Excel tests

### DIFF
--- a/internal/excel/debug_stream_other.go
+++ b/internal/excel/debug_stream_other.go
@@ -2,16 +2,28 @@
 
 package excel
 
-import "io"
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
 
-type debugStreamSession struct{}
+type debugStreamSession struct {
+	pipePath string
+}
 
 func newDebugStreamSession(io.Writer) (*debugStreamSession, error) {
-	return nil, nil
+	return &debugStreamSession{
+		pipePath: fmt.Sprintf(`\\.\pipe\xlflow-debug-%d-%d`, os.Getpid(), time.Now().UnixNano()),
+	}, nil
 }
 
 func (s *debugStreamSession) PipePath() string {
-	return ""
+	if s == nil {
+		return ""
+	}
+	return s.pipePath
 }
 
 func (s *debugStreamSession) Close() error {

--- a/internal/excel/ui_stream_other.go
+++ b/internal/excel/ui_stream_other.go
@@ -2,16 +2,28 @@
 
 package excel
 
-import "io"
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
 
-type uiStreamSession struct{}
+type uiStreamSession struct {
+	pipePath string
+}
 
 func newUIStreamSession(io.Writer) (*uiStreamSession, error) {
-	return nil, nil
+	return &uiStreamSession{
+		pipePath: fmt.Sprintf(`\\.\pipe\xlflow-ui-%d-%d`, os.Getpid(), time.Now().UnixNano()),
+	}, nil
 }
 
 func (s *uiStreamSession) PipePath() string {
-	return ""
+	if s == nil {
+		return ""
+	}
+	return s.pipePath
 }
 
 func (s *uiStreamSession) Close() error {


### PR DESCRIPTION
## Summary
- Generate synthetic debug/UI stream pipe names in non-Windows builds instead of returning nil sessions.
- Keep the runner’s pipe replacement logic consistent across platforms so .NET bridge tests receive a non-empty `DebugStreamPipeName`.
- This removes the CI-only failure in the release workflow’s `go test ./...` run.

## Testing
- `go test ./internal/excel -run TestRunnerDotNetTestUsesDotNetProviderAndPreservesEnvelopeFields -count=1`
- `go test ./...`