### PR TITLE
feat(fmt): enhance line number handling and update documentation

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4094,7 +4094,7 @@ func (a *app) fmtCommand() *cobra.Command {
 						"message": warning.Message,
 					}
 					if warning.Path != "" {
-						item["file"] = warning.Path
+						item["path"] = warning.Path
 					}
 					if warning.Line > 0 {
 						item["line"] = warning.Line

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -853,6 +853,46 @@ func TestFmtLineNumbersWriteJSONViaCLI(t *testing.T) {
 	}
 }
 
+func TestFmtLineNumbersWarningsUsePathInJSONViaCLI(t *testing.T) {
+	dir := t.TempDir()
+	setupFmtProjectDir(t, dir)
+	path := filepath.Join(dir, "src", "modules", "Sample.bas")
+	input := "10  ' legacy comment\nPublic Sub Sample()\n    x = 1\nEnd Sub\n"
+	if err := os.WriteFile(path, []byte(input), 0644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	a := &app{
+		cwd:            dir,
+		stdout:         &stdout,
+		stderr:         new(bytes.Buffer),
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"--json", "fmt", "--line-numbers", "add", path})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("fmt --line-numbers warning --json error = %v, exit = %d", err, output.ExitCode(err))
+	}
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("json output should be valid: %v\n%s", err, stdout.String())
+	}
+	outputMap := env["output"].(map[string]any)
+	lineNumbers := outputMap["line_numbers"].(map[string]any)
+	warnings, ok := lineNumbers["warnings"].([]any)
+	if !ok || len(warnings) == 0 {
+		t.Fatalf("expected line_numbers warnings, got %#v", lineNumbers["warnings"])
+	}
+	warning := warnings[0].(map[string]any)
+	if warning["path"] == nil || warning["path"] == "" {
+		t.Fatalf("expected warning.path, got %#v", warning)
+	}
+	if _, exists := warning["file"]; exists {
+		t.Fatalf("did not expect warning.file key, got %#v", warning)
+	}
+}
+
 func TestFmtJSONTargetContractDefaultScope(t *testing.T) {
 	dir := t.TempDir()
 	setupFmtProjectDir(t, dir)

--- a/internal/vbafmt/fmt_test.go
+++ b/internal/vbafmt/fmt_test.go
@@ -1413,6 +1413,62 @@ func TestFormatTextWithLineNumbersSkipsAmbiguousNumericLabels(t *testing.T) {
 	}
 }
 
+func TestFormatTextWithLineNumbersIgnoresGoToInsideStringLiteral(t *testing.T) {
+	input := "Public Sub Sample()\n    MsgBox \"GoTo 10\"\n    x = 1\nEnd Sub\n"
+	got, detail, err := formatTextDetailed(input, false, FormatConfig{LineNumbers: LineNumberModeAdd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Warnings) != 0 {
+		t.Fatalf("did not expect numeric-label warning for string literal: %#v", detail.Warnings)
+	}
+	for _, want := range []string{
+		"10      MsgBox \"GoTo 10\"",
+		"20      x = 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected numbered output %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatTextWithLineNumbersAddSkipsLegacyNumberedComment(t *testing.T) {
+	input := "10  ' legacy comment\nPublic Sub Sample()\n    x = 1\nEnd Sub\n"
+	got, detail, err := formatTextDetailed(input, false, FormatConfig{LineNumbers: LineNumberModeAdd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Warnings) == 0 {
+		t.Fatal("expected warning for legacy numbered non-executable line")
+	}
+	if got != FormatMust(t, input) {
+		t.Fatalf("legacy numbered comment should prevent add rewrite:\n%s", got)
+	}
+}
+
+func TestFormatTextWithLineNumbersRenumberIncludesLegacyNumberedComment(t *testing.T) {
+	input := "10  ' legacy comment\n20  Public Sub Sample()\n30      x = 1\nEnd Sub\n"
+	got, detail, err := formatTextDetailed(input, false, FormatConfig{LineNumbers: LineNumberModeRenumber})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Warnings) != 0 {
+		t.Fatalf("did not expect warning: %#v", detail.Warnings)
+	}
+	for _, want := range []string{
+		"10  ' legacy comment",
+		"20  Public Sub Sample()",
+		"30      x = 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected renumbered output %q:\n%s", want, got)
+		}
+	}
+	if strings.Count(got, "\n10  ") > 1 {
+		t.Fatalf("renumber should not produce duplicate labels:\n%s", got)
+	}
+}
+
 func TestRunLineNumberSummary(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Sample.bas")

--- a/internal/vbafmt/fmt_test.go
+++ b/internal/vbafmt/fmt_test.go
@@ -1469,6 +1469,31 @@ func TestFormatTextWithLineNumbersRenumberIncludesLegacyNumberedComment(t *testi
 	}
 }
 
+func TestFormatTextWithLineNumbersRenumberLegacyOnlyNumberedLines(t *testing.T) {
+	input := "30  ' legacy comment a\n90  ' legacy comment b\n"
+	got, detail, err := formatTextDetailed(input, false, FormatConfig{LineNumbers: LineNumberModeRenumber})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Warnings) != 0 {
+		t.Fatalf("did not expect warning: %#v", detail.Warnings)
+	}
+	for _, want := range []string{
+		"10  ' legacy comment a",
+		"20  ' legacy comment b",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected renumbered legacy-only line %q:\n%s", want, got)
+		}
+	}
+	if !detail.Changed {
+		t.Fatalf("expected renumber legacy-only lines to report changed")
+	}
+	if detail.LinesRenumbered != 2 {
+		t.Fatalf("expected 2 renumbered lines, got %d", detail.LinesRenumbered)
+	}
+}
+
 func TestRunLineNumberSummary(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Sample.bas")

--- a/internal/vbafmt/line_numbers.go
+++ b/internal/vbafmt/line_numbers.go
@@ -359,7 +359,7 @@ func applyLineNumberMode(lines []formattedLine, mode LineNumberMode, refs []nume
 		result.Changed = result.LinesRemoved > 0
 		return renderFormattedLinesWithoutLineNumbers(lines), result
 	case LineNumberModeRenumber:
-		if eligibleCount == 0 {
+		if eligibleCount == 0 && numberedNonEligibleCount == 0 {
 			return renderFormattedLines(lines, nil), result
 		}
 		assignments := make(map[int]int)

--- a/internal/vbafmt/line_numbers.go
+++ b/internal/vbafmt/line_numbers.go
@@ -91,7 +91,7 @@ func collectNumericLabelReferences(lines []string) []numericLabelReference {
 	for i, line := range lines {
 		directive := parseLineNumberDirective(line)
 		content := directive.Content
-		stripped := stripTrailingComment(content)
+		stripped := stripStringLiterals(stripTrailingComment(content))
 		matches := numericLabelTargetRe.FindAllStringSubmatch(stripped, -1)
 		for _, match := range matches {
 			if len(match) != 2 {
@@ -108,6 +108,27 @@ func collectNumericLabelReferences(lines []string) []numericLabelReference {
 		}
 	}
 	return refs
+}
+
+func stripStringLiterals(line string) string {
+	var b strings.Builder
+	inString := false
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if ch == '"' {
+			if inString && i+1 < len(line) && line[i+1] == '"' {
+				i++
+				continue
+			}
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		b.WriteByte(ch)
+	}
+	return b.String()
 }
 
 func normalizeFormattedLines(lines []formattedLine) []formattedLine {
@@ -283,7 +304,11 @@ func applyLineNumberMode(lines []formattedLine, mode LineNumberMode, refs []nume
 
 	eligibleCount := 0
 	numberedEligibleCount := 0
+	numberedNonEligibleCount := 0
 	for _, line := range lines {
+		if line.HadLineNumber && !line.Eligible {
+			numberedNonEligibleCount++
+		}
 		if !line.Eligible {
 			continue
 		}
@@ -304,9 +329,9 @@ func applyLineNumberMode(lines []formattedLine, mode LineNumberMode, refs []nume
 
 	switch mode {
 	case LineNumberModeAdd:
-		if numberedEligibleCount > 0 && numberedEligibleCount < eligibleCount {
+		if numberedNonEligibleCount > 0 || (numberedEligibleCount > 0 && numberedEligibleCount < eligibleCount) {
 			result.Warnings = append(result.Warnings, LineNumberWarning{
-				Message: "Skipped line-number add because the file mixes numbered and unnumbered executable statements; use renumber to normalize first.",
+				Message: "Skipped line-number add because the file already contains legacy line numbers outside the supported executable-statement set or mixes numbered and unnumbered executable statements; use renumber to normalize first.",
 			})
 			return renderFormattedLines(lines, nil), result
 		}
@@ -340,7 +365,7 @@ func applyLineNumberMode(lines []formattedLine, mode LineNumberMode, refs []nume
 		assignments := make(map[int]int)
 		next := 10
 		for i, line := range lines {
-			if !line.Eligible {
+			if !line.Eligible && !line.HadLineNumber {
 				continue
 			}
 			assignments[i] = next

--- a/vitepress/commands/fmt.md
+++ b/vitepress/commands/fmt.md
@@ -74,10 +74,8 @@ cat MyModule.bas | xlflow fmt --stdin --json
 
 > [!NOTE]
 > Plain `xlflow fmt` uses `--line-numbers preserve`. It does not add line numbers automatically, but it preserves existing ones where possible.
-
 > [!NOTE]
 > `--stdin --json` writes the JSON envelope to stdout instead of formatted text. The envelope includes `output.changed` / `output.unchanged` summary fields but does not include the formatted source body. `--stdin` cannot be combined with `--line-numbers`.
-
 > [!NOTE]
 > `fmt --line-numbers ...` still follows the normal `fmt` contract. Without `--write`, it only reports what would change. Use `--write` to persist the numbered or de-numbered source.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed line number detection to ignore numeric references inside string literals, preventing false positives in control-flow analysis.
  * Improved warning detection for legacy numbered comment lines during line-number operations.
  * Enhanced renumbering logic to properly handle previously numbered lines.

* **Documentation**
  * Clarified `--stdin --json` behavior and `--line-numbers` restrictions in the `fmt` command documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->