### PR TITLE
Fix .NET bridge COM/RPC formatting failures and poison dead sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed `.NET` bridge macro runs so Excel is stabilized and the STA message loop is pumped around `Application.Run`, improving reliability for formatting/layout operations such as `Range.Interior.Color`, `Range.Clear`, row height updates, and protection state reads. Fatal COM/RPC failures such as `0x800706BE` now return `excel_com_rpc_failure` with `h_result` and run diagnostics, and live sessions are marked poisoned instead of being silently reused.
 - Added best-effort `.NET` VBE selection diagnostics for suppressed compile/runtime dialogs in `xlflow run --bridge dotnet --json` and compile failures in `xlflow push`, including selected component, procedure, source path, source-file line range, selected line text, and non-fatal capture-attempt metadata when Excel exposes it.
 - Improved `.NET` dialog watcher button diagnostics and action selection by capturing Win32 button `access_key`, `control_id`, and `enabled` metadata. VBA runtime suppression now prefers accelerator keys such as `D` for Debug and `E` for End before localized text fallback, improving tolerance for non-English Excel/VBE UI.
 - Fixed `.NET` VBE runtime location capture after `xlflow session start` so the first failing `run` no longer reports stale module header lines such as `Option Explicit` before VBE has moved the selection to the actual error line.

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Program.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Program.cs
@@ -5,9 +5,6 @@ public static class Program
     [STAThread]
     public static int Main(string[] args)
     {
-        var automationCulture = System.Globalization.CultureInfo.GetCultureInfo("en-US");
-        Thread.CurrentThread.CurrentCulture = automationCulture;
-        Thread.CurrentThread.CurrentUICulture = automationCulture;
         using var messageFilter = Services.ExcelBridgeSupport.RegisterOleMessageFilter();
         if (args.Contains("--run-worker", StringComparer.OrdinalIgnoreCase))
         {

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Program.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Program.cs
@@ -5,6 +5,10 @@ public static class Program
     [STAThread]
     public static int Main(string[] args)
     {
+        var automationCulture = System.Globalization.CultureInfo.GetCultureInfo("en-US");
+        Thread.CurrentThread.CurrentCulture = automationCulture;
+        Thread.CurrentThread.CurrentUICulture = automationCulture;
+        using var messageFilter = Services.ExcelBridgeSupport.RegisterOleMessageFilter();
         if (args.Contains("--run-worker", StringComparer.OrdinalIgnoreCase))
         {
             return Workers.MacroRunWorker.Run();

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -70,11 +70,27 @@ internal static class BridgePayload
     }
 }
 
-internal sealed record SessionMetadata(long Hwnd, int Pid, string WorkbookPath);
+internal sealed record SessionMetadata(
+    long Hwnd,
+    int Pid,
+    string WorkbookPath,
+    bool Poisoned = false,
+    string PoisonedAt = "",
+    string PoisonReason = "",
+    string HResult = "",
+    string LastCommand = "");
 
 internal sealed record ExcelSessionAttachment(object Excel, object Workbook, string SessionMode);
 
 internal sealed record ExcelProcessInfo(int ProcessId, bool? HasWorkbook);
+
+internal sealed class SessionPoisonedException(SessionMetadata metadata)
+    : InvalidOperationException("xlflow session is poisoned after a fatal Excel COM/RPC failure")
+{
+    public SessionMetadata Metadata { get; } = metadata;
+}
+
+internal sealed record ComFailureInfo(bool Fatal, string HResult, int Number, string Message);
 
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The .NET bridge only runs on Windows with Excel COM automation.")]
 [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Bridge support intentionally treats COM inspection as best-effort and normalizes failures to null/false or structured bridge errors.")]
@@ -106,7 +122,12 @@ internal static class ExcelBridgeSupport
         var hwnd = TryGetInt64(root, "hwnd");
         var pid = TryGetInt32(root, "pid");
         var workbookPath = BridgePayload.GetString(root, "workbook_path") ?? "";
-        return new SessionMetadata(hwnd, pid, workbookPath);
+        var poisoned = TryGetBool(root, "poisoned");
+        var poisonedAt = BridgePayload.GetString(root, "poisoned_at") ?? "";
+        var poisonReason = BridgePayload.GetString(root, "poison_reason") ?? "";
+        var hResult = BridgePayload.GetString(root, "h_result") ?? "";
+        var lastCommand = BridgePayload.GetString(root, "last_command") ?? "";
+        return new SessionMetadata(hwnd, pid, workbookPath, poisoned, poisonedAt, poisonReason, hResult, lastCommand);
     }
 
     public static void WriteSessionMetadata(string metadataPath, object excel, string workbookPath)
@@ -127,6 +148,46 @@ internal static class ExcelBridgeSupport
             ["hwnd"] = GetExcelMainHwnd(excel),
             ["pid"] = GetExcelProcessId(excel),
             ["workbook_path"] = NormalizePath(workbookPath),
+        };
+
+        File.WriteAllText(metadataPath, JsonSerializer.Serialize(payload));
+    }
+
+    public static void MarkSessionPoisoned(string metadataPath, string workbookPath, string reason, string hResult, string lastCommand)
+    {
+        if (string.IsNullOrWhiteSpace(metadataPath))
+        {
+            return;
+        }
+
+        var metadata = ReadSessionMetadata(metadataPath);
+        if (metadata is null)
+        {
+            return;
+        }
+
+        workbookPath = NormalizePath(workbookPath);
+        if (!string.IsNullOrWhiteSpace(metadata.WorkbookPath) && !PathsEqual(metadata.WorkbookPath, workbookPath))
+        {
+            return;
+        }
+
+        var parent = Path.GetDirectoryName(metadataPath);
+        if (!string.IsNullOrWhiteSpace(parent))
+        {
+            Directory.CreateDirectory(parent);
+        }
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["hwnd"] = metadata.Hwnd,
+            ["pid"] = metadata.Pid,
+            ["workbook_path"] = string.IsNullOrWhiteSpace(metadata.WorkbookPath) ? workbookPath : NormalizePath(metadata.WorkbookPath),
+            ["poisoned"] = true,
+            ["poisoned_at"] = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+            ["poison_reason"] = reason,
+            ["h_result"] = hResult,
+            ["last_command"] = lastCommand,
         };
 
         File.WriteAllText(metadataPath, JsonSerializer.Serialize(payload));
@@ -157,6 +218,7 @@ internal static class ExcelBridgeSupport
 
         if (useSession)
         {
+            ThrowIfSessionPoisoned(metadataPath, workbookPath);
             var excel = RunPhase("get_session_excel", () => GetSessionExcel(metadataPath))
                 ?? throw new InvalidOperationException("xlflow session is not running");
             var workbook = RunPhase("get_session_workbook", () => GetOpenWorkbook(excel, workbookPath));
@@ -165,6 +227,7 @@ internal static class ExcelBridgeSupport
 
         if (SessionMetadataMatchesWorkbook(metadataPath, workbookPath))
         {
+            ThrowIfSessionPoisoned(metadataPath, workbookPath);
             var excel = RunPhase("get_auto_session_excel", () => GetExcelFromSessionMetadata(metadataPath));
             if (excel is not null)
             {
@@ -183,6 +246,22 @@ internal static class ExcelBridgeSupport
         throw new InvalidOperationException("no matching xlflow session workbook is running; run xlflow session start or use the configured workbook session");
     }
 
+    public static void ThrowIfSessionPoisoned(string metadataPath, string workbookPath)
+    {
+        var metadata = ReadSessionMetadata(metadataPath);
+        if (metadata is null || !metadata.Poisoned)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(metadata.WorkbookPath) && !PathsEqual(metadata.WorkbookPath, workbookPath))
+        {
+            return;
+        }
+
+        throw new SessionPoisonedException(metadata);
+    }
+
     public static ExcelSessionAttachment OpenWorkbookDirect(string workbookPath, bool visible, bool disableAutomationMacros = true)
     {
         workbookPath = NormalizePath(workbookPath);
@@ -192,39 +271,139 @@ internal static class ExcelBridgeSupport
             throw new InvalidOperationException($"bridge_file_not_openable: File does not appear to be an Excel workbook: {workbookPath}");
         }
 
-        var excelType = Type.GetTypeFromProgID("Excel.Application")
-            ?? throw new InvalidOperationException("Excel.Application COM class is not registered");
-        var excel = Activator.CreateInstance(excelType)
-            ?? throw new InvalidOperationException("Failed to create Excel.Application COM instance");
-
+        var excel = CreateExcelApplicationWithPowerShell(workbookPath, visible, disableAutomationMacros);
+        object? workbook = null;
         try
         {
-            dynamic app = excel;
-            app.Visible = visible;
-            app.DisplayAlerts = false;
-            app.EnableEvents = false;
-            try
-            {
-                app.AutomationSecurity = disableAutomationMacros ? 3 : 1;
-            }
-            catch
-            {
-                // best-effort: some hosts may not expose AutomationSecurity
-            }
-
-            object workbook = app.Workbooks.Open(workbookPath);
+            workbook = GetOpenWorkbook(excel, workbookPath);
             return new ExcelSessionAttachment(excel, workbook, "none");
         }
         catch (InvalidOperationException)
         {
+            ReleaseComObject(workbook);
             ReleaseComObject(excel);
             throw;
         }
         catch (Exception ex)
         {
+            ReleaseComObject(workbook);
             ReleaseComObject(excel);
             var detail = UnwrapComErrorMessage(ex);
             throw new InvalidOperationException($"bridge_file_not_openable: {detail}", ex);
+        }
+    }
+
+    private static object CreateExcelApplicationWithPowerShell(string workbookPath, bool visible, bool disableAutomationMacros)
+    {
+        var scriptPath = Path.Combine(Path.GetTempPath(), "xlflow-open-excel-" + Guid.NewGuid().ToString("N") + ".ps1");
+        var outputPath = Path.Combine(Path.GetTempPath(), "xlflow-open-excel-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            File.WriteAllText(scriptPath, PowerShellOpenWorkbookScript());
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-ExecutionPolicy");
+            startInfo.ArgumentList.Add("Bypass");
+            startInfo.ArgumentList.Add("-File");
+            startInfo.ArgumentList.Add(scriptPath);
+            startInfo.ArgumentList.Add("-WorkbookPath");
+            startInfo.ArgumentList.Add(workbookPath);
+            startInfo.ArgumentList.Add("-OutputPath");
+            startInfo.ArgumentList.Add(outputPath);
+            startInfo.ArgumentList.Add("-Visible");
+            startInfo.ArgumentList.Add(visible ? "true" : "false");
+            startInfo.ArgumentList.Add("-DisableAutomationMacros");
+            startInfo.ArgumentList.Add(disableAutomationMacros ? "true" : "false");
+
+            using var process = Process.Start(startInfo);
+            if (process is null || !process.WaitForExit(120_000) || !File.Exists(outputPath))
+            {
+                throw new InvalidOperationException("PowerShell Excel launcher did not return a result.");
+            }
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(outputPath));
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("ok", out var ok) || !ok.GetBoolean())
+            {
+                var message = root.TryGetProperty("message", out var messageElement)
+                    ? messageElement.GetString()
+                    : "PowerShell Excel launcher failed.";
+                throw new InvalidOperationException(message);
+            }
+
+            var hwnd = root.TryGetProperty("hwnd", out var hwndElement) ? hwndElement.GetInt64() : 0;
+            var pid = root.TryGetProperty("pid", out var pidElement) ? pidElement.GetInt32() : 0;
+            var excel = hwnd != 0 ? TryGetExcelByHwnd(hwnd) : null;
+            excel ??= pid > 0 ? TryGetExcelByProcessId(pid) : null;
+            return excel ?? throw new InvalidOperationException("PowerShell created Excel, but xlflow could not attach to it.");
+        }
+        finally
+        {
+            TryDelete(scriptPath);
+            TryDelete(outputPath);
+        }
+    }
+
+    private static string PowerShellOpenWorkbookScript()
+    {
+        return """
+            param(
+              [string]$WorkbookPath,
+              [string]$OutputPath,
+              [string]$Visible = "false",
+              [string]$DisableAutomationMacros = "true"
+            )
+            $ErrorActionPreference = 'Stop'
+            function Write-Result($payload) {
+              $payload | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+            }
+            Add-Type -TypeDefinition @"
+            using System;
+            using System.Runtime.InteropServices;
+            public static class XlflowWindowPid {
+              [DllImport("user32.dll")]
+              public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out int processId);
+            }
+            "@
+            try {
+              $excel = New-Object -ComObject Excel.Application
+              $excel.Visible = [bool]::Parse($Visible)
+              $excel.DisplayAlerts = $false
+              $excel.EnableEvents = $false
+              try {
+                if ([bool]::Parse($DisableAutomationMacros)) {
+                  $excel.AutomationSecurity = 3
+                } else {
+                  $excel.AutomationSecurity = 1
+                }
+              } catch {}
+              $workbook = $excel.Workbooks.Open($WorkbookPath)
+              $excelPid = 0
+              [void][XlflowWindowPid]::GetWindowThreadProcessId([intptr]$excel.Hwnd, [ref]$excelPid)
+              Write-Result @{ ok = $true; hwnd = [int64]$excel.Hwnd; pid = [int]$excelPid }
+            } catch {
+              Write-Result @{ ok = $false; message = [string]$_.Exception.Message; hresult = [int]$_.Exception.HResult }
+            }
+            """;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // best-effort temp cleanup
         }
     }
 
@@ -777,7 +956,7 @@ internal static class ExcelBridgeSupport
         {
             return action();
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException and not SessionPoisonedException)
         {
             throw new InvalidOperationException(
                 $"{phase} failed: {FormatExceptionDetail(ex)}",
@@ -805,6 +984,138 @@ internal static class ExcelBridgeSupport
             return $"{ex.Message} ({ex.InnerException.Message})";
         }
         return ex.Message;
+    }
+
+    public static ComFailureInfo ClassifyComFailure(Exception ex)
+    {
+        var detail = ex.InnerException ?? ex;
+        var number = detail.HResult;
+        var hResult = FormatHResult(number);
+        return new ComFailureInfo(IsFatalComFailure(number), hResult, number, FormatExceptionDetail(ex));
+    }
+
+    public static bool IsFatalComFailure(int number)
+    {
+        return unchecked((uint)number) switch
+        {
+            0x800706BE => true, // RPC_S_CALL_FAILED
+            0x800706BA => true, // RPC_S_SERVER_UNAVAILABLE
+            0x80010108 => true, // RPC_E_DISCONNECTED
+            0x80010105 => true, // RPC_E_SERVERFAULT
+            0x80010001 => true, // RPC_E_CALL_REJECTED
+            _ => false,
+        };
+    }
+
+    public static string FormatHResult(int number)
+    {
+        return "0x" + unchecked((uint)number).ToString("X8", CultureInfo.InvariantCulture);
+    }
+
+    public static void StabilizeExcelForMacroRun(object excel, string workbookPath, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow.Add(timeout);
+        Exception? lastError = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var workbook = GetOpenWorkbook(excel, workbookPath);
+                try
+                {
+                    dynamic wb = workbook;
+                    wb.Activate();
+                }
+                finally
+                {
+                    ReleaseComObject(workbook);
+                }
+
+                dynamic app = excel;
+                try
+                {
+                    _ = app.Ready;
+                }
+                catch
+                {
+                    // Some Excel hosts reject Ready during startup; DoEvents and retry below.
+                }
+                TryDoEvents(excel);
+                PumpWaitingMessages();
+                return;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+                if (ClassifyComFailure(ex).Fatal)
+                {
+                    throw;
+                }
+                SleepAndPump(TimeSpan.FromMilliseconds(100));
+            }
+        }
+
+        if (lastError is not null)
+        {
+            throw new InvalidOperationException("Excel did not become ready for macro execution.", lastError);
+        }
+    }
+
+    public static void TryDoEvents(object? excel)
+    {
+        if (excel is null)
+        {
+            return;
+        }
+
+        try
+        {
+            dynamic app = excel;
+            app.Run("DoEvents");
+        }
+        catch
+        {
+            // DoEvents is best-effort only.
+        }
+    }
+
+    public static void SleepAndPump(TimeSpan duration)
+    {
+        var deadline = DateTime.UtcNow.Add(duration);
+        while (DateTime.UtcNow < deadline)
+        {
+            PumpWaitingMessages();
+            Thread.Sleep(Math.Min(25, Math.Max(1, (int)(deadline - DateTime.UtcNow).TotalMilliseconds)));
+        }
+        PumpWaitingMessages();
+    }
+
+    public static void PumpWaitingMessages()
+    {
+        while (NativeMethods.PeekMessage(out var message, IntPtr.Zero, 0, 0, NativeMethods.PmRemove))
+        {
+            NativeMethods.TranslateMessage(ref message);
+            NativeMethods.DispatchMessage(ref message);
+        }
+    }
+
+    public static IDisposable RegisterOleMessageFilter()
+    {
+        if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
+        {
+            return NullDisposable.Instance;
+        }
+
+        try
+        {
+            var filter = new OleMessageFilter();
+            var hr = NativeMethods.CoRegisterMessageFilter(filter, out var previous);
+            return hr == 0 ? new OleMessageFilterRegistration(filter, previous) : NullDisposable.Instance;
+        }
+        catch
+        {
+            return NullDisposable.Instance;
+        }
     }
 
     public static void Set(object comObject, string memberName, object? value)
@@ -1180,9 +1491,95 @@ internal static class ExcelBridgeSupport
         return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0L;
     }
 
+    private static bool TryGetBool(JsonElement element, string name)
+    {
+        var value = BridgePayload.GetString(element, name);
+        return bool.TryParse(value, out var parsed) && parsed;
+    }
+
+    private sealed class NullDisposable : IDisposable
+    {
+        public static readonly NullDisposable Instance = new();
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class OleMessageFilterRegistration(IOleMessageFilter current, IOleMessageFilter? previous) : IDisposable
+    {
+        private bool _disposed;
+        private IOleMessageFilter? _current = current;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            try
+            {
+                _ = NativeMethods.CoRegisterMessageFilter(previous, out _);
+            }
+            catch
+            {
+                // best-effort restoration
+            }
+            _current = null;
+        }
+    }
+
+    [ComImport]
+    [Guid("00000016-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IOleMessageFilter
+    {
+        [PreserveSig]
+        int HandleInComingCall(int dwCallType, IntPtr htaskCaller, int dwTickCount, IntPtr lpInterfaceInfo);
+
+        [PreserveSig]
+        int RetryRejectedCall(IntPtr htaskCallee, int dwTickCount, int dwRejectType);
+
+        [PreserveSig]
+        int MessagePending(IntPtr htaskCallee, int dwTickCount, int dwPendingType);
+    }
+
+    private sealed class OleMessageFilter : IOleMessageFilter
+    {
+        public int HandleInComingCall(int dwCallType, IntPtr htaskCaller, int dwTickCount, IntPtr lpInterfaceInfo)
+        {
+            return 0;
+        }
+
+        public int RetryRejectedCall(IntPtr htaskCallee, int dwTickCount, int dwRejectType)
+        {
+            const int serverCallRetryLater = 2;
+            return dwRejectType == serverCallRetryLater && dwTickCount < 10_000 ? 99 : -1;
+        }
+
+        public int MessagePending(IntPtr htaskCallee, int dwTickCount, int dwPendingType)
+        {
+            return 2;
+        }
+    }
+
     private static class NativeMethods
     {
+        public const uint PmRemove = 0x0001;
+
         public delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Message
+        {
+            public IntPtr Hwnd;
+            public uint Msg;
+            public IntPtr WParam;
+            public IntPtr LParam;
+            public uint Time;
+            public int PtX;
+            public int PtY;
+        }
 
         [DllImport("user32.dll")]
         public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
@@ -1211,5 +1608,19 @@ internal static class ExcelBridgeSupport
             int dwId,
             ref Guid riid,
             [MarshalAs(UnmanagedType.Interface)] out object? ppvObject);
+
+        [DllImport("ole32.dll")]
+        public static extern int CoRegisterMessageFilter(
+            [MarshalAs(UnmanagedType.Interface)] IOleMessageFilter? newFilter,
+            [MarshalAs(UnmanagedType.Interface)] out IOleMessageFilter? oldFilter);
+
+        [DllImport("user32.dll")]
+        public static extern bool PeekMessage(out Message lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax, uint wRemoveMsg);
+
+        [DllImport("user32.dll")]
+        public static extern bool TranslateMessage(ref Message lpMsg);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr DispatchMessage(ref Message lpMsg);
     }
 }

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -99,6 +99,7 @@ internal static class ExcelBridgeSupport
 {
     private const int ObjIdNativeOm = unchecked((int)0xFFFFFFF0);
     private static readonly Guid DispatchGuid = new("00020400-0000-0000-C000-000000000046");
+    internal static CultureInfo ComInvokeCulture => CultureInfo.CurrentCulture;
 
     public static string NormalizePath(string path)
     {
@@ -271,139 +272,44 @@ internal static class ExcelBridgeSupport
             throw new InvalidOperationException($"bridge_file_not_openable: File does not appear to be an Excel workbook: {workbookPath}");
         }
 
-        var excel = CreateExcelApplicationWithPowerShell(workbookPath, visible, disableAutomationMacros);
-        object? workbook = null;
+        var excelType = Type.GetTypeFromProgID("Excel.Application")
+            ?? throw new InvalidOperationException("Excel.Application COM class is not registered");
+        var excel = Activator.CreateInstance(excelType)
+            ?? throw new InvalidOperationException("Failed to create Excel.Application COM instance");
+
         try
         {
-            workbook = GetOpenWorkbook(excel, workbookPath);
+            ConfigureExcelForAutomation(excel, visible, disableAutomationMacros);
+            dynamic app = excel;
+            object workbook = app.Workbooks.Open(workbookPath);
             return new ExcelSessionAttachment(excel, workbook, "none");
         }
         catch (InvalidOperationException)
         {
-            ReleaseComObject(workbook);
             ReleaseComObject(excel);
             throw;
         }
         catch (Exception ex)
         {
-            ReleaseComObject(workbook);
             ReleaseComObject(excel);
             var detail = UnwrapComErrorMessage(ex);
             throw new InvalidOperationException($"bridge_file_not_openable: {detail}", ex);
         }
     }
 
-    private static object CreateExcelApplicationWithPowerShell(string workbookPath, bool visible, bool disableAutomationMacros)
+    private static void ConfigureExcelForAutomation(object excel, bool visible, bool disableAutomationMacros)
     {
-        var scriptPath = Path.Combine(Path.GetTempPath(), "xlflow-open-excel-" + Guid.NewGuid().ToString("N") + ".ps1");
-        var outputPath = Path.Combine(Path.GetTempPath(), "xlflow-open-excel-" + Guid.NewGuid().ToString("N") + ".json");
+        dynamic app = excel;
+        app.Visible = visible;
+        app.DisplayAlerts = false;
+        app.EnableEvents = false;
         try
         {
-            File.WriteAllText(scriptPath, PowerShellOpenWorkbookScript());
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "powershell.exe",
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-            startInfo.ArgumentList.Add("-NoProfile");
-            startInfo.ArgumentList.Add("-ExecutionPolicy");
-            startInfo.ArgumentList.Add("Bypass");
-            startInfo.ArgumentList.Add("-File");
-            startInfo.ArgumentList.Add(scriptPath);
-            startInfo.ArgumentList.Add("-WorkbookPath");
-            startInfo.ArgumentList.Add(workbookPath);
-            startInfo.ArgumentList.Add("-OutputPath");
-            startInfo.ArgumentList.Add(outputPath);
-            startInfo.ArgumentList.Add("-Visible");
-            startInfo.ArgumentList.Add(visible ? "true" : "false");
-            startInfo.ArgumentList.Add("-DisableAutomationMacros");
-            startInfo.ArgumentList.Add(disableAutomationMacros ? "true" : "false");
-
-            using var process = Process.Start(startInfo);
-            if (process is null || !process.WaitForExit(120_000) || !File.Exists(outputPath))
-            {
-                throw new InvalidOperationException("PowerShell Excel launcher did not return a result.");
-            }
-
-            using var doc = JsonDocument.Parse(File.ReadAllText(outputPath));
-            var root = doc.RootElement;
-            if (!root.TryGetProperty("ok", out var ok) || !ok.GetBoolean())
-            {
-                var message = root.TryGetProperty("message", out var messageElement)
-                    ? messageElement.GetString()
-                    : "PowerShell Excel launcher failed.";
-                throw new InvalidOperationException(message);
-            }
-
-            var hwnd = root.TryGetProperty("hwnd", out var hwndElement) ? hwndElement.GetInt64() : 0;
-            var pid = root.TryGetProperty("pid", out var pidElement) ? pidElement.GetInt32() : 0;
-            var excel = hwnd != 0 ? TryGetExcelByHwnd(hwnd) : null;
-            excel ??= pid > 0 ? TryGetExcelByProcessId(pid) : null;
-            return excel ?? throw new InvalidOperationException("PowerShell created Excel, but xlflow could not attach to it.");
-        }
-        finally
-        {
-            TryDelete(scriptPath);
-            TryDelete(outputPath);
-        }
-    }
-
-    private static string PowerShellOpenWorkbookScript()
-    {
-        return """
-            param(
-              [string]$WorkbookPath,
-              [string]$OutputPath,
-              [string]$Visible = "false",
-              [string]$DisableAutomationMacros = "true"
-            )
-            $ErrorActionPreference = 'Stop'
-            function Write-Result($payload) {
-              $payload | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $OutputPath -Encoding UTF8
-            }
-            Add-Type -TypeDefinition @"
-            using System;
-            using System.Runtime.InteropServices;
-            public static class XlflowWindowPid {
-              [DllImport("user32.dll")]
-              public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out int processId);
-            }
-            "@
-            try {
-              $excel = New-Object -ComObject Excel.Application
-              $excel.Visible = [bool]::Parse($Visible)
-              $excel.DisplayAlerts = $false
-              $excel.EnableEvents = $false
-              try {
-                if ([bool]::Parse($DisableAutomationMacros)) {
-                  $excel.AutomationSecurity = 3
-                } else {
-                  $excel.AutomationSecurity = 1
-                }
-              } catch {}
-              $workbook = $excel.Workbooks.Open($WorkbookPath)
-              $excelPid = 0
-              [void][XlflowWindowPid]::GetWindowThreadProcessId([intptr]$excel.Hwnd, [ref]$excelPid)
-              Write-Result @{ ok = $true; hwnd = [int64]$excel.Hwnd; pid = [int]$excelPid }
-            } catch {
-              Write-Result @{ ok = $false; message = [string]$_.Exception.Message; hresult = [int]$_.Exception.HResult }
-            }
-            """;
-    }
-
-    private static void TryDelete(string path)
-    {
-        try
-        {
-            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
-            {
-                File.Delete(path);
-            }
+            app.AutomationSecurity = disableAutomationMacros ? 3 : 1;
         }
         catch
         {
-            // best-effort temp cleanup
+            // best-effort: some hosts may not expose AutomationSecurity
         }
     }
 
@@ -874,7 +780,7 @@ internal static class ExcelBridgeSupport
             null,
             comObject,
             args,
-            CultureInfo.InvariantCulture);
+            ComInvokeCulture);
     }
 
     public static object? InvokeMethod(object comObject, string memberName, params object?[] args)
@@ -885,7 +791,7 @@ internal static class ExcelBridgeSupport
             null,
             comObject,
             args,
-            CultureInfo.InvariantCulture);
+            ComInvokeCulture);
     }
 
     public static object? InvokeViaDynamic(object comObject, string memberName, params object?[] args)

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunService.cs
@@ -28,6 +28,7 @@ public sealed class ExcelRunService : IRunService
         var sessionAttached = false;
         var sessionMode = "none";
         var skipComCleanup = false;
+        var retriedWithPowerShell = false;
 
         try
         {
@@ -37,6 +38,7 @@ public sealed class ExcelRunService : IRunService
             workbook = openResult.Workbook;
             sessionAttached = openResult.SessionAttached;
             sessionMode = openResult.SessionMode;
+            ExcelBridgeSupport.StabilizeExcelForMacroRun(excel, args.WorkbookPath, TimeSpan.FromSeconds(3));
 
             var dirtyKnown = ExcelBridgeSupport.TryGetWorkbookDirtyState(workbook, out var dirtyState);
             var dirty = sessionAttached ? dirtyKnown ? dirtyState : true : false;
@@ -105,6 +107,7 @@ public sealed class ExcelRunService : IRunService
 
             runtimeState = ApplyRuntimeMarkers(workbook, args);
             var runtimeInjected = runtimeState.Applied;
+            ExcelBridgeSupport.SleepAndPump(TimeSpan.FromMilliseconds(150));
 
             var macroReference = BuildWorkbookQualifiedMacroReference(workbook, macroName);
             if (!args.Direct)
@@ -125,17 +128,12 @@ public sealed class ExcelRunService : IRunService
             }
 
             var sw = Stopwatch.StartNew();
-            var invocation = InvokeWithWorker(
-                new MacroRunWorkerRequest(
-                    excelProcessId,
-                    excelHwnd,
-                    macroReference,
-                    (args.Direct ? macroArgs : [])
-                        .Select(argument => new MacroRunWorkerArgument(argument.Type, argument.Value))
-                        .ToArray(),
-                    WorkbookPath: args.WorkbookPath),
+            var invocation = InvokeInProcess(
+                excel,
+                macroReference,
+                args.Direct ? macroArgs : [],
+                excelProcessId,
                 excelHwnd,
-                DialogKind.Any,
                 args.SuppressModalErrors,
                 ResolveTimeout(request, args, commandStopwatch.Elapsed),
                 cancellationToken,
@@ -177,6 +175,36 @@ public sealed class ExcelRunService : IRunService
                 }
             }
 
+            string? retryError = null;
+            int? retryErrorNumber = null;
+            if (runError is not null &&
+                IsOfficeTypeLibraryFailure(runErrorNumber) &&
+                macroArgs.Count == 0 &&
+                string.IsNullOrWhiteSpace(args.SaveAsPath))
+            {
+                var retryHwnd = excelHwnd;
+                if (!sessionAttached)
+                {
+                    CloseWorkbook(workbook, excel);
+                    workbook = null;
+                    excel = null;
+                    retryHwnd = 0;
+                }
+                if (TryRetryMacroWithPowerShell(args, sessionAttached, retryHwnd, out retryError, out retryErrorNumber))
+                {
+                    retriedWithPowerShell = true;
+                    runError = null;
+                    runErrorNumber = null;
+                    runErrorLine = null;
+                    logs.Add("retried macro through PowerShell COM after Office type-library failure");
+                }
+            }
+            if (runError is not null && IsOfficeTypeLibraryFailure(runErrorNumber) && retryError is not null)
+            {
+                runError = retryError;
+                runErrorNumber = retryErrorNumber;
+            }
+
             if (!runTimedOut)
             {
                 RemoveTemporaryComponent(vbProject, runnerComponent);
@@ -195,10 +223,25 @@ public sealed class ExcelRunService : IRunService
 
             if (runError is not null)
             {
+                var fatalComFailure = invocation.Result?.Error is not null &&
+                    ExcelBridgeSupport.IsFatalComFailure(invocation.Result.Error.Number);
+                var fatalHResult = fatalComFailure
+                    ? ExcelBridgeSupport.FormatHResult(invocation.Result!.Error!.Number)
+                    : null;
+                var fatalStage = invocation.Result?.Error?.Stage ?? "invoke_macro";
                 var compileFailure = !runTimedOut && IsLikelyVbaCompileFailure(runError, runErrorNumber, invocation.Dialog);
-                var errorCode = runTimedOut ? "macro_timeout" : compileFailure ? "vba_compile_failed" : ClassifyRunError(runError, runErrorNumber);
-                var errorPhase = compileFailure ? "compile_vba" : "invoke_macro";
+                var errorCode = fatalComFailure ? "excel_com_rpc_failure" : runTimedOut ? "macro_timeout" : compileFailure ? "vba_compile_failed" : ClassifyRunError(runError, runErrorNumber);
+                var errorPhase = fatalComFailure ? fatalStage : compileFailure ? "compile_vba" : "invoke_macro";
                 logs.Add(compileFailure ? $"VBA compile failed: {runError}" : $"macro execution failed: {runError}");
+                if (fatalComFailure && sessionAttached)
+                {
+                    ExcelBridgeSupport.MarkSessionPoisoned(
+                        args.MetadataPath,
+                        args.WorkbookPath,
+                        runError,
+                        fatalHResult ?? "",
+                        "run");
+                }
                 if (sessionAttached)
                 {
                     dirty = true;
@@ -217,6 +260,7 @@ public sealed class ExcelRunService : IRunService
                     session_mode = sessionMode,
                     session_requested = args.UseSession,
                     auto_session = sessionAttached && !args.UseSession,
+                    reused = sessionAttached,
                     saved = false,
                     dirty,
                     needs_save = needsSave,
@@ -234,6 +278,20 @@ public sealed class ExcelRunService : IRunService
                         line = runErrorLine,
                     },
                 };
+
+                if (fatalComFailure)
+                {
+                    extensions["com"] = BuildComFailureDiagnostics(
+                        args,
+                        runError,
+                        fatalHResult ?? "",
+                        fatalStage,
+                        excelProcessId,
+                        excelHwnd,
+                        invocation.WorkerProcessId,
+                        sessionAttached,
+                        sessionMode);
+                }
 
                 if (!string.IsNullOrEmpty(args.RuntimeMode))
                 {
@@ -278,7 +336,11 @@ public sealed class ExcelRunService : IRunService
                         Message: runError,
                         Phase: errorPhase,
                         Source: "xlflow-excel-bridge",
-                        Number: runErrorNumber),
+                        Number: runErrorNumber,
+                        HResult: fatalHResult,
+                        Details: fatalComFailure
+                            ? BuildComFailureDetails(args, fatalStage, excelProcessId, excelHwnd, invocation.WorkerProcessId, sessionAttached, sessionMode)
+                            : null),
                     Logs = logs,
                     Extensions = extensions,
                 };
@@ -286,8 +348,17 @@ public sealed class ExcelRunService : IRunService
 
             var saved = false;
             var saveAsCopy = false;
-            if (!string.IsNullOrWhiteSpace(args.SaveAsPath))
+            if (retriedWithPowerShell)
             {
+                saved = args.SaveWorkbook;
+            }
+            else if (!string.IsNullOrWhiteSpace(args.SaveAsPath))
+            {
+                if (workbook is null)
+                {
+                    throw new InvalidOperationException("Workbook is not available for SaveCopyAs after macro retry.");
+                }
+
                 var saveAsPath = ExcelBridgeSupport.NormalizePath(args.SaveAsPath);
                 AssertSaveAsExtension(args.WorkbookPath, saveAsPath);
                 ExcelBridgeSupport.RunPhase("save_as", () => ExcelBridgeSupport.InvokeViaDynamic(workbook, "SaveCopyAs", saveAsPath));
@@ -295,6 +366,11 @@ public sealed class ExcelRunService : IRunService
             }
             else if (args.SaveWorkbook)
             {
+                if (workbook is null)
+                {
+                    throw new InvalidOperationException("Workbook is not available for Save after macro retry.");
+                }
+
                 ExcelBridgeSupport.RunPhase("save_workbook", () => ExcelBridgeSupport.InvokeViaDynamic(workbook, "Save"));
                 saved = true;
             }
@@ -391,14 +467,35 @@ public sealed class ExcelRunService : IRunService
                 Phase: "run",
                 Source: "xlflow-excel-bridge"));
         }
+        catch (SessionPoisonedException ex)
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                Code: "session_poisoned",
+                Message: "The xlflow session was marked poisoned after a fatal Excel COM/RPC failure. Run `xlflow session stop --json` and start a fresh session.",
+                Phase: "run",
+                Source: "xlflow-excel-bridge",
+                HResult: ex.Metadata.HResult,
+                Details: new Dictionary<string, object?>
+                {
+                    ["workbook_path"] = ex.Metadata.WorkbookPath,
+                    ["excel_pid"] = ex.Metadata.Pid,
+                    ["excel_hwnd"] = ex.Metadata.Hwnd,
+                    ["poisoned_at"] = ex.Metadata.PoisonedAt,
+                    ["poison_reason"] = ex.Metadata.PoisonReason,
+                    ["last_command"] = ex.Metadata.LastCommand,
+                }));
+        }
         catch (Exception ex)
         {
             var detail = ExcelBridgeSupport.FormatExceptionDetail(ex);
+            var comFailure = ExcelBridgeSupport.ClassifyComFailure(ex);
             return BridgeResponse.Failed(request, new BridgeError(
-                Code: "macro_failed",
+                Code: comFailure.Fatal ? "excel_com_rpc_failure" : "macro_failed",
                 Message: detail,
                 Phase: "run",
-                Source: "xlflow-excel-bridge"));
+                Source: "xlflow-excel-bridge",
+                Number: comFailure.Fatal ? comFailure.Number : null,
+                HResult: comFailure.Fatal ? comFailure.HResult : null));
         }
         finally
         {
@@ -438,7 +535,9 @@ public sealed class ExcelRunService : IRunService
         builder.AppendLine("  startedAt = Timer");
         builder.AppendLine("  targetMacro = \"'\" & ThisWorkbook.Name & \"'!\" & " + ToVbaString(macroName));
         builder.AppendLine("  On Error GoTo Handler");
+        builder.AppendLine("  DoEvents");
         builder.AppendLine(invocation.ToString());
+        builder.AppendLine("  DoEvents");
         builder.AppendLine("  RunMacro = Array(True, " + ToVbaString(moduleName) + ", CLng(0), \"\", CLng(0), CLng((Timer - startedAt) * 1000))");
         builder.AppendLine("  Exit Function");
         builder.AppendLine("Handler:");
@@ -483,7 +582,7 @@ public sealed class ExcelRunService : IRunService
         bool suppressModalErrors,
         TimeSpan timeout,
         CancellationToken cancellationToken,
-        IVbeSelectionLocator? selectionLocator = null)
+        VbeSelectionLocator? selectionLocator = null)
     {
         return ExcelWorkerInvocation.InvokeWithWorker(
             workerRequest,
@@ -495,13 +594,160 @@ public sealed class ExcelRunService : IRunService
             selectionLocator);
     }
 
+    private static WorkerInvocationResult InvokeInProcess(
+        object excel,
+        string macroReference,
+        IReadOnlyList<MacroArg> macroArgs,
+        int excelProcessId,
+        long excelHwnd,
+        bool suppressModalErrors,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        VbeSelectionLocator? selectionLocator = null)
+    {
+        var watcher = new DialogWatcher();
+        var actionPolicy = suppressModalErrors
+            ? selectionLocator is not null
+                ? DialogActionPolicy.SuppressVbaErrorWithRuntimeDebug
+                : DialogActionPolicy.SuppressVbaError
+            : DialogActionPolicy.ObserveOnly;
+        var watchRequest = new DialogWatchRequest(
+            excelProcessId,
+            excelHwnd,
+            DialogKind.Any,
+            actionPolicy,
+            timeout,
+            TimeSpan.FromMilliseconds(50));
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var locationCaptures = new List<VbeSelectionCapture>();
+        var locationCaptureGate = new object();
+
+        void CaptureBefore(DialogKind kind)
+        {
+            if ((kind is DialogKind.Compile or DialogKind.Runtime) && selectionLocator is not null)
+            {
+                lock (locationCaptureGate)
+                {
+                    locationCaptures.Add(selectionLocator.Capture("before_dialog_action"));
+                }
+            }
+        }
+
+        void CaptureAfter(DialogKind kind)
+        {
+            lock (locationCaptureGate)
+            {
+                if ((kind is DialogKind.Compile or DialogKind.Runtime) &&
+                    selectionLocator is not null &&
+                    !locationCaptures.Any(capture => capture.HasReliableLocation))
+                {
+                    locationCaptures.Add(selectionLocator.Capture("after_dialog_action"));
+                }
+                if (kind == DialogKind.Runtime)
+                {
+                    selectionLocator?.ResetBreakMode();
+                }
+            }
+        }
+
+        VbeSelectionCapture MergeCurrentCaptures()
+        {
+            lock (locationCaptureGate)
+            {
+                if (locationCaptures.Count == 0)
+                {
+                    return VbeSelectionCapture.Empty;
+                }
+                var location = locationCaptures
+                    .Select(capture => capture.Location)
+                    .Where(location => location is not null)
+                    .OrderByDescending(location => VbeSelectionScorer.Score(location!))
+                    .FirstOrDefault();
+                return new VbeSelectionCapture(location, locationCaptures.SelectMany(capture => capture.Attempts).ToArray());
+            }
+        }
+
+        var watcherTask = Task.Run(() => watcher.WaitForDialog(watchRequest, CaptureBefore, CaptureAfter, linked.Token), linked.Token);
+        MacroRunWorkerResult? result;
+        var stage = "application_run";
+        try
+        {
+            var invokeArgs = new List<object?> { macroReference };
+            foreach (var argument in macroArgs)
+            {
+                invokeArgs.Add(ConvertArgument(argument));
+            }
+
+            var value = ExcelBridgeSupport.InvokeMethod(excel, "Run", invokeArgs.ToArray());
+            stage = "post_run_pump";
+            ExcelBridgeSupport.SleepAndPump(TimeSpan.FromMilliseconds(100));
+            result = new MacroRunWorkerResult(true, true, NormalizeMacroValue(value), null);
+        }
+        catch (Exception ex)
+        {
+            var detail = ex.InnerException ?? ex;
+            result = new MacroRunWorkerResult(
+                Completed: true,
+                Ok: false,
+                Value: null,
+                Error: new MacroRunWorkerError(
+                    ExcelBridgeSupport.FormatExceptionDetail(ex),
+                    detail.Source ?? "xlflow-excel-bridge",
+                    detail.HResult,
+                    stage));
+        }
+
+        var postDialog = WaitForPostWorkerDialog(
+            watcher,
+            watcherTask,
+            watchRequest,
+            operation: "run",
+            result,
+            linked.Token,
+            CaptureBefore,
+            CaptureAfter);
+        linked.Cancel();
+        if (postDialog is not null)
+        {
+            return new WorkerInvocationResult(result, postDialog, [postDialog], MergeCurrentCaptures(), false, Environment.ProcessId);
+        }
+        return new WorkerInvocationResult(result, null, [], MergeCurrentCaptures(), false, Environment.ProcessId);
+    }
+
+    private static object ConvertArgument(MacroArg argument)
+    {
+        return argument.Type.ToLowerInvariant() switch
+        {
+            "int" => int.Parse(argument.Value, NumberStyles.Integer, CultureInfo.InvariantCulture),
+            "double" => double.Parse(argument.Value, NumberStyles.Float, CultureInfo.InvariantCulture),
+            "bool" => bool.Parse(argument.Value),
+            _ => argument.Value,
+        };
+    }
+
+    private static object? NormalizeMacroValue(object? value)
+    {
+        if (value is Array array)
+        {
+            var items = new object?[array.Length];
+            for (var i = 0; i < array.Length; i++)
+            {
+                items[i] = array.GetValue(i);
+            }
+            return items;
+        }
+        return value;
+    }
+
     internal static DialogSnapshot? WaitForPostWorkerDialog(
         DialogWatcher watcher,
         Task<DialogSnapshot?> watcherTask,
         DialogWatchRequest watchRequest,
         string operation,
         MacroRunWorkerResult? result,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action<DialogKind>? beforeAction = null,
+        Action<DialogKind>? afterAction = null)
     {
         return ExcelWorkerInvocation.WaitForPostWorkerDialog(
             watcher,
@@ -509,7 +755,9 @@ public sealed class ExcelRunService : IRunService
             watchRequest,
             operation,
             result,
-            cancellationToken);
+            cancellationToken,
+            beforeAction,
+            afterAction);
     }
 
     private static BridgeResponse BuildCompileFailureResponse(
@@ -528,6 +776,21 @@ public sealed class ExcelRunService : IRunService
             : invocation.TimedOut
                 ? "VBE Compile timed out."
                 : invocation.Result?.Error?.Message ?? "VBE Compile failed.";
+        var fatalComFailure = invocation.Result?.Error is not null &&
+            ExcelBridgeSupport.IsFatalComFailure(invocation.Result.Error.Number);
+        var fatalHResult = fatalComFailure
+            ? ExcelBridgeSupport.FormatHResult(invocation.Result!.Error!.Number)
+            : null;
+        var fatalStage = invocation.Result?.Error?.Stage ?? "compile_vba";
+        if (fatalComFailure && sessionAttached)
+        {
+            ExcelBridgeSupport.MarkSessionPoisoned(
+                args.MetadataPath,
+                args.WorkbookPath,
+                message,
+                fatalHResult ?? "",
+                "run");
+        }
         logs.Add($"VBE Compile failed: {message}");
         var extensions = new Dictionary<string, object?>
         {
@@ -552,17 +815,34 @@ public sealed class ExcelRunService : IRunService
             },
             ["run_diagnostic"] = BuildRunDiagnostic("compile", invocation, new { macro = args.MacroName }, invocation.TimedOut),
         };
+        if (fatalComFailure)
+        {
+            extensions["com"] = BuildComFailureDiagnostics(
+                args,
+                message,
+                fatalHResult ?? "",
+                fatalStage,
+                0,
+                0,
+                invocation.WorkerProcessId,
+                sessionAttached,
+                sessionMode);
+        }
         return new BridgeResponse
         {
             RequestId = request.RequestId,
             Command = request.Command,
             Status = BridgeStatus.Failed,
             Error = new BridgeError(
-                Code: "vba_compile_failed",
+                Code: fatalComFailure ? "excel_com_rpc_failure" : "vba_compile_failed",
                 Message: message,
-                Phase: "compile_vba",
+                Phase: fatalComFailure ? fatalStage : "compile_vba",
                 Source: "xlflow-excel-bridge",
-                Number: invocation.Result?.Error?.Number),
+                Number: invocation.Result?.Error?.Number,
+                HResult: fatalHResult,
+                Details: fatalComFailure
+                    ? BuildComFailureDetails(args, fatalStage, 0, 0, invocation.WorkerProcessId, sessionAttached, sessionMode)
+                    : null),
             Logs = logs,
             Extensions = extensions,
         };
@@ -662,6 +942,62 @@ public sealed class ExcelRunService : IRunService
         return diagnostic;
     }
 
+    internal static Dictionary<string, object?> BuildComFailureDiagnostics(
+        RunCommandArguments args,
+        string message,
+        string hResult,
+        string stage,
+        int excelProcessId,
+        long excelHwnd,
+        int workerProcessId,
+        bool sessionAttached,
+        string sessionMode)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["fatal"] = true,
+            ["message"] = message,
+            ["h_result"] = hResult,
+            ["stage"] = stage,
+            ["macro"] = args.MacroName,
+            ["excel_pid"] = excelProcessId,
+            ["excel_hwnd"] = excelHwnd,
+            ["worker_pid"] = workerProcessId,
+            ["session_id"] = string.IsNullOrWhiteSpace(args.MetadataPath) ? null : args.MetadataPath,
+            ["session_mode"] = sessionMode,
+            ["visible"] = args.Visible,
+            ["headless"] = !args.Visible,
+            ["workbook_reused"] = sessionAttached,
+            ["workbook_reuse_mode"] = sessionAttached ? sessionMode : "direct",
+            ["poisoned"] = sessionAttached,
+        };
+    }
+
+    internal static IReadOnlyDictionary<string, object?> BuildComFailureDetails(
+        RunCommandArguments args,
+        string stage,
+        int excelProcessId,
+        long excelHwnd,
+        int workerProcessId,
+        bool sessionAttached,
+        string sessionMode)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["macro"] = args.MacroName,
+            ["stage"] = stage,
+            ["excel_pid"] = excelProcessId,
+            ["excel_hwnd"] = excelHwnd,
+            ["worker_pid"] = workerProcessId,
+            ["session_id"] = string.IsNullOrWhiteSpace(args.MetadataPath) ? null : args.MetadataPath,
+            ["session_mode"] = sessionMode,
+            ["visible"] = args.Visible,
+            ["headless"] = !args.Visible,
+            ["workbook_reused"] = sessionAttached,
+            ["workbook_reuse_mode"] = sessionAttached ? sessionMode : "direct",
+        };
+    }
+
     private static void SetProperty(object comObject, string name, object value)
     {
         comObject.GetType().InvokeMember(
@@ -696,6 +1032,16 @@ public sealed class ExcelRunService : IRunService
 
     private static RuntimeInjectionHelper.RuntimeInjectionState ApplyRuntimeMarkers(object workbook, RunCommandArguments args)
     {
+        if (IsDefaultRuntimeWithoutInjectedFeatures(args))
+        {
+            return new RuntimeInjectionHelper.RuntimeInjectionState
+            {
+                Mode = args.RuntimeMode,
+                Source = args.RuntimeSource,
+                Applied = false,
+            };
+        }
+
         return RuntimeInjectionHelper.ApplyRuntimeInjection(
             workbook,
             args.RuntimeMode,
@@ -708,6 +1054,15 @@ public sealed class ExcelRunService : IRunService
             args.UIStreamEnabled,
             args.UIStreamPipeName,
             args.UIStreamRedactInput);
+    }
+
+    private static bool IsDefaultRuntimeWithoutInjectedFeatures(RunCommandArguments args)
+    {
+        return string.Equals(args.RuntimeSource, "default", StringComparison.OrdinalIgnoreCase) &&
+            string.IsNullOrWhiteSpace(args.MsgBoxResponsesJSON) &&
+            string.IsNullOrWhiteSpace(args.InputResponsesJSON) &&
+            string.IsNullOrWhiteSpace(args.FileDialogResponsesJSON) &&
+            (!args.UIStreamEnabled || string.IsNullOrWhiteSpace(args.UIStreamPipeName));
     }
 
     private static void RestoreRuntimeMarkers(object? workbook, RuntimeInjectionHelper.RuntimeInjectionState? state)
@@ -757,6 +1112,10 @@ public sealed class ExcelRunService : IRunService
             {
                 var attachment = ExcelBridgeSupport.AttachToSessionWorkbook(workbookPath, metadataPath, false);
                 return (attachment.Excel, attachment.Workbook, true, attachment.SessionMode);
+            }
+            catch (SessionPoisonedException)
+            {
+                throw;
             }
             catch
             {
@@ -820,6 +1179,217 @@ public sealed class ExcelRunService : IRunService
         }
 
         return message.Contains("0x800A9C68", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool IsOfficeTypeLibraryFailure(int? number)
+    {
+        return number == unchecked((int)0x80028018);
+    }
+
+    private static bool TryRetryMacroWithPowerShell(
+        RunCommandArguments args,
+        bool sessionAttached,
+        long excelHwnd,
+        out string? error,
+        out int? errorNumber)
+    {
+        error = null;
+        errorNumber = null;
+
+        var scriptPath = Path.Combine(Path.GetTempPath(), "xlflow-run-retry-" + Guid.NewGuid().ToString("N") + ".ps1");
+        var outputPath = Path.Combine(Path.GetTempPath(), "xlflow-run-retry-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            File.WriteAllText(scriptPath, PowerShellRetryScript());
+            var macroReference = "'" + Path.GetFileName(args.WorkbookPath).Replace("'", "''", StringComparison.Ordinal) + "'!" + args.MacroName;
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-ExecutionPolicy");
+            startInfo.ArgumentList.Add("Bypass");
+            startInfo.ArgumentList.Add("-File");
+            startInfo.ArgumentList.Add(scriptPath);
+            startInfo.ArgumentList.Add("-WorkbookPath");
+            startInfo.ArgumentList.Add(args.WorkbookPath);
+            startInfo.ArgumentList.Add("-MacroReference");
+            startInfo.ArgumentList.Add(macroReference);
+            startInfo.ArgumentList.Add("-OutputPath");
+            startInfo.ArgumentList.Add(outputPath);
+            startInfo.ArgumentList.Add("-Visible");
+            startInfo.ArgumentList.Add(args.Visible ? "true" : "false");
+            startInfo.ArgumentList.Add("-UseSession");
+            startInfo.ArgumentList.Add(sessionAttached ? "true" : "false");
+            startInfo.ArgumentList.Add("-SaveWorkbook");
+            startInfo.ArgumentList.Add(args.SaveWorkbook ? "true" : "false");
+            startInfo.ArgumentList.Add("-ExcelHwnd");
+            startInfo.ArgumentList.Add(excelHwnd.ToString(CultureInfo.InvariantCulture));
+
+            using var process = Process.Start(startInfo);
+            if (process is null || !process.WaitForExit(120_000) || !File.Exists(outputPath))
+            {
+                error = "PowerShell COM retry did not return a result.";
+                return false;
+            }
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(outputPath));
+            var root = doc.RootElement;
+            if (root.TryGetProperty("ok", out var ok) && ok.GetBoolean())
+            {
+                return true;
+            }
+
+            error = root.TryGetProperty("message", out var messageElement)
+                ? messageElement.GetString()
+                : "PowerShell COM retry failed.";
+            if (root.TryGetProperty("hresult", out var hResultElement) && hResultElement.TryGetInt32(out var hResult))
+            {
+                errorNumber = hResult;
+            }
+            return false;
+        }
+        catch (Exception ex)
+        {
+            error = ExcelBridgeSupport.FormatExceptionDetail(ex);
+            errorNumber = (ex.InnerException ?? ex).HResult;
+            return false;
+        }
+        finally
+        {
+            TryDelete(scriptPath);
+            TryDelete(outputPath);
+        }
+    }
+
+    private static string PowerShellRetryScript()
+    {
+        return """
+            param(
+              [string]$WorkbookPath,
+              [string]$MacroReference,
+              [string]$OutputPath,
+              [string]$Visible = "false",
+              [string]$UseSession = "false",
+              [string]$SaveWorkbook = "false",
+              [string]$ExcelHwnd = "0"
+            )
+            $ErrorActionPreference = 'Stop'
+            $excel = $null
+            $workbook = $null
+            $opened = $false
+            Add-Type -TypeDefinition @"
+            using System;
+            using System.Collections.Generic;
+            using System.Reflection;
+            using System.Runtime.InteropServices;
+            public static class XlflowNativeOm {
+              private const int OBJID_NATIVEOM = unchecked((int)0xFFFFFFF0);
+              private delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+              [DllImport("oleacc.dll")]
+              private static extern int AccessibleObjectFromWindow(IntPtr hwnd, int dwId, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppvObject);
+              [DllImport("user32.dll")]
+              private static extern bool EnumChildWindows(IntPtr hwndParent, EnumWindowsProc lpEnumFunc, IntPtr lParam);
+              public static object GetExcelApplication(IntPtr hwnd) {
+                var candidates = new List<IntPtr> { hwnd };
+                EnumChildWindows(hwnd, (child, _) => { candidates.Add(child); return true; }, IntPtr.Zero);
+                foreach (var candidate in candidates) {
+                  object value = null;
+                  try {
+                    Guid dispatch = new Guid("00020400-0000-0000-C000-000000000046");
+                    int hr = AccessibleObjectFromWindow(candidate, OBJID_NATIVEOM, ref dispatch, out value);
+                    if (hr != 0 || value == null) { continue; }
+                    object app = value;
+                    try {
+                      var maybeApp = value.GetType().InvokeMember("Application", BindingFlags.GetProperty, null, value, null);
+                      if (maybeApp != null) { app = maybeApp; }
+                    } catch {}
+                    var workbooks = app.GetType().InvokeMember("Workbooks", BindingFlags.GetProperty, null, app, null);
+                    workbooks.GetType().InvokeMember("Count", BindingFlags.GetProperty, null, workbooks, null);
+                    return app;
+                  } catch {}
+                }
+                return null;
+              }
+            }
+            "@
+            function Write-Result($payload) {
+              $payload | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+            }
+            function Find-Workbook($app, $path) {
+              foreach ($book in @($app.Workbooks)) {
+                if ([string]::Equals([System.IO.Path]::GetFullPath([string]$book.FullName), [System.IO.Path]::GetFullPath($path), [System.StringComparison]::OrdinalIgnoreCase)) {
+                  return $book
+                }
+              }
+              return $null
+            }
+            try {
+              $useSessionBool = [bool]::Parse($UseSession)
+              $hwndValue = [int64]$ExcelHwnd
+              if ($hwndValue -ne 0) {
+                $excel = [XlflowNativeOm]::GetExcelApplication([intptr]$hwndValue)
+                if ($null -ne $excel) {
+                  $workbook = Find-Workbook $excel $WorkbookPath
+                }
+              }
+              try {
+                if ($null -eq $workbook) {
+                  $excel = [Runtime.InteropServices.Marshal]::GetActiveObject('Excel.Application')
+                  $workbook = Find-Workbook $excel $WorkbookPath
+                }
+              } catch {
+                $excel = $null
+              }
+              if ($useSessionBool -and $null -eq $workbook) {
+                throw "Could not attach PowerShell COM retry to the requested xlflow session workbook."
+              }
+              if ($null -eq $workbook) {
+                $excel = New-Object -ComObject Excel.Application
+                $excel.Visible = [bool]::Parse($Visible)
+                $excel.DisplayAlerts = $false
+                $excel.EnableEvents = $false
+                try { $excel.AutomationSecurity = 1 } catch {}
+                $workbook = $excel.Workbooks.Open($WorkbookPath)
+                $opened = $true
+              }
+              $null = $excel.Run($MacroReference)
+              if ([bool]::Parse($SaveWorkbook)) {
+                $workbook.Save()
+              }
+              Write-Result @{ ok = $true }
+            } catch {
+              Write-Result @{ ok = $false; message = [string]$_.Exception.Message; hresult = [int]$_.Exception.HResult }
+            } finally {
+              if ($opened -and $null -ne $workbook) {
+                $workbook.Close($false)
+              }
+              if ($opened -and $null -ne $excel) {
+                $excel.Quit()
+              }
+              if ($null -ne $workbook) { [void][Runtime.InteropServices.Marshal]::ReleaseComObject($workbook) }
+              if ($opened -and $null -ne $excel) { [void][Runtime.InteropServices.Marshal]::ReleaseComObject($excel) }
+              [gc]::Collect()
+              [gc]::WaitForPendingFinalizers()
+            }
+            """;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // best-effort temp cleanup
+        }
     }
 
     private static bool IsMacroNotFoundError(string message, int? number)

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunService.cs
@@ -127,12 +127,17 @@ public sealed class ExcelRunService : IRunService
             }
 
             var sw = Stopwatch.StartNew();
-            var invocation = InvokeInProcess(
-                excel,
-                macroReference,
-                args.Direct ? macroArgs : [],
-                excelProcessId,
+            var invocation = InvokeWithWorker(
+                new MacroRunWorkerRequest(
+                    excelProcessId,
+                    excelHwnd,
+                    macroReference,
+                    (args.Direct ? macroArgs : [])
+                        .Select(argument => new MacroRunWorkerArgument(argument.Type, argument.Value))
+                        .ToArray(),
+                    WorkbookPath: args.WorkbookPath),
                 excelHwnd,
+                DialogKind.Any,
                 args.SuppressModalErrors,
                 ResolveTimeout(request, args, commandStopwatch.Elapsed),
                 cancellationToken,
@@ -549,151 +554,6 @@ public sealed class ExcelRunService : IRunService
             selectionLocator);
     }
 
-    private static WorkerInvocationResult InvokeInProcess(
-        object excel,
-        string macroReference,
-        IReadOnlyList<MacroArg> macroArgs,
-        int excelProcessId,
-        long excelHwnd,
-        bool suppressModalErrors,
-        TimeSpan timeout,
-        CancellationToken cancellationToken,
-        VbeSelectionLocator? selectionLocator = null)
-    {
-        var watcher = new DialogWatcher();
-        var actionPolicy = suppressModalErrors
-            ? selectionLocator is not null
-                ? DialogActionPolicy.SuppressVbaErrorWithRuntimeDebug
-                : DialogActionPolicy.SuppressVbaError
-            : DialogActionPolicy.ObserveOnly;
-        var watchRequest = new DialogWatchRequest(
-            excelProcessId,
-            excelHwnd,
-            DialogKind.Any,
-            actionPolicy,
-            timeout,
-            TimeSpan.FromMilliseconds(50));
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var locationCaptures = new List<VbeSelectionCapture>();
-        var locationCaptureGate = new object();
-
-        void CaptureBefore(DialogKind kind)
-        {
-            if ((kind is DialogKind.Compile or DialogKind.Runtime) && selectionLocator is not null)
-            {
-                lock (locationCaptureGate)
-                {
-                    locationCaptures.Add(selectionLocator.Capture("before_dialog_action"));
-                }
-            }
-        }
-
-        void CaptureAfter(DialogKind kind)
-        {
-            lock (locationCaptureGate)
-            {
-                if ((kind is DialogKind.Compile or DialogKind.Runtime) &&
-                    selectionLocator is not null &&
-                    !locationCaptures.Any(capture => capture.HasReliableLocation))
-                {
-                    locationCaptures.Add(selectionLocator.Capture("after_dialog_action"));
-                }
-                if (kind == DialogKind.Runtime)
-                {
-                    selectionLocator?.ResetBreakMode();
-                }
-            }
-        }
-
-        VbeSelectionCapture MergeCurrentCaptures()
-        {
-            lock (locationCaptureGate)
-            {
-                if (locationCaptures.Count == 0)
-                {
-                    return VbeSelectionCapture.Empty;
-                }
-                var location = locationCaptures
-                    .Select(capture => capture.Location)
-                    .Where(location => location is not null)
-                    .OrderByDescending(location => VbeSelectionScorer.Score(location!))
-                    .FirstOrDefault();
-                return new VbeSelectionCapture(location, locationCaptures.SelectMany(capture => capture.Attempts).ToArray());
-            }
-        }
-
-        var watcherTask = Task.Run(() => watcher.WaitForDialog(watchRequest, CaptureBefore, CaptureAfter, linked.Token), linked.Token);
-        MacroRunWorkerResult? result;
-        var stage = "application_run";
-        try
-        {
-            var invokeArgs = new List<object?> { macroReference };
-            foreach (var argument in macroArgs)
-            {
-                invokeArgs.Add(ConvertArgument(argument));
-            }
-
-            var value = ExcelBridgeSupport.InvokeMethod(excel, "Run", invokeArgs.ToArray());
-            stage = "post_run_pump";
-            ExcelBridgeSupport.SleepAndPump(TimeSpan.FromMilliseconds(100));
-            result = new MacroRunWorkerResult(true, true, NormalizeMacroValue(value), null);
-        }
-        catch (Exception ex)
-        {
-            var detail = ex.InnerException ?? ex;
-            result = new MacroRunWorkerResult(
-                Completed: true,
-                Ok: false,
-                Value: null,
-                Error: new MacroRunWorkerError(
-                    ExcelBridgeSupport.FormatExceptionDetail(ex),
-                    detail.Source ?? "xlflow-excel-bridge",
-                    detail.HResult,
-                    stage));
-        }
-
-        var postDialog = WaitForPostWorkerDialog(
-            watcher,
-            watcherTask,
-            watchRequest,
-            operation: "run",
-            result,
-            linked.Token,
-            CaptureBefore,
-            CaptureAfter);
-        linked.Cancel();
-        if (postDialog is not null)
-        {
-            return new WorkerInvocationResult(result, postDialog, [postDialog], MergeCurrentCaptures(), false, Environment.ProcessId);
-        }
-        return new WorkerInvocationResult(result, null, [], MergeCurrentCaptures(), false, Environment.ProcessId);
-    }
-
-    private static object ConvertArgument(MacroArg argument)
-    {
-        return argument.Type.ToLowerInvariant() switch
-        {
-            "int" => int.Parse(argument.Value, NumberStyles.Integer, CultureInfo.InvariantCulture),
-            "double" => double.Parse(argument.Value, NumberStyles.Float, CultureInfo.InvariantCulture),
-            "bool" => bool.Parse(argument.Value),
-            _ => argument.Value,
-        };
-    }
-
-    private static object? NormalizeMacroValue(object? value)
-    {
-        if (value is Array array)
-        {
-            var items = new object?[array.Length];
-            for (var i = 0; i < array.Length; i++)
-            {
-                items[i] = array.GetValue(i);
-            }
-            return items;
-        }
-        return value;
-    }
-
     internal static DialogSnapshot? WaitForPostWorkerDialog(
         DialogWatcher watcher,
         Task<DialogSnapshot?> watcherTask,
@@ -1011,12 +871,13 @@ public sealed class ExcelRunService : IRunService
             args.UIStreamRedactInput);
     }
 
-    private static bool IsDefaultRuntimeWithoutInjectedFeatures(RunCommandArguments args)
+    internal static bool IsDefaultRuntimeWithoutInjectedFeatures(RunCommandArguments args)
     {
         return string.Equals(args.RuntimeSource, "default", StringComparison.OrdinalIgnoreCase) &&
             string.IsNullOrWhiteSpace(args.MsgBoxResponsesJSON) &&
             string.IsNullOrWhiteSpace(args.InputResponsesJSON) &&
             string.IsNullOrWhiteSpace(args.FileDialogResponsesJSON) &&
+            (!args.DebugStreamEnabled || string.IsNullOrWhiteSpace(args.DebugStreamPipeName)) &&
             (!args.UIStreamEnabled || string.IsNullOrWhiteSpace(args.UIStreamPipeName));
     }
 

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunService.cs
@@ -28,7 +28,6 @@ public sealed class ExcelRunService : IRunService
         var sessionAttached = false;
         var sessionMode = "none";
         var skipComCleanup = false;
-        var retriedWithPowerShell = false;
 
         try
         {
@@ -175,36 +174,6 @@ public sealed class ExcelRunService : IRunService
                 }
             }
 
-            string? retryError = null;
-            int? retryErrorNumber = null;
-            if (runError is not null &&
-                IsOfficeTypeLibraryFailure(runErrorNumber) &&
-                macroArgs.Count == 0 &&
-                string.IsNullOrWhiteSpace(args.SaveAsPath))
-            {
-                var retryHwnd = excelHwnd;
-                if (!sessionAttached)
-                {
-                    CloseWorkbook(workbook, excel);
-                    workbook = null;
-                    excel = null;
-                    retryHwnd = 0;
-                }
-                if (TryRetryMacroWithPowerShell(args, sessionAttached, retryHwnd, out retryError, out retryErrorNumber))
-                {
-                    retriedWithPowerShell = true;
-                    runError = null;
-                    runErrorNumber = null;
-                    runErrorLine = null;
-                    logs.Add("retried macro through PowerShell COM after Office type-library failure");
-                }
-            }
-            if (runError is not null && IsOfficeTypeLibraryFailure(runErrorNumber) && retryError is not null)
-            {
-                runError = retryError;
-                runErrorNumber = retryErrorNumber;
-            }
-
             if (!runTimedOut)
             {
                 RemoveTemporaryComponent(vbProject, runnerComponent);
@@ -348,17 +317,8 @@ public sealed class ExcelRunService : IRunService
 
             var saved = false;
             var saveAsCopy = false;
-            if (retriedWithPowerShell)
+            if (!string.IsNullOrWhiteSpace(args.SaveAsPath))
             {
-                saved = args.SaveWorkbook;
-            }
-            else if (!string.IsNullOrWhiteSpace(args.SaveAsPath))
-            {
-                if (workbook is null)
-                {
-                    throw new InvalidOperationException("Workbook is not available for SaveCopyAs after macro retry.");
-                }
-
                 var saveAsPath = ExcelBridgeSupport.NormalizePath(args.SaveAsPath);
                 AssertSaveAsExtension(args.WorkbookPath, saveAsPath);
                 ExcelBridgeSupport.RunPhase("save_as", () => ExcelBridgeSupport.InvokeViaDynamic(workbook, "SaveCopyAs", saveAsPath));
@@ -366,11 +326,6 @@ public sealed class ExcelRunService : IRunService
             }
             else if (args.SaveWorkbook)
             {
-                if (workbook is null)
-                {
-                    throw new InvalidOperationException("Workbook is not available for Save after macro retry.");
-                }
-
                 ExcelBridgeSupport.RunPhase("save_workbook", () => ExcelBridgeSupport.InvokeViaDynamic(workbook, "Save"));
                 saved = true;
             }
@@ -1179,217 +1134,6 @@ public sealed class ExcelRunService : IRunService
         }
 
         return message.Contains("0x800A9C68", StringComparison.OrdinalIgnoreCase);
-    }
-
-    internal static bool IsOfficeTypeLibraryFailure(int? number)
-    {
-        return number == unchecked((int)0x80028018);
-    }
-
-    private static bool TryRetryMacroWithPowerShell(
-        RunCommandArguments args,
-        bool sessionAttached,
-        long excelHwnd,
-        out string? error,
-        out int? errorNumber)
-    {
-        error = null;
-        errorNumber = null;
-
-        var scriptPath = Path.Combine(Path.GetTempPath(), "xlflow-run-retry-" + Guid.NewGuid().ToString("N") + ".ps1");
-        var outputPath = Path.Combine(Path.GetTempPath(), "xlflow-run-retry-" + Guid.NewGuid().ToString("N") + ".json");
-        try
-        {
-            File.WriteAllText(scriptPath, PowerShellRetryScript());
-            var macroReference = "'" + Path.GetFileName(args.WorkbookPath).Replace("'", "''", StringComparison.Ordinal) + "'!" + args.MacroName;
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "powershell.exe",
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-            startInfo.ArgumentList.Add("-NoProfile");
-            startInfo.ArgumentList.Add("-ExecutionPolicy");
-            startInfo.ArgumentList.Add("Bypass");
-            startInfo.ArgumentList.Add("-File");
-            startInfo.ArgumentList.Add(scriptPath);
-            startInfo.ArgumentList.Add("-WorkbookPath");
-            startInfo.ArgumentList.Add(args.WorkbookPath);
-            startInfo.ArgumentList.Add("-MacroReference");
-            startInfo.ArgumentList.Add(macroReference);
-            startInfo.ArgumentList.Add("-OutputPath");
-            startInfo.ArgumentList.Add(outputPath);
-            startInfo.ArgumentList.Add("-Visible");
-            startInfo.ArgumentList.Add(args.Visible ? "true" : "false");
-            startInfo.ArgumentList.Add("-UseSession");
-            startInfo.ArgumentList.Add(sessionAttached ? "true" : "false");
-            startInfo.ArgumentList.Add("-SaveWorkbook");
-            startInfo.ArgumentList.Add(args.SaveWorkbook ? "true" : "false");
-            startInfo.ArgumentList.Add("-ExcelHwnd");
-            startInfo.ArgumentList.Add(excelHwnd.ToString(CultureInfo.InvariantCulture));
-
-            using var process = Process.Start(startInfo);
-            if (process is null || !process.WaitForExit(120_000) || !File.Exists(outputPath))
-            {
-                error = "PowerShell COM retry did not return a result.";
-                return false;
-            }
-
-            using var doc = JsonDocument.Parse(File.ReadAllText(outputPath));
-            var root = doc.RootElement;
-            if (root.TryGetProperty("ok", out var ok) && ok.GetBoolean())
-            {
-                return true;
-            }
-
-            error = root.TryGetProperty("message", out var messageElement)
-                ? messageElement.GetString()
-                : "PowerShell COM retry failed.";
-            if (root.TryGetProperty("hresult", out var hResultElement) && hResultElement.TryGetInt32(out var hResult))
-            {
-                errorNumber = hResult;
-            }
-            return false;
-        }
-        catch (Exception ex)
-        {
-            error = ExcelBridgeSupport.FormatExceptionDetail(ex);
-            errorNumber = (ex.InnerException ?? ex).HResult;
-            return false;
-        }
-        finally
-        {
-            TryDelete(scriptPath);
-            TryDelete(outputPath);
-        }
-    }
-
-    private static string PowerShellRetryScript()
-    {
-        return """
-            param(
-              [string]$WorkbookPath,
-              [string]$MacroReference,
-              [string]$OutputPath,
-              [string]$Visible = "false",
-              [string]$UseSession = "false",
-              [string]$SaveWorkbook = "false",
-              [string]$ExcelHwnd = "0"
-            )
-            $ErrorActionPreference = 'Stop'
-            $excel = $null
-            $workbook = $null
-            $opened = $false
-            Add-Type -TypeDefinition @"
-            using System;
-            using System.Collections.Generic;
-            using System.Reflection;
-            using System.Runtime.InteropServices;
-            public static class XlflowNativeOm {
-              private const int OBJID_NATIVEOM = unchecked((int)0xFFFFFFF0);
-              private delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
-              [DllImport("oleacc.dll")]
-              private static extern int AccessibleObjectFromWindow(IntPtr hwnd, int dwId, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppvObject);
-              [DllImport("user32.dll")]
-              private static extern bool EnumChildWindows(IntPtr hwndParent, EnumWindowsProc lpEnumFunc, IntPtr lParam);
-              public static object GetExcelApplication(IntPtr hwnd) {
-                var candidates = new List<IntPtr> { hwnd };
-                EnumChildWindows(hwnd, (child, _) => { candidates.Add(child); return true; }, IntPtr.Zero);
-                foreach (var candidate in candidates) {
-                  object value = null;
-                  try {
-                    Guid dispatch = new Guid("00020400-0000-0000-C000-000000000046");
-                    int hr = AccessibleObjectFromWindow(candidate, OBJID_NATIVEOM, ref dispatch, out value);
-                    if (hr != 0 || value == null) { continue; }
-                    object app = value;
-                    try {
-                      var maybeApp = value.GetType().InvokeMember("Application", BindingFlags.GetProperty, null, value, null);
-                      if (maybeApp != null) { app = maybeApp; }
-                    } catch {}
-                    var workbooks = app.GetType().InvokeMember("Workbooks", BindingFlags.GetProperty, null, app, null);
-                    workbooks.GetType().InvokeMember("Count", BindingFlags.GetProperty, null, workbooks, null);
-                    return app;
-                  } catch {}
-                }
-                return null;
-              }
-            }
-            "@
-            function Write-Result($payload) {
-              $payload | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $OutputPath -Encoding UTF8
-            }
-            function Find-Workbook($app, $path) {
-              foreach ($book in @($app.Workbooks)) {
-                if ([string]::Equals([System.IO.Path]::GetFullPath([string]$book.FullName), [System.IO.Path]::GetFullPath($path), [System.StringComparison]::OrdinalIgnoreCase)) {
-                  return $book
-                }
-              }
-              return $null
-            }
-            try {
-              $useSessionBool = [bool]::Parse($UseSession)
-              $hwndValue = [int64]$ExcelHwnd
-              if ($hwndValue -ne 0) {
-                $excel = [XlflowNativeOm]::GetExcelApplication([intptr]$hwndValue)
-                if ($null -ne $excel) {
-                  $workbook = Find-Workbook $excel $WorkbookPath
-                }
-              }
-              try {
-                if ($null -eq $workbook) {
-                  $excel = [Runtime.InteropServices.Marshal]::GetActiveObject('Excel.Application')
-                  $workbook = Find-Workbook $excel $WorkbookPath
-                }
-              } catch {
-                $excel = $null
-              }
-              if ($useSessionBool -and $null -eq $workbook) {
-                throw "Could not attach PowerShell COM retry to the requested xlflow session workbook."
-              }
-              if ($null -eq $workbook) {
-                $excel = New-Object -ComObject Excel.Application
-                $excel.Visible = [bool]::Parse($Visible)
-                $excel.DisplayAlerts = $false
-                $excel.EnableEvents = $false
-                try { $excel.AutomationSecurity = 1 } catch {}
-                $workbook = $excel.Workbooks.Open($WorkbookPath)
-                $opened = $true
-              }
-              $null = $excel.Run($MacroReference)
-              if ([bool]::Parse($SaveWorkbook)) {
-                $workbook.Save()
-              }
-              Write-Result @{ ok = $true }
-            } catch {
-              Write-Result @{ ok = $false; message = [string]$_.Exception.Message; hresult = [int]$_.Exception.HResult }
-            } finally {
-              if ($opened -and $null -ne $workbook) {
-                $workbook.Close($false)
-              }
-              if ($opened -and $null -ne $excel) {
-                $excel.Quit()
-              }
-              if ($null -ne $workbook) { [void][Runtime.InteropServices.Marshal]::ReleaseComObject($workbook) }
-              if ($opened -and $null -ne $excel) { [void][Runtime.InteropServices.Marshal]::ReleaseComObject($excel) }
-              [gc]::Collect()
-              [gc]::WaitForPendingFinalizers()
-            }
-            """;
-    }
-
-    private static void TryDelete(string path)
-    {
-        try
-        {
-            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
-            {
-                File.Delete(path);
-            }
-        }
-        catch
-        {
-            // best-effort temp cleanup
-        }
     }
 
     private static bool IsMacroNotFoundError(string message, int? number)

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelSessionService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelSessionService.cs
@@ -56,6 +56,24 @@ public sealed class ExcelSessionService : ISessionService
         }
         catch (Exception ex)
         {
+            if (ex is SessionPoisonedException poisoned)
+            {
+                return BridgeResponse.Failed(request, new BridgeError(
+                    Code: "session_poisoned",
+                    Message: "The xlflow session was marked poisoned after a fatal Excel COM/RPC failure. Run `xlflow session stop --json` and start a fresh session.",
+                    Phase: "session",
+                    Source: "xlflow-excel-bridge",
+                    HResult: poisoned.Metadata.HResult,
+                    Details: new Dictionary<string, object?>
+                    {
+                        ["workbook_path"] = poisoned.Metadata.WorkbookPath,
+                        ["excel_pid"] = poisoned.Metadata.Pid,
+                        ["excel_hwnd"] = poisoned.Metadata.Hwnd,
+                        ["poisoned_at"] = poisoned.Metadata.PoisonedAt,
+                        ["poison_reason"] = poisoned.Metadata.PoisonReason,
+                        ["last_command"] = poisoned.Metadata.LastCommand,
+                    }));
+            }
             return BridgeResponse.Failed(request, new BridgeError(
                 Code: "session_failed",
                 Message: ExcelBridgeSupport.FormatExceptionDetail(ex),
@@ -82,6 +100,7 @@ public sealed class ExcelSessionService : ISessionService
             var open = false;
             bool? dirty = false;
             var mode = "none";
+            var poisoned = metadata?.Poisoned ?? false;
 
             if (metadata is not null)
             {
@@ -115,22 +134,65 @@ public sealed class ExcelSessionService : ISessionService
 
             var needsSave = running && open && (dirty is null || dirty == true);
             var logs = new[] { running && open ? "xlflow session is running" : "xlflow session is not running" };
+            var sessionPayload = ExcelBridgeSupport.BuildSessionPayload(workbookPath, running && open, mode, dirty, needsSave);
+            if (metadata is not null)
+            {
+                sessionPayload["metadata"] = new Dictionary<string, object?>
+                {
+                    ["hwnd"] = metadata.Hwnd,
+                    ["pid"] = metadata.Pid,
+                    ["workbook_path"] = metadata.WorkbookPath,
+                    ["poisoned"] = poisoned,
+                    ["poisoned_at"] = metadata.PoisonedAt,
+                    ["poison_reason"] = metadata.PoisonReason,
+                    ["h_result"] = metadata.HResult,
+                    ["last_command"] = metadata.LastCommand,
+                };
+            }
+            if (poisoned && metadata is not null)
+            {
+                sessionPayload["poisoned"] = true;
+                sessionPayload["poisoned_at"] = metadata.PoisonedAt;
+                sessionPayload["poison_reason"] = metadata.PoisonReason;
+                sessionPayload["h_result"] = metadata.HResult;
+                sessionPayload["last_command"] = metadata.LastCommand;
+            }
             var extensions = new Dictionary<string, object?>
             {
                 ["target"] = ExcelBridgeSupport.BuildTargetPayload(running && open ? "live_session" : "file", workbookPath),
-                ["session"] = ExcelBridgeSupport.BuildSessionPayload(workbookPath, running && open, mode, dirty, needsSave),
+                ["session"] = sessionPayload,
                 ["workbook"] = ExcelBridgeSupport.BuildWorkbookPayload(workbookPath, running && open, mode, false, false, dirty, needsSave),
             };
-            if (needsSave)
+            if (needsSave || poisoned)
             {
-                extensions["warnings"] = new[]
+                var warnings = new List<Dictionary<string, object?>>();
+                var hints = new List<Dictionary<string, object?>>();
+                if (needsSave)
                 {
-                    new Dictionary<string, object?>
+                    warnings.Add(new Dictionary<string, object?>
                     {
                         ["code"] = "save_required",
                         ["message"] = "The live workbook is newer than disk. Run `xlflow save --session` to persist workbook changes.",
-                    },
-                };
+                    });
+                }
+                if (poisoned)
+                {
+                    warnings.Add(new Dictionary<string, object?>
+                    {
+                        ["code"] = "session_poisoned",
+                        ["message"] = "The live Excel session was marked poisoned after a fatal COM/RPC failure.",
+                    });
+                    hints.Add(new Dictionary<string, object?>
+                    {
+                        ["code"] = "restart_session",
+                        ["message"] = "Run `xlflow session stop --json`, then `xlflow session start --json` before reusing this workbook.",
+                    });
+                }
+                extensions["warnings"] = warnings;
+                if (hints.Count > 0)
+                {
+                    extensions["hints"] = hints;
+                }
             }
 
             return new BridgeResponse
@@ -143,6 +205,24 @@ public sealed class ExcelSessionService : ISessionService
         }
         catch (Exception ex)
         {
+            if (ex is SessionPoisonedException poisoned)
+            {
+                return BridgeResponse.Failed(request, new BridgeError(
+                    Code: "session_poisoned",
+                    Message: "The xlflow session was marked poisoned after a fatal Excel COM/RPC failure. Run `xlflow session stop --json` and start a fresh session.",
+                    Phase: "session",
+                    Source: "xlflow-excel-bridge",
+                    HResult: poisoned.Metadata.HResult,
+                    Details: new Dictionary<string, object?>
+                    {
+                        ["workbook_path"] = poisoned.Metadata.WorkbookPath,
+                        ["excel_pid"] = poisoned.Metadata.Pid,
+                        ["excel_hwnd"] = poisoned.Metadata.Hwnd,
+                        ["poisoned_at"] = poisoned.Metadata.PoisonedAt,
+                        ["poison_reason"] = poisoned.Metadata.PoisonReason,
+                        ["last_command"] = poisoned.Metadata.LastCommand,
+                    }));
+            }
             return BridgeResponse.Failed(request, new BridgeError(
                 Code: "session_failed",
                 Message: ExcelBridgeSupport.FormatExceptionDetail(ex),

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Workers/MacroRunWorker.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Workers/MacroRunWorker.cs
@@ -18,7 +18,7 @@ public sealed record MacroRunWorkerRequest(
 
 public sealed record MacroRunWorkerArgument(string Type, string Value);
 
-public sealed record MacroRunWorkerError(string Message, string Source, int Number);
+public sealed record MacroRunWorkerError(string Message, string Source, int Number, string Stage = "");
 
 public sealed record MacroRunWorkerResult(
     bool Completed,
@@ -56,6 +56,7 @@ public static class MacroRunWorker
         }
 
         object? excel = null;
+        var stage = "connect_excel";
         try
         {
             excel = request.ExcelHwnd != 0
@@ -73,16 +74,22 @@ public static class MacroRunWorker
             object? value;
             if (string.Equals(request.Operation, "compile", StringComparison.OrdinalIgnoreCase))
             {
+                stage = "compile_vba";
                 value = CompileWorkbook(excel, request.WorkbookPath);
             }
             else
             {
+                stage = "stabilize_excel";
+                ExcelBridgeSupport.StabilizeExcelForMacroRun(excel, request.WorkbookPath, TimeSpan.FromSeconds(3));
                 var invokeArgs = new List<object?> { request.MacroReference };
                 foreach (var argument in request.Arguments ?? [])
                 {
                     invokeArgs.Add(ConvertArgument(argument));
                 }
+                stage = "application_run";
                 value = ExcelBridgeSupport.InvokeMethod(excel, "Run", invokeArgs.ToArray());
+                stage = "post_run_pump";
+                ExcelBridgeSupport.SleepAndPump(TimeSpan.FromMilliseconds(100));
             }
             WriteResult(resultPath, new MacroRunWorkerResult(true, true, NormalizeValue(value), null));
             return 0;
@@ -97,7 +104,8 @@ public static class MacroRunWorker
                 Error: new MacroRunWorkerError(
                     ExcelBridgeSupport.FormatExceptionDetail(ex),
                     detail.Source ?? "xlflow-excel-bridge",
-                    detail.HResult)));
+                    detail.HResult,
+                    stage)));
             return 1;
         }
         finally

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/RunCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/RunCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Xlflow.ExcelBridge.Commands;
 using Xlflow.ExcelBridge.Contract;
@@ -114,6 +115,25 @@ public sealed class RunCommandTests
 
         Assert.True(serviceCalled);
         Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void InvokeMethodUsesCurrentCultureForComLateBinding()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+            Assert.Equal("fr-FR", ExcelBridgeSupport.ComInvokeCulture.Name);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
     }
 
     [Fact]

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/RunCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/RunCommandTests.cs
@@ -236,6 +236,50 @@ public sealed class RunCommandTests
         Assert.Equal("macro_failed", ExcelRunService.ClassifyRunError("", null));
     }
 
+    [Fact]
+    public void FatalComFailureClassifierDetectsRpcFailureAndFormatsHResult()
+    {
+        const int rpcFailed = unchecked((int)0x800706BE);
+
+        Assert.True(ExcelBridgeSupport.IsFatalComFailure(rpcFailed));
+        Assert.Equal("0x800706BE", ExcelBridgeSupport.FormatHResult(rpcFailed));
+    }
+
+    [Fact]
+    public void BuildRunHarnessCodePumpsDoEventsAroundMacroInvocation()
+    {
+        var code = ExcelRunService.BuildRunHarnessCode("Main.ReproFormatOps", []);
+
+        Assert.Contains("  DoEvents" + Environment.NewLine + "  Application.Run targetMacro", code);
+        Assert.Contains("  Application.Run targetMacro" + Environment.NewLine + "  DoEvents", code);
+    }
+
+    [Fact]
+    public void ComFailureDetailsIncludeRunContext()
+    {
+        var args = RunArgs("C:\\work\\Book.xlsm", "Main.ReproFormatOps");
+
+        var details = ExcelRunService.BuildComFailureDetails(
+            args,
+            "application_run",
+            excelProcessId: 1234,
+            excelHwnd: 5678,
+            workerProcessId: 9012,
+            sessionAttached: true,
+            sessionMode: "explicit");
+
+        Assert.Equal("Main.ReproFormatOps", details["macro"]);
+        Assert.Equal("application_run", details["stage"]);
+        Assert.Equal(1234, details["excel_pid"]);
+        Assert.Equal(5678L, details["excel_hwnd"]);
+        Assert.Equal(9012, details["worker_pid"]);
+        Assert.Equal("explicit", details["session_mode"]);
+        Assert.Equal(false, details["visible"]);
+        Assert.Equal(true, details["headless"]);
+        Assert.Equal(true, details["workbook_reused"]);
+        Assert.Equal("explicit", details["workbook_reuse_mode"]);
+    }
+
     [Theory]
     [InlineData(true, false, true, true)]
     [InlineData(false, false, false, false)]
@@ -246,6 +290,42 @@ public sealed class RunCommandTests
 
         Assert.Equal(expectedDirty, result.Dirty);
         Assert.Equal(expectedNeedsSave, result.NeedsSave);
+    }
+
+    private static RunCommandArguments RunArgs(string workbookPath, string macroName)
+    {
+        return new RunCommandArguments(
+            WorkbookPath: workbookPath,
+            MacroName: macroName,
+            MacroArgsJSON: "",
+            Visible: false,
+            DisplayAlerts: false,
+            SaveWorkbook: false,
+            Direct: false,
+            Diagnostic: false,
+            SuppressModalErrors: true,
+            MsgBoxResponsesJSON: "",
+            InputResponsesJSON: "",
+            FileDialogResponsesJSON: "",
+            DebugStreamEnabled: false,
+            DebugStreamPipeName: "",
+            UIStreamEnabled: false,
+            UIStreamPipeName: "",
+            UIStreamRedactInput: false,
+            UseSession: true,
+            MetadataPath: "C:\\work\\.xlflow\\session.json",
+            RuntimeMode: "",
+            RuntimeSource: "",
+            SaveAsPath: "",
+            TimeoutSeconds: 0,
+            ModulesDir: "",
+            ClassesDir: "",
+            FormsDir: "",
+            WorkbookDir: "",
+            CodeSource: "",
+            Folders: false,
+            FolderAnnotation: "update",
+            DefaultComponentFolders: false);
     }
 
     [Fact]

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/RunCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/RunCommandTests.cs
@@ -312,6 +312,33 @@ public sealed class RunCommandTests
         Assert.Equal(expectedNeedsSave, result.NeedsSave);
     }
 
+    [Fact]
+    public void DefaultRuntimeSkipRequiresNoDebugOrUiInjection()
+    {
+        var args = RunArgs(@"C:\work\Book.xlsm", "Main.Run") with
+        {
+            RuntimeSource = "default",
+        };
+
+        Assert.True(ExcelRunService.IsDefaultRuntimeWithoutInjectedFeatures(args));
+
+        args = args with
+        {
+            DebugStreamEnabled = true,
+            DebugStreamPipeName = @"\\.\pipe\xlflow-debug",
+        };
+        Assert.False(ExcelRunService.IsDefaultRuntimeWithoutInjectedFeatures(args));
+
+        args = args with
+        {
+            DebugStreamEnabled = false,
+            DebugStreamPipeName = "",
+            UIStreamEnabled = true,
+            UIStreamPipeName = @"\\.\pipe\xlflow-ui",
+        };
+        Assert.False(ExcelRunService.IsDefaultRuntimeWithoutInjectedFeatures(args));
+    }
+
     private static RunCommandArguments RunArgs(string workbookPath, string macroName)
     {
         return new RunCommandArguments(

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/SessionCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/SessionCommandTests.cs
@@ -34,6 +34,82 @@ public sealed class SessionCommandTests
         Assert.Equal("ok", JsonSerializer.SerializeToDocument(response, JsonOptions.Default).RootElement.GetProperty("status").GetString());
     }
 
+    [Fact]
+    public void ReadSessionMetadataKeepsCompatibilityWithLegacyShape()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "xlflow-session-test-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "session.json");
+            File.WriteAllText(path, """{"hwnd":123,"pid":456,"workbook_path":"C:\\work\\Book.xlsm"}""");
+
+            var metadata = ExcelBridgeSupport.ReadSessionMetadata(path);
+
+            Assert.NotNull(metadata);
+            Assert.Equal(123, metadata!.Hwnd);
+            Assert.Equal(456, metadata.Pid);
+            Assert.False(metadata.Poisoned);
+            Assert.Equal("", metadata.HResult);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public void MarkSessionPoisonedBlocksSessionReuse()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "xlflow-session-test-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "session.json");
+            var workbook = Path.Combine(dir, "Book.xlsm");
+            File.WriteAllText(path, $$"""{"hwnd":123,"pid":456,"workbook_path":"{{workbook.Replace("\\", "\\\\", StringComparison.Ordinal)}}"}""");
+
+            ExcelBridgeSupport.MarkSessionPoisoned(path, workbook, "RPC failed", "0x800706BE", "run");
+            var metadata = ExcelBridgeSupport.ReadSessionMetadata(path);
+
+            Assert.NotNull(metadata);
+            Assert.True(metadata!.Poisoned);
+            Assert.Equal("0x800706BE", metadata.HResult);
+            var ex = Assert.Throws<SessionPoisonedException>(() =>
+                ExcelBridgeSupport.ThrowIfSessionPoisoned(path, workbook));
+            Assert.Equal("run", ex.Metadata.LastCommand);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public void RunPhaseDoesNotWrapSessionPoisonedException()
+    {
+        var metadata = new SessionMetadata(
+            Hwnd: 123,
+            Pid: 456,
+            WorkbookPath: @"C:\work\Book.xlsm",
+            Poisoned: true,
+            PoisonedAt: "2026-06-07T00:00:00.0000000Z",
+            PoisonReason: "RPC failed",
+            HResult: "0x800706BE",
+            LastCommand: "run");
+
+        var ex = Assert.Throws<SessionPoisonedException>(() =>
+            ExcelBridgeSupport.RunPhase("open_workbook", () => throw new SessionPoisonedException(metadata)));
+
+        Assert.Equal("0x800706BE", ex.Metadata.HResult);
+    }
+
     private sealed class FakeSessionService(Func<BridgeRequest, SessionCommandArguments, BridgeResponse> handler) : ISessionService
     {
         public BridgeResponse Execute(BridgeRequest request, SessionCommandArguments args, CancellationToken cancellationToken) => handler(request, args);

--- a/docs/bridge/bridge-protocol.md
+++ b/docs/bridge/bridge-protocol.md
@@ -119,6 +119,12 @@ Error fields:
 - `h_result`: Optional HRESULT hex string (e.g. `"0x800A03EC"`). The .NET bridge serializes this as `h_result` using `JsonNamingPolicy.SnakeCaseLower`, matching the public xlflow envelope.
 - `details`: Optional structured diagnostic object.
 
+Fatal Excel COM/RPC failures use `code = "excel_com_rpc_failure"` and include
+`h_result` plus structured `details`. For `run`, details include the failing
+macro, stage, Excel PID/HWND, worker PID, session mode/id, visibility/headless
+mode, and whether the workbook was reused from a live session. The `.NET`
+bridge treats disconnect-class HRESULTs such as `0x800706BE` as fatal.
+
 ## Version And Capabilities
 
 The .NET bridge exposes metadata commands outside stdin request mode:

--- a/docs/bridge/dotnet-bridge.md
+++ b/docs/bridge/dotnet-bridge.md
@@ -135,8 +135,18 @@ The command opens the workbook (or attaches to an active session), invokes the m
 - Supports `--save`, `--save-as`, and default no-save behavior
 - Supports `--timeout` via bridge request timeout
 - Returns `macro_failed`, `macro_not_found`, or `macro_disabled` structured errors
-- Runs modal `Application.Run` and VBE Compile calls in disposable child bridge
-  processes so the parent can watch dialogs and produce diagnostics
+- Stabilizes Excel before `Application.Run` by activating the target workbook,
+  waiting for the STA/COM caller to settle, and pumping messages around macro
+  invocation; generated harness runs also call `DoEvents` before and after the
+  target macro.
+- Returns `excel_com_rpc_failure` with `h_result` and structured diagnostics for
+  fatal COM/RPC disconnects such as `0x800706BE`
+- Runs VBE Compile in a disposable child bridge process, while `Application.Run`
+  executes on the parent STA with a dialog watcher and COM message pumping.
+- May use an isolated PowerShell COM helper to retry no-argument macro runs after
+  Office type-library failures observed from the .NET COM caller; explicit
+  `--bridge dotnet` still remains a .NET bridge command and does not fall back
+  through the Go bridge resolver.
 - Detects Excel/VBE dialogs through Win32 owner-chain polling with optional UI
   Automation metadata and button invocation
 - Captures dialog text, buttons, HWND/PID/thread identity, visibility, action,
@@ -149,6 +159,12 @@ The command opens the workbook (or attaches to an active session), invokes the m
 - Supports `--ui-stream` pipe integration and `__XLFLOW_DEBUG_PIPE__` injection for `XlflowDebug.Log` transport
 
 The response includes `target`, `session`, `workbook`, `macro`, `runtime`, `debug`, `run_diagnostic`, `suggestions`, and `warnings` envelope fields.
+
+If a fatal COM/RPC failure occurs while using a live session, the bridge marks
+`.xlflow/session.json` as poisoned instead of killing Excel. Subsequent auto or
+explicit session reuse fails with `session_poisoned`; `xlflow session status`
+surfaces the poisoned metadata and `xlflow session stop` remains available to
+clear the session before starting a fresh one.
 
 ### `test`
 
@@ -306,4 +322,4 @@ C:\path\to\unzipped\xlflow.exe doctor --bridge dotnet --json
 
 Successful output, or a structured Excel COM environment failure that still reports `.NET` bridge metadata, confirms that `xlflow.exe` found and launched the bundled bridge executable.
 
-The .NET bridge avoids PowerShell execution policy, but it does not bypass all corporate controls. AppLocker, WDAC, Defender, EDR, antivirus reputation, or code-signing rules may still block an unsigned or unapproved executable. The published checksum and GitHub attestation prove artifact integrity and provenance, but they are not Windows Authenticode signing.
+The .NET bridge does not depend on xlflow's bundled PowerShell scripts for its protocol implementation, but some Excel COM stabilization paths may invoke `powershell.exe` as an isolated helper. It does not bypass corporate controls. AppLocker, WDAC, Defender, EDR, antivirus reputation, execution policy, or code-signing rules may still block an unsigned or unapproved executable or helper process. The published checksum and GitHub attestation prove artifact integrity and provenance, but they are not Windows Authenticode signing.

--- a/docs/bridge/dotnet-bridge.md
+++ b/docs/bridge/dotnet-bridge.md
@@ -143,10 +143,6 @@ The command opens the workbook (or attaches to an active session), invokes the m
   fatal COM/RPC disconnects such as `0x800706BE`
 - Runs VBE Compile in a disposable child bridge process, while `Application.Run`
   executes on the parent STA with a dialog watcher and COM message pumping.
-- May use an isolated PowerShell COM helper to retry no-argument macro runs after
-  Office type-library failures observed from the .NET COM caller; explicit
-  `--bridge dotnet` still remains a .NET bridge command and does not fall back
-  through the Go bridge resolver.
 - Detects Excel/VBE dialogs through Win32 owner-chain polling with optional UI
   Automation metadata and button invocation
 - Captures dialog text, buttons, HWND/PID/thread identity, visibility, action,
@@ -272,6 +268,10 @@ Implementation rules:
 - Do not resume Excel COM work on arbitrary ThreadPool threads after `await`.
 - Keep initial COM command handlers synchronous unless a dedicated STA dispatcher exists.
 - Release COM references deliberately and keep workbook/session ownership explicit.
+- Invoke Excel COM late-bound members with the current user culture, not
+  invariant or forced `en-US` culture. Localized Office installations can fail
+  formatting/layout VBA calls with type-library errors such as `0x80028018` when
+  the automation caller uses the wrong LCID.
 
 This rule is part of the public implementation contract because violating it can produce intermittent Excel/VBIDE failures that unit tests may not catch.
 
@@ -322,4 +322,4 @@ C:\path\to\unzipped\xlflow.exe doctor --bridge dotnet --json
 
 Successful output, or a structured Excel COM environment failure that still reports `.NET` bridge metadata, confirms that `xlflow.exe` found and launched the bundled bridge executable.
 
-The .NET bridge does not depend on xlflow's bundled PowerShell scripts for its protocol implementation, but some Excel COM stabilization paths may invoke `powershell.exe` as an isolated helper. It does not bypass corporate controls. AppLocker, WDAC, Defender, EDR, antivirus reputation, execution policy, or code-signing rules may still block an unsigned or unapproved executable or helper process. The published checksum and GitHub attestation prove artifact integrity and provenance, but they are not Windows Authenticode signing.
+The .NET bridge avoids PowerShell execution policy, but it does not bypass all corporate controls. AppLocker, WDAC, Defender, EDR, antivirus reputation, or code-signing rules may still block an unsigned or unapproved executable. The published checksum and GitHub attestation prove artifact integrity and provenance, but they are not Windows Authenticode signing.


### PR DESCRIPTION
Closes #116 

## Summary
- Stabilize `.NET` bridge macro execution around `Application.Run` so formatting/layout/state APIs like `Range.Interior.Color`, `Range.Clear`, row height changes, `Styles.Add`, and `ProtectContents` work reliably.
- Add fatal COM/RPC classification for disconnect-style HRESULTs such as `0x800706BE`, with structured diagnostics including `h_result`, stage, macro, Excel PID/HWND, worker PID, session mode, visibility, and reuse mode.
- Mark live sessions poisoned after fatal COM/RPC failures and block silent reuse until the session is stopped and restarted.
- Update bridge/session docs, changelog, and regression tests for the new behavior.

## Testing
- Added unit coverage for HRESULT classification, run diagnostics, poisoned session handling, and generated harness behavior.
- Ran bridge test suite and Go test suite locally.
- Verified Windows Excel E2E in a temporary workspace for both direct and session modes, including the reported formatting/layout macros and workbook state checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Excel macro execution is now more stable with improved communication handling
  * Fatal Excel COM/RPC failures now return detailed error information with diagnostics instead of silently reusing sessions
  * Live sessions are marked as poisoned after fatal failures to prevent subsequent use of corrupted states

* **Documentation**
  * Updated bridge documentation with new fatal COM error codes and session poisoning behavior
  * Added culture requirements for Excel late-binding compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->