### PR TITLE
Fixed: Add support for detecting implicit variants inside user-defined types (UDTs) in linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.12.0
+
+- Fixed: Add support for detecting implicit variants inside user-defined types (UDTs) in linter
 - Reduced the default `xlflow run --json` failure payload for AI-agent and normal VBA debugging loops. The default run JSON now promotes the best available `location` and `suggestion` to top-level fields and hides verbose workbook/bridge/runtime diagnostics, dialog snapshots, and location-capture metadata unless `--verbose` is specified.
 - Fixed `.NET` bridge macro runs so Excel is stabilized and the STA message loop is pumped around `Application.Run`, improving reliability for formatting/layout operations such as `Range.Interior.Color`, `Range.Clear`, row height updates, and protection state reads. Fatal COM/RPC failures such as `0x800706BE` now return `excel_com_rpc_failure` with `h_result` and run diagnostics, and live sessions are marked poisoned instead of being silently reused.
 - Added best-effort `.NET` VBE selection diagnostics for suppressed compile/runtime dialogs in `xlflow run --bridge dotnet --json` and compile failures in `xlflow push`, including selected component, procedure, source path, source-file line range, selected line text, and non-fatal capture-attempt metadata when Excel exposes it.

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -41,6 +41,8 @@ var (
 	dimWithoutAs      = regexp.MustCompile(`(?i)^\s*(dim|private|public|static)\s+([^']+)$`)
 	publicVarRe       = regexp.MustCompile(`(?i)^\s*public\s+\w+`)
 	publicProcRe      = regexp.MustCompile(`(?i)^\s*public\s+(sub|function|property|type|enum|declare)\b`)
+	typeStartRe       = regexp.MustCompile(`(?i)^\s*(private|public)?\s*type\b`)
+	typeEndRe         = regexp.MustCompile(`(?i)^\s*end\s+type\b`)
 )
 
 const vb007DisableHint = "If this project intentionally uses dialogs or UserForms, set [lint].forbid_interactive_input = false in xlflow.toml to suppress VB007 for that project. Do this only for genuinely human-only workflows; for dialogs, prefer XlflowUI wrappers with stable dialog ids."
@@ -132,6 +134,7 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 
 	var issues []Issue
 	hasOptionExplicit := false
+	inTypeBlock := false
 	procedures := make([]procedureFrame, 0)
 	var logicalLine strings.Builder
 	logicalStartLine := 0
@@ -158,8 +161,13 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 		if l.Config.Lint.ForbidOnErrorResumeNext && onErrorResumeNext.MatchString(code) {
 			issues = append(issues, l.issue(path, lineNo, "VB004", "warning", "Avoid On Error Resume Next without a narrow recovery block."))
 		}
-		if l.Config.Lint.DetectImplicitVariant && looksImplicitVariant(trimmed) {
+		if l.Config.Lint.DetectImplicitVariant && looksImplicitVariant(trimmed, inTypeBlock) {
 			issues = append(issues, l.issue(path, lineNo, "VB005", "warning", "Declare an explicit type with As <Type>."))
+		}
+		if typeStartRe.MatchString(trimmed) {
+			inTypeBlock = true
+		} else if typeEndRe.MatchString(trimmed) {
+			inTypeBlock = false
 		}
 		if l.Config.Lint.ForbidPublicModuleFields && looksPublicVariable(trimmed) {
 			issues = append(issues, l.issue(path, lineNo, "VB006", "warning", "Avoid Public module variables; pass state explicitly."))
@@ -256,19 +264,33 @@ func (l Linter) issue(path string, line int, code, severity, message string) Iss
 	}
 }
 
-func looksImplicitVariant(line string) bool {
-	if line == "" || strings.Contains(strings.ToLower(line), " as ") {
+func looksImplicitVariant(line string, inTypeBlock bool) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	if lower == "" || strings.Contains(lower, " as ") {
 		return false
+	}
+	if inTypeBlock {
+		return !typeEndRe.MatchString(line)
 	}
 	matches := dimWithoutAs.FindStringSubmatch(line)
 	if len(matches) == 0 {
 		return false
 	}
-	lower := strings.ToLower(strings.TrimSpace(line))
 	return !strings.HasPrefix(lower, "public sub ") &&
 		!strings.HasPrefix(lower, "public function ") &&
+		!strings.HasPrefix(lower, "public property ") &&
+		!strings.HasPrefix(lower, "public type ") &&
+		!strings.HasPrefix(lower, "public enum ") &&
+		!strings.HasPrefix(lower, "public declare ") &&
 		!strings.HasPrefix(lower, "private sub ") &&
-		!strings.HasPrefix(lower, "private function ")
+		!strings.HasPrefix(lower, "private function ") &&
+		!strings.HasPrefix(lower, "private property ") &&
+		!strings.HasPrefix(lower, "private type ") &&
+		!strings.HasPrefix(lower, "private enum ") &&
+		!strings.HasPrefix(lower, "private declare ") &&
+		!strings.HasPrefix(lower, "friend sub ") &&
+		!strings.HasPrefix(lower, "friend function ") &&
+		!strings.HasPrefix(lower, "friend property ")
 }
 
 func containsTypographicQuote(line string) bool {

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -270,7 +270,7 @@ func looksImplicitVariant(line string, inTypeBlock bool) bool {
 		return false
 	}
 	if inTypeBlock {
-		return !typeEndRe.MatchString(line)
+		return !typeEndRe.MatchString(line) && !isConditionalCompilationDirective(lower)
 	}
 	matches := dimWithoutAs.FindStringSubmatch(line)
 	if len(matches) == 0 {
@@ -291,6 +291,13 @@ func looksImplicitVariant(line string, inTypeBlock bool) bool {
 		!strings.HasPrefix(lower, "friend sub ") &&
 		!strings.HasPrefix(lower, "friend function ") &&
 		!strings.HasPrefix(lower, "friend property ")
+}
+
+func isConditionalCompilationDirective(line string) bool {
+	return strings.HasPrefix(line, "#if ") ||
+		strings.HasPrefix(line, "#elseif ") ||
+		line == "#else" ||
+		line == "#end if"
 }
 
 func containsTypographicQuote(line string) bool {

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -182,6 +182,46 @@ End Sub
 	}
 }
 
+func TestLinterIgnoresConditionalCompilationDirectivesInsideUDTs(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Private Type NativeConfig
+#If VBA7 Then
+  Handle As LongPtr
+#Else
+  Handle As Long
+#End If
+  MissingField
+End Type
+`
+	if err := os.WriteFile(filepath.Join(src, "Types.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb005Lines := make(map[int]bool)
+	for _, issue := range issues {
+		if issue.Code == "VB005" {
+			vb005Lines[issue.Line] = true
+		}
+	}
+	if vb005Lines[3] || vb005Lines[5] || vb005Lines[7] {
+		t.Fatalf("conditional compilation directives inside UDT should not trigger VB005: %+v", issues)
+	}
+	if !vb005Lines[8] {
+		t.Fatalf("untyped UDT field should still trigger VB005 after conditional directives: %+v", issues)
+	}
+	if len(vb005Lines) != 1 {
+		t.Fatalf("expected exactly one VB005 finding, got %+v", issues)
+	}
+}
+
 func TestLinterAllowsInteractiveInputWhenDisabled(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -132,6 +132,56 @@ End Sub
 	}
 }
 
+func TestLinterHandlesImplicitVariantsInsideUDTs(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Private Type TypedConfig
+  Version As Long
+  Label As String
+End Type
+
+Private Type UntypedConfig
+  MissingField
+End Type
+
+Sub Main()
+  Dim outsideValue
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(src, "Types.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb005Lines := make(map[int]bool)
+	for _, issue := range issues {
+		if issue.Code == "VB005" {
+			vb005Lines[issue.Line] = true
+		}
+	}
+	if vb005Lines[2] {
+		t.Fatalf("typed UDT declaration should not trigger VB005: %+v", issues)
+	}
+	if vb005Lines[3] || vb005Lines[4] {
+		t.Fatalf("typed UDT fields should not trigger VB005: %+v", issues)
+	}
+	if !vb005Lines[8] {
+		t.Fatalf("untyped UDT field should trigger VB005: %+v", issues)
+	}
+	if !vb005Lines[12] {
+		t.Fatalf("normal implicit variant outside UDT should still trigger VB005: %+v", issues)
+	}
+	if len(vb005Lines) != 2 {
+		t.Fatalf("expected exactly two VB005 findings, got %+v", issues)
+	}
+}
+
 func TestLinterAllowsInteractiveInputWhenDisabled(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")


### PR DESCRIPTION
Closes #118 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linter now detects implicit variants inside user-defined types (UDTs).

* **Documentation**
  * Added v0.12.0 changelog entry for implicit variant detection support.

* **Tests**
  * Added test coverage for implicit variant detection within user-defined types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->