### PR TITLE
Remove the xlflow doctor guidance during installation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -150,7 +150,6 @@ pull → fmt → edit → push → lint → test/run → inspect
 
 ```powershell
 irm https://harumiweb.github.io/xlflow/install.ps1 | iex
-xlflow doctor
 ```
 
 ### Uninstall

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ For the fastest path for humans and AI agents:
 
 ```powershell
 irm https://harumiweb.github.io/xlflow/install.ps1 | iex
-xlflow doctor
 ```
 
 ### Uninstall

--- a/vitepress/installation.md
+++ b/vitepress/installation.md
@@ -8,7 +8,7 @@ If you want the fastest path:
 
 ```powershell
 irm https://harumiweb.github.io/xlflow/install.ps1 | iex
-xlflow doctor
+xlflow new
 ```
 
 ### Uninstall

--- a/vitepress/public/install.ps1
+++ b/vitepress/public/install.ps1
@@ -251,7 +251,7 @@ function Install-Xlflow {
 
         Write-Output ""
         Write-Info "Install complete."
-        Write-Info "Next step: xlflow doctor"
+        Write-Info "Next step: xlflow new"
         Write-Info "Release source: $(Get-ReleasePageUrl -RepoOwner $RepoOwner -RepoName $RepoName)"
     } catch {
         Write-Warning $_


### PR DESCRIPTION
The doctor command is only intended for use within an xlflow project, so it should not be suggested immediately after installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions with a simplified PowerShell one-liner command for faster and easier setup. Installation guidance is now consistent across all language versions.

* **Chores**
  * Modified post-installation step guidance to direct users appropriately after completing setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->