### PR TITLE
Enhance safety and startup behavior of xlflow-excel-bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to xlflow will be documented in this file.
 ## Unreleased
 
 - Added a GitHub Pages-hosted PowerShell installer at `https://harumiweb.github.io/xlflow/install.ps1`, including review-first safer install guidance, one-line quick install guidance, and `-Action uninstall` support that removes `%LOCALAPPDATA%\xlflow` and its user PATH entry.
+- Hardened `xlflow-excel-bridge.exe` direct startup so no-arg, help, version, and invalid launches exit immediately with clear output, while `xlflow.exe` uses an explicit internal run flag before starting the actual bridge runtime.
 
 ## v0.12.2
 

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/BridgeStartup.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/BridgeStartup.cs
@@ -1,0 +1,90 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge;
+
+internal static class BridgeStartup
+{
+    internal const string InternalRunFlag = "--bridge-internal-run";
+    private static readonly string[] HelpFlags = ["--help", "-h", "/?"];
+
+    internal static int Run(
+        string[] args,
+        TextReader stdin,
+        TextWriter stdout,
+        TextWriter stderr,
+        Func<IDisposable> registerMessageFilter,
+        Func<int> runWorker,
+        Func<string[], TextReader, TextWriter, TextWriter, int> runBridgeHost)
+    {
+        if (HasAny(args, HelpFlags))
+        {
+            WriteHelp(stdout);
+            return 0;
+        }
+
+        if (Has(args, "--version"))
+        {
+            stdout.WriteLine($"{BridgeInfo.Current().Name} {BridgeInfo.Current().Version}");
+            return 0;
+        }
+
+        if (args.Length == 0)
+        {
+            stdout.WriteLine("xlflow-excel-bridge is an internal helper executable for xlflow.");
+            stdout.WriteLine("Please run it through `xlflow`.");
+            return 0;
+        }
+
+        if (Has(args, "--version-json") || Has(args, "--capabilities-json"))
+        {
+            return runBridgeHost(args, stdin, stdout, stderr);
+        }
+
+        if (!Has(args, InternalRunFlag))
+        {
+            stderr.WriteLine("Invalid arguments. Use --help for usage.");
+            return 2;
+        }
+
+        var runtimeArgs = args.Where(arg => !string.Equals(arg, InternalRunFlag, StringComparison.OrdinalIgnoreCase)).ToArray();
+
+        using var messageFilter = registerMessageFilter();
+        if (Has(runtimeArgs, "--run-worker"))
+        {
+            return runWorker();
+        }
+
+        return runBridgeHost(runtimeArgs, stdin, stdout, stderr);
+    }
+
+    private static bool Has(string[] args, string value)
+    {
+        return args.Contains(value, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool HasAny(string[] args, IEnumerable<string> values)
+    {
+        foreach (var value in values)
+        {
+            if (Has(args, value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void WriteHelp(TextWriter stdout)
+    {
+        stdout.WriteLine("xlflow-excel-bridge is an internal helper executable for xlflow.");
+        stdout.WriteLine();
+        stdout.WriteLine("Usage:");
+        stdout.WriteLine("  xlflow-excel-bridge --help");
+        stdout.WriteLine("  xlflow-excel-bridge --version");
+        stdout.WriteLine("  xlflow-excel-bridge --version-json");
+        stdout.WriteLine("  xlflow-excel-bridge --capabilities-json");
+        stdout.WriteLine();
+        stdout.WriteLine("Run bridge operations through xlflow.");
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Program.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Program.cs
@@ -7,16 +7,17 @@ public static class Program
     [STAThread]
     public static int Main(string[] args)
     {
-        using var messageFilter = Services.ExcelBridgeSupport.RegisterOleMessageFilter();
         using var stdin = new StreamReader(Console.OpenStandardInput(), new UTF8Encoding(false, true), detectEncodingFromByteOrderMarks: false);
         using var stdout = new StreamWriter(Console.OpenStandardOutput(), new UTF8Encoding(false)) { AutoFlush = true };
         using var stderr = new StreamWriter(Console.OpenStandardError(), new UTF8Encoding(false)) { AutoFlush = true };
 
-        if (args.Contains("--run-worker", StringComparer.OrdinalIgnoreCase))
-        {
-            return Workers.MacroRunWorker.Run();
-        }
-
-        return BridgeHost.Run(args, stdin, stdout, stderr);
+        return BridgeStartup.Run(
+            args,
+            stdin,
+            stdout,
+            stderr,
+            Services.ExcelBridgeSupport.RegisterOleMessageFilter,
+            Workers.MacroRunWorker.Run,
+            (startupArgs, startupStdin, startupStdout, startupStderr) => BridgeHost.Run(startupArgs, startupStdin, startupStdout, startupStderr));
     }
 }

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Workers/MacroRunWorker.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Workers/MacroRunWorker.cs
@@ -415,6 +415,7 @@ public sealed class MacroRunWorkerProcess : IDisposable
             }
             startInfo.ArgumentList.Add(assemblyPath);
         }
+        startInfo.ArgumentList.Add(BridgeStartup.InternalRunFlag);
         startInfo.ArgumentList.Add("--run-worker");
         startInfo.Environment[MacroRunWorker.RequestPathEnv] = requestPath;
         startInfo.Environment[MacroRunWorker.ResultPathEnv] = resultPath;

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeStartupTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeStartupTests.cs
@@ -1,0 +1,126 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class BridgeStartupTests
+{
+    [Fact]
+    public void NoArgumentsPrintsExplanationAndExitsZero()
+    {
+        using var stdin = TextReader.Null;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var registerCalls = 0;
+        var hostCalls = 0;
+
+        var code = BridgeStartup.Run([], stdin, stdout, stderr, () => new CallbackDisposable(() => registerCalls++), () => 99, (_, _, _, _) =>
+        {
+            hostCalls++;
+            return 98;
+        });
+
+        Assert.Equal(0, code);
+        Assert.Contains("internal helper executable", stdout.ToString());
+        Assert.Contains("Please run it through `xlflow`.", stdout.ToString());
+        Assert.Equal(string.Empty, stderr.ToString());
+        Assert.Equal(0, registerCalls);
+        Assert.Equal(0, hostCalls);
+    }
+
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("-h")]
+    public void HelpFlagsPrintUsageAndExitZero(string arg)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+
+        var code = BridgeStartup.Run([arg], TextReader.Null, stdout, stderr, NoopDisposable, () => 99, (_, _, _, _) => 98);
+
+        Assert.Equal(0, code);
+        Assert.Contains("Usage:", stdout.ToString());
+        Assert.Equal(string.Empty, stderr.ToString());
+    }
+
+    [Fact]
+    public void VersionPrintsHumanReadableVersionAndExitsZero()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+
+        var code = BridgeStartup.Run(["--version"], TextReader.Null, stdout, stderr, NoopDisposable, () => 99, (_, _, _, _) => 98);
+
+        Assert.Equal(0, code);
+        Assert.Contains("xlflow-excel-bridge", stdout.ToString());
+        Assert.Contains(BridgeInfo.Current().Version, stdout.ToString());
+        Assert.Equal(string.Empty, stderr.ToString());
+    }
+
+    [Fact]
+    public void InvalidArgumentsFailFastWithoutInitializingRuntime()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var registerCalls = 0;
+
+        var code = BridgeStartup.Run(["--bogus"], TextReader.Null, stdout, stderr, () => new CallbackDisposable(() => registerCalls++), () => 99, (_, _, _, _) => 98);
+
+        Assert.Equal(2, code);
+        Assert.Equal(string.Empty, stdout.ToString());
+        Assert.Contains("Invalid arguments", stderr.ToString());
+        Assert.Equal(0, registerCalls);
+    }
+
+    [Fact]
+    public void InternalRunFlagStartsBridgeHost()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var registerCalls = 0;
+        var hostCalls = 0;
+        string[]? forwardedArgs = null;
+
+        var code = BridgeStartup.Run([BridgeStartup.InternalRunFlag], TextReader.Null, stdout, stderr, () => new CallbackDisposable(() => registerCalls++), () => 99, (args, _, _, _) =>
+        {
+            hostCalls++;
+            forwardedArgs = args;
+            return 7;
+        });
+
+        Assert.Equal(7, code);
+        Assert.Equal(1, registerCalls);
+        Assert.Equal(1, hostCalls);
+        Assert.NotNull(forwardedArgs);
+        Assert.Empty(forwardedArgs!);
+    }
+
+    [Fact]
+    public void InternalWorkerModeRequiresInternalFlag()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var workerCalls = 0;
+
+        var code = BridgeStartup.Run([BridgeStartup.InternalRunFlag, "--run-worker"], TextReader.Null, stdout, stderr, NoopDisposable, () =>
+        {
+            workerCalls++;
+            return 5;
+        }, (_, _, _, _) => 98);
+
+        Assert.Equal(5, code);
+        Assert.Equal(1, workerCalls);
+    }
+
+    private static IDisposable NoopDisposable()
+    {
+        return new CallbackDisposable(() => { });
+    }
+
+    private sealed class CallbackDisposable(Action callback) : IDisposable
+    {
+        public void Dispose()
+        {
+            callback();
+        }
+    }
+}

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/MacroRunWorkerTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/MacroRunWorkerTests.cs
@@ -10,6 +10,7 @@ public sealed class MacroRunWorkerTests
         var startInfo = MacroRunWorkerProcess.CreateStartInfo("request.json", "result.json");
 
         Assert.False(startInfo.UseShellExecute);
+        Assert.Contains(BridgeStartup.InternalRunFlag, startInfo.ArgumentList);
         Assert.Contains("--run-worker", startInfo.ArgumentList);
         Assert.Equal("request.json", startInfo.Environment["XLFLOW_WORKER_REQUEST_PATH"]);
         Assert.Equal("result.json", startInfo.Environment["XLFLOW_WORKER_RESULT_PATH"]);

--- a/docs/bridge/dotnet-bridge.md
+++ b/docs/bridge/dotnet-bridge.md
@@ -258,6 +258,15 @@ The bridge is a separate executable named `xlflow-excel-bridge.exe`.
 
 The Go CLI starts it for command-scoped work and communicates through stdin/stdout JSON. stdout is reserved for protocol JSON only. Diagnostic logs go into response `logs` or stderr.
 
+Direct launches are intentionally fail-fast hardened:
+
+- `xlflow-excel-bridge.exe` with no arguments prints a short explanation and exits `0`
+- `xlflow-excel-bridge.exe --help` and `-h` print help and exit `0`
+- `xlflow-excel-bridge.exe --version` prints the bridge version and exits `0`
+- invalid arguments print a clear error and exit without starting Excel, COM, UI Automation, or the long-running bridge host
+
+The long-running bridge runtime now requires an explicit internal flag. `xlflow.exe` passes that flag automatically when it launches the bundled bridge, but direct users and external validators should only observe immediate informational or error output.
+
 ## COM Threading Rule
 
 Excel COM operations must run in an STA context.

--- a/internal/excel/bridge/dotnet.go
+++ b/internal/excel/bridge/dotnet.go
@@ -15,6 +15,7 @@ import (
 
 const dotNetBridgeBinaryName = "xlflow-excel-bridge"
 const dotNetBridgeProjectRelativePath = "bridge/dotnet/src/Xlflow.ExcelBridge/Xlflow.ExcelBridge.csproj"
+const dotNetBridgeInternalRunFlag = "--bridge-internal-run"
 
 var dotNetLookPath = exec.LookPath
 var dotNetBridgeCandidatesFunc = dotNetBridgeCandidates
@@ -118,7 +119,8 @@ func (p DotNetProvider) Execute(ctx context.Context, req Request) (Response, err
 		return Response{}, err
 	}
 
-	cmd := exec.CommandContext(ctx, command, args...)
+	execArgs := dotNetBridgeRuntimeArgs(args)
+	cmd := exec.CommandContext(ctx, command, execArgs...)
 	cmd.Stdin = bytes.NewReader(body)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -144,6 +146,12 @@ func (p DotNetProvider) Execute(ctx context.Context, req Request) (Response, err
 		return response, err
 	}
 	return response, nil
+}
+
+func dotNetBridgeRuntimeArgs(args []string) []string {
+	runtimeArgs := append([]string{}, args...)
+	runtimeArgs = append(runtimeArgs, dotNetBridgeInternalRunFlag)
+	return runtimeArgs
 }
 
 func DotNetBridgeCommand() (string, []string, error) {

--- a/internal/excel/bridge/dotnet_test.go
+++ b/internal/excel/bridge/dotnet_test.go
@@ -50,6 +50,30 @@ func TestDotNetBridgeCommandFallsBackToInstalledBridgeWhenSDKMissing(t *testing.
 	}
 }
 
+func TestDotNetBridgeInternalRunFlagConstant(t *testing.T) {
+	if dotNetBridgeInternalRunFlag != "--bridge-internal-run" {
+		t.Fatalf("dotNetBridgeInternalRunFlag = %q, want %q", dotNetBridgeInternalRunFlag, "--bridge-internal-run")
+	}
+}
+
+func TestDotNetBridgeRuntimeArgsAppendsInternalRunFlag(t *testing.T) {
+	base := []string{"bridge.dll", "--extra"}
+	got := dotNetBridgeRuntimeArgs(base)
+
+	if len(got) != 3 {
+		t.Fatalf("len(dotNetBridgeRuntimeArgs()) = %d, want 3: %v", len(got), got)
+	}
+	if got[0] != "bridge.dll" || got[1] != "--extra" {
+		t.Fatalf("dotNetBridgeRuntimeArgs() changed base args order: %v", got)
+	}
+	if got[2] != dotNetBridgeInternalRunFlag {
+		t.Fatalf("dotNetBridgeRuntimeArgs() missing internal run flag: %v", got)
+	}
+	if len(base) != 2 {
+		t.Fatalf("dotNetBridgeRuntimeArgs() mutated input slice length: %v", base)
+	}
+}
+
 func TestRepoLocalDotNetBridgeProjectPathExists(t *testing.T) {
 	projectPath, ok := repoLocalDotNetBridgeProjectPath()
 	if !ok {


### PR DESCRIPTION
Closes #129

Improve the startup process of xlflow-excel-bridge to ensure immediate termination with clear output for no arguments, help, version, or invalid arguments. Introduce an internal run flag for proper execution flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened the Excel bridge executable to fail fast on direct execution. It now exits immediately with clear output when launched without arguments, with help or version flags, or with invalid arguments, instead of starting the full bridge runtime.

* **Documentation**
  * Updated bridge documentation to clarify hardened startup behavior and immediate-exit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->