### PR TITLE
Added an execution path to delegate from WSL to Windows xlflow

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,9 +27,22 @@ builds:
             -Runtime win-x64
             -OutputDir ./bridge/dotnet/artifacts/publish/win-x64
           output: true
+  - id: xlflow-linux
+    main: ./cmd/xlflow
+    binary: xlflow
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }} -X main.date={{ .Date }}
+    goos:
+      - linux
+    goarch:
+      - amd64
 
 archives:
-  - id: xlflow
+  - id: xlflow-windows
     ids:
       - xlflow
     formats:
@@ -43,6 +56,18 @@ archives:
       - README.md
       - src: bridge/dotnet/artifacts/publish/{{ if eq .Os "windows" }}win-x64{{ else }}missing{{ end }}/xlflow-excel-bridge.exe
         strip_parent: true
+  - id: xlflow-linux
+    ids:
+      - xlflow-linux
+    formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE
+      - README.md
 
 checksum:
   name_template: checksums.txt
@@ -99,7 +124,7 @@ winget:
       - vba
       - automation
     ids:
-      - xlflow
+      - xlflow-windows
     repository:
       owner: harumiWeb
       name: winget-pkgs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.13.0
+
+- Added WSL development support that delegates Excel-related commands to Windows `xlflow.exe`, translates Windows-mounted project paths, preserves command streams and exit codes, and extends `doctor` with WSL/Windows diagnostics. Linux x64 release archives are now published for the WSL frontend.
+- Added a GitHub Pages-hosted WSL/Linux frontend installer at `https://harumiweb.github.io/xlflow/install.sh`, including one-line `curl | sh` install guidance and `--uninstall` support.
+- Added `task wsl-install`, `task wsl-uninstall`, and `task uninstall` helpers for installing or removing local Go bin xlflow binaries during delegation testing.
 - Added a GitHub Pages-hosted PowerShell installer at `https://harumiweb.github.io/xlflow/install.ps1`, including review-first safer install guidance, one-line quick install guidance, and `-Action uninstall` support that removes `%LOCALAPPDATA%\xlflow` and its user PATH entry.
 - Hardened `xlflow-excel-bridge.exe` direct startup so no-arg, help, version, and invalid launches exit immediately with clear output, while `xlflow.exe` uses an explicit internal run flag before starting the actual bridge runtime.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -115,7 +115,7 @@ pull → fmt → edit → push → lint → test/run → inspect
 | AIエージェント連携 | 安定した JSON を返し、Codex / Claude / Cursor / Gemini / GitHub Copilot 風ワークフローなどに使わせるための Skill をインストール |
 
 > [!IMPORTANT]
-> xlflow は **Windows-first** のツールです。Workbook 操作には **Microsoft Excel + COM** と Windows 既定の `.NET` Excel bridge を使用し、PowerShell bridge は明示指定用の legacy fallback として維持されます。
+> xlflow は workbook 実行について **Windows-first** のツールです。Workbook 操作には Windows 上の **Microsoft Excel + COM** と `.NET` Excel bridge を使用します。WSL は Windows 側の xlflow へ Excel 関連コマンドを委譲することで、開発 frontend として利用できます。
 
 ---
 
@@ -186,14 +186,14 @@ scoop install xlflow
 
 ### GitHub Releases
 
-Windows 向けの事前ビルド済みバイナリは次のページから取得できます。
+Windows x64 と Linux x64 向けの事前ビルド済みバイナリは次のページから取得できます。
 
 [https://github.com/harumiWeb/xlflow/releases](https://github.com/harumiWeb/xlflow/releases)
 
 > [!IMPORTANT]
-> 現在の事前ビルド配布は **Windows 向けのみ** です。
-> Workbook を操作する command には、**Microsoft Excel**、Excel COM automation、**VBA プロジェクト オブジェクト モデルへのアクセスを信頼する** 設定が必要です。
+> Workbook を操作する command には、Windows 上の **Microsoft Excel**、Excel COM automation、**VBA プロジェクト オブジェクト モデルへのアクセスを信頼する** 設定が必要です。
 > Windows 向け release ZIP には `xlflow.exe` と `xlflow-excel-bridge.exe` の両方が含まれます。Go CLI には runtime PowerShell bridge script も埋め込まれているため、workbook command のために sidecar `*.ps1` file を別配布する必要はありません。
+> Linux x64 archive は WSL/frontend CLI のみを含み、Windows `.NET` bridge は含みません。
 
 > [!WARNING]
 > `xlflow-excel-bridge.exe` は PowerShell execution policy の影響を受けませんが、AppLocker、WDAC、Defender / EDR policy、antivirus reputation、unsigned executable rule などでブロックされる可能性はあります。公開している checksum と GitHub attestation で確認できるのは artifact の integrity と provenance であり、Windows の Authenticode signing ではありません。
@@ -247,6 +247,52 @@ Taskfile を使用している場合:
 ```bash
 task run -- --help
 ```
+
+---
+
+## WSL で開発する
+
+WSL は編集と自動化の frontend として利用でき、Excel の実行 backend は Windows のままです。
+Excel は WSL 内では起動しません。Workbook command は Windows 側の `xlflow.exe` へ委譲され、そこから同梱の `.NET` bridge と Microsoft Excel COM automation が使われます。
+
+推奨セットアップ:
+
+1. まず Windows 側に xlflow をインストールします。installer、winget、Scoop、または Windows release ZIP を使えます。
+2. WSL shell から WSL frontend をインストールします。
+
+```bash
+curl -fsSL https://harumiweb.github.io/xlflow/install.sh | sh
+```
+
+3. xlflow project は `/mnt/c/dev/my-vba-project` のような Windows-mounted path 配下に置いてください。
+
+> [!WARNING]
+> `/home/user/project` のような WSL 専用 path は、委譲された Excel automation では正式サポート外です。Windows Excel と COM から見える workbook path が必要です。
+
+作業を始める前に WSL から診断を実行します。
+
+```bash
+xlflow doctor --json
+```
+
+WSL から Windows 側の executable を見つけられない場合は、明示的に指定できます。
+
+```bash
+export XLFLOW_WINDOWS_EXE='C:\Users\you\AppData\Local\xlflow\xlflow.exe'
+```
+
+日常的な macro 開発では、Excel を開いたまま編集ループを回せる session workflow を推奨します。
+
+```bash
+xlflow session start --json
+xlflow push --fast --session --no-save --json
+xlflow run Main.Run --session --json
+xlflow inspect cell --sheet Sheet1 --address A1 --session --json
+xlflow save --session --json
+xlflow session stop --json
+```
+
+`lint`、`fmt`、`analyze`、`diff` などの source-only command は WSL 内で実行できます。`new`、`init`、`pull`、`push`、`run`、`test`、`inspect`、`save`、`doctor` などの Excel-backed command は Windows へ自動委譲されます。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pull → fmt → edit → push → lint → test/run → inspect
 | AI agents      | Return stable JSON and install bundled Skills for Codex, Claude, Cursor, Gemini, GitHub Copilot-style agent workflows, and other agents           |
 
 > [!IMPORTANT]
-> xlflow is **Windows-first**. Workbook operations use **Microsoft Excel + COM** through the `.NET` Excel bridge by default on Windows, with PowerShell retained as an explicit legacy fallback.
+> xlflow is **Windows-first** for workbook execution. Workbook operations use **Microsoft Excel + COM** through the `.NET` Excel bridge by default on Windows. WSL can be used as the development frontend by delegating Excel-related commands to the Windows installation.
 
 ---
 
@@ -185,14 +185,14 @@ scoop install xlflow
 
 ### GitHub Releases
 
-Download prebuilt Windows binaries from:
+Download prebuilt Windows and Linux x64 binaries from:
 
 [https://github.com/harumiWeb/xlflow/releases](https://github.com/harumiWeb/xlflow/releases)
 
 > [!IMPORTANT]
-> Current prebuilt distribution targets **Windows** only.
-> Commands that interact with workbooks still require **Microsoft Excel**, Excel COM automation, and **Trust access to the VBA project object model**.
+> Commands that interact with workbooks still require **Microsoft Excel**, Excel COM automation, and **Trust access to the VBA project object model** on Windows.
 > The Windows release ZIP includes both `xlflow.exe` and `xlflow-excel-bridge.exe`. The Go CLI still embeds the runtime PowerShell bridge scripts, so workbook commands do not require sidecar `*.ps1` files.
+> The Linux x64 archive contains the WSL/frontend CLI only and does not include the Windows `.NET` bridge.
 
 > [!WARNING]
 > `xlflow-excel-bridge.exe` avoids PowerShell execution policy, but it can still be blocked by AppLocker, WDAC, Defender or EDR policy, antivirus reputation, or unsigned-executable rules. The published checksum and GitHub attestation verify artifact integrity and provenance; they do not provide Windows Authenticode signing.
@@ -246,6 +246,52 @@ With Taskfile:
 ```bash
 task run -- --help
 ```
+
+---
+
+## WSL Development
+
+WSL can be used as the editing and automation frontend while Windows remains the Excel execution backend.
+Excel is not started inside WSL; workbook commands are delegated to the Windows `xlflow.exe`, which then uses the bundled `.NET` bridge and Microsoft Excel COM automation.
+
+Recommended setup:
+
+1. Install xlflow on Windows first, using the installer, winget, Scoop, or the Windows release ZIP.
+2. Install the WSL frontend from a WSL shell:
+
+```bash
+curl -fsSL https://harumiweb.github.io/xlflow/install.sh | sh
+```
+
+3. Keep xlflow projects under a Windows-mounted path such as `/mnt/c/dev/my-vba-project`.
+
+> [!WARNING]
+> Projects under WSL-only paths such as `/home/user/project` are not supported for delegated Excel automation because Windows Excel and COM need a Windows-visible workbook path.
+
+Run diagnostics from WSL before starting work:
+
+```bash
+xlflow doctor --json
+```
+
+If the Windows executable is not discoverable from WSL, point xlflow at it explicitly:
+
+```bash
+export XLFLOW_WINDOWS_EXE='C:\Users\you\AppData\Local\xlflow\xlflow.exe'
+```
+
+For day-to-day macro development, use a session so Excel stays open across the edit loop:
+
+```bash
+xlflow session start --json
+xlflow push --fast --session --no-save --json
+xlflow run Main.Run --session --json
+xlflow inspect cell --sheet Sheet1 --address A1 --session --json
+xlflow save --session --json
+xlflow session stop --json
+```
+
+Source-only commands such as `lint`, `fmt`, `analyze`, and `diff` can run locally in WSL. Excel-backed commands such as `new`, `init`, `pull`, `push`, `run`, `test`, `inspect`, `save`, and `doctor` delegate to Windows automatically.
 
 ---
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,61 @@ tasks:
       - go install ./cmd/xlflow
       - powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\build-dotnet-bridge.ps1' -InstallToGoBin
 
+  uninstall:
+    desc: Remove xlflow and the Excel bridge from the local Go bin directory
+    cmds:
+      - |
+        powershell -NoProfile -ExecutionPolicy Bypass -Command '
+        $ErrorActionPreference = "Stop"
+        $goBin = (go env GOBIN).Trim()
+        if ([string]::IsNullOrWhiteSpace($goBin)) {
+          $goPath = (go env GOPATH).Trim()
+          if ([string]::IsNullOrWhiteSpace($goPath)) {
+            throw "Unable to resolve GOBIN/GOPATH from go env."
+          }
+          $goBin = Join-Path ($goPath.Split([IO.Path]::PathSeparator)[0]) "bin"
+        }
+        foreach ($name in @("xlflow.exe", "xlflow-excel-bridge.exe")) {
+          $path = Join-Path $goBin $name
+          if (Test-Path -LiteralPath $path) {
+            Remove-Item -LiteralPath $path -Force
+            Write-Output ("Removed " + $path)
+          } else {
+            Write-Output ("Not found: " + $path)
+          }
+        }
+        '
+
+  wsl-install:
+    desc: Install the xlflow frontend binary into the current WSL environment
+    cmds:
+      - go install ./cmd/xlflow
+      - |
+        bin="$(go env GOBIN)"
+        if [ -z "$bin" ]; then
+          bin="$(go env GOPATH | cut -d: -f1)/bin"
+        fi
+        printf "Installed xlflow to %s/xlflow\n" "$bin"
+        if ! command -v xlflow >/dev/null 2>&1; then
+          printf "Warning: xlflow is not on PATH inside WSL. Add %s to PATH.\n" "$bin"
+        fi
+
+  wsl-uninstall:
+    desc: Remove the xlflow frontend binary from the current WSL Go bin directory
+    cmds:
+      - |
+        bin="$(go env GOBIN)"
+        if [ -z "$bin" ]; then
+          bin="$(go env GOPATH | cut -d: -f1)/bin"
+        fi
+        target="$bin/xlflow"
+        if [ -e "$target" ]; then
+          rm -f "$target"
+          printf "Removed %s\n" "$target"
+        else
+          printf "Not found: %s\n" "$target"
+        fi
+
   run:
     desc: Run xlflow without install
     cmds:

--- a/docs/adr/ADR-0011-wsl-windows-cli-delegation.md
+++ b/docs/adr/ADR-0011-wsl-windows-cli-delegation.md
@@ -1,0 +1,83 @@
+# ADR-0011: WSL Development Through Windows xlflow Delegation
+
+## Status
+
+Accepted
+
+## Context
+
+AI agents and developers often keep Git, editors, and Linux tooling in WSL, but
+Excel, VBA, COM, VBIDE, and UI Automation remain Windows-only dependencies.
+Running the Windows `.NET` bridge directly from the WSL Go process would split
+CLI responsibility across operating systems and duplicate path, output, and
+exit-code handling already owned by the Windows CLI.
+
+Projects stored only in the WSL filesystem are not reliably visible to Excel.
+Windows-mounted paths such as `/mnt/c/...` provide a stable shared filesystem
+boundary.
+
+## Decision
+
+Treat WSL as a development frontend and delegate Excel-related commands to an
+installed Windows `xlflow.exe`.
+
+- Detect WSL from `WSL_INTEROP`, `WSL_DISTRO_NAME`, or `/proc/version`.
+- Support delegated projects only under `/mnt/<drive>/...`.
+- Resolve Windows xlflow from `XLFLOW_WINDOWS_EXE`, then `xlflow.exe` on the
+  interoperable PATH.
+- Translate WSL absolute path arguments with `wslpath -w`; keep relative paths
+  relative to the shared project working directory.
+- Delegate the complete Windows CLI command rather than invoking the `.NET`
+  bridge directly. Windows xlflow continues to own configuration, preflight,
+  bridge selection, output envelopes, and Excel automation.
+- Preserve stdin, stdout, stderr, and the Windows process exit code. `doctor` is
+  the exception: WSL captures Windows JSON, adds host, executable, bridge, Excel,
+  and path-translation diagnostics, then renders the combined envelope.
+- Add xlflow runtime variables such as `XLFLOW_MODE` and
+  `XLFLOW_EXCEL_BRIDGE` to `WSLENV` for the delegated Win32 process.
+- Keep source-only commands local to WSL. Help and shell completion are never
+  delegated.
+- Set an internal environment marker on child processes to prevent recursive
+  delegation.
+
+The Windows and WSL xlflow versions may differ. `doctor` reports the mismatch as
+a warning but does not block delegation.
+
+## Consequences
+
+- Positive: Agents can perform edit, push, run, test, inspect, and session
+  workflows from WSL while using real Windows Excel.
+- Positive: JSON and exit-code behavior remains defined by the existing Windows
+  CLI contract.
+- Positive: The `.NET` bridge remains a Windows implementation detail and does
+  not gain a second WSL-specific protocol.
+- Negative: Users must install xlflow on both WSL and Windows.
+- Negative: Projects under `/home`, WSL virtual disks, or other
+  Windows-invisible paths are rejected for delegated commands.
+- Negative: Absolute path-bearing CLI arguments require explicit translation
+  coverage as new path options are added.
+- Negative: End-to-end verification requires a real WSL, Windows, and Excel
+  environment in addition to cross-platform unit tests.
+
+## Alternatives Considered
+
+1. **Run the Windows `.NET` bridge directly from WSL** — Rejected because it
+   bypasses Windows CLI preflight, provider selection, output mapping, and
+   compatibility checks.
+2. **Delegate every command to Windows** — Rejected because source linting,
+   formatting, analysis, Git, and agent tooling should retain native WSL paths
+   and performance.
+3. **Copy WSL-only projects to a temporary Windows directory** — Rejected
+   because synchronization, file identity, generated state, and failure
+   recovery would become implicit and unsafe.
+4. **Add a daemon or network service on Windows** — Rejected because WSL
+   interoperability can launch the existing executable without introducing a
+   persistent service or authentication surface.
+
+## Related
+
+- `docs/adr/ADR-0001-agent-ready-vba-cli-architecture.md`
+- `docs/adr/ADR-0008-dotnet-excel-bridge.md`
+- `docs/adr/ADR-0009-bridge-provider-contract.md`
+- `docs/specs/cli-contract.md`
+- `vitepress/installation.md`

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -4,7 +4,7 @@
 
 This spec defines the MVP command, configuration, JSON output, and exit-code contracts for xlflow.
 
-xlflow is a Windows-first Go CLI that treats Excel VBA projects as source-controlled code. Excel operations use the `.NET` Excel bridge by default on Windows, with the PowerShell bridge retained as an explicit legacy fallback. Source-only commands such as `lint` should remain testable without Excel installed.
+xlflow is a Windows-first Go CLI that treats Excel VBA projects as source-controlled code. Excel operations use the `.NET` Excel bridge by default on Windows, with the PowerShell bridge retained as an explicit legacy fallback. WSL is supported as a development frontend by delegating Excel-related commands to Windows `xlflow.exe`. Source-only commands such as `lint` remain local and testable without Excel installed.
 
 ## Commands
 
@@ -65,6 +65,12 @@ xlflow [--json] version [--verbose]
 
 `--bridge` is also a persistent global flag for Excel bridge-backed commands. Supported values are `auto`, `powershell`, and `dotnet`. Resolution order is `--bridge`, then `XLFLOW_EXCEL_BRIDGE`, then `[excel].bridge`, then the default `auto`. On Windows, `auto` prefers the `.NET` bridge and falls back to PowerShell only when `.NET` is unavailable, incompatible, or unsupported for the requested command. Explicit `--bridge dotnet` is strict and does not implicitly fall back to PowerShell. Explicit `--bridge powershell` always uses the legacy PowerShell bridge.
 
+Under WSL, Excel-related top-level commands are delegated to Windows `xlflow.exe`: `new`, `init`, `doctor`, `attach`, `list`, `form`, `pull`, `push`, `rollback`, `session`, `save`, `status`, `runner`, `run`, `export-image`, `edit`, `macros`, `ui`, `test`, `inspect`, `check`, and `process`. Source-oriented commands remain in WSL: `backup`, `diff`, `inspect-gui`, `lint`, `fmt`, `analyze`, `generate`, `module`, `skill`, `version`, and completion/help. Delegation preserves stdin, stdout, stderr, JSON envelopes, and the Windows process exit code.
+
+Delegated projects must be located under a Windows-mounted drive such as `/mnt/c/...`. The WSL working directory and absolute workbook, source/spec, input, save, and output path arguments are translated with `wslpath -w`; relative paths remain relative to the shared project directory. WSL-only absolute paths such as `/home/user/project` fail before Windows starts. Windows xlflow resolution uses `XLFLOW_WINDOWS_EXE` first and then `xlflow.exe` from the interoperable PATH. The override accepts either a Windows absolute path or a WSL path to an `.exe`.
+
+The delegated process extends `WSLENV` with xlflow-owned runtime variables, including `XLFLOW_EXCEL_BRIDGE`, `XLFLOW_MODE`, and `XLFLOW_NO_UPDATE_CHECK`, so their WSL values reach Windows. Projects that require additional custom environment variables inside VBA must add those names to `WSLENV` themselves.
+
 When `--json` is not set, output is optimized for humans rather than machines. Interactive terminals may use Bubble Tea/Lipgloss presentation, color, and progress spinners for Excel COM-backed commands. Non-interactive output, such as CI logs and pipes, stays static and text-oriented while preserving the same command result information. Machine consumers must use `--json` instead of parsing human output.
 
 Excel COM-backed commands report progress on stderr. Interactive stderr terminals may show Bubble Tea/Lipgloss spinner output, while `--json` or non-interactive runs fall back to line-oriented stderr progress so stdout remains a single final human result or JSON envelope. Commands that stream UI or debug events to stderr may suppress separate progress output. Agents should wait for process exit instead of parsing interim stderr progress text.
@@ -75,7 +81,7 @@ Excel COM-backed commands report progress on stderr. Interactive stderr terminal
 
 Excel COM-backed commands also include top-level `bridge` metadata identifying the xlflow Excel bridge process. The fields vary by bridge provider. The PowerShell bridge returns `host` (process name, e.g. `pwsh.exe`), `edition` (e.g. `Core` or `Desktop`), and `version` (PowerShell version). The .NET bridge returns `name`, `version`, `protocol_version`, `runtime`, `architecture`, and may also include `commit`. If workbook VBA launches its own external PowerShell process, that workbook-side host may differ and must be inspected separately.
 
-`doctor --json` adds a top-level `diagnostics` object. Provider-specific `bridge` metadata and `diagnostics` serve different purposes: `bridge` identifies the bridge process itself, while `diagnostics` describes the probed Excel/runtime environment. `diagnostics.requested_bridge` records the requested mode, `diagnostics.selected_bridge` records the resolved provider, `diagnostics.fallback` reports whether `auto` fell back to PowerShell, and `diagnostics.legacy` reports whether the final provider is the legacy PowerShell bridge. With `.NET`, successful output also includes `diagnostics.protocol_version`, nested `runtime`, and nested `excel` probe fields. With PowerShell, callers must not assume the same nested shape unless the provider contract explicitly documents it for that bridge.
+`doctor --json` adds a top-level `diagnostics` object. Provider-specific `bridge` metadata and `diagnostics` serve different purposes: `bridge` identifies the bridge process itself, while `diagnostics` describes the probed Excel/runtime environment. `diagnostics.requested_bridge` records the requested mode, `diagnostics.selected_bridge` records the resolved provider, `diagnostics.fallback` reports whether `auto` fell back to PowerShell, and `diagnostics.legacy` reports whether the final provider is the legacy PowerShell bridge. With `.NET`, successful output also includes `diagnostics.protocol_version`, nested `runtime`, and nested `excel` probe fields. With PowerShell, callers must not assume the same nested shape unless the provider contract explicitly documents it for that bridge. Under WSL, the delegated Windows result is preserved and augmented with `diagnostics.host`, `diagnostics.windows`, and `diagnostics.path_translation`. These report WSL/distro detection, Windows xlflow path/version, bridge and Excel availability, and the translated project working directory. A WSL/Windows xlflow version mismatch is a warning rather than a hard failure.
 
 `new` creates a fresh macro-enabled workbook under `build/`, scaffolds the same project layout as `init`, and then automatically `push`es the scaffolded VBA source into that workbook so the initial workbook and `src/` tree start in sync. Without an argument it creates `build/Book.xlsm`; when the argument has no extension, `.xlsm` is appended. Any other extension is rejected because workbook creation always uses Excel macro-enabled format `52`. New projects write `[userform].code_source = "sidecar"` into `xlflow.toml`.
 
@@ -260,7 +266,7 @@ All JSON output uses a stable top-level envelope.
 
 Command-specific fields are added at the top level:
 
-- `diagnostics` for `doctor` (includes `excel.com_activation` which indicates successful `Excel.Application` creation on the STA thread)
+- `diagnostics` for `doctor` (includes `excel.com_activation` which indicates successful `Excel.Application` creation on the STA thread; WSL adds `host`, `windows`, and `path_translation`)
 - `workbook` and `backup` for Excel file commands
 - `source` for commands that write project source files
 - `macro` for `run`
@@ -394,13 +400,17 @@ When no Excel processes are running, `process` is an empty array and the command
 - `process_enumeration_failed` (exit code 3): process enumeration failed at the system level.
 - `process_termination_failed` (exit code 3): one or more targeted processes could not be terminated.
 - `process_cleanup_failed` (exit code 3): an unexpected error occurred during process cleanup.
+- `windows_xlflow_not_found` (exit code 3): WSL could not resolve the Windows `xlflow.exe`.
+- `wsl_project_path_unsupported` (exit code 3): a delegated project or absolute path is not under `/mnt/<drive>`.
+- `wsl_path_translation_failed` (exit code 3): `wslpath` could not translate a required path.
+- `windows_xlflow_execution_failed` (exit code 3): WSL could not start Windows xlflow or could not decode delegated doctor output.
 
 ## Exit Codes
 
 - `0`: success
 - `1`: user-code or validation failure, including lint findings, analysis findings, GUI boundary preflight failures, macro failure, macro timeout, VBE compile failure, missing macro target, removed-helper findings, missing UI sheets or buttons, VBA test failure, no tests found, missing filter targets, active workbook mismatches, duplicate test names, invalid exported ranges, existing output files, unsupported export-image formats, unsupported form export-image formats, missing UserForms, `form_already_exists`, `unsupported_form_control`, `designer_write_failed`, capture window lookup failures, image capture failures, `edit` session requirements, invalid workbook edit selectors, invalid edit colors, `fmt_check_failed` (unformatted files in `--check` mode), and workbook event-handler failures returned by the bridge
 - `2`: CLI argument or configuration error, including invalid `push`, `run`, `session`, `save`, `runner`, `export-image`, `form build`, `form export-image`, `edit`, and `process` option combinations, invalid `fmt` mode combinations, plus `process_args_invalid` and `process_not_found` errors from the bridge
-- `3`: environment failure, including Excel, COM, VBIDE, PowerShell, script execution failures, and process enumeration/termination errors (`process_enumeration_failed`, `process_termination_failed`, `process_cleanup_failed`)
+- `3`: environment failure, including Excel, COM, VBIDE, PowerShell, script execution failures, WSL delegation failures, and process enumeration/termination errors (`process_enumeration_failed`, `process_termination_failed`, `process_cleanup_failed`)
 
 `diff` intentionally returns `0` when differences are found. Consumers should inspect `diff.summary.total_diffs` to distinguish changed and unchanged inputs.
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,6 +43,7 @@ type app struct {
 	json           bool
 	bridge         string
 	cwd            string
+	rawArgs        []string
 	stdout         io.Writer
 	stderr         io.Writer
 	stdoutTerminal func() bool
@@ -112,7 +113,7 @@ func ExecuteWithBuildInfo(info BuildInfo) error {
 	if err != nil {
 		return output.WithExitCode(output.ExitEnvironment, err)
 	}
-	a := &app{cwd: cwd, buildInfo: info.withDefaults()}
+	a := &app{cwd: cwd, rawArgs: append([]string{}, os.Args[1:]...), buildInfo: info.withDefaults()}
 	root := a.rootCommand()
 	return root.Execute()
 }
@@ -140,6 +141,9 @@ func (a *app) rootCommand() *cobra.Command {
 		Short:         "Agent-ready VBA development framework",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return a.delegateWSLCommand(cmd)
+		},
 	}
 	root.PersistentFlags().BoolVar(&a.json, "json", false, "write machine-readable JSON output")
 	root.PersistentFlags().StringVar(&a.bridge, "bridge", "", "Excel bridge mode: auto, powershell, dotnet")

--- a/internal/cli/wsl_delegation.go
+++ b/internal/cli/wsl_delegation.go
@@ -1,0 +1,398 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/harumiWeb/xlflow/internal/output"
+	"github.com/harumiWeb/xlflow/internal/wsl"
+)
+
+var (
+	isWSL                    = wsl.IsWSL
+	wslDistroName            = wsl.DistroName
+	resolveWindowsExecutable = wsl.ResolveWindowsExecutable
+	translateWSLPath         = wsl.ToWindowsPath
+	translateWSLArgs         = wsl.TranslateArgs
+	newDelegatedCommand      = exec.CommandContext
+)
+
+var delegatedTopLevelCommands = map[string]struct{}{
+	"attach":       {},
+	"check":        {},
+	"doctor":       {},
+	"edit":         {},
+	"export-image": {},
+	"form":         {},
+	"init":         {},
+	"inspect":      {},
+	"list":         {},
+	"macros":       {},
+	"new":          {},
+	"process":      {},
+	"pull":         {},
+	"push":         {},
+	"rollback":     {},
+	"run":          {},
+	"runner":       {},
+	"save":         {},
+	"session":      {},
+	"status":       {},
+	"test":         {},
+	"ui":           {},
+}
+
+var errWSLDelegated = errors.New("wsl delegated command completed")
+
+func (a *app) delegateWSLCommand(cmd *cobra.Command) error {
+	if len(a.rawArgs) == 0 || !isWSL() || strings.TrimSpace(os.Getenv(wsl.EnvDelegated)) != "" {
+		return nil
+	}
+	topLevel := topLevelCommandName(cmd)
+	if !shouldDelegateTopLevelCommand(topLevel) {
+		return nil
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	windowsCWD, err := translateWSLPath(ctx, a.cwd)
+	if err != nil {
+		if topLevel == "doctor" {
+			return a.writeWSLDoctorFailure(err, "", "", false)
+		}
+		return a.writeWSLFailure(topLevel, err)
+	}
+	executable, windowsExecutable, err := resolveWindowsExecutable(ctx)
+	if err != nil {
+		if topLevel == "doctor" {
+			return a.writeWSLDoctorFailure(err, windowsCWD, "", false)
+		}
+		return a.writeWSLFailure(topLevel, err)
+	}
+	args, err := translateWSLArgs(ctx, a.rawArgs)
+	if err != nil {
+		if topLevel == "doctor" {
+			return a.writeWSLDoctorFailure(err, windowsCWD, windowsExecutable, true)
+		}
+		return a.writeWSLFailure(topLevel, err)
+	}
+
+	if topLevel == "doctor" {
+		return a.runDelegatedDoctor(ctx, executable, windowsExecutable, windowsCWD, args)
+	}
+	return a.runDelegatedCommand(ctx, topLevel, executable, args)
+}
+
+func shouldDelegateTopLevelCommand(name string) bool {
+	_, ok := delegatedTopLevelCommands[name]
+	return ok
+}
+
+func topLevelCommandName(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	current := cmd
+	for current.Parent() != nil && current.Parent().Parent() != nil {
+		current = current.Parent()
+	}
+	return current.Name()
+}
+
+func (a *app) runDelegatedCommand(ctx context.Context, commandName string, executable string, args []string) error {
+	child := newDelegatedCommand(ctx, executable, args...)
+	child.Dir = a.cwd
+	child.Stdin = os.Stdin
+	child.Stdout = a.stdoutWriter()
+	child.Stderr = a.stderrWriter()
+	child.Env = delegatedEnvironment()
+	err := child.Run()
+	if err == nil {
+		return output.WithExitCode(output.ExitSuccess, errWSLDelegated)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return output.WithExitCode(exitErr.ExitCode(), err)
+	}
+	return a.writeFailure(commandName, output.ExitEnvironment, "windows_xlflow_execution_failed", err)
+}
+
+func (a *app) runDelegatedDoctor(ctx context.Context, executable string, windowsExecutable string, windowsCWD string, args []string) error {
+	doctorArgs := ensureJSONFlag(args)
+	var stdout bytes.Buffer
+	child := newDelegatedCommand(ctx, executable, doctorArgs...)
+	child.Dir = a.cwd
+	child.Stdin = os.Stdin
+	child.Stdout = &stdout
+	child.Stderr = a.stderrWriter()
+	child.Env = delegatedEnvironment()
+	runErr := child.Run()
+	exitCode := output.ExitSuccess
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return a.writeWSLDoctorFailure(
+				&wsl.Error{Code: "windows_xlflow_execution_failed", Message: runErr.Error(), Err: runErr},
+				windowsCWD,
+				windowsExecutable,
+				true,
+			)
+		}
+	}
+
+	var env output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		return a.writeWSLDoctorFailure(
+			&wsl.Error{
+				Code:    "windows_xlflow_execution_failed",
+				Message: fmt.Sprintf("Windows xlflow doctor returned invalid JSON: %v", err),
+				Err:     err,
+			},
+			windowsCWD,
+			windowsExecutable,
+			true,
+		)
+	}
+	diagnostics := mapValue(env.Diagnostics)
+	diagnostics["host"] = map[string]any{
+		"os":      "linux",
+		"is_wsl":  true,
+		"distro":  wslDistroName(),
+		"version": a.buildInfo.Version,
+	}
+	diagnostics["windows"] = map[string]any{
+		"xlflow_found":    true,
+		"xlflow_path":     windowsExecutable,
+		"xlflow_version":  a.windowsVersion(ctx, executable),
+		"bridge_found":    delegatedDoctorBridgeFound(env, diagnostics),
+		"excel_available": delegatedDoctorExcelAvailable(env, diagnostics),
+	}
+	diagnostics["path_translation"] = map[string]any{
+		"supported":    true,
+		"wsl_path":     a.cwd,
+		"windows_path": windowsCWD,
+	}
+	env.Diagnostics = diagnostics
+	a.addDelegatedVersionWarning(&env, diagnostics)
+	if err := a.write(env, exitCode); err != nil {
+		return err
+	}
+	return output.WithExitCode(output.ExitSuccess, errWSLDelegated)
+}
+
+func (a *app) windowsVersion(ctx context.Context, executable string) string {
+	var stdout bytes.Buffer
+	child := newDelegatedCommand(ctx, executable, "--json", "version")
+	child.Dir = a.cwd
+	child.Stdout = &stdout
+	child.Stderr = a.stderrWriter()
+	child.Env = delegatedEnvironment()
+	if err := child.Run(); err != nil {
+		return ""
+	}
+	var env output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		return ""
+	}
+	return stringValueFromMap(mapValue(env.Version), "version")
+}
+
+func (a *app) addDelegatedVersionWarning(env *output.Envelope, diagnostics map[string]any) {
+	windows := mapValue(diagnostics["windows"])
+	windowsVersion := stringValueFromMap(windows, "xlflow_version")
+	localVersion := strings.TrimSpace(a.buildInfo.Version)
+	if windowsVersion == "" || localVersion == "" || windowsVersion == "dev" || localVersion == "dev" || windowsVersion == localVersion {
+		return
+	}
+	warnings := anySlice(env.Warnings)
+	warnings = append(warnings, map[string]any{
+		"code":    "wsl_windows_version_mismatch",
+		"message": fmt.Sprintf("WSL xlflow version %s differs from Windows xlflow version %s.", localVersion, windowsVersion),
+	})
+	env.Warnings = warnings
+}
+
+func delegatedDoctorBridgeFound(env output.Envelope, diagnostics map[string]any) bool {
+	if env.Bridge != nil || stringValueFromMap(diagnostics, "selected_bridge") != "" {
+		return true
+	}
+	if env.Error == nil {
+		return false
+	}
+	return env.Error.Code != "bridge_not_available" &&
+		env.Error.Code != "dotnet_missing" &&
+		env.Error.Code != "dotnet_runtime_missing" &&
+		env.Error.Code != "powershell_missing"
+}
+
+func delegatedDoctorExcelAvailable(env output.Envelope, diagnostics map[string]any) bool {
+	excel := mapValue(diagnostics["excel"])
+	if value, ok := excel["com_activation"].(bool); ok {
+		return value
+	}
+	if value, ok := diagnostics["excel_installed"].(bool); ok {
+		return value
+	}
+	return false
+}
+
+func ensureJSONFlag(args []string) []string {
+	for _, arg := range args {
+		if arg == "--json" {
+			return append([]string{}, args...)
+		}
+	}
+	result := append([]string{}, args...)
+	return append(result, "--json")
+}
+
+func delegatedEnvironment() []string {
+	env := append([]string{}, os.Environ()...)
+	env = setEnvironmentValue(env, wsl.EnvDelegated, "1")
+	env = setEnvironmentValue(env, "WSLENV", mergeWSLEnv(os.Getenv("WSLENV"),
+		wsl.EnvDelegated,
+		"XLFLOW_EXCEL_BRIDGE",
+		"XLFLOW_MODE",
+		"XLFLOW_NO_UPDATE_CHECK",
+	))
+	return env
+}
+
+func mergeWSLEnv(current string, names ...string) string {
+	entries := strings.Split(current, ":")
+	seen := make(map[string]struct{}, len(entries)+len(names))
+	result := make([]string, 0, len(entries)+len(names))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		name := entry
+		if before, _, ok := strings.Cut(entry, "/"); ok {
+			name = before
+		}
+		seen[name] = struct{}{}
+		result = append(result, entry)
+	}
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name+"/w")
+	}
+	return strings.Join(result, ":")
+}
+
+func setEnvironmentValue(env []string, name string, value string) []string {
+	prefix := name + "="
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}
+
+func (a *app) writeWSLFailure(commandName string, err error) error {
+	var wslErr *wsl.Error
+	if errors.As(err, &wslErr) {
+		return a.writeFailure(commandName, output.ExitEnvironment, wslErr.Code, wslErr)
+	}
+	return a.writeFailure(commandName, output.ExitEnvironment, "windows_xlflow_execution_failed", err)
+}
+
+func (a *app) writeWSLDoctorFailure(err error, windowsCWD string, windowsExecutable string, executableFound bool) error {
+	code := "windows_xlflow_execution_failed"
+	message := err.Error()
+	var wslErr *wsl.Error
+	if errors.As(err, &wslErr) {
+		code = wslErr.Code
+		message = wslErr.Message
+	}
+	env := output.Failure("doctor", output.Error{
+		Code:    code,
+		Message: message,
+		Source:  "xlflow",
+		Phase:   "wsl.delegate",
+	})
+	env.Diagnostics = map[string]any{
+		"host": map[string]any{
+			"os":      "linux",
+			"is_wsl":  true,
+			"distro":  wslDistroName(),
+			"version": a.buildInfo.Version,
+		},
+		"windows": map[string]any{
+			"xlflow_found":    executableFound,
+			"xlflow_path":     windowsExecutable,
+			"xlflow_version":  "",
+			"bridge_found":    false,
+			"excel_available": false,
+		},
+		"path_translation": map[string]any{
+			"supported":    windowsCWD != "",
+			"wsl_path":     a.cwd,
+			"windows_path": windowsCWD,
+		},
+	}
+	return a.write(env, output.ExitEnvironment)
+}
+
+func mapValue(value any) map[string]any {
+	if value == nil {
+		return map[string]any{}
+	}
+	if typed, ok := value.(map[string]any); ok {
+		return typed
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return map[string]any{}
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil || result == nil {
+		return map[string]any{}
+	}
+	return result
+}
+
+func stringValueFromMap(value map[string]any, key string) string {
+	raw, ok := value[key]
+	if !ok {
+		return ""
+	}
+	text, _ := raw.(string)
+	return strings.TrimSpace(text)
+}
+
+func anySlice(value any) []any {
+	if value == nil {
+		return nil
+	}
+	if typed, ok := value.([]any); ok {
+		return typed
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	var result []any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil
+	}
+	return result
+}

--- a/internal/cli/wsl_delegation.go
+++ b/internal/cli/wsl_delegation.go
@@ -33,7 +33,6 @@ var delegatedTopLevelCommands = map[string]struct{}{
 	"export-image": {},
 	"form":         {},
 	"init":         {},
-	"inspect":      {},
 	"list":         {},
 	"macros":       {},
 	"new":          {},
@@ -57,7 +56,7 @@ func (a *app) delegateWSLCommand(cmd *cobra.Command) error {
 		return nil
 	}
 	topLevel := topLevelCommandName(cmd)
-	if !shouldDelegateTopLevelCommand(topLevel) {
+	if !shouldDelegateCommand(cmd, topLevel) {
 		return nil
 	}
 
@@ -96,6 +95,28 @@ func (a *app) delegateWSLCommand(cmd *cobra.Command) error {
 func shouldDelegateTopLevelCommand(name string) bool {
 	_, ok := delegatedTopLevelCommands[name]
 	return ok
+}
+
+func shouldDelegateCommand(cmd *cobra.Command, topLevel string) bool {
+	if topLevel == "inspect" {
+		return shouldDelegateInspectCommand(cmd)
+	}
+	return shouldDelegateTopLevelCommand(topLevel)
+}
+
+func shouldDelegateInspectCommand(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	switch cmd.Name() {
+	case "form":
+		return true
+	case "workbook", "sheets", "range", "used-range", "cell":
+		flag := cmd.Flags().Lookup("session")
+		return flag != nil && flag.Value.String() == "true"
+	default:
+		return false
+	}
 }
 
 func topLevelCommandName(cmd *cobra.Command) string {
@@ -272,28 +293,42 @@ func delegatedEnvironment() []string {
 
 func mergeWSLEnv(current string, names ...string) string {
 	entries := strings.Split(current, ":")
-	seen := make(map[string]struct{}, len(entries)+len(names))
+	indexByName := make(map[string]int, len(entries)+len(names))
 	result := make([]string, 0, len(entries)+len(names))
 	for _, entry := range entries {
 		entry = strings.TrimSpace(entry)
 		if entry == "" {
 			continue
 		}
-		name := entry
-		if before, _, ok := strings.Cut(entry, "/"); ok {
-			name = before
-		}
-		seen[name] = struct{}{}
+		name, _ := splitWSLEnvEntry(entry)
+		indexByName[name] = len(result)
 		result = append(result, entry)
 	}
 	for _, name := range names {
-		if _, ok := seen[name]; ok {
+		if index, ok := indexByName[name]; ok {
+			result[index] = ensureWSLEnvFlag(result[index], "w")
 			continue
 		}
-		seen[name] = struct{}{}
+		indexByName[name] = len(result)
 		result = append(result, name+"/w")
 	}
 	return strings.Join(result, ":")
+}
+
+func splitWSLEnvEntry(entry string) (string, string) {
+	name, flags, ok := strings.Cut(entry, "/")
+	if !ok {
+		return entry, ""
+	}
+	return name, flags
+}
+
+func ensureWSLEnvFlag(entry string, flag string) string {
+	name, flags := splitWSLEnvEntry(entry)
+	if strings.Contains(flags, flag) {
+		return entry
+	}
+	return name + "/" + flags + flag
 }
 
 func setEnvironmentValue(env []string, name string, value string) []string {

--- a/internal/cli/wsl_delegation_test.go
+++ b/internal/cli/wsl_delegation_test.go
@@ -23,12 +23,12 @@ import (
 func TestDelegatedTopLevelCommands(t *testing.T) {
 	delegated := []string{
 		"attach", "check", "doctor", "edit", "export-image", "form", "init",
-		"inspect", "list", "macros", "new", "process", "pull", "push", "rollback",
+		"list", "macros", "new", "process", "pull", "push", "rollback",
 		"run", "runner", "save", "session", "status", "test", "ui",
 	}
 	local := []string{
 		"backup", "completion", "diff", "fmt", "generate", "inspect-gui", "lint",
-		"module", "skill", "version",
+		"inspect", "module", "skill", "version",
 	}
 	for _, name := range delegated {
 		if !shouldDelegateTopLevelCommand(name) {
@@ -42,6 +42,41 @@ func TestDelegatedTopLevelCommands(t *testing.T) {
 	}
 	if len(delegatedTopLevelCommands) != len(delegated) {
 		t.Fatalf("delegated command count = %d, want %d", len(delegatedTopLevelCommands), len(delegated))
+	}
+}
+
+func TestShouldDelegateInspectCommand(t *testing.T) {
+	cases := []struct {
+		name    string
+		session bool
+		want    bool
+	}{
+		{name: "form", want: true},
+		{name: "workbook", want: false},
+		{name: "workbook", session: true, want: true},
+		{name: "sheets", want: false},
+		{name: "sheets", session: true, want: true},
+		{name: "range", want: false},
+		{name: "range", session: true, want: true},
+		{name: "used-range", want: false},
+		{name: "used-range", session: true, want: true},
+		{name: "cell", want: false},
+		{name: "cell", session: true, want: true},
+		{name: "unknown", want: false},
+	}
+	for _, tt := range cases {
+		t.Run(fmt.Sprintf("%s/session=%v", tt.name, tt.session), func(t *testing.T) {
+			cmd := &cobra.Command{Use: tt.name}
+			cmd.Flags().Bool("session", false, "")
+			if tt.session {
+				if err := cmd.Flags().Set("session", "true"); err != nil {
+					t.Fatalf("set session flag: %v", err)
+				}
+			}
+			if got := shouldDelegateInspectCommand(cmd); got != tt.want {
+				t.Fatalf("shouldDelegateInspectCommand() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -457,7 +492,15 @@ func TestDelegationTestHelpers(t *testing.T) {
 
 func TestMergeWSLEnvPreservesExistingEntries(t *testing.T) {
 	got := mergeWSLEnv("GOPATH/l:XLFLOW_MODE", "XLFLOW_MODE", "XLFLOW_EXCEL_BRIDGE")
-	if got != "GOPATH/l:XLFLOW_MODE:XLFLOW_EXCEL_BRIDGE/w" {
+	if got != "GOPATH/l:XLFLOW_MODE/w:XLFLOW_EXCEL_BRIDGE/w" {
+		t.Fatalf("mergeWSLEnv() = %q", got)
+	}
+}
+
+func TestMergeWSLEnvUpgradesExistingOneWayEntries(t *testing.T) {
+	got := mergeWSLEnv("XLFLOW_MODE/u:XLFLOW_EXCEL_BRIDGE/up:XLFLOW_NO_UPDATE_CHECK/w", "XLFLOW_MODE", "XLFLOW_EXCEL_BRIDGE", "XLFLOW_NO_UPDATE_CHECK", "XLFLOW_WINDOWS_DELEGATED")
+	want := "XLFLOW_MODE/uw:XLFLOW_EXCEL_BRIDGE/upw:XLFLOW_NO_UPDATE_CHECK/w:XLFLOW_WINDOWS_DELEGATED/w"
+	if got != want {
 		t.Fatalf("mergeWSLEnv() = %q", got)
 	}
 }

--- a/internal/cli/wsl_delegation_test.go
+++ b/internal/cli/wsl_delegation_test.go
@@ -1,0 +1,463 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/harumiWeb/xlflow/internal/output"
+	"github.com/harumiWeb/xlflow/internal/wsl"
+)
+
+func TestDelegatedTopLevelCommands(t *testing.T) {
+	delegated := []string{
+		"attach", "check", "doctor", "edit", "export-image", "form", "init",
+		"inspect", "list", "macros", "new", "process", "pull", "push", "rollback",
+		"run", "runner", "save", "session", "status", "test", "ui",
+	}
+	local := []string{
+		"backup", "completion", "diff", "fmt", "generate", "inspect-gui", "lint",
+		"module", "skill", "version",
+	}
+	for _, name := range delegated {
+		if !shouldDelegateTopLevelCommand(name) {
+			t.Errorf("%s should be delegated", name)
+		}
+	}
+	for _, name := range local {
+		if shouldDelegateTopLevelCommand(name) {
+			t.Errorf("%s should remain local", name)
+		}
+	}
+	if len(delegatedTopLevelCommands) != len(delegated) {
+		t.Fatalf("delegated command count = %d, want %d", len(delegatedTopLevelCommands), len(delegated))
+	}
+}
+
+func TestTopLevelCommandName(t *testing.T) {
+	root := &cobra.Command{Use: "xlflow"}
+	form := &cobra.Command{Use: "form"}
+	build := &cobra.Command{Use: "build"}
+	root.AddCommand(form)
+	form.AddCommand(build)
+	if got := topLevelCommandName(build); got != "form" {
+		t.Fatalf("topLevelCommandName() = %q, want form", got)
+	}
+}
+
+func TestDelegateWSLCommandPreservesStreamsArgumentsAndExitCode(t *testing.T) {
+	restore := stubWSLDelegationGlobals(t)
+	defer restore()
+
+	t.Setenv("GO_WANT_WSL_HELPER_PROCESS", "1")
+	t.Setenv("WSL_HELPER_MODE", "echo")
+	t.Setenv("WSL_HELPER_EXIT", "7")
+
+	isWSL = func() bool { return true }
+	translateWSLPath = func(context.Context, string) (string, error) { return `C:\dev\project`, nil }
+	resolveWindowsExecutable = func(context.Context) (string, string, error) {
+		return "ignored.exe", `C:\tools\xlflow.exe`, nil
+	}
+	translateWSLArgs = func(_ context.Context, args []string) ([]string, error) {
+		got := append([]string{}, args...)
+		got[len(got)-1] = `C:\dev\Book.xlsm`
+		return got, nil
+	}
+	newDelegatedCommand = delegatedHelperCommand
+
+	dir := t.TempDir()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	a := &app{
+		cwd:       dir,
+		rawArgs:   []string{"--json", "run", "/mnt/c/dev/Book.xlsm"},
+		stdout:    &stdout,
+		stderr:    &stderr,
+		buildInfo: BuildInfo{Version: "1.2.3"},
+	}
+	root := &cobra.Command{Use: "xlflow"}
+	run := &cobra.Command{Use: "run"}
+	root.AddCommand(run)
+
+	err := a.delegateWSLCommand(run)
+	if code := output.ExitCode(err); code != 7 {
+		t.Fatalf("exit code = %d, want 7; err=%v", code, err)
+	}
+	if !strings.Contains(stdout.String(), `ARGS=--json|run|C:\dev\Book.xlsm`) {
+		t.Fatalf("stdout did not preserve translated args:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "DELEGATED=1") {
+		t.Fatalf("stdout did not report delegation marker:\n%s", stdout.String())
+	}
+	for _, want := range []string{"XLFLOW_WINDOWS_DELEGATED/w", "XLFLOW_EXCEL_BRIDGE/w", "XLFLOW_MODE/w", "XLFLOW_NO_UPDATE_CHECK/w"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout did not report WSLENV entry %q:\n%s", want, stdout.String())
+		}
+	}
+	if !strings.Contains(stdout.String(), "CWD="+dir) {
+		t.Fatalf("stdout did not report delegated cwd:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "helper stderr") {
+		t.Fatalf("stderr was not preserved:\n%s", stderr.String())
+	}
+}
+
+func TestDelegateWSLCommandStopsLocalRunEAfterSuccessfulDelegation(t *testing.T) {
+	restore := stubWSLDelegationGlobals(t)
+	defer restore()
+
+	t.Setenv("GO_WANT_WSL_HELPER_PROCESS", "1")
+	t.Setenv("WSL_HELPER_MODE", "echo")
+
+	isWSL = func() bool { return true }
+	translateWSLPath = func(context.Context, string) (string, error) { return `C:\dev\project`, nil }
+	resolveWindowsExecutable = func(context.Context) (string, string, error) {
+		return "ignored.exe", `C:\tools\xlflow.exe`, nil
+	}
+	translateWSLArgs = func(_ context.Context, args []string) ([]string, error) { return args, nil }
+	newDelegatedCommand = delegatedHelperCommand
+
+	var stdout bytes.Buffer
+	a := &app{
+		cwd:       t.TempDir(),
+		rawArgs:   []string{"new", "Book.xlsm", "--json"},
+		stdout:    &stdout,
+		buildInfo: BuildInfo{Version: "1.2.3"},
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"new", "Book.xlsm", "--json"})
+
+	err := root.Execute()
+	if !errors.Is(err, errWSLDelegated) {
+		t.Fatalf("root.Execute() error = %v, want delegated sentinel", err)
+	}
+	if code := output.ExitCode(err); code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if strings.Contains(stdout.String(), "refusing to overwrite") {
+		t.Fatalf("local RunE appears to have continued:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ARGS=new|Book.xlsm|--json") {
+		t.Fatalf("delegated helper did not run:\n%s", stdout.String())
+	}
+}
+
+func TestDelegateWSLCommandSkipsWhenRawArgsUnavailable(t *testing.T) {
+	restore := stubWSLDelegationGlobals(t)
+	defer restore()
+
+	isWSL = func() bool { return true }
+	translateWSLPath = func(context.Context, string) (string, error) {
+		t.Fatal("translateWSLPath must not be called without rawArgs")
+		return "", nil
+	}
+
+	a := &app{cwd: "/tmp/xlflow-test"}
+	root := &cobra.Command{Use: "xlflow"}
+	run := &cobra.Command{Use: "run"}
+	root.AddCommand(run)
+
+	if err := a.delegateWSLCommand(run); err != nil {
+		t.Fatalf("delegateWSLCommand() error = %v", err)
+	}
+}
+
+func TestDelegateWSLCommandWritesStructuredResolutionFailure(t *testing.T) {
+	restore := stubWSLDelegationGlobals(t)
+	defer restore()
+
+	isWSL = func() bool { return true }
+	translateWSLPath = func(context.Context, string) (string, error) { return `C:\dev\project`, nil }
+	resolveWindowsExecutable = func(context.Context) (string, string, error) {
+		return "", "", &wsl.Error{Code: "windows_xlflow_not_found", Message: "not found"}
+	}
+
+	var stdout bytes.Buffer
+	a := &app{
+		json:      true,
+		cwd:       "/mnt/c/dev/project",
+		rawArgs:   []string{"--json", "run"},
+		stdout:    &stdout,
+		buildInfo: BuildInfo{Version: "1.2.3"},
+	}
+	root := &cobra.Command{Use: "xlflow"}
+	run := &cobra.Command{Use: "run"}
+	root.AddCommand(run)
+
+	err := a.delegateWSLCommand(run)
+	if code := output.ExitCode(err); code != output.ExitEnvironment {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitEnvironment)
+	}
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("invalid JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	if env.Error == nil || env.Error.Code != "windows_xlflow_not_found" {
+		t.Fatalf("error = %+v", env.Error)
+	}
+}
+
+func TestDelegateWSLDoctorReportsMissingWindowsExecutable(t *testing.T) {
+	restore := stubWSLDelegationGlobals(t)
+	defer restore()
+
+	isWSL = func() bool { return true }
+	wslDistroName = func() string { return "Ubuntu" }
+	translateWSLPath = func(context.Context, string) (string, error) { return `C:\dev\project`, nil }
+	resolveWindowsExecutable = func(context.Context) (string, string, error) {
+		return "", "", &wsl.Error{Code: "windows_xlflow_not_found", Message: "not found"}
+	}
+
+	var stdout bytes.Buffer
+	a := &app{
+		json:      true,
+		cwd:       "/mnt/c/dev/project",
+		rawArgs:   []string{"doctor", "--json"},
+		stdout:    &stdout,
+		buildInfo: BuildInfo{Version: "1.2.3"},
+	}
+	root := &cobra.Command{Use: "xlflow"}
+	doctor := &cobra.Command{Use: "doctor"}
+	root.AddCommand(doctor)
+
+	err := a.delegateWSLCommand(doctor)
+	if code := output.ExitCode(err); code != output.ExitEnvironment {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitEnvironment)
+	}
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("invalid JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	windows := mapValue(mapValue(env.Diagnostics)["windows"])
+	if windows["xlflow_found"] != false || windows["bridge_found"] != false || windows["excel_available"] != false {
+		t.Fatalf("windows diagnostics = %#v", windows)
+	}
+	pathTranslation := mapValue(mapValue(env.Diagnostics)["path_translation"])
+	if pathTranslation["supported"] != true {
+		t.Fatalf("path translation diagnostics = %#v", pathTranslation)
+	}
+}
+
+func TestRunDelegatedDoctorMergesWSLDiagnostics(t *testing.T) {
+	restore := stubWSLDelegationGlobals(t)
+	defer restore()
+
+	t.Setenv("GO_WANT_WSL_HELPER_PROCESS", "1")
+	t.Setenv("WSL_HELPER_MODE", "doctor-success")
+	newDelegatedCommand = delegatedHelperCommand
+	wslDistroName = func() string { return "Ubuntu-24.04" }
+
+	dir := t.TempDir()
+	var stdout bytes.Buffer
+	a := &app{
+		json:      true,
+		cwd:       dir,
+		stdout:    &stdout,
+		buildInfo: BuildInfo{Version: "1.2.3"},
+	}
+	err := a.runDelegatedDoctor(
+		context.Background(),
+		"ignored.exe",
+		`C:\tools\xlflow.exe`,
+		`C:\dev\project`,
+		[]string{"doctor"},
+	)
+	if !errors.Is(err, errWSLDelegated) {
+		t.Fatalf("runDelegatedDoctor() error = %v, want delegated sentinel", err)
+	}
+	if code := output.ExitCode(err); code != output.ExitSuccess {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("invalid JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	diagnostics := mapValue(env.Diagnostics)
+	host := mapValue(diagnostics["host"])
+	if host["is_wsl"] != true || host["distro"] != "Ubuntu-24.04" {
+		t.Fatalf("host diagnostics = %#v", host)
+	}
+	windows := mapValue(diagnostics["windows"])
+	if windows["xlflow_found"] != true || windows["bridge_found"] != true || windows["excel_available"] != true {
+		t.Fatalf("windows diagnostics = %#v", windows)
+	}
+	if windows["xlflow_version"] != "1.2.4" {
+		t.Fatalf("windows xlflow version = %#v", windows["xlflow_version"])
+	}
+	pathTranslation := mapValue(diagnostics["path_translation"])
+	if pathTranslation["windows_path"] != `C:\dev\project` || pathTranslation["supported"] != true {
+		t.Fatalf("path translation diagnostics = %#v", pathTranslation)
+	}
+	warnings := anySlice(env.Warnings)
+	if len(warnings) != 1 || mapValue(warnings[0])["code"] != "wsl_windows_version_mismatch" {
+		t.Fatalf("warnings = %#v", warnings)
+	}
+}
+
+func TestRunDelegatedDoctorPreservesWindowsFailureAndExitCode(t *testing.T) {
+	restore := stubWSLDelegationGlobals(t)
+	defer restore()
+
+	t.Setenv("GO_WANT_WSL_HELPER_PROCESS", "1")
+	t.Setenv("WSL_HELPER_MODE", "doctor-failure")
+	newDelegatedCommand = delegatedHelperCommand
+
+	dir := t.TempDir()
+	var stdout bytes.Buffer
+	a := &app{
+		json:      true,
+		cwd:       dir,
+		stdout:    &stdout,
+		buildInfo: BuildInfo{Version: "dev"},
+	}
+	err := a.runDelegatedDoctor(context.Background(), "ignored.exe", `C:\tools\xlflow.exe`, `C:\dev\project`, []string{"--json", "doctor"})
+	if code := output.ExitCode(err); code != output.ExitEnvironment {
+		t.Fatalf("exit code = %d, want %d; err=%v", code, output.ExitEnvironment, err)
+	}
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("invalid JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	if env.Error == nil || env.Error.Code != "excel_com_failure" {
+		t.Fatalf("error = %+v", env.Error)
+	}
+	windows := mapValue(mapValue(env.Diagnostics)["windows"])
+	if windows["excel_available"] != false {
+		t.Fatalf("windows diagnostics = %#v", windows)
+	}
+}
+
+func TestRunDelegatedDoctorRejectsInvalidJSON(t *testing.T) {
+	restore := stubWSLDelegationGlobals(t)
+	defer restore()
+
+	t.Setenv("GO_WANT_WSL_HELPER_PROCESS", "1")
+	t.Setenv("WSL_HELPER_MODE", "doctor-invalid")
+	newDelegatedCommand = delegatedHelperCommand
+
+	dir := t.TempDir()
+	var stdout bytes.Buffer
+	a := &app{
+		json:      true,
+		cwd:       dir,
+		stdout:    &stdout,
+		buildInfo: BuildInfo{Version: "dev"},
+	}
+	err := a.runDelegatedDoctor(context.Background(), "ignored.exe", `C:\tools\xlflow.exe`, `C:\dev\project`, []string{"doctor"})
+	if code := output.ExitCode(err); code != output.ExitEnvironment {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitEnvironment)
+	}
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("invalid JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	if env.Error == nil || env.Error.Code != "windows_xlflow_execution_failed" {
+		t.Fatalf("error = %+v", env.Error)
+	}
+	windows := mapValue(mapValue(env.Diagnostics)["windows"])
+	if windows["xlflow_found"] != true || windows["excel_available"] != false {
+		t.Fatalf("windows diagnostics = %#v", windows)
+	}
+}
+
+func TestWSLDelegationHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_WSL_HELPER_PROCESS") != "1" {
+		return
+	}
+	args := helperArgs(os.Args)
+	mode := os.Getenv("WSL_HELPER_MODE")
+	switch {
+	case containsArgument(args, "version"):
+		fmt.Print(`{"status":"ok","command":"version","error":null,"logs":[],"version":{"version":"1.2.4","commit":"test","date":"today"}}`)
+	case mode == "doctor-success":
+		fmt.Print(`{"status":"ok","command":"doctor","error":null,"logs":[],"diagnostics":{"selected_bridge":"dotnet","excel":{"com_activation":true,"vbide_access":true}},"bridge":{"name":"xlflow-excel-bridge"}}`)
+	case mode == "doctor-failure":
+		fmt.Print(`{"status":"failed","command":"doctor","error":{"code":"excel_com_failure","message":"Excel COM activation failed"},"logs":[]}`)
+		os.Exit(output.ExitEnvironment)
+	case mode == "doctor-invalid":
+		fmt.Print(`not-json`)
+	case mode == "echo":
+		fmt.Printf("ARGS=%s\n", strings.Join(args, "|"))
+		fmt.Printf("DELEGATED=%s\n", os.Getenv(wsl.EnvDelegated))
+		fmt.Printf("WSLENV=%s\n", os.Getenv("WSLENV"))
+		cwd, _ := os.Getwd()
+		fmt.Printf("CWD=%s\n", cwd)
+		fmt.Fprintln(os.Stderr, "helper stderr")
+		exitCode, _ := strconv.Atoi(os.Getenv("WSL_HELPER_EXIT"))
+		os.Exit(exitCode)
+	default:
+		fmt.Printf(`{"status":"failed","command":"doctor","error":{"code":"unexpected_helper_mode","message":%q},"logs":[]}`, mode)
+		os.Exit(output.ExitEnvironment)
+	}
+	os.Exit(0)
+}
+
+func delegatedHelperCommand(ctx context.Context, _ string, args ...string) *exec.Cmd {
+	helperArgs := []string{"-test.run=TestWSLDelegationHelperProcess", "--"}
+	helperArgs = append(helperArgs, args...)
+	return exec.CommandContext(ctx, os.Args[0], helperArgs...)
+}
+
+func helperArgs(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return args[i+1:]
+		}
+	}
+	return nil
+}
+
+func containsArgument(args []string, target string) bool {
+	for _, arg := range args {
+		if arg == target {
+			return true
+		}
+	}
+	return false
+}
+
+func stubWSLDelegationGlobals(t *testing.T) func() {
+	t.Helper()
+	originalIsWSL := isWSL
+	originalDistro := wslDistroName
+	originalResolve := resolveWindowsExecutable
+	originalTranslatePath := translateWSLPath
+	originalTranslateArgs := translateWSLArgs
+	originalCommand := newDelegatedCommand
+	return func() {
+		isWSL = originalIsWSL
+		wslDistroName = originalDistro
+		resolveWindowsExecutable = originalResolve
+		translateWSLPath = originalTranslatePath
+		translateWSLArgs = originalTranslateArgs
+		newDelegatedCommand = originalCommand
+	}
+}
+
+func TestDelegationTestHelpers(t *testing.T) {
+	if got := helperArgs([]string{"test", "--", "run", "Main"}); !reflect.DeepEqual(got, []string{"run", "Main"}) {
+		t.Fatalf("helperArgs() = %#v", got)
+	}
+	if got := filepath.Base(os.Args[0]); got == "" {
+		t.Fatal(errors.New("test executable path is empty"))
+	}
+}
+
+func TestMergeWSLEnvPreservesExistingEntries(t *testing.T) {
+	got := mergeWSLEnv("GOPATH/l:XLFLOW_MODE", "XLFLOW_MODE", "XLFLOW_EXCEL_BRIDGE")
+	if got != "GOPATH/l:XLFLOW_MODE:XLFLOW_EXCEL_BRIDGE/w" {
+		t.Fatalf("mergeWSLEnv() = %q", got)
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -535,9 +535,40 @@ func (r renderer) renderDoctor(env Envelope) string {
 		return r.renderLogs(env)
 	}
 	excel := objectMap(diag["excel"])
+	host := objectMap(diag["host"])
+	windows := objectMap(diag["windows"])
+	pathTranslation := objectMap(diag["path_translation"])
 	workbook := objectMap(env.Workbook)
 	var b strings.Builder
 	b.WriteString("\n")
+	if boolValue(host, "is_wsl") {
+		distro := stringValue(host, "distro")
+		if distro == "" {
+			distro = "detected"
+		}
+		b.WriteString(kv("WSL", distro))
+	}
+	if len(windows) > 0 {
+		detail := stringValue(windows, "xlflow_path")
+		if version := stringValue(windows, "xlflow_version"); version != "" {
+			if detail != "" {
+				detail += " "
+			}
+			detail += "(" + version + ")"
+		}
+		if detail == "" {
+			detail = "Windows xlflow.exe"
+		}
+		b.WriteString(r.checkLine(boolValue(windows, "xlflow_found"), "Windows xlflow", detail))
+		b.WriteString(r.checkLine(boolValue(windows, "bridge_found"), "Windows bridge", "Excel bridge is available"))
+	}
+	if len(pathTranslation) > 0 {
+		detail := stringValue(pathTranslation, "windows_path")
+		if detail == "" {
+			detail = "Windows-visible project path"
+		}
+		b.WriteString(r.checkLine(boolValue(pathTranslation, "supported"), "Path translation", detail))
+	}
 	if selected := stringValue(diag, "selected_bridge"); selected != "" {
 		b.WriteString(kv("Selected bridge", selected))
 	}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -603,6 +603,41 @@ func TestWriteWithOptionsRendersDoctorChecklistFromDotNetBridge(t *testing.T) {
 	}
 }
 
+func TestWriteWithOptionsRendersWSLDoctorDiagnostics(t *testing.T) {
+	env := New("doctor")
+	env.Diagnostics = map[string]any{
+		"host": map[string]any{
+			"os":     "linux",
+			"is_wsl": true,
+			"distro": "Ubuntu-24.04",
+		},
+		"windows": map[string]any{
+			"xlflow_found":   true,
+			"xlflow_path":    `C:\tools\xlflow.exe`,
+			"xlflow_version": "1.2.3",
+			"bridge_found":   true,
+		},
+		"path_translation": map[string]any{
+			"supported":    true,
+			"windows_path": `C:\dev\project`,
+		},
+		"excel": map[string]any{
+			"com_activation": true,
+			"vbide_access":   true,
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteWithOptions(&buf, env, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, want := range []string{"WSL:", "Ubuntu-24.04", "Windows xlflow", `C:\tools\xlflow.exe`, "Windows bridge", "Path translation", `C:\dev\project`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestWriteWithOptionsRendersRunSummaryAndDebug(t *testing.T) {
 	env := New("run")
 	env.Macro = map[string]any{"name": "Main.Run", "duration_ms": 42}

--- a/internal/wsl/wsl.go
+++ b/internal/wsl/wsl.go
@@ -1,0 +1,363 @@
+package wsl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	EnvWindowsExecutable = "XLFLOW_WINDOWS_EXE"
+	EnvDelegated         = "XLFLOW_WINDOWS_DELEGATED"
+)
+
+type Error struct {
+	Code    string
+	Message string
+	Err     error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+type CommandRunner func(context.Context, string, ...string) ([]byte, error)
+
+type LookPathFunc func(string) (string, error)
+
+type StatFunc func(string) (os.FileInfo, error)
+
+func IsWSL() bool {
+	return IsWSLFor(runtime.GOOS, os.Getenv, os.ReadFile)
+}
+
+func IsWSLFor(goos string, getenv func(string) string, readFile func(string) ([]byte, error)) bool {
+	if goos != "linux" {
+		return false
+	}
+	if strings.TrimSpace(getenv("WSL_INTEROP")) != "" || strings.TrimSpace(getenv("WSL_DISTRO_NAME")) != "" {
+		return true
+	}
+	data, err := readFile("/proc/version")
+	if err != nil {
+		return false
+	}
+	version := strings.ToLower(string(data))
+	return strings.Contains(version, "microsoft") || strings.Contains(version, "wsl")
+}
+
+func DistroName() string {
+	return strings.TrimSpace(os.Getenv("WSL_DISTRO_NAME"))
+}
+
+func IsWindowsDriveMount(path string) bool {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	if len(clean) < len("/mnt/c") || !strings.HasPrefix(clean, "/mnt/") {
+		return false
+	}
+	rest := strings.TrimPrefix(clean, "/mnt/")
+	if len(rest) < 1 || !isASCIIAlpha(rest[0]) {
+		return false
+	}
+	return len(rest) == 1 || rest[1] == '/'
+}
+
+func ToWindowsPath(ctx context.Context, path string) (string, error) {
+	return ToWindowsPathWith(ctx, path, runCommand)
+}
+
+func ToWindowsPathWith(ctx context.Context, path string, run CommandRunner) (string, error) {
+	if !IsWindowsDriveMount(path) {
+		return "", &Error{
+			Code:    "wsl_project_path_unsupported",
+			Message: fmt.Sprintf("path %q is not under a Windows-mounted drive such as /mnt/c", path),
+		}
+	}
+	return runWSLPath(ctx, run, "-w", path)
+}
+
+func ToUnixPath(ctx context.Context, path string) (string, error) {
+	return ToUnixPathWith(ctx, path, runCommand)
+}
+
+func ToUnixPathWith(ctx context.Context, path string, run CommandRunner) (string, error) {
+	return runWSLPath(ctx, run, "-u", path)
+}
+
+func ResolveWindowsExecutable(ctx context.Context) (string, string, error) {
+	return ResolveWindowsExecutableWith(
+		ctx,
+		os.Getenv,
+		exec.LookPath,
+		os.Stat,
+		func(ctx context.Context, path string) (string, error) {
+			return ToUnixPath(ctx, path)
+		},
+		func(ctx context.Context, path string) (string, error) {
+			return ToWindowsPath(ctx, path)
+		},
+	)
+}
+
+func ResolveWindowsExecutableWith(
+	ctx context.Context,
+	getenv func(string) string,
+	lookPath LookPathFunc,
+	stat StatFunc,
+	toUnix func(context.Context, string) (string, error),
+	toWindows func(context.Context, string) (string, error),
+) (string, string, error) {
+	candidate := strings.TrimSpace(getenv(EnvWindowsExecutable))
+	if candidate != "" {
+		resolved := candidate
+		if isWindowsAbsolutePath(candidate) {
+			var err error
+			resolved, err = toUnix(ctx, candidate)
+			if err != nil {
+				return "", "", &Error{
+					Code:    "wsl_path_translation_failed",
+					Message: fmt.Sprintf("failed to translate %s to a WSL path", EnvWindowsExecutable),
+					Err:     err,
+				}
+			}
+		}
+		if err := validateExecutable(resolved, stat); err != nil {
+			return "", "", err
+		}
+		windowsPath := candidate
+		if !isWindowsAbsolutePath(candidate) {
+			var err error
+			windowsPath, err = toWindows(ctx, resolved)
+			if err != nil {
+				return "", "", &Error{
+					Code:    "wsl_path_translation_failed",
+					Message: fmt.Sprintf("failed to translate %s to a Windows path", EnvWindowsExecutable),
+					Err:     err,
+				}
+			}
+		}
+		return resolved, windowsPath, nil
+	}
+
+	resolved, err := lookPath("xlflow.exe")
+	if err != nil {
+		return "", "", &Error{
+			Code:    "windows_xlflow_not_found",
+			Message: "Windows xlflow.exe was not found; install xlflow on Windows or set XLFLOW_WINDOWS_EXE",
+			Err:     err,
+		}
+	}
+	if err := validateExecutable(resolved, stat); err != nil {
+		return "", "", err
+	}
+	windowsPath, err := toWindows(ctx, resolved)
+	if err != nil {
+		return "", "", &Error{
+			Code:    "wsl_path_translation_failed",
+			Message: "failed to translate the resolved Windows xlflow executable path",
+			Err:     err,
+		}
+	}
+	return resolved, windowsPath, nil
+}
+
+func TranslateArgs(ctx context.Context, args []string) ([]string, error) {
+	return TranslateArgsWith(ctx, args, func(ctx context.Context, path string) (string, error) {
+		return ToWindowsPath(ctx, path)
+	})
+}
+
+func TranslateArgsWith(ctx context.Context, args []string, translate func(context.Context, string) (string, error)) ([]string, error) {
+	translated := make([]string, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		value, err := translateArgument(ctx, arg, translate)
+		if err != nil {
+			return nil, err
+		}
+		translated[i] = value
+		if flagName, inlineValue, hasInlineValue := splitLongFlag(arg); flagName != "" {
+			switch {
+			case hasInlineValue && isPathFlag(flagName):
+				translatedValue, err := translatePathValue(ctx, inlineValue, translate)
+				if err != nil {
+					return nil, err
+				}
+				translated[i] = flagName + "=" + translatedValue
+			case hasInlineValue && flagName == "--filedialog":
+				translatedValue, err := translateFileDialogValue(ctx, inlineValue, translate)
+				if err != nil {
+					return nil, err
+				}
+				translated[i] = flagName + "=" + translatedValue
+			case !hasInlineValue && flagTakesValue(flagName) && i+1 < len(args):
+				i++
+				next := args[i]
+				switch {
+				case isPathFlag(flagName):
+					translated[i], err = translatePathValue(ctx, next, translate)
+				case flagName == "--filedialog":
+					translated[i], err = translateFileDialogValue(ctx, next, translate)
+				default:
+					translated[i] = next
+				}
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return translated, nil
+}
+
+func translateArgument(ctx context.Context, arg string, translate func(context.Context, string) (string, error)) (string, error) {
+	if isWSLAbsolutePath(arg) {
+		return translateAbsoluteArgument(ctx, arg, translate)
+	}
+	return arg, nil
+}
+
+func translatePathValue(ctx context.Context, value string, translate func(context.Context, string) (string, error)) (string, error) {
+	if isWSLAbsolutePath(value) {
+		return translateAbsoluteArgument(ctx, value, translate)
+	}
+	return value, nil
+}
+
+func translateFileDialogValue(ctx context.Context, value string, translate func(context.Context, string) (string, error)) (string, error) {
+	if prefix, path, ok := strings.Cut(value, "=/"); ok {
+		translated, err := translateAbsoluteArgument(ctx, "/"+path, translate)
+		if err != nil {
+			return "", err
+		}
+		return prefix + "=" + translated, nil
+	}
+	return value, nil
+}
+
+func splitLongFlag(arg string) (string, string, bool) {
+	if !strings.HasPrefix(arg, "--") {
+		return "", "", false
+	}
+	name, value, ok := strings.Cut(arg, "=")
+	return name, value, ok
+}
+
+func isPathFlag(name string) bool {
+	switch name {
+	case "--input", "--out", "--output-dir", "--save-as":
+		return true
+	default:
+		return false
+	}
+}
+
+func flagTakesValue(name string) bool {
+	switch name {
+	case "--address", "--agent", "--arg", "--backup", "--bridge", "--cell", "--clear",
+		"--columns", "--events", "--filedialog", "--fill", "--filter", "--format",
+		"--formula", "--id", "--initializer", "--input", "--inputbox", "--line-numbers", "--macro",
+		"--module", "--msgbox", "--name", "--out", "--output-dir", "--range", "--rows",
+		"--save-as", "--sheet", "--tag", "--target", "--text", "--timeout", "--value",
+		"--vba-after", "--vba-before":
+		return true
+	default:
+		return false
+	}
+}
+
+func translateAbsoluteArgument(ctx context.Context, path string, translate func(context.Context, string) (string, error)) (string, error) {
+	if !IsWindowsDriveMount(path) {
+		return "", &Error{
+			Code:    "wsl_project_path_unsupported",
+			Message: fmt.Sprintf("absolute WSL path %q is not visible to Windows; use a project path under /mnt/<drive>", path),
+		}
+	}
+	translated, err := translate(ctx, path)
+	if err != nil {
+		var wslErr *Error
+		if errors.As(err, &wslErr) {
+			return "", err
+		}
+		return "", &Error{
+			Code:    "wsl_path_translation_failed",
+			Message: fmt.Sprintf("failed to translate WSL path %q", path),
+			Err:     err,
+		}
+	}
+	return strings.TrimSpace(translated), nil
+}
+
+func runWSLPath(ctx context.Context, run CommandRunner, mode string, path string) (string, error) {
+	output, err := run(ctx, "wslpath", mode, path)
+	if err != nil {
+		return "", &Error{
+			Code:    "wsl_path_translation_failed",
+			Message: fmt.Sprintf("wslpath %s failed for %q", mode, path),
+			Err:     err,
+		}
+	}
+	translated := strings.TrimSpace(string(output))
+	if translated == "" {
+		return "", &Error{
+			Code:    "wsl_path_translation_failed",
+			Message: fmt.Sprintf("wslpath %s returned an empty path for %q", mode, path),
+		}
+	}
+	return translated, nil
+}
+
+func runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+func validateExecutable(path string, stat StatFunc) error {
+	if !strings.EqualFold(filepath.Ext(path), ".exe") {
+		return &Error{
+			Code:    "windows_xlflow_not_found",
+			Message: fmt.Sprintf("Windows xlflow path %q must reference an .exe file", path),
+		}
+	}
+	info, err := stat(path)
+	if err != nil {
+		return &Error{
+			Code:    "windows_xlflow_not_found",
+			Message: fmt.Sprintf("Windows xlflow executable %q was not found", path),
+			Err:     err,
+		}
+	}
+	if info.IsDir() {
+		return &Error{
+			Code:    "windows_xlflow_not_found",
+			Message: fmt.Sprintf("Windows xlflow path %q is a directory", path),
+		}
+	}
+	return nil
+}
+
+func isWindowsAbsolutePath(path string) bool {
+	return len(path) >= 3 && isASCIIAlpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/')
+}
+
+func isWSLAbsolutePath(path string) bool {
+	return strings.HasPrefix(path, "/")
+}
+
+func isASCIIAlpha(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
+}

--- a/internal/wsl/wsl_test.go
+++ b/internal/wsl/wsl_test.go
@@ -1,0 +1,233 @@
+package wsl
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestIsWSLFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		goos     string
+		env      map[string]string
+		version  string
+		readErr  error
+		expected bool
+	}{
+		{name: "non linux", goos: "windows", env: map[string]string{"WSL_INTEROP": "/run/WSL/1"}},
+		{name: "interop", goos: "linux", env: map[string]string{"WSL_INTEROP": "/run/WSL/1"}, expected: true},
+		{name: "distro", goos: "linux", env: map[string]string{"WSL_DISTRO_NAME": "Ubuntu"}, expected: true},
+		{name: "proc version", goos: "linux", version: "Linux version 5.15.90.1-microsoft-standard-WSL2", expected: true},
+		{name: "plain linux", goos: "linux", version: "Linux version 6.8.0"},
+		{name: "proc unavailable", goos: "linux", readErr: os.ErrNotExist},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := IsWSLFor(
+				test.goos,
+				func(key string) string { return test.env[key] },
+				func(string) ([]byte, error) { return []byte(test.version), test.readErr },
+			)
+			if got != test.expected {
+				t.Fatalf("IsWSLFor() = %v, want %v", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestIsWindowsDriveMount(t *testing.T) {
+	tests := map[string]bool{
+		"/mnt/c":                   true,
+		"/mnt/d/dev/project":       true,
+		"/mnt/C/日本語 project":       true,
+		"/home/user/project":       false,
+		"/mnt":                     false,
+		"/mnt/shared/project":      false,
+		`C:\dev\project`:           false,
+		"/mnt/candidate/not-drive": false,
+	}
+	for path, expected := range tests {
+		if got := IsWindowsDriveMount(path); got != expected {
+			t.Errorf("IsWindowsDriveMount(%q) = %v, want %v", path, got, expected)
+		}
+	}
+}
+
+func TestToWindowsPathWith(t *testing.T) {
+	got, err := ToWindowsPathWith(context.Background(), "/mnt/c/dev/日本語 project", func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "wslpath" || !reflect.DeepEqual(args, []string{"-w", "/mnt/c/dev/日本語 project"}) {
+			t.Fatalf("command = %s %v", name, args)
+		}
+		return []byte("C:\\dev\\日本語 project\r\n"), nil
+	})
+	if err != nil {
+		t.Fatalf("ToWindowsPathWith() error = %v", err)
+	}
+	if got != `C:\dev\日本語 project` {
+		t.Fatalf("ToWindowsPathWith() = %q", got)
+	}
+}
+
+func TestToWindowsPathWithRejectsWSLOnlyPath(t *testing.T) {
+	_, err := ToWindowsPathWith(context.Background(), "/home/user/project", nil)
+	assertWSLErrorCode(t, err, "wsl_project_path_unsupported")
+}
+
+func TestTranslateArgsWith(t *testing.T) {
+	translate := func(_ context.Context, path string) (string, error) {
+		return "WIN[" + path + "]", nil
+	}
+	args := []string{
+		"--json",
+		"run",
+		"/mnt/c/dev/Book.xlsm",
+		"--input=/mnt/d/input.xlsm",
+		"--save-as",
+		"/mnt/c/out/Result.xlsm",
+		"--filedialog",
+		"get-open:source=/mnt/c/data/input.csv",
+		"--arg",
+		"string:/home/user/not-a-path-argument",
+		"--value",
+		"/home/user/literal-cell-value",
+		"--msgbox=confirm=/home/user/literal-response",
+	}
+	got, err := TranslateArgsWith(context.Background(), args, translate)
+	if err != nil {
+		t.Fatalf("TranslateArgsWith() error = %v", err)
+	}
+	want := []string{
+		"--json",
+		"run",
+		"WIN[/mnt/c/dev/Book.xlsm]",
+		"--input=WIN[/mnt/d/input.xlsm]",
+		"--save-as",
+		"WIN[/mnt/c/out/Result.xlsm]",
+		"--filedialog",
+		"get-open:source=WIN[/mnt/c/data/input.csv]",
+		"--arg",
+		"string:/home/user/not-a-path-argument",
+		"--value",
+		"/home/user/literal-cell-value",
+		"--msgbox=confirm=/home/user/literal-response",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TranslateArgsWith() = %#v, want %#v", got, want)
+	}
+}
+
+func TestTranslateArgsWithRejectsWSLOnlyAbsolutePath(t *testing.T) {
+	_, err := TranslateArgsWith(context.Background(), []string{"run", "--input", "/home/user/Book.xlsm"}, func(context.Context, string) (string, error) {
+		return "", nil
+	})
+	assertWSLErrorCode(t, err, "wsl_project_path_unsupported")
+}
+
+func TestResolveWindowsExecutableWithPrefersEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "xlflow.exe")
+	if err := os.WriteFile(executable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, windowsPath, err := ResolveWindowsExecutableWith(
+		context.Background(),
+		func(key string) string {
+			if key == EnvWindowsExecutable {
+				return `C:\tools\xlflow.exe`
+			}
+			return ""
+		},
+		func(string) (string, error) {
+			return "", errors.New("PATH must not be used")
+		},
+		os.Stat,
+		func(context.Context, string) (string, error) { return executable, nil },
+		func(context.Context, string) (string, error) { return "", errors.New("not needed") },
+	)
+	if err != nil {
+		t.Fatalf("ResolveWindowsExecutableWith() error = %v", err)
+	}
+	if got != executable || windowsPath != `C:\tools\xlflow.exe` {
+		t.Fatalf("ResolveWindowsExecutableWith() = (%q, %q)", got, windowsPath)
+	}
+}
+
+func TestResolveWindowsExecutableWithUsesPath(t *testing.T) {
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "xlflow.exe")
+	if err := os.WriteFile(executable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, windowsPath, err := ResolveWindowsExecutableWith(
+		context.Background(),
+		func(string) string { return "" },
+		func(name string) (string, error) {
+			if name != "xlflow.exe" {
+				t.Fatalf("LookPath(%q)", name)
+			}
+			return executable, nil
+		},
+		os.Stat,
+		nil,
+		func(_ context.Context, path string) (string, error) {
+			return `C:\tools\xlflow.exe`, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("ResolveWindowsExecutableWith() error = %v", err)
+	}
+	if got != executable || windowsPath != `C:\tools\xlflow.exe` {
+		t.Fatalf("ResolveWindowsExecutableWith() = (%q, %q)", got, windowsPath)
+	}
+}
+
+func TestResolveWindowsExecutableWithRejectsMissingAndNonExe(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		_, _, err := ResolveWindowsExecutableWith(
+			context.Background(),
+			func(string) string { return "" },
+			func(string) (string, error) { return "", os.ErrNotExist },
+			os.Stat,
+			nil,
+			nil,
+		)
+		assertWSLErrorCode(t, err, "windows_xlflow_not_found")
+	})
+
+	t.Run("non exe", func(t *testing.T) {
+		path := "/mnt/c/tools/xlflow"
+		_, _, err := ResolveWindowsExecutableWith(
+			context.Background(),
+			func(key string) string {
+				if key == EnvWindowsExecutable {
+					return path
+				}
+				return ""
+			},
+			nil,
+			func(candidate string) (os.FileInfo, error) {
+				t.Fatalf("stat should not be called for non-exe candidate %q", candidate)
+				return nil, nil
+			},
+			nil,
+			nil,
+		)
+		assertWSLErrorCode(t, err, "windows_xlflow_not_found")
+	})
+}
+
+func assertWSLErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+	var wslErr *Error
+	if !errors.As(err, &wslErr) {
+		t.Fatalf("error = %v, want *Error", err)
+	}
+	if wslErr.Code != code {
+		t.Fatalf("error code = %q, want %q", wslErr.Code, code)
+	}
+}

--- a/vitepress/ai-agents/index.md
+++ b/vitepress/ai-agents/index.md
@@ -26,6 +26,18 @@ xlflow run Main.Run --headless --session --json
 xlflow save --session --json
 ```
 
+When the agent runs inside WSL, keep the repository under `/mnt/<drive>/...` and install xlflow on both WSL and Windows. The same commands transparently delegate Excel operations to Windows while `lint`, `fmt`, and `analyze` remain in WSL. Prefer the session-first sequence:
+
+```bash
+xlflow doctor --json
+xlflow session start --json
+xlflow push --fast --session --no-save --json
+xlflow run Main.Run --diagnostic --session --json
+xlflow inspect workbook --session --json
+xlflow save --session --json
+xlflow session stop --json
+```
+
 If a run fails, check state and recover with a short loop:
 
 ```bash

--- a/vitepress/commands/doctor.md
+++ b/vitepress/commands/doctor.md
@@ -38,6 +38,14 @@ Successful `--json` output uses the xlflow envelope plus the `diagnostics` objec
 
 On Windows, `doctor` prefers the `.NET` bridge in `auto` mode. The nested `diagnostics` object always reports the requested bridge mode, the selected provider, and whether `auto` fell back to the legacy PowerShell bridge.
 
+Under WSL, `doctor` invokes Windows xlflow and augments the Windows result with:
+
+- `diagnostics.host`: Linux/WSL detection, distro, and WSL xlflow version.
+- `diagnostics.windows`: Windows xlflow path/version plus bridge and Excel availability.
+- `diagnostics.path_translation`: WSL and Windows project paths and support status.
+
+A version mismatch between WSL and Windows xlflow is reported as a warning but does not block delegation.
+
 ```json
 {
   "status": "ok",
@@ -60,6 +68,34 @@ On Windows, `doctor` prefers the `.NET` bridge in `auto` mode. The nested `diagn
       "vbide_access": true,
       "automation_security": 1,
       "trust_vba_access": null
+    }
+  }
+}
+```
+
+WSL output includes the same Windows diagnostics plus the delegation boundary:
+
+```json
+{
+  "status": "ok",
+  "command": "doctor",
+  "diagnostics": {
+    "host": {
+      "os": "linux",
+      "is_wsl": true,
+      "distro": "Ubuntu-24.04"
+    },
+    "windows": {
+      "xlflow_found": true,
+      "xlflow_path": "C:\\Users\\me\\AppData\\Local\\xlflow\\xlflow.exe",
+      "xlflow_version": "0.13.0",
+      "bridge_found": true,
+      "excel_available": true
+    },
+    "path_translation": {
+      "supported": true,
+      "wsl_path": "/mnt/c/dev/project",
+      "windows_path": "C:\\dev\\project"
     }
   }
 }

--- a/vitepress/concepts/ai-agent-workflow.md
+++ b/vitepress/concepts/ai-agent-workflow.md
@@ -21,6 +21,7 @@ xlflow session stop --json
 Rules for agents:
 
 - Prefer `--json`.
+- Under WSL, keep projects under `/mnt/<drive>/...`; Excel-related commands delegate to Windows xlflow.
 - Run `doctor` before changing source for environment failures.
 - Use `macros` before guessing a `run` target.
 - Replace raw `MsgBox` / `InputBox` with `XlflowUI` and pass `--msgbox` / `--inputbox` during unattended `run` or `test` flows.

--- a/vitepress/design/architecture.md
+++ b/vitepress/design/architecture.md
@@ -1,12 +1,15 @@
 # Architecture
 
-xlflow is a Windows-first Go CLI using Cobra for command routing, `xlflow.toml` for project configuration, stable JSON envelopes for automation, and a Windows bridge layer that now prefers the `.NET` Excel bridge while retaining PowerShell as a legacy fallback.
+xlflow is a Windows-first Go CLI using Cobra for command routing, `xlflow.toml` for project configuration, stable JSON envelopes for automation, and a Windows bridge layer that now prefers the `.NET` Excel bridge while retaining PowerShell as a legacy fallback. Under WSL, source-only commands remain local while Excel-related commands delegate to Windows `xlflow.exe`.
 
 Key decisions:
 
 - Excel-dependent commands require Windows, Excel, the configured bridge provider, and VBIDE trust settings.
+- WSL projects that use Excel delegation must live under a Windows-mounted path such as `/mnt/c/...`.
 - Non-Excel source checks remain testable without Excel.
 - GUI interactions are explicit boundaries, not hidden automation targets.
 - VBE compile diagnostics are handled narrowly because they are editor diagnostics, not workbook business UI.
 
 Source ADR: [`docs/adr/ADR-0001-agent-ready-vba-cli-architecture.md`](https://github.com/harumiWeb/xlflow/blob/main/docs/adr/ADR-0001-agent-ready-vba-cli-architecture.md)
+
+WSL delegation ADR: [`docs/adr/ADR-0011-wsl-windows-cli-delegation.md`](https://github.com/harumiWeb/xlflow/blob/main/docs/adr/ADR-0011-wsl-windows-cli-delegation.md)

--- a/vitepress/installation.md
+++ b/vitepress/installation.md
@@ -64,6 +64,49 @@ These checks validate artifact integrity and provenance metadata. They are not W
 
 The `.NET` bridge executable avoids PowerShell execution policy, but it can still be blocked by AppLocker, WDAC, Defender or EDR policy, antivirus reputation, or other unsigned-executable controls in managed Windows environments.
 
+## WSL development frontend
+
+Install xlflow on both Windows and WSL. Use the Windows installer, winget, Scoop, or Windows release archive for `xlflow.exe` plus `xlflow-excel-bridge.exe`.
+
+From a WSL shell, install the Linux frontend with:
+
+```bash
+curl -fsSL https://harumiweb.github.io/xlflow/install.sh | sh
+```
+
+To remove the WSL frontend installed by this script:
+
+```bash
+curl -fsSL https://harumiweb.github.io/xlflow/install.sh | sh -s -- --uninstall
+```
+
+The installer writes `xlflow` to `$HOME/.local/bin` by default. Override that with `XLFLOW_INSTALL_DIR` or `--install-dir`.
+
+From a WSL shell in a source checkout, install the current frontend build with:
+
+```bash
+task wsl-install
+```
+
+Store projects under a Windows-mounted path:
+
+```bash
+cd /mnt/c/dev/my-vba-project
+xlflow doctor --json
+```
+
+Excel-related commands automatically delegate to Windows xlflow. Source-only commands such as `lint`, `fmt`, and `analyze` stay in WSL.
+
+If WSL cannot discover `xlflow.exe` through Windows PATH interoperability, configure it explicitly:
+
+```bash
+export XLFLOW_WINDOWS_EXE='C:\Users\me\AppData\Local\xlflow\xlflow.exe'
+```
+
+WSL-only paths such as `/home/user/project` are unsupported for Excel delegation. Move the project under `/mnt/c`, `/mnt/d`, or another Windows-mounted drive.
+
+xlflow forwards its own runtime environment variables through `WSLENV`. If workbook VBA depends on additional custom WSL environment variables, add those variable names to `WSLENV` so the Windows Excel process can read them.
+
 ## Go developers
 
 ```bash

--- a/vitepress/public/install.sh
+++ b/vitepress/public/install.sh
@@ -125,6 +125,43 @@ select_linux_asset_url() {
   fail "could not find a Linux x64 tar.gz asset in the latest release"
 }
 
+select_checksums_url() {
+  release_json="$1"
+  url=$(printf '%s\n' "$release_json" |
+    sed -n 's/.*"browser_download_url":[[:space:]]*"\([^"]*checksums\.txt\)".*/\1/p' |
+    head -n 1)
+  if [ -n "$url" ]; then
+    printf '%s\n' "$url"
+    return
+  fi
+
+  fail "could not find checksums.txt in the latest release"
+}
+
+verify_checksum() {
+  archive_path="$1"
+  archive_name="$2"
+  checksums_url="$3"
+
+  checksums_path=$(mktemp)
+  download_to_file "$checksums_url" "$checksums_path"
+
+  expected=$(awk -v name="$archive_name" '$2 == name || $2 == "*" name { print $1; exit }' "$checksums_path")
+  rm -f "$checksums_path"
+  [ -n "$expected" ] || fail "could not find checksum for $archive_name"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$archive_path" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$archive_path" | awk '{print $1}')
+  else
+    fail "sha256sum or shasum is required for checksum verification"
+  fi
+
+  [ "$actual" = "$expected" ] || fail "checksum verification failed for $archive_name"
+  info "Verified checksum for $archive_name"
+}
+
 profile_file() {
   shell_name=$(basename "${SHELL:-sh}")
   case "$shell_name" in
@@ -195,6 +232,7 @@ install_xlflow() {
   need_cmd tar
   need_cmd sed
   need_cmd grep
+  need_cmd awk
   need_cmd find
   need_cmd mktemp
 
@@ -210,11 +248,14 @@ install_xlflow() {
   info "Fetching latest release metadata from $api_url"
   release_json=$(download_to_stdout "$api_url")
   asset_url=$(select_linux_asset_url "$release_json")
+  checksums_url=$(select_checksums_url "$release_json")
   archive_path="$tmp_root/xlflow-linux.tar.gz"
   extract_dir="$tmp_root/extract"
+  archive_name=$(basename "$asset_url")
 
-  info "Downloading $(basename "$asset_url")"
+  info "Downloading $archive_name"
   download_to_file "$asset_url" "$archive_path"
+  verify_checksum "$archive_path" "$archive_name" "$checksums_url"
 
   info "Extracting archive"
   mkdir -p "$extract_dir"

--- a/vitepress/public/install.sh
+++ b/vitepress/public/install.sh
@@ -1,0 +1,265 @@
+#!/bin/sh
+set -eu
+
+action="install"
+install_dir="${XLFLOW_INSTALL_DIR:-$HOME/.local/bin}"
+owner="${XLFLOW_OWNER:-harumiWeb}"
+repo="${XLFLOW_REPO:-xlflow}"
+modify_path="1"
+
+info() {
+  printf '[xlflow] %s\n' "$1"
+}
+
+fail() {
+  printf '[xlflow] ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [options]
+
+Install the xlflow Linux frontend binary for WSL development.
+
+Options:
+  --install-dir DIR   Install directory (default: $HOME/.local/bin)
+  --uninstall         Remove xlflow from the install directory
+  --no-modify-path    Do not add the install directory to a shell profile
+  --owner OWNER       GitHub owner (default: harumiWeb)
+  --repo REPO         GitHub repo (default: xlflow)
+  -h, --help          Show this help
+
+Environment:
+  XLFLOW_INSTALL_DIR  Install directory override
+  XLFLOW_OWNER        GitHub owner override
+  XLFLOW_REPO         GitHub repo override
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --install-dir)
+      [ "$#" -ge 2 ] || fail "--install-dir requires a value"
+      install_dir="$2"
+      shift 2
+      ;;
+    --uninstall)
+      action="uninstall"
+      shift
+      ;;
+    --no-modify-path)
+      modify_path="0"
+      shift
+      ;;
+    --owner)
+      [ "$#" -ge 2 ] || fail "--owner requires a value"
+      owner="$2"
+      shift 2
+      ;;
+    --repo)
+      [ "$#" -ge 2 ] || fail "--repo requires a value"
+      repo="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+download_to_stdout() {
+  url="$1"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL -H "Accept: application/vnd.github+json" -H "User-Agent: xlflow-install-script" "$url"
+    return
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO- --header="Accept: application/vnd.github+json" --header="User-Agent: xlflow-install-script" "$url"
+    return
+  fi
+  fail "curl or wget is required"
+}
+
+download_to_file() {
+  url="$1"
+  path="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL -H "User-Agent: xlflow-install-script" -o "$path" "$url"
+    return
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO "$path" --header="User-Agent: xlflow-install-script" "$url"
+    return
+  fi
+  fail "curl or wget is required"
+}
+
+select_linux_asset_url() {
+  release_json="$1"
+  preferred=$(printf '%s\n' "$release_json" |
+    sed -n 's/.*"browser_download_url":[[:space:]]*"\([^"]*xlflow_linux_x86_64\.tar\.gz\)".*/\1/p' |
+    head -n 1)
+  if [ -n "$preferred" ]; then
+    printf '%s\n' "$preferred"
+    return
+  fi
+
+  fallback=$(printf '%s\n' "$release_json" |
+    sed -n 's/.*"browser_download_url":[[:space:]]*"\([^"]*\)".*/\1/p' |
+    grep -Ei 'linux.*(x86_64|amd64).*\.tar\.gz$' |
+    head -n 1 || true)
+  if [ -n "$fallback" ]; then
+    printf '%s\n' "$fallback"
+    return
+  fi
+
+  fail "could not find a Linux x64 tar.gz asset in the latest release"
+}
+
+profile_file() {
+  shell_name=$(basename "${SHELL:-sh}")
+  case "$shell_name" in
+    zsh)
+      printf '%s\n' "$HOME/.zshrc"
+      ;;
+    bash)
+      printf '%s\n' "$HOME/.bashrc"
+      ;;
+    *)
+      printf '%s\n' "$HOME/.profile"
+      ;;
+  esac
+}
+
+path_entry_expr() {
+  case "$install_dir" in
+    "$HOME"/*)
+      suffix=${install_dir#"$HOME"/}
+      printf '$HOME/%s\n' "$suffix"
+      ;;
+    *)
+      printf '%s\n' "$install_dir"
+      ;;
+  esac
+}
+
+ensure_path_profile() {
+  [ "$modify_path" = "1" ] || return 0
+
+  case ":$PATH:" in
+    *":$install_dir:"*) return 0 ;;
+  esac
+
+  profile=$(profile_file)
+  entry=$(path_entry_expr)
+
+  touch "$profile"
+  if grep -q '>>> xlflow installer >>>' "$profile"; then
+    info "PATH block already exists in $profile"
+    return 0
+  fi
+
+  {
+    printf '\n# >>> xlflow installer >>>\n'
+    printf 'export PATH="%s:$PATH"\n' "$entry"
+    printf '# <<< xlflow installer <<<\n'
+  } >>"$profile"
+
+  info "Added $install_dir to PATH in $profile"
+  info "Open a new shell or run: export PATH=\"$install_dir:\$PATH\""
+}
+
+remove_path_profile() {
+  profile=$(profile_file)
+  [ -f "$profile" ] || return 0
+  tmp_file=$(mktemp)
+  sed '/# >>> xlflow installer >>>/,/# <<< xlflow installer <<</d' "$profile" >"$tmp_file"
+  if ! cmp -s "$profile" "$tmp_file"; then
+    mv "$tmp_file" "$profile"
+    info "Removed xlflow PATH block from $profile"
+  else
+    rm -f "$tmp_file"
+  fi
+}
+
+install_xlflow() {
+  need_cmd tar
+  need_cmd sed
+  need_cmd grep
+  need_cmd find
+  need_cmd mktemp
+
+  api_url="https://api.github.com/repos/$owner/$repo/releases/latest"
+  release_url="https://github.com/$owner/$repo/releases/latest"
+  tmp_root=$(mktemp -d)
+
+  cleanup() {
+    rm -rf "$tmp_root"
+  }
+  trap cleanup EXIT INT TERM
+
+  info "Fetching latest release metadata from $api_url"
+  release_json=$(download_to_stdout "$api_url")
+  asset_url=$(select_linux_asset_url "$release_json")
+  archive_path="$tmp_root/xlflow-linux.tar.gz"
+  extract_dir="$tmp_root/extract"
+
+  info "Downloading $(basename "$asset_url")"
+  download_to_file "$asset_url" "$archive_path"
+
+  info "Extracting archive"
+  mkdir -p "$extract_dir"
+  tar -xzf "$archive_path" -C "$extract_dir"
+
+  xlflow_bin=$(find "$extract_dir" -type f -name xlflow -perm -u+x | head -n 1)
+  if [ -z "$xlflow_bin" ]; then
+    xlflow_bin=$(find "$extract_dir" -type f -name xlflow | head -n 1)
+  fi
+  [ -n "$xlflow_bin" ] || fail "downloaded archive did not contain xlflow"
+
+  info "Installing to $install_dir"
+  mkdir -p "$install_dir"
+  cp "$xlflow_bin" "$install_dir/xlflow"
+  chmod 0755 "$install_dir/xlflow"
+
+  ensure_path_profile
+
+  info "Verifying installation"
+  "$install_dir/xlflow" version
+
+  info "Install complete."
+  info "Next step: xlflow doctor --json"
+  info "Release source: $release_url"
+}
+
+uninstall_xlflow() {
+  if [ -f "$install_dir/xlflow" ]; then
+    rm -f "$install_dir/xlflow"
+    info "Removed $install_dir/xlflow"
+  else
+    info "No xlflow binary found at $install_dir/xlflow"
+  fi
+  remove_path_profile
+  info "Uninstall complete."
+}
+
+case "$action" in
+  install)
+    install_xlflow
+    ;;
+  uninstall)
+    uninstall_xlflow
+    ;;
+  *)
+    fail "unsupported action: $action"
+    ;;
+esac

--- a/vitepress/reference/environment-variables.md
+++ b/vitepress/reference/environment-variables.md
@@ -1,7 +1,8 @@
 # Environment Variables
 
-| Variable                 | Purpose                                                                             |
-| ------------------------ | ----------------------------------------------------------------------------------- |
-| `XLFLOW_NO_UPDATE_CHECK` | Set to `1` to disable the interactive release update check during `new` and `init`. |
+| Variable                 | Purpose                                                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------- |
+| `XLFLOW_NO_UPDATE_CHECK` | Set to `1` to disable the interactive release update check during `new` and `init`.     |
+| `XLFLOW_WINDOWS_EXE`     | Under WSL, override the Windows `xlflow.exe` used for delegated Excel-related commands. |
 
 Workbook-backed commands also reflect the local Excel, COM, PowerShell, and VBIDE environment. Run `xlflow doctor --json` before debugging source when environment setup is uncertain.

--- a/vitepress/reference/error-codes.md
+++ b/vitepress/reference/error-codes.md
@@ -21,5 +21,9 @@ Common examples:
 - `fmt_args_invalid`
 - `fmt_stdin_read_failed`
 - `fmt_stdin_write_failed`
+- `windows_xlflow_not_found`
+- `wsl_project_path_unsupported`
+- `wsl_path_translation_failed`
+- `windows_xlflow_execution_failed`
 
 Lint codes include `VB001` through `VB013`. Analyzer codes include `VBA101` and later runtime-risk findings.


### PR DESCRIPTION
Closes #109 

## Summary
- Enabled transparent delegation of Excel-related commands from `xlflow` on WSL to `xlflow.exe` on the Windows side.
- Provided official support for projects under `/mnt/<drive>` and restricted WSL-specific paths with a structured error.
- Added diagnostics for WSL, Windows, and path translation to `doctor --json`, and updated the ADR and various documentation.
- Added a `curl | sh` installer for WSL, as well as `task wsl-install`, `task wsl-uninstall`, and `task uninstall` commands.

## Testing
- `go test ./...`
- `golangci-lint run`
- `pnpm exec oxfmt --check README.md README.ja.md vitepress/installation.md CHANGELOG.md Taskfile.yml`
- `pnpm run docs:build`
- Verified `task --list` and temporary directory cleanup tasks for WSL / Go binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WSL development support with automatic Excel command delegation to Windows
  * Released Linux x64 binaries for WSL/Linux frontend environments
  * Added `install.sh` script for Linux installation via curl

* **Documentation**
  * Added WSL Development section to README with setup and workflow guidance
  * Enhanced `doctor` command to display WSL-specific diagnostics including path translation and bridge availability
  * Clarified platform-specific binary contents and requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->