### PR TITLE
ci: add Linux build/test job to PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,26 @@ jobs:
       - run: dotnet test bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/Xlflow.ExcelBridge.Tests.csproj
       - run: go vet ./...
 
+  test-linux:
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - run: go build ./...
+      - run: go test ./...
+      - run: dotnet test bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/Xlflow.ExcelBridge.Tests.csproj
+      - run: go vet ./...
+
   security:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true'


### PR DESCRIPTION
Adds an additive `test-linux` job to `ci.yml`, mirroring the existing `test` job on `ubuntu-latest`, per the proposal in #139.

PR CI currently runs only on `windows-latest`, so the Linux `go build` / `go test` path is verified only at release time (`release.yml` on `ubuntu-latest`). A change that breaks the Linux build can merge green and surface only when cutting a release. This job moves that check earlier, to PR review.

The job reuses the `changes` gate and matches the action versions/pins of the existing jobs. It runs `go build ./...`, `go test ./...`, the .NET bridge tests, and `go vet ./...` — the same Linux checks `release.yml` already runs.

No change to `release.yml`, `lint`, or `security`.

Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with expanded test coverage and build validation on Linux platforms to improve overall code quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->