### PR TITLE
docs: ADR-0012 + pack spec for experimental pack command

### DIFF
--- a/docs/adr/ADR-0012-pack-command.md
+++ b/docs/adr/ADR-0012-pack-command.md
@@ -1,0 +1,87 @@
+# ADR-0012: Cross-Platform pack Command for Source-to-Artifact Workbook Generation
+
+## Status
+
+Accepted
+
+## Context
+
+xlflow treats VBA projects as source-controlled code. Most commands already operate on the source tree and are cross-platform. `push` is the one source-to-workbook command that still requires Windows and Excel: writing VBA back into a workbook means regenerating `xl/vbaProject.bin`, and today that happens through the Excel/VBIDE bridge as a live read-modify-write of the loaded workbook.
+
+CI pipelines, containers, release packaging, and headless or agent-driven workflows need to produce an `.xlsm` artifact from source without a Windows-plus-Excel host. Everything else inside an `.xlsm` is OOXML XML that any platform can already produce. `xl/vbaProject.bin` — an OLE/CFB container holding MS-OVBA-compressed sources — is the single opaque piece that keeps that capability Windows-bound.
+
+ADR-0008 already drew the relevant boundary. It placed source-tree management, lint/format/analysis, and release packaging in the Go core, and stated that source-only commands remain cross-platform while Windows/Excel automation stays in the bridge. Generating `xl/vbaProject.bin` from on-disk `.bas`/`.cls` sources is a source-to-artifact transform of the same kind: it works purely at the file level, never touches COM, VBIDE, or Win32, and never launches Excel.
+
+A pure-Go, file-level writer cannot, however, provide what the live `push` path provides. It performs no VBE compile validation, no runtime validation, and gives no guarantee that every host-specific project state is interpreted exactly as Excel would. It is therefore not a drop-in replacement for `push`.
+
+Feasibility is established. `ovba-writer` (https://github.com/kay-ws/ovba-writer), a standalone pure-Go reference implementation, reads and writes source-only `vbaProject.bin`, round-trips real Excel-compiled workbooks (cross-checked against `olevba`), and produces bins that real Excel recompiles and runs.
+
+## Decision
+
+Introduce a new, experimental, cross-platform command `xlflow pack` that builds an `.xlsm` artifact from the source tree plus a workbook template, entirely in Go at the file level. It regenerates `xl/vbaProject.bin` from source and replaces that one entry inside the workbook zip.
+
+`pack` is a separate command, not a mode or backend of `push`:
+
+- `push` is unchanged. It remains the Excel/VBIDE-backed live-session path and still requires Windows and Excel.
+- The backend a command uses must not depend on project configuration. xlflow will not add an `xlflow.toml` switch that turns `push` into a file-level writer, because that would make a command's meaning depend on config and be confusing in CI logs, in support and debugging, and for agents.
+
+The initial MVP boundary is deliberately narrow and fail-loud:
+
+- the command is gated behind `--experimental`;
+- `--out` is required; `pack` never overwrites the template or configured source workbook in place;
+- `pack` operates only on closed workbook files, never on active sessions or live workbooks;
+- `--template` is optional and falls back to the source workbook configured in `xlflow.toml`;
+- standard and class modules are supported first; document modules only where they map safely against the template;
+- JSON output identifies the backend as the experimental pure-Go packer and reports that VBE compile validation was not performed;
+- the pure-Go packaging path has Linux tests;
+- unsupported cases fail with specific errors rather than best-effort behavior.
+
+Unsupported in the MVP, each a loud and specific error: active sessions or live workbooks, in-place overwrite of the template/source workbook, protected VBA projects, signed VBA projects, full UserForm/`.frx` generation, and unknown or ambiguous VBA project layouts.
+
+The contract for command shape, the JSON envelope, and exit codes lives in `docs/specs/pack-command.md`.
+
+### Ownership and attribution
+
+`pack`'s implementation, test harness, and compatibility behavior live in an xlflow-internal package, `internal/pack`. xlflow owns the public behavior and the maintenance responsibility, because this is a core artifact-generation path.
+
+`ovba-writer` is a reference implementation and feasibility proof, not a long-term dependency. xlflow does not take a direct module dependency on it; the logic is reimplemented in-repo and the reference is credited by link. Both `ovba-writer` and xlflow are MIT-licensed, so reuse is license-compatible. Because `pack` is not a `go.mod` dependency, no entry in `THIRD_PARTY_LICENCES.md` is required.
+
+### Staged scope
+
+`pack` matures before it loses the experimental gate:
+
+- **Initial MVP** — as described above.
+- **Before non-experimental status** — broader document-module fixtures; hardened signed/protected project detection beyond the MVP's baseline reject-on-detect; non-ASCII/Japanese source fixtures; Windows/Excel smoke tests that open the generated workbook and compile/run a minimal macro; a documented UserForm preservation/update strategy; and docs stating that `pack` does not compile or run VBA.
+- **UserForms, staged in three steps** — (1) preserve the template's existing designer streams unchanged, generating no forms; (2) update form code-behind while keeping the template's designer state; (3) full reconstruction from exported `.frm`/`.frx` as a separate, higher-risk phase. Only step (1)'s "carry existing designer streams through untouched" is compatible with the MVP, and only when the forms already exist in the template.
+
+### No VBE validation
+
+"No VBE validation" is a permanent semantic boundary, not a temporary limitation. `pack` never compiles or executes VBA. Its output is a file artifact whose correctness against the VBE has not been verified; Excel compiles it from source on first open. Every `pack` run reports this in its output. Consumers that need compile or runtime validation must use the Excel/VBIDE-backed `push` path on Windows.
+
+## Consequences
+
+- Positive: `push` semantics are unchanged; the live-session workflow does not regress.
+- Positive: a cross-platform path exists for CI, containers, release packaging, and headless or agent artifact generation, with no Windows-plus-Excel host.
+- Positive: keeping the backend independent of configuration means a command's meaning stays stable and legible in CI logs and to agents.
+- Positive: ownership in `internal/pack` keeps the artifact-generation path's maintenance and compatibility behavior inside xlflow.
+- Negative: `pack` output lacks VBE compile and runtime validation; consumers must treat it as unvalidated, and the contract must keep saying so.
+- Negative: two commands (`pack`, `push`) with overlapping inputs but different guarantees increase the surface to document and explain.
+- Negative: xlflow takes on maintenance of MS-OVBA and OLE/CFB compatibility behavior in-repo rather than delegating it to an external module.
+- Negative: the experimental surface needs staged hardening — fixtures, detection, smoke tests — before it can be considered stable.
+
+## Alternatives Considered
+
+1. **Make `push` itself cross-platform / Excel-free** — Rejected because it would change `push`'s validation guarantees and conflate the live-session, VBE-validated semantics with an unvalidated file-level transform under one command name.
+2. **Add an `xlflow.toml` switch that changes `push`'s backend** — Rejected because a command's behavior would then depend on project configuration, which is confusing in CI logs, in support and debugging, and for agents.
+3. **Implement Excel automation in Go** (ADR-0008 Alternative #2) — Not applicable and rejected. `pack` never touches COM, VBIDE, or Win32 and never launches Excel. It is a file-level transform, not automation, so it does not recreate interop complexity in the CLI process.
+4. **Take a long-term direct dependency on `ovba-writer`** — Rejected because a core artifact-generation path should not depend on an external module whose maintenance xlflow cannot control. The implementation is internalized under `internal/pack`, with the reference credited.
+5. **Include full UserForm/`.frx` generation in the MVP** — Rejected as higher-risk. UserForm support is staged, starting with carrying existing template designer streams through untouched.
+
+## Related
+
+- `docs/adr/ADR-0008-dotnet-excel-bridge.md`
+- `docs/adr/ADR-0001-agent-ready-vba-cli-architecture.md`
+- `docs/specs/pack-command.md`
+- `docs/specs/cli-contract.md`
+- https://github.com/kay-ws/ovba-writer
+- xlflow issue #143

--- a/docs/specs/pack-command.md
+++ b/docs/specs/pack-command.md
@@ -1,0 +1,117 @@
+# xlflow `pack` Command (Experimental)
+
+## Status
+
+Experimental and not yet implemented. This spec defines the intended contract for the pure-Go `pack` path so it can be reviewed before any implementation lands. When `pack` leaves experimental status, this contract folds into `docs/specs/cli-contract.md`. See `docs/adr/ADR-0012-pack-command.md` for the rationale and the `pack`/`push` boundary.
+
+## Scope
+
+`pack` builds a macro-enabled workbook artifact (`.xlsm`) from the xlflow source tree plus a workbook template, entirely in Go at the file level. It regenerates `xl/vbaProject.bin` from `.bas`/`.cls` sources and replaces that single entry inside the workbook zip. It never opens Excel and never uses COM or VBIDE, and it performs no VBE compile or runtime validation.
+
+`pack` does not change `push`. `push` remains the Excel/VBIDE-backed live-session path on Windows.
+
+## Command
+
+```text
+xlflow [--json] pack --out <path.xlsm> [--template <path.xlsm>] --experimental
+```
+
+- `--out <path>` (required): destination artifact path. Must end in `.xlsm`. May overwrite an existing output file, but must not resolve to the template or the configured source workbook (see Template handling). A missing `--out` fails with `pack_args_invalid` (exit 2).
+- `--template <path>` (optional): the workbook template the artifact is based on. When omitted, `pack` uses the source workbook configured in `xlflow.toml` under `[excel].path`. The template provides workbook structure — sheets, document-module hosts, and any existing designer streams; `pack` replaces only `xl/vbaProject.bin`.
+- `--experimental` (required while experimental): without it, `pack` fails with `pack_experimental_required` (exit 2).
+- `--json`: persistent global flag; emits the standard envelope (see Output / JSON contract).
+
+`--bridge` does not apply to `pack`. `pack` uses no Excel bridge.
+
+## Template and source workbook handling
+
+- The template is read-only. `pack` never writes back into it. `--out` must resolve to a different path than both the template and the configured source workbook; otherwise `pack` fails with `pack_in_place_overwrite` (exit 2).
+- `pack` operates only on closed workbook files. If a live xlflow session or an open workbook for the target is detected, `pack` fails with `pack_active_session` (exit 2) rather than reading possibly-dirty live state.
+- Document-module hosts (`ThisWorkbook`, sheet modules) come from the template. `pack` maps document-module source onto them only when the mapping is unambiguous.
+
+## Supported source (MVP)
+
+- **Standard modules** (`.bas`) and **class modules** (`.cls`): regenerated into `xl/vbaProject.bin` from source.
+- **Document modules**: supported only where they map safely against the template's existing document modules.
+- **Existing UserForm designer streams in the template**: carried through byte-for-byte, untouched. `pack` does not generate or modify form layout.
+
+## Unsupported cases (fail-loud)
+
+Each unsupported case is a specific, loud error. `pack` never falls back to best-effort behavior.
+
+| Case | Error code | Exit |
+| --- | --- | --- |
+| active xlflow session / live workbook | `pack_active_session` | 2 |
+| in-place overwrite of the template/source workbook | `pack_in_place_overwrite` | 2 |
+| protected VBA project | `pack_protected_project` | 1 |
+| signed VBA project | `pack_signed_project` | 1 |
+| full UserForm / `.frx` generation | `pack_userform_generation_unsupported` | 1 |
+| unknown or ambiguous VBA project layout | `pack_ambiguous_layout` | 1 |
+| missing `--out`, bad extension, other arg errors | `pack_args_invalid` | 2 |
+| missing `--experimental` | `pack_experimental_required` | 2 |
+| template/source workbook not found or unreadable | `pack_template_not_found` | 2 |
+
+## Output / JSON contract
+
+On success with `--json`, `pack` emits the standard envelope (`status`, `command = "pack"`, `error = null`, `logs`) plus two top-level fields:
+
+- `output`: the produced artifact, mirroring the `export-image` `output` object — `path`, `format` (`"xlsm"`), and optional `created_parent_dirs`.
+- `pack`: identifies the backend and the validation posture.
+
+```json
+{
+  "status": "ok",
+  "command": "pack",
+  "error": null,
+  "output": {
+    "path": "dist/Book.xlsm",
+    "format": "xlsm"
+  },
+  "pack": {
+    "backend": "pure-go",
+    "experimental": true,
+    "vbe_validation": "not_performed",
+    "template": "build/Book.xlsm",
+    "modules": { "standard": 3, "class": 2, "document": 1, "carried_streams": 4 }
+  },
+  "warnings": [
+    { "code": "vbe_validation_skipped", "message": "pack did not open Excel; no VBE compile or runtime validation was performed." }
+  ],
+  "logs": []
+}
+```
+
+The backend identifier `pack.backend = "pure-go"` is deliberately distinct from the Excel-bridge `bridge` metadata defined in `cli-contract.md`, because `pack` uses no Excel bridge process. The `vbe_validation_skipped` warning is emitted on every successful run. Machine consumers must read `pack.vbe_validation` — not the absence of errors — to decide whether the artifact has been VBE-validated; it never is.
+
+## Exit codes
+
+`pack` follows the shared exit-code contract in `cli-contract.md`:
+
+- `0`: success.
+- `1`: validation/content failure detected from the project or template — protected project, signed project, ambiguous layout, unsupported UserForm generation.
+- `2`: CLI argument or configuration error — missing `--out`, missing `--experimental`, bad extension, in-place overwrite, active session, template not found.
+- `3`: environment failure — I/O failure writing the artifact or reading the template after validation has passed.
+
+## No VBE validation contract
+
+`pack` never compiles or executes VBA. The generated workbook is produced at the file level; Excel compiles it from source on first open. `pack` therefore cannot detect compile errors, runtime errors, or host-specific interpretation differences. This is a permanent property of the pure-Go path, not a temporary MVP gap. Every run reports `pack.vbe_validation = "not_performed"` and emits the `vbe_validation_skipped` warning. Consumers that need compile or runtime validation must use the Excel/VBIDE-backed `push` path on Windows.
+
+## Linux test strategy
+
+`pack` is a Go-core, file-level path, so it is fully testable on Linux without Excel:
+
+- **Golden / byte-exact tests**: regenerate `xl/vbaProject.bin` for fixture projects and compare against committed golden bins; round-trip read → write → read for stability.
+- **Source cross-checks**: decompress the regenerated module streams and compare against expected source text (and, where available, against `olevba` output) to confirm MS-OVBA correctness.
+- **Negative tests**: each unsupported case asserts the documented error code and exit code.
+
+These run on the existing Linux PR CI lane; no Windows runner is required for the `pack` path. Windows/Excel smoke tests that open the artifact and run a macro are a pre-stable milestone, not part of the MVP CI.
+
+## Staged UserForm plan
+
+See ADR-0012 for the rationale. Summary:
+
+- **Stage 1 (MVP-compatible)**: carry existing template designer streams through untouched; never generate forms.
+- **Stage 2**: update form code-behind while keeping the template's designer state.
+- **Stage 3**: full reconstruction from exported `.frm`/`.frx` — a separate, higher-risk phase.
+
+The reference implementation has demonstrated the Stage 1 / Stage 2 round-trip against real Excel, including a nested Frame/MultiPage form whose designer sub-storages round-trip byte-for-byte. That informs the staging but is not part of the MVP.


### PR DESCRIPTION

This is the design/ADR-style PR we agreed on in #143. It adds design documentation only — no code, and no change to `push`.

## What this adds

- `docs/adr/ADR-0012-pack-command.md` — the decision and the `pack`/`push` boundary (the "why").
- `docs/specs/pack-command.md` — the command shape, MVP scope, unsupported cases, output/JSON contract, exit codes, and Linux test strategy (the "how"). Marked experimental; it folds into `cli-contract.md` when `pack` leaves experimental status.

The split follows the repository's ADR/spec separation: the ADR records the policy and rationale, the spec records the contract. The spec stays out of `cli-contract.md` for now because `pack` is not yet implemented and that file documents shipped behavior.

## Coverage

Mapping the points you listed in #143 to where they are covered:

| Point | Where |
| --- | --- |
| command shape and CLI behavior | spec: Command, Template and source workbook handling |
| MVP scope | ADR: Decision (MVP boundary); spec: Supported source |
| explicitly unsupported cases | ADR: Decision; spec: Unsupported cases (table with error/exit codes) |
| template/source workbook handling | spec: Template and source workbook handling |
| output/JSON contract | spec: Output / JSON contract |
| "no VBE validation" contract | ADR: No VBE validation; spec: No VBE validation contract |
| Linux test strategy | spec: Linux test strategy |
| staged UserForm plan | ADR: Staged scope; spec: Staged UserForm plan |
| implementation ownership / attribution | ADR: Ownership and attribution |

## Key boundaries captured

- `pack` is a separate experimental command, not a mode or backend of `push`; `push` is unchanged. The backend a command uses never depends on `xlflow.toml`.
- `pack` is pure-Go and file-level: it regenerates `xl/vbaProject.bin` from source and replaces that one zip entry, never touching COM/VBIDE and never opening Excel. "No VBE validation" is a permanent property, surfaced as `pack.vbe_validation = "not_performed"` plus a `vbe_validation_skipped` warning on every run.
- Ownership lives in `internal/pack`. `ovba-writer` is linked as a reference implementation and feasibility proof, not a dependency; the logic is reimplemented in-repo. Both projects are MIT, so reuse is license-compatible, and because `pack` is not a `go.mod` dependency no `THIRD_PARTY_LICENCES.md` entry is needed.

## Not in this PR

No code, no wiring into `push`, no `internal/pack` package yet. If this design reads right, the next step is the first implementation PR: the `internal/pack` package plus golden/negative tests on the Linux CI lane, still with no change to `push`.

Refs #143.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Architecture Decision Record and specification for the experimental `pack` command, enabling generation of macro-enabled Excel workbooks from source code across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->