### PR TITLE
Restructuring xlflow lint using tree-sitter-vba AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Refactored `xlflow lint` to use `tree-sitter-vba` AST-backed checks for core declaration, member-access, and error-handling rules, including per-declarator implicit `Variant` diagnostics and parser recovery findings.
+- Documented the full `xlflow lint` rule list on the command page, including `VB001` through `VB014` codes and severity levels.
 - Added `xlflow inspect calls`, a source-only tree-sitter-vba call-site extractor for exported VBA files with caller context, argument summaries, source ranges, conservative project-symbol resolution, JSON output, and compact grouped text output.
 - Added `xlflow inspect symbols`, a source-only tree-sitter-vba symbol indexer for exported `.bas`, `.cls`, and `.frm` VBA files with JSON and compact outline output.
 - Updated `xlflow inspect symbols` for the tree-sitter-vba 0.6.0 declaration node shape changes, including split property and declare nodes.

--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,8 @@
 
 <div align="center">
 
-![GitHub Release](https://img.shields.io/github/v/release/harumiWeb/xlflow?include_prereleases) ![WinGet Package Version](https://img.shields.io/winget/v/HarumiWeb.Xlflow) ![Scoop](https://img.shields.io/scoop/v/xlflow?bucket=https%3A%2F%2Fgithub.com%2FharumiWeb%2Fscoop-bucket) ![GitHub License](https://img.shields.io/github/license/harumiWeb/xlflow) ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/harumiWeb/xlflow) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/harumiWeb/xlflow)
+![GitHub Release](https://img.shields.io/github/v/release/harumiWeb/xlflow?include_prereleases) ![WinGet Package Version](https://img.shields.io/winget/v/HarumiWeb.Xlflow) ![Scoop](https://img.shields.io/scoop/v/xlflow?bucket=https%3A%2F%2Fgithub.com%2FharumiWeb%2Fscoop-bucket) ![GitHub License](https://img.shields.io/github/license/harumiWeb/xlflow) ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/harumiweb/xlflow/total)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/harumiWeb/xlflow) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/harumiWeb/xlflow)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 
 <div align="center">
 
-![GitHub Release](https://img.shields.io/github/v/release/harumiWeb/xlflow?include_prereleases) ![WinGet Package Version](https://img.shields.io/winget/v/HarumiWeb.Xlflow) ![Scoop](https://img.shields.io/scoop/v/xlflow?bucket=https%3A%2F%2Fgithub.com%2FharumiWeb%2Fscoop-bucket) ![GitHub License](https://img.shields.io/github/license/harumiWeb/xlflow) ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/harumiWeb/xlflow) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/harumiWeb/xlflow)
+![GitHub Release](https://img.shields.io/github/v/release/harumiWeb/xlflow?include_prereleases) ![WinGet Package Version](https://img.shields.io/winget/v/HarumiWeb.Xlflow) ![Scoop](https://img.shields.io/scoop/v/xlflow?bucket=https%3A%2F%2Fgithub.com%2FharumiWeb%2Fscoop-bucket) ![GitHub License](https://img.shields.io/github/license/harumiWeb/xlflow) ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/harumiweb/xlflow/total)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/harumiWeb/xlflow) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/harumiWeb/xlflow)
 
 </div>
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -434,6 +434,10 @@ End Sub
 
 ## Lint Rules
 
+Lint issue objects contain `code`, `severity`, `file`, `line`, `message`, and may include `column`, `kind`, `symbol`, and `suggestion`. `column` is 1-based when available and omitted for legacy line-only findings.
+
+Core declaration, member-access, and error-handling rules use `tree-sitter-vba` so comments, string literals, procedure scope, and individual declarators are handled structurally.
+
 - `VB001`: missing `Option Explicit`
 - `VB002`: `Select` usage
 - `VB003`: `Activate` usage
@@ -447,10 +451,11 @@ End Sub
 - `VB011`: unexpected `End Sub`, `End Function`, or `End Property`
 - `VB012`: mismatched procedure end statement
 - `VB013`: missing whitespace before a line-continuation underscore
+- `VB014`: `tree-sitter-vba` parser recovery found syntax errors or missing syntax nodes
 
 Projects that intentionally use interactive GUI entrypoints may set `[lint].forbid_interactive_input = false` to suppress `VB007`. This changes lint behavior only; `run --headless` still rejects GUI boundaries during preflight.
 
-Compile-dialog prevention findings `VB008` through `VB013` are always enabled and block source preflight before `push` or `run` opens Excel.
+Compile-dialog prevention findings `VB008` through `VB014` are always enabled and block source preflight before `push` or `run` opens Excel.
 
 ## Analysis Rules
 

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -1,25 +1,27 @@
 package lint
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/gui"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 type Issue struct {
-	Code       string `json:"code"`
-	Severity   string `json:"severity"`
-	File       string `json:"file"`
-	Line       int    `json:"line"`
-	Message    string `json:"message"`
-	Kind       string `json:"kind,omitempty"`
-	Symbol     string `json:"symbol,omitempty"`
-	Suggestion string `json:"suggestion,omitempty"`
+	Code             string `json:"code"`
+	Severity         string `json:"severity"`
+	File             string `json:"file"`
+	Line             int    `json:"line"`
+	Column           int    `json:"column,omitempty"`
+	Message          string `json:"message"`
+	Kind             string `json:"kind,omitempty"`
+	Symbol           string `json:"symbol,omitempty"`
+	Suggestion       string `json:"suggestion,omitempty"`
+	parserRecoveryOK bool   `json:"-"`
 }
 
 type Linter struct {
@@ -35,14 +37,21 @@ type procedureFrame struct {
 }
 
 var (
-	selectRe          = regexp.MustCompile(`(?i)\.\s*select\b`)
-	activateRe        = regexp.MustCompile(`(?i)\.\s*activate\b`)
-	onErrorResumeNext = regexp.MustCompile(`(?i)\bon\s+error\s+resume\s+next\b`)
-	dimWithoutAs      = regexp.MustCompile(`(?i)^\s*(dim|private|public|static)\s+([^']+)$`)
-	publicVarRe       = regexp.MustCompile(`(?i)^\s*public\s+\w+`)
-	publicProcRe      = regexp.MustCompile(`(?i)^\s*public\s+(sub|function|property|type|enum|declare)\b`)
-	typeStartRe       = regexp.MustCompile(`(?i)^\s*(private|public)?\s*type\b`)
-	typeEndRe         = regexp.MustCompile(`(?i)^\s*end\s+type\b`)
+	procedureKinds = map[string]bool{
+		"sub_declaration":               true,
+		"function_declaration":          true,
+		"property_declaration":          true,
+		"property_get_declaration":      true,
+		"property_let_declaration":      true,
+		"property_set_declaration":      true,
+		"declare_statement":             true,
+		"declare_sub_statement":         true,
+		"declare_function_statement":    true,
+		"event_declaration":             true,
+		"event_statement":               true,
+		"external_sub_declaration":      true,
+		"external_function_declaration": true,
+	}
 )
 
 const vb007DisableHint = "If this project intentionally uses dialogs or UserForms, set [lint].forbid_interactive_input = false in xlflow.toml to suppress VB007 for that project. Do this only for genuinely human-only workflows; for dialogs, prefer XlflowUI wrappers with stable dialog ids."
@@ -127,50 +136,78 @@ func (l Linter) shouldIncludeFile(path string) bool {
 }
 
 func (l Linter) lintFile(path string) ([]Issue, error) {
-	f, err := os.Open(path)
+	source, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
+	issues, err := l.textSafetyIssues(path, string(source))
+	if err != nil {
+		return nil, err
+	}
+
+	parser, err := vbaast.NewParser()
+	if err != nil {
+		return nil, err
+	}
+	defer parser.Close()
+	parsed := parser.Parse(path, source)
+	defer parsed.Close()
+
+	ctx := astLintContext{linter: l, path: path, source: source}
+	ctx.lint(parsed.Root)
+	issues = append(issues, ctx.issues...)
+	if shouldReportParseIssue(parsed, issues) {
+		issues = append(issues, ctx.parseIssue(parsed.Root))
+	}
+
+	if l.Config.Lint.ForbidInteractiveInput {
+		boundaries, err := gui.Analyzer{RootDir: l.RootDir, Config: l.Config}.AnalyzeFile(path)
+		if err != nil {
+			return nil, err
+		}
+		for _, boundary := range boundaries {
+			issues = append(issues, Issue{
+				Code:       "VB007",
+				Severity:   "warning",
+				File:       boundary.File,
+				Line:       boundary.Line,
+				Message:    boundary.Message + " " + boundary.Suggestion + " " + vb007DisableHint,
+				Kind:       boundary.Kind,
+				Symbol:     boundary.Symbol,
+				Suggestion: boundary.Suggestion,
+			})
+		}
+	}
+	return issues, nil
+}
+
+func (l Linter) textSafetyIssues(path string, source string) ([]Issue, error) {
 	var issues []Issue
-	hasOptionExplicit := false
-	inTypeBlock := false
 	procedures := make([]procedureFrame, 0)
+	inTypeBlock := false
 	var logicalLine strings.Builder
 	logicalStartLine := 0
-	scanner := bufio.NewScanner(f)
-	lineNo := 0
-	for scanner.Scan() {
-		lineNo++
-		line := scanner.Text()
+	lines := strings.Split(strings.ReplaceAll(source, "\r\n", "\n"), "\n")
+	for i, line := range lines {
+		lineNo := i + 1
 		code := gui.StripComment(line)
 		detectionCode := maskStringLiterals(code)
 		trimmed := strings.TrimSpace(code)
-		if strings.EqualFold(trimmed, "Option Explicit") {
-			hasOptionExplicit = true
+		lower := strings.ToLower(trimmed)
+		if isTypeEndLine(lower) {
+			inTypeBlock = false
+		}
+		if l.Config.Lint.DetectImplicitVariant && inTypeBlock && looksImplicitTypeField(trimmed) {
+			issue := l.issue(path, lineNo, "VB005", "warning", "Declare an explicit type with As <Type>.")
+			issue.parserRecoveryOK = true
+			issues = append(issues, issue)
+		}
+		if isTypeStartLine(lower) {
+			inTypeBlock = true
 		}
 		if missingLineContinuationWhitespace(detectionCode) {
 			issues = append(issues, l.issue(path, lineNo, "VB013", "error", "Line-continuation underscore must be preceded by whitespace."))
-		}
-		if l.Config.Lint.ForbidSelect && selectRe.MatchString(code) {
-			issues = append(issues, l.issue(path, lineNo, "VB002", "warning", "Avoid Select. Use direct object references instead."))
-		}
-		if l.Config.Lint.ForbidActivate && activateRe.MatchString(code) {
-			issues = append(issues, l.issue(path, lineNo, "VB003", "warning", "Avoid Activate. Use direct object references instead."))
-		}
-		if l.Config.Lint.ForbidOnErrorResumeNext && onErrorResumeNext.MatchString(code) {
-			issues = append(issues, l.issue(path, lineNo, "VB004", "warning", "Avoid On Error Resume Next without a narrow recovery block."))
-		}
-		if l.Config.Lint.DetectImplicitVariant && looksImplicitVariant(trimmed, inTypeBlock) {
-			issues = append(issues, l.issue(path, lineNo, "VB005", "warning", "Declare an explicit type with As <Type>."))
-		}
-		if typeStartRe.MatchString(trimmed) {
-			inTypeBlock = true
-		} else if typeEndRe.MatchString(trimmed) {
-			inTypeBlock = false
-		}
-		if l.Config.Lint.ForbidPublicModuleFields && looksPublicVariable(trimmed) {
-			issues = append(issues, l.issue(path, lineNo, "VB006", "warning", "Avoid Public module variables; pass state explicitly."))
 		}
 		if containsTypographicQuote(code) {
 			issues = append(issues, l.issue(path, lineNo, "VB008", "error", "Typographic quote found in VBA source. Use straight double quotes for string delimiters before pushing to Excel."))
@@ -197,15 +234,6 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 		logicalLine.Reset()
 		logicalStartLine = 0
 	}
-	if err := scanner.Err(); err != nil {
-		if closeErr := f.Close(); closeErr != nil {
-			return nil, closeErr
-		}
-		return nil, err
-	}
-	if err := f.Close(); err != nil {
-		return nil, err
-	}
 	if logicalLine.Len() > 0 {
 		for _, statement := range splitStatements(logicalLine.String()) {
 			issues = append(issues, l.procedureBoundaryIssues(path, logicalStartLine, statement, &procedures)...)
@@ -216,88 +244,198 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 		issue.Symbol = procedure.Name
 		issues = append(issues, issue)
 	}
-	if l.Config.Lint.RequireOptionExplicit && !hasOptionExplicit {
-		issues = append([]Issue{l.issue(path, 1, "VB001", "error", "Missing Option Explicit.")}, issues...)
-	}
-	if l.Config.Lint.ForbidInteractiveInput {
-		boundaries, err := gui.Analyzer{RootDir: l.RootDir, Config: l.Config}.AnalyzeFile(path)
-		if err != nil {
-			return nil, err
-		}
-		for _, boundary := range boundaries {
-			issues = append(issues, Issue{
-				Code:       "VB007",
-				Severity:   "warning",
-				File:       boundary.File,
-				Line:       boundary.Line,
-				Message:    boundary.Message + " " + boundary.Suggestion + " " + vb007DisableHint,
-				Kind:       boundary.Kind,
-				Symbol:     boundary.Symbol,
-				Suggestion: boundary.Suggestion,
-			})
-		}
-	}
 	return issues, nil
+}
+
+type astLintContext struct {
+	linter            Linter
+	path              string
+	source            []byte
+	issues            []Issue
+	hasOptionExplicit bool
+}
+
+func (c *astLintContext) lint(root *tree_sitter.Node) {
+	c.visit(root, false, false)
+	if c.linter.Config.Lint.RequireOptionExplicit && !c.hasOptionExplicit {
+		c.issues = append([]Issue{c.linter.issue(c.path, 1, "VB001", "error", "Missing Option Explicit.")}, c.issues...)
+	}
+}
+
+func (c *astLintContext) visit(node *tree_sitter.Node, inProcedure bool, inType bool) {
+	if node == nil {
+		return
+	}
+	kind := node.Kind()
+	switch kind {
+	case "option_statement":
+		if strings.EqualFold(normalizedNodeText(node, c.source), "Option Explicit") {
+			c.hasOptionExplicit = true
+		}
+	case "type_declaration":
+		inType = true
+	case "qualified_member_expression", "implicit_member_expression":
+		c.memberAccessIssue(node)
+	case "on_error_statement":
+		c.onErrorIssue(node)
+	case "variable_declaration":
+		c.variableDeclarationIssues(node, inProcedure, inType)
+	}
+	if procedureKinds[kind] {
+		inProcedure = true
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		c.visit(node.NamedChild(i), inProcedure, inType)
+	}
+}
+
+func (c *astLintContext) memberAccessIssue(node *tree_sitter.Node) {
+	property := node.ChildByFieldName("property")
+	if property == nil {
+		return
+	}
+	name := cleanIdentifier(property.Utf8Text(c.source))
+	switch {
+	case c.linter.Config.Lint.ForbidSelect && strings.EqualFold(name, "Select"):
+		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(property), "VB002", "warning", "Avoid Select. Use direct object references instead."))
+	case c.linter.Config.Lint.ForbidActivate && strings.EqualFold(name, "Activate"):
+		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(property), "VB003", "warning", "Avoid Activate. Use direct object references instead."))
+	}
+}
+
+func (c *astLintContext) onErrorIssue(node *tree_sitter.Node) {
+	if !c.linter.Config.Lint.ForbidOnErrorResumeNext {
+		return
+	}
+	if strings.EqualFold(normalizedNodeText(node, c.source), "On Error Resume Next") {
+		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(node), "VB004", "warning", "Avoid On Error Resume Next without a narrow recovery block."))
+	}
+}
+
+func (c *astLintContext) variableDeclarationIssues(node *tree_sitter.Node, inProcedure bool, inType bool) {
+	if c.linter.Config.Lint.ForbidPublicModuleFields && !inProcedure && !inType && strings.EqualFold(visibilityText(node, c.source), "Public") {
+		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(node), "VB006", "warning", "Avoid Public module variables; pass state explicitly."))
+	}
+	if !c.linter.Config.Lint.DetectImplicitVariant {
+		return
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil || child.Kind() != "variable_declarator" || typeText(child, c.source) != "" {
+			continue
+		}
+		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(child), "VB005", "warning", "Declare an explicit type with As <Type>."))
+	}
+}
+
+func (c *astLintContext) parseIssue(root *tree_sitter.Node) Issue {
+	r := vbaast.Range{StartLine: 1, StartColumn: 1}
+	if node := firstParseProblem(root); node != nil {
+		r = vbaast.NodeRange(node)
+	}
+	return c.linter.issueAt(c.path, r, "VB014", "error", "VBA parser recovered from syntax errors; inspect this source before pushing to Excel.")
+}
+
+func firstParseProblem(node *tree_sitter.Node) *tree_sitter.Node {
+	if node == nil {
+		return nil
+	}
+	if node.IsError() || node.IsMissing() {
+		return node
+	}
+	for i := uint(0); i < node.ChildCount(); i++ {
+		if found := firstParseProblem(node.Child(i)); found != nil {
+			return found
+		}
+	}
+	return nil
 }
 
 func PushBlockingIssues(issues []Issue) []Issue {
 	blocking := make([]Issue, 0)
 	for _, issue := range issues {
-		if issue.Code == "VB008" || issue.Code == "VB009" || issue.Code == "VB010" || issue.Code == "VB011" || issue.Code == "VB012" || issue.Code == "VB013" {
+		if issue.Code == "VB008" || issue.Code == "VB009" || issue.Code == "VB010" || issue.Code == "VB011" || issue.Code == "VB012" || issue.Code == "VB013" || issue.Code == "VB014" {
 			blocking = append(blocking, issue)
 		}
 	}
 	return blocking
 }
 
+func hasSpecificSyntaxIssue(issues []Issue) bool {
+	for _, issue := range issues {
+		if issue.Code == "VB008" || issue.Code == "VB009" || issue.Code == "VB010" || issue.Code == "VB011" || issue.Code == "VB012" || issue.Code == "VB013" {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldReportParseIssue(parsed *vbaast.ParseResult, issues []Issue) bool {
+	if parsed == nil || (!parsed.HasError && !parsed.HasMissing) || hasSpecificSyntaxIssue(issues) {
+		return false
+	}
+	problemLines := parseProblemLines(parsed.Root)
+	if len(problemLines) == 0 {
+		return true
+	}
+	for line := range problemLines {
+		if !hasIssueAtLine(issues, "VB005", line) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseProblemLines(root *tree_sitter.Node) map[int]bool {
+	lines := make(map[int]bool)
+	collectParseProblemLines(root, lines)
+	return lines
+}
+
+func collectParseProblemLines(node *tree_sitter.Node, lines map[int]bool) {
+	if node == nil {
+		return
+	}
+	if node.IsError() || node.IsMissing() {
+		r := vbaast.NodeRange(node)
+		if r.StartLine > 0 {
+			lines[r.StartLine] = true
+		}
+	}
+	for i := uint(0); i < node.ChildCount(); i++ {
+		collectParseProblemLines(node.Child(i), lines)
+	}
+}
+
+func hasIssueAtLine(issues []Issue, code string, line int) bool {
+	for _, issue := range issues {
+		if issue.Code == code && issue.Line == line && issue.parserRecoveryOK {
+			return true
+		}
+	}
+	return false
+}
+
 func (l Linter) issue(path string, line int, code, severity, message string) Issue {
+	return l.issueAt(path, vbaast.Range{StartLine: line}, code, severity, message)
+}
+
+func (l Linter) issueAt(path string, r vbaast.Range, code, severity, message string) Issue {
 	file, err := filepath.Rel(l.RootDir, path)
 	if err != nil {
 		file = path
+	}
+	if r.StartLine == 0 {
+		r.StartLine = 1
 	}
 	return Issue{
 		Code:     code,
 		Severity: severity,
 		File:     filepath.ToSlash(file),
-		Line:     line,
+		Line:     r.StartLine,
+		Column:   r.StartColumn,
 		Message:  message,
 	}
-}
-
-func looksImplicitVariant(line string, inTypeBlock bool) bool {
-	lower := strings.ToLower(strings.TrimSpace(line))
-	if lower == "" || strings.Contains(lower, " as ") {
-		return false
-	}
-	if inTypeBlock {
-		return !typeEndRe.MatchString(line) && !isConditionalCompilationDirective(lower)
-	}
-	matches := dimWithoutAs.FindStringSubmatch(line)
-	if len(matches) == 0 {
-		return false
-	}
-	return !strings.HasPrefix(lower, "public sub ") &&
-		!strings.HasPrefix(lower, "public function ") &&
-		!strings.HasPrefix(lower, "public property ") &&
-		!strings.HasPrefix(lower, "public type ") &&
-		!strings.HasPrefix(lower, "public enum ") &&
-		!strings.HasPrefix(lower, "public declare ") &&
-		!strings.HasPrefix(lower, "private sub ") &&
-		!strings.HasPrefix(lower, "private function ") &&
-		!strings.HasPrefix(lower, "private property ") &&
-		!strings.HasPrefix(lower, "private type ") &&
-		!strings.HasPrefix(lower, "private enum ") &&
-		!strings.HasPrefix(lower, "private declare ") &&
-		!strings.HasPrefix(lower, "friend sub ") &&
-		!strings.HasPrefix(lower, "friend function ") &&
-		!strings.HasPrefix(lower, "friend property ")
-}
-
-func isConditionalCompilationDirective(line string) bool {
-	return strings.HasPrefix(line, "#if ") ||
-		strings.HasPrefix(line, "#elseif ") ||
-		line == "#else" ||
-		line == "#end if"
 }
 
 func containsTypographicQuote(line string) bool {
@@ -318,6 +456,124 @@ func containsLikelyCStyleQuoteEscape(line string) bool {
 		}
 	}
 	return false
+}
+
+func isTypeStartLine(lower string) bool {
+	fields := strings.Fields(lower)
+	if len(fields) == 0 {
+		return false
+	}
+	if fields[0] == "type" {
+		return true
+	}
+	return len(fields) > 1 && (fields[0] == "private" || fields[0] == "public") && fields[1] == "type"
+}
+
+func isTypeEndLine(lower string) bool {
+	fields := strings.Fields(lower)
+	return len(fields) == 2 && fields[0] == "end" && fields[1] == "type"
+}
+
+func looksImplicitTypeField(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	if lower == "" || strings.Contains(lower, " as ") || isConditionalCompilationDirective(lower) {
+		return false
+	}
+	return !isTypeStartLine(lower) && !isTypeEndLine(lower)
+}
+
+func isConditionalCompilationDirective(line string) bool {
+	return strings.HasPrefix(line, "#if ") ||
+		strings.HasPrefix(line, "#elseif ") ||
+		line == "#else" ||
+		line == "#end if"
+}
+
+func normalizedNodeText(node *tree_sitter.Node, source []byte) string {
+	return strings.Join(strings.Fields(node.Utf8Text(source)), " ")
+}
+
+func visibilityText(node *tree_sitter.Node, source []byte) string {
+	if visibility := node.ChildByFieldName("visibility"); visibility != nil {
+		return normalizeKeyword(visibility.Utf8Text(source))
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child != nil && child.Kind() == "visibility" {
+			return normalizeKeyword(child.Utf8Text(source))
+		}
+	}
+	text := node.Utf8Text(source)
+	for _, word := range []string{"Public", "Private", "Friend"} {
+		if hasWord(text, word) {
+			return word
+		}
+	}
+	return ""
+}
+
+func typeText(node *tree_sitter.Node, source []byte) string {
+	asType := node.ChildByFieldName("type")
+	if asType == nil {
+		asType = firstNamedChildKind(node, "as_type_clause")
+	}
+	if asType == nil {
+		return ""
+	}
+	if typeExpr := asType.ChildByFieldName("type"); typeExpr != nil {
+		return strings.TrimSpace(typeExpr.Utf8Text(source))
+	}
+	text := strings.TrimSpace(asType.Utf8Text(source))
+	if strings.HasPrefix(strings.ToLower(text), "as ") {
+		return strings.TrimSpace(text[3:])
+	}
+	return text
+}
+
+func firstNamedChildKind(node *tree_sitter.Node, kind string) *tree_sitter.Node {
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child != nil && child.Kind() == kind {
+			return child
+		}
+	}
+	return nil
+}
+
+func cleanIdentifier(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.Trim(text, "[]")
+	text = strings.TrimRight(text, "$%&#@^!")
+	return text
+}
+
+func normalizeKeyword(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	lower := strings.ToLower(text)
+	return strings.ToUpper(lower[:1]) + lower[1:]
+}
+
+func hasWord(text, word string) bool {
+	fields := strings.FieldsFunc(text, func(r rune) bool {
+		return !isVBAIdentifierRune(r)
+	})
+	for _, field := range fields {
+		if strings.EqualFold(field, word) {
+			return true
+		}
+	}
+	return false
+}
+
+func isVBAIdentifierRune(r rune) bool {
+	switch r {
+	case '_', '$', '%', '&', '!', '#', '@', '^':
+		return true
+	}
+	return r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z'
 }
 
 func (l Linter) procedureBoundaryIssues(path string, lineNo int, line string, procedures *[]procedureFrame) []Issue {
@@ -517,11 +773,4 @@ func endsWithIdentifierUnderscore(line string) bool {
 
 func isIdentifierChar(b byte) bool {
 	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
-}
-
-func looksPublicVariable(line string) bool {
-	if !publicVarRe.MatchString(line) {
-		return false
-	}
-	return !publicProcRe.MatchString(line)
 }

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -132,6 +132,147 @@ End Sub
 	}
 }
 
+func TestLinterUsesASTForDeclaratorsAndColumns(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Public SharedState As String
+Private c As String, d
+
+Sub Main()
+  Dim a, b As Long
+  Dim localValue
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb005 := issuesByCode(issues, "VB005")
+	if len(vb005) != 3 {
+		t.Fatalf("expected three VB005 findings, got %+v", vb005)
+	}
+	assertIssue(t, vb005, "VB005", 3)
+	assertIssue(t, vb005, "VB005", 6)
+	assertIssue(t, vb005, "VB005", 7)
+	a := findIssue(t, vb005, "VB005", 6)
+	if a.Column != 7 {
+		t.Fatalf("expected Dim a column 7, got %+v", a)
+	}
+	for _, issue := range vb005 {
+		if issue.Line == 6 && issue.Column != 7 {
+			t.Fatalf("Dim a should be the only line 6 implicit Variant, got %+v", vb005)
+		}
+	}
+	vb006 := issuesByCode(issues, "VB006")
+	if len(vb006) != 1 || vb006[0].Line != 2 {
+		t.Fatalf("expected only module-level Public variable to trigger VB006, got %+v", vb006)
+	}
+}
+
+func TestLinterASTIgnoresCommentsAndStringsForKeywordRules(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Sub Main()
+  Debug.Print ".Select .Activate On Error Resume Next"
+  ' Range("A1").Select
+  ' ActiveCell.Activate
+  ' On Error Resume Next
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, code := range []string{"VB002", "VB003", "VB004"} {
+		if got := issuesByCode(issues, code); len(got) != 0 {
+			t.Fatalf("%s should ignore comments and strings, got %+v", code, got)
+		}
+	}
+}
+
+func TestLinterASTDetectsMemberAccessAndOnError(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Sub Main()
+  Range("A1").Select
+  ActiveCell.Activate
+  With Worksheets(1)
+    .Range("A1").Select
+  End With
+  On Error Resume Next
+  On Error GoTo ErrHandler
+ErrHandler:
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb002 := issuesByCode(issues, "VB002")
+	if len(vb002) != 2 {
+		t.Fatalf("expected two Select findings, got %+v", vb002)
+	}
+	assertIssue(t, vb002, "VB002", 3)
+	assertIssue(t, vb002, "VB002", 6)
+	vb003 := issuesByCode(issues, "VB003")
+	if len(vb003) != 1 || vb003[0].Line != 4 {
+		t.Fatalf("expected one Activate finding, got %+v", vb003)
+	}
+	vb004 := issuesByCode(issues, "VB004")
+	if len(vb004) != 1 || vb004[0].Line != 8 {
+		t.Fatalf("expected only On Error Resume Next to trigger VB004, got %+v", vb004)
+	}
+}
+
+func TestLinterReportsParserRecovery(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Option Explicit
+Sub Main(
+  Range("A1").Value = 1
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb014 := issuesByCode(issues, "VB014")
+	if len(vb014) == 0 {
+		t.Fatalf("expected parser recovery issue, got %+v", issues)
+	}
+	if vb014[0].Line == 0 || vb014[0].Column == 0 {
+		t.Fatalf("expected parser recovery issue to include line and column, got %+v", vb014[0])
+	}
+	assertIssue(t, PushBlockingIssues(issues), "VB014", vb014[0].Line)
+}
+
 func TestLinterHandlesImplicitVariantsInsideUDTs(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
@@ -180,6 +321,9 @@ End Sub
 	if len(vb005Lines) != 2 {
 		t.Fatalf("expected exactly two VB005 findings, got %+v", issues)
 	}
+	if got := issuesByCode(issues, "VB014"); len(got) != 0 {
+		t.Fatalf("legal UDT implicit Variant fallback should not also trigger VB014: %+v", got)
+	}
 }
 
 func TestLinterIgnoresConditionalCompilationDirectivesInsideUDTs(t *testing.T) {
@@ -219,6 +363,9 @@ End Type
 	}
 	if len(vb005Lines) != 1 {
 		t.Fatalf("expected exactly one VB005 finding, got %+v", issues)
+	}
+	if got := issuesByCode(issues, "VB014"); len(got) != 0 {
+		t.Fatalf("legal UDT implicit Variant fallback should not also trigger VB014: %+v", got)
 	}
 }
 
@@ -611,4 +758,14 @@ func findIssue(t *testing.T, issues []Issue, code string, line int) Issue {
 	}
 	t.Fatalf("missing issue %s at line %d in %+v", code, line, issues)
 	return Issue{}
+}
+
+func issuesByCode(issues []Issue, code string) []Issue {
+	var filtered []Issue
+	for _, issue := range issues {
+		if issue.Code == code {
+			filtered = append(filtered, issue)
+		}
+	}
+	return filtered
 }

--- a/vitepress/commands/lint.md
+++ b/vitepress/commands/lint.md
@@ -30,20 +30,48 @@ xlflow lint --json
 Use `lint --json` in agent loops before `push` to catch source problems while Excel is still closed.
 :::
 
+## Rules
+
+| Code    | Severity | Description                                                                                                                |
+| ------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `VB001` | error    | Missing `Option Explicit`.                                                                                                 |
+| `VB002` | warning  | `Select` member access such as `Range("A1").Select`.                                                                       |
+| `VB003` | warning  | `Activate` member access such as `ActiveCell.Activate`.                                                                    |
+| `VB004` | warning  | Broad `On Error Resume Next`.                                                                                              |
+| `VB005` | warning  | Possible implicit `Variant`, including individual untyped declarators in one `Dim` statement.                              |
+| `VB006` | warning  | Module-level `Public` variable.                                                                                            |
+| `VB007` | warning  | Automation-hostile GUI boundary such as raw dialogs, file pickers, UserForms, message pumps, or external process launches. |
+| `VB008` | error    | Typographic quote character that can trigger VBE compile dialogs.                                                          |
+| `VB009` | error    | Likely C-style quote escape in a VBA string literal.                                                                       |
+| `VB010` | error    | Unterminated `Sub`, `Function`, or `Property` procedure.                                                                   |
+| `VB011` | error    | Unexpected `End Sub`, `End Function`, or `End Property`.                                                                   |
+| `VB012` | error    | Mismatched procedure end statement.                                                                                        |
+| `VB013` | error    | Missing whitespace before a line-continuation underscore.                                                                  |
+| `VB014` | error    | `tree-sitter-vba` parser recovery found syntax errors or missing syntax nodes.                                             |
+
+Core declaration, member-access, and error-handling checks are AST-backed. They ignore comments and strings, distinguish module-level declarations from procedure-local declarations, and report individual declarators such as `a` in `Dim a, b As Long`.
+
 ## JSON Output Example
 
-Successful `--json` output uses the xlflow envelope plus command-specific fields.
+Failed `--json` output uses the xlflow envelope plus command-specific fields.
 
 ```json
 {
-  "status": "error",
+  "status": "failed",
   "command": "lint",
+  "error": {
+    "code": "lint_failed",
+    "message": "1 lint issue(s) found"
+  },
+  "logs": [],
   "issues": [
     {
+      "code": "VB005",
+      "severity": "warning",
       "file": "src/modules/Main.bas",
       "line": 7,
-      "code": "vba_syntax_risk",
-      "severity": "error"
+      "column": 7,
+      "message": "Declare an explicit type with As <Type>."
     }
   ]
 }

--- a/vitepress/design/linter.md
+++ b/vitepress/design/linter.md
@@ -2,6 +2,8 @@
 
 The linter catches automation-hostile VBA and syntax patterns that can block agents or surface modal dialogs.
 
+Declaration, member-access, and error-handling checks are backed by `tree-sitter-vba`, so findings can distinguish comments and strings from executable code, module-level declarations from procedure-local declarations, and individual declarators in one `Dim` statement.
+
 Rules include:
 
 - Missing `Option Explicit`

--- a/vitepress/reference/error-codes.md
+++ b/vitepress/reference/error-codes.md
@@ -26,4 +26,4 @@ Common examples:
 - `wsl_path_translation_failed`
 - `windows_xlflow_execution_failed`
 
-Lint codes include `VB001` through `VB013`. Analyzer codes include `VBA101` and later runtime-risk findings.
+Lint codes include `VB001` through `VB014`. Analyzer codes include `VBA101` and later runtime-risk findings.


### PR DESCRIPTION
## Summary
- Replaced xlflow lint with a tree-sitter-vba based AST inspection to perform structural evaluation of declarations, member accesses, and error handling.
- Added reporting for individual declarators like Dim a, b As Long, module-level Public, and syntax anomalies resulting from parser recovery as VB005 / VB006 / VB014.
- Updated the lint command page, design documents, error code list, README badges, and CHANGELOG.

## Testing
- Added unit tests for internal/lint to verify AST-based detection, exclusion of comments/strings, and parser recovery diagnostics.
- Added regression checks for existing lint-related tests.