### PR TITLE
Enhance lint with AST-backed static analysis rules

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -600,6 +600,32 @@ detect_implicit_variant = true
 forbid_public_module_fields = true
 # ヘッドレス実行時の対話型入力（MsgBox、InputBoxなど）を禁止します。
 forbid_interactive_input = true
+# 修飾されていない Range/Cells/Rows/Columns アクセスを禁止します。
+forbid_unqualified_excel_objects = true
+# 通常実行が error handler label に落ちる procedure を検出します。
+detect_error_handler_fallthrough = true
+# 復元経路が明確でない Application state 変更を検出します。
+detect_application_state_restore = true
+# module 変数や procedure 名を隠す local 名を検出します。
+detect_scope_shadowing = false
+# 一部の declarator だけに型が付く Dim 文を説明します。
+detect_multiple_declarator_clarity = true
+# 未参照の procedure-local 変数を検出します。
+detect_unused_local_variables = false
+# 未参照の Private procedure を検出します。
+detect_unused_private_procedures = false
+# 紛らわしい parenthesized call syntax を検出します。
+detect_confusing_call_syntax = true
+# For Each control variable の宣言・型の問題を検出します。
+detect_for_each_control_type = true
+# ActiveWorkbook/ActiveSheet/ActiveCell/Selection 依存を禁止します。
+forbid_active_object_dependency = true
+# Nothing check 前に使われる Range.Find 結果を検出します。
+detect_range_find_nothing_check = false
+# error handler 外に見える Resume 文を検出します。
+detect_dangerous_resume = true
+# nested With 内の曖昧な implicit Excel member を検出します。
+detect_nested_with_ambiguity = false
 ```
 
 `project.entry` は `xlflow run` の macro 名を省略した場合に使われます。

--- a/README.md
+++ b/README.md
@@ -102,17 +102,17 @@ pull → fmt → edit → push → lint → test/run → inspect
 
 ## What xlflow can do
 
-| Area           | Capabilities                                                                                                                                      |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Source control | Export and import standard modules, class modules, UserForms, and document modules                                                                |
-| Execution      | Run macros from the CLI with typed arguments                                                                                                      |
-| Testing        | Discover and run VBA test procedures                                                                                                              |
-| Formatting     | Conservative, non-destructive VBA formatting for `.bas` and `.cls` source files                                                                   |
-| Linting        | Catch `Option Explicit` omissions, `Select`/`Activate`, broad error handling, implicit variants, public module fields, and interactive operations |
-| GUI safety     | Detect file pickers, input boxes, modal message boxes, and other automation-hostile boundaries                                                    |
-| Debugging      | Collect terminal logs and return runtime diagnostics                                                                                              |
-| Diffing        | Compare workbook cell values, formulas, sheet structure, and exported VBA source                                                                  |
-| AI agents      | Return stable JSON and install bundled Skills for Codex, Claude, Cursor, Gemini, GitHub Copilot-style agent workflows, and other agents           |
+| Area           | Capabilities                                                                                                                                                                 |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Source control | Export and import standard modules, class modules, UserForms, and document modules                                                                                           |
+| Execution      | Run macros from the CLI with typed arguments                                                                                                                                 |
+| Testing        | Discover and run VBA test procedures                                                                                                                                         |
+| Formatting     | Conservative, non-destructive VBA formatting for `.bas` and `.cls` source files                                                                                              |
+| Linting        | Catch `Option Explicit` omissions, `Select`/`Activate`, broad error handling, implicit variants, unqualified Excel objects, public module fields, and interactive operations |
+| GUI safety     | Detect file pickers, input boxes, modal message boxes, and other automation-hostile boundaries                                                                               |
+| Debugging      | Collect terminal logs and return runtime diagnostics                                                                                                                         |
+| Diffing        | Compare workbook cell values, formulas, sheet structure, and exported VBA source                                                                                             |
+| AI agents      | Return stable JSON and install bundled Skills for Codex, Claude, Cursor, Gemini, GitHub Copilot-style agent workflows, and other agents                                      |
 
 > [!IMPORTANT]
 > xlflow is **Windows-first** for workbook execution. Workbook operations use **Microsoft Excel + COM** through the `.NET` Excel bridge by default on Windows. WSL can be used as the development frontend by delegating Excel-related commands to the Windows installation.
@@ -600,6 +600,32 @@ detect_implicit_variant = true
 forbid_public_module_fields = true
 # Forbid interactive input (MsgBox, InputBox, etc.) in headless runs.
 forbid_interactive_input = true
+# Forbid unqualified Range/Cells/Rows/Columns access.
+forbid_unqualified_excel_objects = true
+# Detect procedures that can fall through into an error handler.
+detect_error_handler_fallthrough = true
+# Detect Application state changes without an obvious restore path.
+detect_application_state_restore = true
+# Detect local names that shadow module or procedure names.
+detect_scope_shadowing = false
+# Explain mixed Dim declarations where only some declarators are typed.
+detect_multiple_declarator_clarity = true
+# Detect unused procedure-local variables.
+detect_unused_local_variables = false
+# Detect unused Private procedures.
+detect_unused_private_procedures = false
+# Detect confusing parenthesized call syntax.
+detect_confusing_call_syntax = true
+# Detect For Each control variable declaration/type issues.
+detect_for_each_control_type = true
+# Forbid ActiveWorkbook/ActiveSheet/ActiveCell/Selection dependencies.
+forbid_active_object_dependency = true
+# Detect Range.Find results used without a Nothing check.
+detect_range_find_nothing_check = false
+# Detect Resume statements outside likely error handlers.
+detect_dangerous_resume = true
+# Detect nested With blocks with ambiguous implicit Excel members.
+detect_nested_with_ambiguity = false
 ```
 
 `project.entry` is used when `xlflow run` is invoked without a macro name.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -253,6 +253,19 @@ forbid_on_error_resume_next = true
 detect_implicit_variant = true
 forbid_public_module_fields = true
 forbid_interactive_input = true
+forbid_unqualified_excel_objects = true
+detect_error_handler_fallthrough = true
+detect_application_state_restore = true
+detect_scope_shadowing = false
+detect_multiple_declarator_clarity = true
+detect_unused_local_variables = false
+detect_unused_private_procedures = false
+detect_confusing_call_syntax = true
+detect_for_each_control_type = true
+forbid_active_object_dependency = true
+detect_range_find_nothing_check = false
+detect_dangerous_resume = true
+detect_nested_with_ambiguity = false
 ```
 
 ## JSON Envelope
@@ -436,7 +449,7 @@ End Sub
 
 Lint issue objects contain `code`, `severity`, `file`, `line`, `message`, and may include `column`, `kind`, `symbol`, and `suggestion`. `column` is 1-based when available and omitted for legacy line-only findings.
 
-Core declaration, member-access, and error-handling rules use `tree-sitter-vba` so comments, string literals, procedure scope, and individual declarators are handled structurally.
+Core declaration, member-access, error-handling, Excel object, and procedure-scope rules use `tree-sitter-vba` so comments, string literals, procedure scope, and individual declarators are handled structurally.
 
 - `VB001`: missing `Option Explicit`
 - `VB002`: `Select` usage
@@ -452,10 +465,25 @@ Core declaration, member-access, and error-handling rules use `tree-sitter-vba` 
 - `VB012`: mismatched procedure end statement
 - `VB013`: missing whitespace before a line-continuation underscore
 - `VB014`: `tree-sitter-vba` parser recovery found syntax errors or missing syntax nodes
+- `VB015`: unqualified Excel object access such as `Range(...)`, `Cells(...)`, `Rows(...)`, or `Columns(...)`
+- `VB016`: normal execution can fall through into an error-handler label
+- `VB017`: `Application.EnableEvents`, `Application.DisplayAlerts`, or `Application.ScreenUpdating` is disabled without an obvious restore path
+- `VB018`: local declarations or parameters shadow module-level names, procedure names, or same-scope declarations
+- `VB019`: mixed multiple declarators where only some names have explicit `As <Type>`
+- `VB020`: unused procedure-local variable
+- `VB021`: unused private procedure, excluding known event/callback naming patterns
+- `VB022`: confusing parenthesized call syntax such as `Foo (bar)`
+- `VB023`: `For Each` control variable is undeclared or obviously incompatible
+- `VB024`: active object dependency such as `ActiveWorkbook`, `ActiveSheet`, `ActiveCell`, or `Selection`
+- `VB025`: `Range.Find` result is dereferenced before a `Nothing` check
+- `VB026`: `Resume` is used outside a likely error-handler context
+- `VB027`: nested `With` blocks use implicit Excel members whose target can be ambiguous
 
 Projects that intentionally use interactive GUI entrypoints may set `[lint].forbid_interactive_input = false` to suppress `VB007`. This changes lint behavior only; `run --headless` still rejects GUI boundaries during preflight.
 
 Compile-dialog prevention findings `VB008` through `VB014` are always enabled and block source preflight before `push` or `run` opens Excel.
+
+Higher-signal rules `VB015`, `VB016`, `VB017`, `VB019`, `VB022`, `VB023`, `VB024`, and `VB026` are enabled by default. Heavier project-wide or dataflow-sensitive rules `VB018`, `VB020`, `VB021`, `VB025`, and `VB027` are disabled by default and can be enabled with their `[lint]` booleans.
 
 ## Analysis Rules
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,13 +53,26 @@ type UserFormConfig struct {
 }
 
 type LintConfig struct {
-	RequireOptionExplicit    bool `toml:"require_option_explicit"`
-	ForbidSelect             bool `toml:"forbid_select"`
-	ForbidActivate           bool `toml:"forbid_activate"`
-	ForbidOnErrorResumeNext  bool `toml:"forbid_on_error_resume_next"`
-	DetectImplicitVariant    bool `toml:"detect_implicit_variant"`
-	ForbidPublicModuleFields bool `toml:"forbid_public_module_fields"`
-	ForbidInteractiveInput   bool `toml:"forbid_interactive_input"`
+	RequireOptionExplicit           bool `toml:"require_option_explicit"`
+	ForbidSelect                    bool `toml:"forbid_select"`
+	ForbidActivate                  bool `toml:"forbid_activate"`
+	ForbidOnErrorResumeNext         bool `toml:"forbid_on_error_resume_next"`
+	DetectImplicitVariant           bool `toml:"detect_implicit_variant"`
+	ForbidPublicModuleFields        bool `toml:"forbid_public_module_fields"`
+	ForbidInteractiveInput          bool `toml:"forbid_interactive_input"`
+	ForbidUnqualifiedExcelObjects   bool `toml:"forbid_unqualified_excel_objects"`
+	DetectErrorHandlerFallthrough   bool `toml:"detect_error_handler_fallthrough"`
+	DetectApplicationStateRestore   bool `toml:"detect_application_state_restore"`
+	DetectScopeShadowing            bool `toml:"detect_scope_shadowing"`
+	DetectMultipleDeclaratorClarity bool `toml:"detect_multiple_declarator_clarity"`
+	DetectUnusedLocalVariables      bool `toml:"detect_unused_local_variables"`
+	DetectUnusedPrivateProcedures   bool `toml:"detect_unused_private_procedures"`
+	DetectConfusingCallSyntax       bool `toml:"detect_confusing_call_syntax"`
+	DetectForEachControlType        bool `toml:"detect_for_each_control_type"`
+	ForbidActiveObjectDependency    bool `toml:"forbid_active_object_dependency"`
+	DetectRangeFindNothingCheck     bool `toml:"detect_range_find_nothing_check"`
+	DetectDangerousResume           bool `toml:"detect_dangerous_resume"`
+	DetectNestedWithAmbiguity       bool `toml:"detect_nested_with_ambiguity"`
 }
 
 func Default() Config {
@@ -89,13 +102,21 @@ func Default() Config {
 			CodeSource: "sidecar",
 		},
 		Lint: LintConfig{
-			RequireOptionExplicit:    true,
-			ForbidSelect:             true,
-			ForbidActivate:           true,
-			ForbidOnErrorResumeNext:  true,
-			DetectImplicitVariant:    true,
-			ForbidPublicModuleFields: true,
-			ForbidInteractiveInput:   true,
+			RequireOptionExplicit:           true,
+			ForbidSelect:                    true,
+			ForbidActivate:                  true,
+			ForbidOnErrorResumeNext:         true,
+			DetectImplicitVariant:           true,
+			ForbidPublicModuleFields:        true,
+			ForbidInteractiveInput:          true,
+			ForbidUnqualifiedExcelObjects:   true,
+			DetectErrorHandlerFallthrough:   true,
+			DetectApplicationStateRestore:   true,
+			DetectMultipleDeclaratorClarity: true,
+			DetectConfusingCallSyntax:       true,
+			DetectForEachControlType:        true,
+			ForbidActiveObjectDependency:    true,
+			DetectDangerousResume:           true,
 		},
 	}
 }
@@ -270,6 +291,32 @@ detect_implicit_variant = %t
 forbid_public_module_fields = %t
 # Forbid interactive input (MsgBox, InputBox, etc.) in headless runs.
 forbid_interactive_input = %t
+# Forbid unqualified Range/Cells/Rows/Columns access.
+forbid_unqualified_excel_objects = %t
+# Detect procedures that can fall through into an error handler.
+detect_error_handler_fallthrough = %t
+# Detect Application state changes without an obvious restore path.
+detect_application_state_restore = %t
+# Detect local names that shadow module or procedure names.
+detect_scope_shadowing = %t
+# Explain mixed Dim declarations where only some declarators are typed.
+detect_multiple_declarator_clarity = %t
+# Detect unused procedure-local variables.
+detect_unused_local_variables = %t
+# Detect unused Private procedures.
+detect_unused_private_procedures = %t
+# Detect confusing parenthesized call syntax.
+detect_confusing_call_syntax = %t
+# Detect For Each control variable declaration/type issues.
+detect_for_each_control_type = %t
+# Forbid ActiveWorkbook/ActiveSheet/ActiveCell/Selection dependencies.
+forbid_active_object_dependency = %t
+# Detect Range.Find results used without a Nothing check.
+detect_range_find_nothing_check = %t
+# Detect Resume statements outside likely error handlers.
+detect_dangerous_resume = %t
+# Detect nested With blocks with ambiguous implicit Excel members.
+detect_nested_with_ambiguity = %t
 `
 	_, err = fmt.Fprintf(f, tmpl,
 		cfg.Project.Name, cfg.Project.Entry,
@@ -280,6 +327,13 @@ forbid_interactive_input = %t
 		cfg.Lint.RequireOptionExplicit, cfg.Lint.ForbidSelect, cfg.Lint.ForbidActivate,
 		cfg.Lint.ForbidOnErrorResumeNext, cfg.Lint.DetectImplicitVariant,
 		cfg.Lint.ForbidPublicModuleFields, cfg.Lint.ForbidInteractiveInput,
+		cfg.Lint.ForbidUnqualifiedExcelObjects, cfg.Lint.DetectErrorHandlerFallthrough,
+		cfg.Lint.DetectApplicationStateRestore, cfg.Lint.DetectScopeShadowing,
+		cfg.Lint.DetectMultipleDeclaratorClarity, cfg.Lint.DetectUnusedLocalVariables,
+		cfg.Lint.DetectUnusedPrivateProcedures, cfg.Lint.DetectConfusingCallSyntax,
+		cfg.Lint.DetectForEachControlType, cfg.Lint.ForbidActiveObjectDependency,
+		cfg.Lint.DetectRangeFindNothingCheck, cfg.Lint.DetectDangerousResume,
+		cfg.Lint.DetectNestedWithAmbiguity,
 	)
 	return err
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,17 @@ path = "build/Sales.xlsm"
 	if !cfg.Lint.ForbidInteractiveInput {
 		t.Fatalf("interactive input lint default was not applied")
 	}
+	if !cfg.Lint.ForbidUnqualifiedExcelObjects || !cfg.Lint.DetectErrorHandlerFallthrough ||
+		!cfg.Lint.DetectApplicationStateRestore || !cfg.Lint.DetectMultipleDeclaratorClarity ||
+		!cfg.Lint.DetectConfusingCallSyntax || !cfg.Lint.DetectForEachControlType ||
+		!cfg.Lint.ForbidActiveObjectDependency || !cfg.Lint.DetectDangerousResume {
+		t.Fatalf("expected high-signal AST lint defaults to be enabled: %+v", cfg.Lint)
+	}
+	if cfg.Lint.DetectScopeShadowing || cfg.Lint.DetectUnusedLocalVariables ||
+		cfg.Lint.DetectUnusedPrivateProcedures || cfg.Lint.DetectRangeFindNothingCheck ||
+		cfg.Lint.DetectNestedWithAmbiguity {
+		t.Fatalf("expected false-positive-prone AST lint defaults to be opt-in: %+v", cfg.Lint)
+	}
 }
 
 func TestLoadAllowsDisablingInteractiveInputLint(t *testing.T) {

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -3,11 +3,14 @@ package lint
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/gui"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/calls"
+	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -69,6 +72,12 @@ func (l Linter) Run() ([]Issue, error) {
 		}
 		issues = append(issues, fileIssues...)
 	}
+	projectIssues, err := l.projectIssues()
+	if err != nil {
+		return nil, err
+	}
+	issues = append(issues, projectIssues...)
+	sortIssues(issues)
 	return issues, nil
 }
 
@@ -160,6 +169,7 @@ func (l Linter) lintFile(path string) ([]Issue, error) {
 	if shouldReportParseIssue(parsed, issues) {
 		issues = append(issues, ctx.parseIssue(parsed.Root))
 	}
+	issues = append(issues, l.flowIssues(path, string(source), parsed.Root)...)
 
 	if l.Config.Lint.ForbidInteractiveInput {
 		boundaries, err := gui.Analyzer{RootDir: l.RootDir, Config: l.Config}.AnalyzeFile(path)
@@ -253,6 +263,7 @@ type astLintContext struct {
 	source            []byte
 	issues            []Issue
 	hasOptionExplicit bool
+	withDepth         int
 }
 
 func (c *astLintContext) lint(root *tree_sitter.Node) {
@@ -276,6 +287,8 @@ func (c *astLintContext) visit(node *tree_sitter.Node, inProcedure bool, inType 
 		inType = true
 	case "qualified_member_expression", "implicit_member_expression":
 		c.memberAccessIssue(node)
+	case "call_expression":
+		c.callExpressionIssue(node)
 	case "on_error_statement":
 		c.onErrorIssue(node)
 	case "variable_declaration":
@@ -283,6 +296,10 @@ func (c *astLintContext) visit(node *tree_sitter.Node, inProcedure bool, inType 
 	}
 	if procedureKinds[kind] {
 		inProcedure = true
+	}
+	if kind == "with_statement" {
+		c.withDepth++
+		defer func() { c.withDepth-- }()
 	}
 	for i := uint(0); i < node.NamedChildCount(); i++ {
 		c.visit(node.NamedChild(i), inProcedure, inType)
@@ -301,6 +318,36 @@ func (c *astLintContext) memberAccessIssue(node *tree_sitter.Node) {
 	case c.linter.Config.Lint.ForbidActivate && strings.EqualFold(name, "Activate"):
 		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(property), "VB003", "warning", "Avoid Activate. Use direct object references instead."))
 	}
+	if c.linter.Config.Lint.ForbidActiveObjectDependency {
+		if object := node.ChildByFieldName("object"); object != nil && isActiveObjectName(cleanIdentifier(object.Utf8Text(c.source))) {
+			issue := c.linter.issueAt(c.path, vbaast.NodeRange(object), "VB024", "warning", "Avoid active Excel objects; pass or capture explicit Workbook/Worksheet/Range objects.")
+			issue.Symbol = cleanIdentifier(object.Utf8Text(c.source))
+			c.issues = append(c.issues, issue)
+		}
+	}
+	if c.linter.Config.Lint.DetectNestedWithAmbiguity && node.Kind() == "implicit_member_expression" && c.withDepth >= 2 && isExcelObjectAccessName(name) {
+		issue := c.linter.issueAt(c.path, vbaast.NodeRange(property), "VB027", "warning", "Avoid implicit Excel members inside nested With blocks; qualify the target explicitly.")
+		issue.Symbol = "." + name
+		c.issues = append(c.issues, issue)
+	}
+}
+
+func (c *astLintContext) callExpressionIssue(node *tree_sitter.Node) {
+	fn := node.ChildByFieldName("function")
+	if fn == nil {
+		return
+	}
+	name := cleanIdentifier(fn.Utf8Text(c.source))
+	if c.linter.Config.Lint.ForbidUnqualifiedExcelObjects && fn.Kind() == "identifier" && isExcelObjectAccessName(name) {
+		issue := c.linter.issueAt(c.path, vbaast.NodeRange(fn), "VB015", "warning", "Qualify Excel object access with an explicit Worksheet or Workbook object.")
+		issue.Symbol = name
+		c.issues = append(c.issues, issue)
+	}
+	if c.linter.Config.Lint.ForbidActiveObjectDependency && fn.Kind() == "identifier" && isActiveObjectName(name) {
+		issue := c.linter.issueAt(c.path, vbaast.NodeRange(fn), "VB024", "warning", "Avoid active Excel objects; pass or capture explicit Workbook/Worksheet/Range objects.")
+		issue.Symbol = name
+		c.issues = append(c.issues, issue)
+	}
 }
 
 func (c *astLintContext) onErrorIssue(node *tree_sitter.Node) {
@@ -308,13 +355,52 @@ func (c *astLintContext) onErrorIssue(node *tree_sitter.Node) {
 		return
 	}
 	if strings.EqualFold(normalizedNodeText(node, c.source), "On Error Resume Next") {
+		if c.hasNarrowOnErrorReset(vbaast.NodeRange(node).StartLine) {
+			return
+		}
 		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(node), "VB004", "warning", "Avoid On Error Resume Next without a narrow recovery block."))
 	}
+}
+
+func (c *astLintContext) hasNarrowOnErrorReset(startLine int) bool {
+	if startLine <= 0 {
+		return false
+	}
+	lines := normalizedSourceLines(string(c.source))
+	seen := 0
+	for i := startLine; i < len(lines) && seen < 5; i++ {
+		stmt := normalizedCodeLine(lines[i])
+		if stmt == "" {
+			continue
+		}
+		seen++
+		lower := strings.ToLower(stmt)
+		if lower == "on error goto 0" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *astLintContext) variableDeclarationIssues(node *tree_sitter.Node, inProcedure bool, inType bool) {
 	if c.linter.Config.Lint.ForbidPublicModuleFields && !inProcedure && !inType && strings.EqualFold(visibilityText(node, c.source), "Public") {
 		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(node), "VB006", "warning", "Avoid Public module variables; pass state explicitly."))
+	}
+	if c.linter.Config.Lint.DetectMultipleDeclaratorClarity {
+		declarators, typed := 0, 0
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if child == nil || child.Kind() != "variable_declarator" {
+				continue
+			}
+			declarators++
+			if typeText(child, c.source) != "" {
+				typed++
+			}
+		}
+		if declarators > 1 && typed > 0 && typed < declarators {
+			c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(node), "VB019", "warning", "In VBA, each declarator needs its own As <Type>; only explicitly typed names receive that type."))
+		}
 	}
 	if !c.linter.Config.Lint.DetectImplicitVariant {
 		return
@@ -334,6 +420,450 @@ func (c *astLintContext) parseIssue(root *tree_sitter.Node) Issue {
 		r = vbaast.NodeRange(node)
 	}
 	return c.linter.issueAt(c.path, r, "VB014", "error", "VBA parser recovered from syntax errors; inspect this source before pushing to Excel.")
+}
+
+func (l Linter) flowIssues(path string, source string, root *tree_sitter.Node) []Issue {
+	cfg := l.Config.Lint
+	if !cfg.DetectErrorHandlerFallthrough &&
+		!cfg.DetectApplicationStateRestore &&
+		!cfg.DetectConfusingCallSyntax &&
+		!cfg.DetectForEachControlType &&
+		!cfg.ForbidActiveObjectDependency &&
+		!cfg.DetectRangeFindNothingCheck &&
+		!cfg.DetectDangerousResume {
+		return nil
+	}
+	lines := normalizedSourceLines(source)
+	procedures := sourceProceduresFromAST(root, []byte(source))
+	var issues []Issue
+	for _, proc := range procedures {
+		decls := procedureDeclarations(lines, proc)
+		handlerLabels := onErrorHandlerLabels(lines, proc)
+		if cfg.DetectErrorHandlerFallthrough {
+			issues = append(issues, l.errorHandlerFallthroughIssues(path, lines, proc, handlerLabels)...)
+		}
+		if cfg.DetectApplicationStateRestore {
+			issues = append(issues, l.applicationStateIssues(path, lines, proc)...)
+		}
+		if cfg.DetectConfusingCallSyntax {
+			issues = append(issues, l.confusingCallIssues(path, lines, proc)...)
+		}
+		if cfg.DetectForEachControlType {
+			issues = append(issues, l.forEachIssues(path, lines, proc, decls)...)
+		}
+		if cfg.ForbidActiveObjectDependency {
+			issues = append(issues, l.activeObjectIssues(path, lines, proc)...)
+		}
+		if cfg.DetectRangeFindNothingCheck {
+			issues = append(issues, l.rangeFindIssues(path, lines, proc)...)
+		}
+		if cfg.DetectDangerousResume {
+			issues = append(issues, l.dangerousResumeIssues(path, lines, proc, handlerLabels)...)
+		}
+	}
+	return issues
+}
+
+type sourceProcedure struct {
+	Kind      string
+	Name      string
+	StartLine int
+	EndLine   int
+}
+
+type sourceDeclaration struct {
+	Name string
+	Type string
+	Line int
+}
+
+func sourceProceduresFromAST(root *tree_sitter.Node, source []byte) []sourceProcedure {
+	var procedures []sourceProcedure
+	collectSourceProcedures(root, source, &procedures)
+	sort.SliceStable(procedures, func(i, j int) bool {
+		return procedures[i].StartLine < procedures[j].StartLine
+	})
+	return procedures
+}
+
+func collectSourceProcedures(node *tree_sitter.Node, source []byte, procedures *[]sourceProcedure) {
+	if node == nil {
+		return
+	}
+	switch node.Kind() {
+	case "sub_declaration", "function_declaration", "property_declaration", "property_get_declaration", "property_let_declaration", "property_set_declaration":
+		r := vbaast.NodeRange(node)
+		kind := "Sub"
+		if strings.Contains(node.Kind(), "function") {
+			kind = "Function"
+		} else if strings.Contains(node.Kind(), "property") {
+			kind = "Property"
+		}
+		*procedures = append(*procedures, sourceProcedure{
+			Kind:      kind,
+			Name:      nodeProcedureName(node, source),
+			StartLine: r.StartLine,
+			EndLine:   r.EndLine,
+		})
+		return
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		collectSourceProcedures(node.NamedChild(i), source, procedures)
+	}
+}
+
+func nodeProcedureName(node *tree_sitter.Node, source []byte) string {
+	if name := node.ChildByFieldName("name"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	if name := firstNamedChildKind(node, "identifier"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	return ""
+}
+
+func procedureDeclarations(lines []string, proc sourceProcedure) map[string]sourceDeclaration {
+	decls := map[string]sourceDeclaration{}
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		lineNo := i + 1
+		stmt := normalizedCodeLine(lines[i])
+		lower := strings.ToLower(stmt)
+		if strings.HasPrefix(lower, "dim ") || strings.HasPrefix(lower, "static ") {
+			declText := strings.TrimSpace(stmt)
+			declText = strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(strings.TrimPrefix(strings.ToLower(declText), "static ")), "dim "), "dim ")
+			for _, part := range strings.Split(declText, ",") {
+				name, typ := declarationNameAndType(part)
+				if name != "" {
+					decls[strings.ToLower(name)] = sourceDeclaration{Name: name, Type: typ, Line: lineNo}
+				}
+			}
+		}
+	}
+	return decls
+}
+
+func declarationNameAndType(text string) (string, string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", ""
+	}
+	lower := strings.ToLower(text)
+	namePart := text
+	typ := ""
+	if idx := strings.Index(lower, " as "); idx >= 0 {
+		namePart = strings.TrimSpace(text[:idx])
+		typ = strings.TrimSpace(text[idx+4:])
+	}
+	namePart = strings.TrimSpace(strings.TrimLeft(namePart, "()"))
+	nameFields := strings.FieldsFunc(namePart, func(r rune) bool {
+		return !isVBAIdentifierRune(r)
+	})
+	if len(nameFields) == 0 {
+		return "", typ
+	}
+	return cleanIdentifier(nameFields[0]), typ
+}
+
+func onErrorHandlerLabels(lines []string, proc sourceProcedure) map[string]bool {
+	labels := map[string]bool{}
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		stmt := normalizedCodeLine(lines[i])
+		lower := strings.ToLower(stmt)
+		if strings.HasPrefix(lower, "on error goto ") && lower != "on error goto 0" {
+			label := cleanIdentifier(strings.TrimSpace(stmt[len("on error goto "):]))
+			if label != "" {
+				labels[strings.ToLower(label)] = true
+			}
+		}
+	}
+	return labels
+}
+
+func (l Linter) errorHandlerFallthroughIssues(path string, lines []string, proc sourceProcedure, handlerLabels map[string]bool) []Issue {
+	if len(handlerLabels) == 0 {
+		return nil
+	}
+	var issues []Issue
+	lastCode := ""
+	for i := proc.StartLine; i < proc.EndLine-1 && i < len(lines); i++ {
+		lineNo := i + 1
+		stmt := normalizedCodeLine(lines[i])
+		if stmt == "" {
+			continue
+		}
+		if label, ok := labelName(stmt); ok && handlerLabels[strings.ToLower(label)] {
+			if !terminatesNormalFlow(lastCode) {
+				issue := l.issue(path, lineNo, "VB016", "warning", "Add Exit Sub/Function/Property before the error-handler label so normal execution cannot fall through.")
+				issue.Symbol = label
+				issues = append(issues, issue)
+			}
+		}
+		lastCode = stmt
+	}
+	return issues
+}
+
+func (l Linter) applicationStateIssues(path string, lines []string, proc sourceProcedure) []Issue {
+	props := []string{"enableevents", "displayalerts", "screenupdating"}
+	var issues []Issue
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		stmt := normalizedCodeLine(lines[i])
+		lower := compactStatement(strings.ToLower(stmt))
+		for _, prop := range props {
+			target := "application." + prop + "=false"
+			if !strings.Contains(lower, target) {
+				continue
+			}
+			if hasLaterApplicationRestore(lines, proc, i+1, prop) {
+				continue
+			}
+			issue := l.issue(path, i+1, "VB017", "warning", "Restore Application."+applicationStateName(prop)+" on a cleanup path after setting it to False.")
+			issue.Symbol = "Application." + applicationStateName(prop)
+			issues = append(issues, issue)
+		}
+	}
+	return issues
+}
+
+func hasLaterApplicationRestore(lines []string, proc sourceProcedure, start int, prop string) bool {
+	prefix := "application." + prop + "="
+	for i := start; i < proc.EndLine && i < len(lines); i++ {
+		lower := compactStatement(strings.ToLower(normalizedCodeLine(lines[i])))
+		if strings.Contains(lower, prefix) && !strings.Contains(lower, prefix+"false") {
+			return true
+		}
+	}
+	return false
+}
+
+func (l Linter) confusingCallIssues(path string, lines []string, proc sourceProcedure) []Issue {
+	var issues []Issue
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		stmt := normalizedCodeLine(lines[i])
+		name, ok := confusingParenthesizedCall(stmt)
+		if !ok {
+			continue
+		}
+		issue := l.issue(path, i+1, "VB022", "warning", "Avoid ambiguous parenthesized call syntax; use Call "+name+"(...) or pass arguments without parentheses.")
+		issue.Symbol = name
+		issues = append(issues, issue)
+	}
+	return issues
+}
+
+func confusingParenthesizedCall(stmt string) (string, bool) {
+	fields := strings.Fields(stmt)
+	if len(fields) < 2 || !strings.HasPrefix(fields[1], "(") {
+		return "", false
+	}
+	name := cleanIdentifier(fields[0])
+	if name == "" || isStatementKeyword(name) || strings.Contains(stmt, "=") || strings.Contains(name, ".") {
+		return "", false
+	}
+	return name, true
+}
+
+func (l Linter) forEachIssues(path string, lines []string, proc sourceProcedure, decls map[string]sourceDeclaration) []Issue {
+	var issues []Issue
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		stmt := normalizedCodeLine(lines[i])
+		lower := strings.ToLower(stmt)
+		if !strings.HasPrefix(lower, "for each ") {
+			continue
+		}
+		rest := strings.TrimSpace(stmt[len("for each "):])
+		parts := strings.Fields(rest)
+		if len(parts) == 0 {
+			continue
+		}
+		name := cleanIdentifier(parts[0])
+		decl, ok := decls[strings.ToLower(name)]
+		if !ok {
+			issue := l.issue(path, i+1, "VB023", "warning", "Declare the For Each control variable explicitly as Variant or an object type.")
+			issue.Symbol = name
+			issues = append(issues, issue)
+			continue
+		}
+		if isObviouslyScalarType(decl.Type) {
+			issue := l.issue(path, i+1, "VB023", "warning", "For Each control variables should be Variant or object-compatible, not "+decl.Type+".")
+			issue.Symbol = name
+			issues = append(issues, issue)
+		}
+	}
+	return issues
+}
+
+func (l Linter) activeObjectIssues(path string, lines []string, proc sourceProcedure) []Issue {
+	var issues []Issue
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		stmt := normalizedCodeLine(lines[i])
+		for _, name := range []string{"ActiveWorkbook", "ActiveSheet", "ActiveCell", "Selection"} {
+			if strings.Contains(strings.ToLower(stmt), strings.ToLower(name)+".") {
+				continue
+			}
+			if hasWord(stmt, name) {
+				issue := l.issue(path, i+1, "VB024", "warning", "Avoid active Excel objects; pass or capture explicit Workbook/Worksheet/Range objects.")
+				issue.Symbol = name
+				issues = append(issues, issue)
+			}
+		}
+	}
+	return issues
+}
+
+func (l Linter) rangeFindIssues(path string, lines []string, proc sourceProcedure) []Issue {
+	var issues []Issue
+	findAssignments := map[string]int{}
+	guarded := map[string]bool{}
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		lineNo := i + 1
+		stmt := normalizedCodeLine(lines[i])
+		lower := strings.ToLower(stmt)
+		for name := range findAssignments {
+			if strings.Contains(lower, "if "+strings.ToLower(name)+" is nothing") ||
+				strings.Contains(lower, "if not "+strings.ToLower(name)+" is nothing") {
+				guarded[strings.ToLower(name)] = true
+			}
+		}
+		if name, ok := rangeFindAssignment(stmt); ok {
+			findAssignments[strings.ToLower(name)] = lineNo
+			continue
+		}
+		for name, assignLine := range findAssignments {
+			if guarded[name] {
+				continue
+			}
+			if strings.Contains(lower, name+".") {
+				issue := l.issue(path, lineNo, "VB025", "warning", "Check the Range.Find result for Nothing before dereferencing it.")
+				issue.Symbol = name
+				if assignLine > 0 {
+					issue.Suggestion = "Add If " + name + " Is Nothing Then handling after the Find assignment."
+				}
+				issues = append(issues, issue)
+				guarded[name] = true
+			}
+		}
+	}
+	return issues
+}
+
+func rangeFindAssignment(stmt string) (string, bool) {
+	lower := strings.ToLower(stmt)
+	if !strings.Contains(lower, ".find(") && !strings.Contains(lower, ".find ") {
+		return "", false
+	}
+	left, _, ok := strings.Cut(stmt, "=")
+	if !ok {
+		return "", false
+	}
+	left = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(left), "Set "))
+	fields := strings.FieldsFunc(left, func(r rune) bool {
+		return !isVBAIdentifierRune(r)
+	})
+	if len(fields) == 0 {
+		return "", false
+	}
+	return cleanIdentifier(fields[len(fields)-1]), true
+}
+
+func (l Linter) dangerousResumeIssues(path string, lines []string, proc sourceProcedure, handlerLabels map[string]bool) []Issue {
+	var issues []Issue
+	inHandler := false
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		stmt := normalizedCodeLine(lines[i])
+		if label, ok := labelName(stmt); ok && handlerLabels[strings.ToLower(label)] {
+			inHandler = true
+			continue
+		}
+		lower := strings.ToLower(stmt)
+		if lower == "resume" || strings.HasPrefix(lower, "resume ") {
+			if !inHandler {
+				issues = append(issues, l.issue(path, i+1, "VB026", "warning", "Use Resume only inside a clear error-handler block."))
+			}
+		}
+	}
+	return issues
+}
+
+func labelName(stmt string) (string, bool) {
+	stmt = strings.TrimSpace(stmt)
+	if !strings.HasSuffix(stmt, ":") || strings.Contains(stmt, " ") {
+		return "", false
+	}
+	name := cleanIdentifier(strings.TrimSuffix(stmt, ":"))
+	return name, name != ""
+}
+
+func terminatesNormalFlow(stmt string) bool {
+	lower := strings.ToLower(strings.TrimSpace(stmt))
+	return strings.HasPrefix(lower, "exit sub") ||
+		strings.HasPrefix(lower, "exit function") ||
+		strings.HasPrefix(lower, "exit property") ||
+		strings.HasPrefix(lower, "goto ") ||
+		lower == "end"
+}
+
+func normalizedSourceLines(source string) []string {
+	source = strings.ReplaceAll(source, "\r\n", "\n")
+	source = strings.ReplaceAll(source, "\r", "\n")
+	return strings.Split(source, "\n")
+}
+
+func normalizedCodeLine(line string) string {
+	return strings.Join(strings.Fields(maskStringLiterals(gui.StripComment(line))), " ")
+}
+
+func compactStatement(stmt string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(stmt, " ", ""), "\t", "")
+}
+
+func applicationStateName(prop string) string {
+	switch strings.ToLower(prop) {
+	case "enableevents":
+		return "EnableEvents"
+	case "displayalerts":
+		return "DisplayAlerts"
+	case "screenupdating":
+		return "ScreenUpdating"
+	default:
+		return prop
+	}
+}
+
+func isStatementKeyword(name string) bool {
+	switch strings.ToLower(name) {
+	case "if", "for", "do", "loop", "while", "wend", "select", "case", "with", "set", "let", "call", "return", "resume", "on", "dim", "redim":
+		return true
+	default:
+		return false
+	}
+}
+
+func isObviouslyScalarType(typ string) bool {
+	switch strings.ToLower(cleanIdentifier(typ)) {
+	case "byte", "boolean", "integer", "long", "longlong", "longptr", "single", "double", "currency", "decimal", "date", "string":
+		return true
+	default:
+		return false
+	}
+}
+
+func isExcelObjectAccessName(name string) bool {
+	switch strings.ToLower(cleanIdentifier(name)) {
+	case "range", "cells", "rows", "columns":
+		return true
+	default:
+		return false
+	}
+}
+
+func isActiveObjectName(name string) bool {
+	switch strings.ToLower(cleanIdentifier(name)) {
+	case "activeworkbook", "activesheet", "activecell", "selection":
+		return true
+	default:
+		return false
+	}
 }
 
 func firstParseProblem(node *tree_sitter.Node) *tree_sitter.Node {
@@ -359,6 +889,278 @@ func PushBlockingIssues(issues []Issue) []Issue {
 		}
 	}
 	return blocking
+}
+
+func (l Linter) projectIssues() ([]Issue, error) {
+	cfg := l.Config.Lint
+	if !cfg.DetectScopeShadowing && !cfg.DetectUnusedLocalVariables && !cfg.DetectUnusedPrivateProcedures {
+		return nil, nil
+	}
+	result, err := symbols.Inspect(symbols.Options{
+		RootDir:        l.RootDir,
+		Config:         l.Config,
+		IncludePrivate: true,
+		IncludeLabels:  false,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var issues []Issue
+	if cfg.DetectScopeShadowing || cfg.DetectUnusedLocalVariables {
+		issues = append(issues, l.symbolScopeIssues(result)...)
+	}
+	if cfg.DetectUnusedPrivateProcedures {
+		callResult, err := calls.Inspect(calls.Options{RootDir: l.RootDir, Config: l.Config})
+		if err != nil {
+			return nil, err
+		}
+		issues = append(issues, l.unusedPrivateProcedureIssues(result, callResult)...)
+	}
+	return issues, nil
+}
+
+func (l Linter) symbolScopeIssues(result *symbols.Result) []Issue {
+	if result == nil {
+		return nil
+	}
+	var issues []Issue
+	sourceCache := map[string]string{}
+	for _, file := range result.Files {
+		moduleNames := map[string]symbols.Symbol{}
+		procedureNames := map[string]symbols.Symbol{}
+		for _, sym := range file.Symbols {
+			key := strings.ToLower(sym.Name)
+			switch sym.Kind {
+			case "module_variable", "field", "withevents_field", "const":
+				if sym.Parent == "" && sym.Name != "" {
+					moduleNames[key] = sym
+				}
+			case "sub", "function", "property", "property_get", "property_let", "property_set":
+				if sym.Name != "" {
+					procedureNames[key] = sym
+				}
+			}
+		}
+		sameScope := map[string]map[string]symbols.Symbol{}
+		for _, sym := range file.Symbols {
+			if sym.Kind != "local_variable" && (sym.Kind != "const" || sym.Parent == "") {
+				continue
+			}
+			if l.Config.Lint.DetectScopeShadowing {
+				key := strings.ToLower(sym.Name)
+				if shadow, ok := moduleNames[key]; ok {
+					issue := l.issueForSymbol(sym, "VB018", "warning", "Local declaration shadows module-level declaration "+shadow.Name+".")
+					issue.Symbol = sym.Name
+					issues = append(issues, issue)
+				} else if shadow, ok := procedureNames[key]; ok {
+					issue := l.issueForSymbol(sym, "VB018", "warning", "Local declaration shadows procedure "+shadow.Name+".")
+					issue.Symbol = sym.Name
+					issues = append(issues, issue)
+				}
+				scopeKey := sym.File + ":" + sym.Parent
+				if sameScope[scopeKey] == nil {
+					sameScope[scopeKey] = map[string]symbols.Symbol{}
+				}
+				if prior, ok := sameScope[scopeKey][key]; ok {
+					issue := l.issueForSymbol(sym, "VB018", "warning", "Declaration shadows another declaration in the same procedure at line "+intString(prior.StartLine)+".")
+					issue.Symbol = sym.Name
+					issues = append(issues, issue)
+				} else {
+					sameScope[scopeKey][key] = sym
+				}
+			}
+			if l.Config.Lint.DetectUnusedLocalVariables && !isIgnoredLocalName(sym.Name) {
+				source, ok := sourceCache[sym.File]
+				if !ok {
+					body, err := os.ReadFile(filepath.Join(l.RootDir, filepath.FromSlash(sym.File)))
+					if err != nil {
+						continue
+					}
+					source = string(body)
+					sourceCache[sym.File] = source
+				}
+				if !localNameReferenced(source, sym) {
+					issue := l.issueForSymbol(sym, "VB020", "warning", "Procedure-local variable is declared but never referenced.")
+					issue.Symbol = sym.Name
+					issues = append(issues, issue)
+				}
+			}
+		}
+		if l.Config.Lint.DetectScopeShadowing {
+			issues = append(issues, l.parameterShadowingIssues(file, moduleNames, procedureNames)...)
+		}
+	}
+	return issues
+}
+
+func (l Linter) parameterShadowingIssues(file symbols.FileResult, moduleNames, procedureNames map[string]symbols.Symbol) []Issue {
+	var issues []Issue
+	for _, proc := range file.Symbols {
+		if !procedureSymbolKind(proc.Kind) {
+			continue
+		}
+		seen := map[string]symbols.Parameter{}
+		for _, param := range proc.Parameters {
+			key := strings.ToLower(param.Name)
+			if key == "" {
+				continue
+			}
+			if shadow, ok := moduleNames[key]; ok {
+				issue := l.issueForRel(file.Path, proc.StartLine, proc.StartColumn, "VB018", "warning", "Parameter shadows module-level declaration "+shadow.Name+".")
+				issue.Symbol = param.Name
+				issues = append(issues, issue)
+			} else if shadow, ok := procedureNames[key]; ok && !strings.EqualFold(shadow.Name, proc.Name) {
+				issue := l.issueForRel(file.Path, proc.StartLine, proc.StartColumn, "VB018", "warning", "Parameter shadows procedure "+shadow.Name+".")
+				issue.Symbol = param.Name
+				issues = append(issues, issue)
+			}
+			if _, ok := seen[key]; ok {
+				issue := l.issueForRel(file.Path, proc.StartLine, proc.StartColumn, "VB018", "warning", "Parameter shadows another parameter in the same procedure.")
+				issue.Symbol = param.Name
+				issues = append(issues, issue)
+			}
+			seen[key] = param
+		}
+	}
+	return issues
+}
+
+func (l Linter) unusedPrivateProcedureIssues(symbolResult *symbols.Result, callResult *calls.Result) []Issue {
+	if symbolResult == nil {
+		return nil
+	}
+	called := map[string]bool{}
+	if callResult != nil {
+		for _, call := range callResult.Calls {
+			called[strings.ToLower(call.Callee.BaseName)] = true
+			called[strings.ToLower(call.Callee.Member)] = true
+			called[strings.ToLower(call.Callee.Text)] = true
+		}
+	}
+	var issues []Issue
+	for _, file := range symbolResult.Files {
+		for _, sym := range file.Symbols {
+			if !procedureSymbolKind(sym.Kind) || !strings.EqualFold(sym.Visibility, "Private") || isKnownCallbackProcedure(sym.Name) {
+				continue
+			}
+			if called[strings.ToLower(sym.Name)] || called[strings.ToLower(sym.Module+"."+sym.Name)] {
+				continue
+			}
+			issue := l.issueForSymbol(sym, "VB021", "warning", "Private procedure is not called from parsed source.")
+			issue.Symbol = sym.Name
+			issues = append(issues, issue)
+		}
+	}
+	return issues
+}
+
+func (l Linter) issueForSymbol(sym symbols.Symbol, code, severity, message string) Issue {
+	return l.issueForRel(sym.File, sym.StartLine, sym.StartColumn, code, severity, message)
+}
+
+func (l Linter) issueForRel(file string, line, column int, code, severity, message string) Issue {
+	if line == 0 {
+		line = 1
+	}
+	return Issue{
+		Code:     code,
+		Severity: severity,
+		File:     filepath.ToSlash(file),
+		Line:     line,
+		Column:   column,
+		Message:  message,
+	}
+}
+
+func sortIssues(issues []Issue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		a, b := issues[i], issues[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		if a.Column != b.Column {
+			return a.Column < b.Column
+		}
+		return a.Code < b.Code
+	})
+}
+
+func procedureSymbolKind(kind string) bool {
+	switch kind {
+	case "sub", "function", "property", "property_get", "property_let", "property_set":
+		return true
+	default:
+		return false
+	}
+}
+
+func isIgnoredLocalName(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	return name == "" || name == "_" || strings.HasPrefix(name, "unused") || strings.HasPrefix(name, "ignore")
+}
+
+func localNameReferenced(source string, sym symbols.Symbol) bool {
+	lines := normalizedSourceLines(source)
+	needle := sym.Name
+	count := 0
+	for i := sym.StartLine - 1; i < len(lines); i++ {
+		lineNo := i + 1
+		if sym.Parent != "" && sym.EndLine > 0 && lineNo > sym.EndLine {
+			break
+		}
+		line := normalizedCodeLine(lines[i])
+		if lineNo == sym.StartLine {
+			line = stripDeclarationPrefix(line)
+		}
+		if hasWord(line, needle) {
+			count++
+		}
+		if count > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func stripDeclarationPrefix(line string) string {
+	lower := strings.ToLower(line)
+	for _, prefix := range []string{"dim ", "static ", "private ", "public "} {
+		if strings.HasPrefix(lower, prefix) {
+			if idx := strings.Index(line, ","); idx >= 0 {
+				return line[idx+1:]
+			}
+			return ""
+		}
+	}
+	return line
+}
+
+func isKnownCallbackProcedure(name string) bool {
+	lower := strings.ToLower(name)
+	if strings.Contains(lower, "_") {
+		return true
+	}
+	switch lower {
+	case "auto_open", "auto_close", "workbook_open", "workbook_beforeclose":
+		return true
+	default:
+		return false
+	}
+}
+
+func intString(value int) string {
+	if value == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for value > 0 {
+		digits = append([]byte{byte('0' + value%10)}, digits...)
+		value /= 10
+	}
+	return string(digits)
 }
 
 func hasSpecificSyntaxIssue(issues []Issue) bool {

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -530,7 +530,12 @@ func procedureDeclarations(lines []string, proc sourceProcedure) map[string]sour
 		lower := strings.ToLower(stmt)
 		if strings.HasPrefix(lower, "dim ") || strings.HasPrefix(lower, "static ") {
 			declText := strings.TrimSpace(stmt)
-			declText = strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(strings.TrimPrefix(strings.ToLower(declText), "static ")), "dim "), "dim ")
+			if strings.HasPrefix(lower, "static ") {
+				declText = strings.TrimSpace(declText[len("static "):])
+			}
+			if strings.HasPrefix(strings.ToLower(declText), "dim ") {
+				declText = strings.TrimSpace(declText[len("dim "):])
+			}
 			for _, part := range strings.Split(declText, ",") {
 				name, typ := declarationNameAndType(part)
 				if name != "" {
@@ -585,14 +590,14 @@ func (l Linter) errorHandlerFallthroughIssues(path string, lines []string, proc 
 	}
 	var issues []Issue
 	lastCode := ""
-	for i := proc.StartLine; i < proc.EndLine-1 && i < len(lines); i++ {
+	for i := proc.StartLine - 1; i < proc.EndLine-1 && i < len(lines); i++ {
 		lineNo := i + 1
 		stmt := normalizedCodeLine(lines[i])
 		if stmt == "" {
 			continue
 		}
 		if label, ok := labelName(stmt); ok && handlerLabels[strings.ToLower(label)] {
-			if !terminatesNormalFlow(lastCode) {
+			if !isCleanupFallthroughLabel(label) && !terminatesNormalFlow(lastCode) {
 				issue := l.issue(path, lineNo, "VB016", "warning", "Add Exit Sub/Function/Property before the error-handler label so normal execution cannot fall through.")
 				issue.Symbol = label
 				issues = append(issues, issue)
@@ -601,6 +606,15 @@ func (l Linter) errorHandlerFallthroughIssues(path string, lines []string, proc 
 		lastCode = stmt
 	}
 	return issues
+}
+
+func isCleanupFallthroughLabel(label string) bool {
+	switch strings.ToLower(label) {
+	case "cleanup", "clean_up", "finally", "done":
+		return true
+	default:
+		return false
+	}
 }
 
 func (l Linter) applicationStateIssues(path string, lines []string, proc sourceProcedure) []Issue {
@@ -979,7 +993,7 @@ func (l Linter) symbolScopeIssues(result *symbols.Result) []Issue {
 					source = string(body)
 					sourceCache[sym.File] = source
 				}
-				if !localNameReferenced(source, sym) {
+				if !localNameReferenced(source, sym, procedureEndLineForSymbol(file.Symbols, sym)) {
 					issue := l.issueForSymbol(sym, "VB020", "warning", "Procedure-local variable is declared but never referenced.")
 					issue.Symbol = sym.Name
 					issues = append(issues, issue)
@@ -1102,13 +1116,31 @@ func isIgnoredLocalName(name string) bool {
 	return name == "" || name == "_" || strings.HasPrefix(name, "unused") || strings.HasPrefix(name, "ignore")
 }
 
-func localNameReferenced(source string, sym symbols.Symbol) bool {
+func procedureEndLineForSymbol(all []symbols.Symbol, sym symbols.Symbol) int {
+	if sym.Parent == "" {
+		return sym.EndLine
+	}
+	for _, candidate := range all {
+		if !procedureSymbolKind(candidate.Kind) {
+			continue
+		}
+		if !strings.EqualFold(candidate.Name, sym.Parent) {
+			continue
+		}
+		if candidate.StartLine <= sym.StartLine && sym.StartLine <= candidate.EndLine {
+			return candidate.EndLine
+		}
+	}
+	return sym.EndLine
+}
+
+func localNameReferenced(source string, sym symbols.Symbol, endLine int) bool {
 	lines := normalizedSourceLines(source)
 	needle := sym.Name
 	count := 0
 	for i := sym.StartLine - 1; i < len(lines); i++ {
 		lineNo := i + 1
-		if sym.Parent != "" && sym.EndLine > 0 && lineNo > sym.EndLine {
+		if sym.Parent != "" && endLine > 0 && lineNo > endLine {
 			break
 		}
 		line := normalizedCodeLine(lines[i])

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -767,6 +767,26 @@ End Sub
 	assertIssue(t, issues, "VB019", 3)
 }
 
+func TestLinterAllowsCleanupLabelFallthrough(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  On Error GoTo Cleanup
+  DoWork
+Cleanup:
+  CloseThing
+End Sub
+`)
+
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := issuesByCode(issues, "VB016"); len(got) != 0 {
+		t.Fatalf("VB016 should allow normal fallthrough into cleanup labels: %+v", got)
+	}
+}
+
 func TestLinterAllowsQualifiedExcelAccessAndNarrowResumeNext(t *testing.T) {
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
@@ -805,14 +825,14 @@ End Sub
 Public Sub Run()
   Dim moduleValue As Long
   Dim staleValue As Long
-  Dim item As Long
+  Dim Item As Long
   Application.EnableEvents = False
   ActiveSheet.Range("A1").Value = 1
   Set found = Range("A:A").Find("x")
   Debug.Print found.Value
   Foo (bar)
-  For Each item In Range("A1:A2")
-  Next item
+  For Each Item In Range("A1:A2")
+  Next Item
   Resume Next
   Used
 End Sub
@@ -839,6 +859,30 @@ End Sub
 		"VB026": 18,
 	} {
 		assertIssue(t, issues, code, line)
+	}
+	if issue := findIssue(t, issues, "VB023", 16); issue.Symbol != "Item" {
+		t.Fatalf("expected VB023 to preserve declaration casing, got %+v", issue)
+	}
+}
+
+func TestLinterUnusedLocalVariableUsesProcedureBounds(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim total As Long
+  total = 1
+  Debug.Print total
+End Sub
+`)
+	cfg := config.Default()
+	cfg.Lint.DetectUnusedLocalVariables = true
+
+	issues, err := Linter{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := issuesByCode(issues, "VB020"); len(got) != 0 {
+		t.Fatalf("VB020 should scan to the enclosing procedure end: %+v", got)
 	}
 }
 

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -744,6 +744,167 @@ func TestLinterSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
 	}
 }
 
+func TestLinterFindsDefaultASTBackedRules(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim a, b As Long
+  Range("A1").Value = 1
+  Worksheets(1).Range("A1").Value = 2
+  On Error GoTo ErrHandler
+  Debug.Print "work"
+ErrHandler:
+  Debug.Print Err.Description
+End Sub
+`)
+
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertIssue(t, issues, "VB015", 4)
+	assertIssue(t, issues, "VB016", 8)
+	assertIssue(t, issues, "VB019", 3)
+}
+
+func TestLinterAllowsQualifiedExcelAccessAndNarrowResumeNext(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim ws As Worksheet
+  Set ws = ThisWorkbook.Worksheets(1)
+  ws.Range("A1").Value = 1
+  With ws
+    .Cells(1, 1).Value = 1
+  End With
+  On Error Resume Next
+  Err.Clear
+  On Error GoTo 0
+End Sub
+`)
+
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, code := range []string{"VB004", "VB015"} {
+		if got := issuesByCode(issues, code); len(got) != 0 {
+			t.Fatalf("%s should not trigger for qualified/narrow pattern: %+v", code, got)
+		}
+	}
+}
+
+func TestLinterOptInProcedureLocalRules(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Private moduleValue As Long
+Private Sub Used()
+End Sub
+Private Sub Unused()
+End Sub
+Public Sub Run()
+  Dim moduleValue As Long
+  Dim staleValue As Long
+  Dim item As Long
+  Application.EnableEvents = False
+  ActiveSheet.Range("A1").Value = 1
+  Set found = Range("A:A").Find("x")
+  Debug.Print found.Value
+  Foo (bar)
+  For Each item In Range("A1:A2")
+  Next item
+  Resume Next
+  Used
+End Sub
+`)
+	cfg := config.Default()
+	cfg.Lint.DetectScopeShadowing = true
+	cfg.Lint.DetectUnusedLocalVariables = true
+	cfg.Lint.DetectUnusedPrivateProcedures = true
+	cfg.Lint.DetectRangeFindNothingCheck = true
+
+	issues, err := Linter{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for code, line := range map[string]int{
+		"VB017": 11,
+		"VB018": 8,
+		"VB020": 9,
+		"VB021": 5,
+		"VB022": 15,
+		"VB023": 16,
+		"VB024": 12,
+		"VB025": 14,
+		"VB026": 18,
+	} {
+		assertIssue(t, issues, code, line)
+	}
+}
+
+func TestLinterDetectsNestedWithAmbiguityWhenEnabled(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  With ThisWorkbook
+    With .Worksheets(1)
+      .Range("A1").Value = 1
+    End With
+  End With
+End Sub
+`)
+	cfg := config.Default()
+	cfg.Lint.DetectNestedWithAmbiguity = true
+	issues, err := Linter{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertIssue(t, issues, "VB027", 5)
+}
+
+func TestLinterNewASTRulesIgnoreCommentsAndStrings(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Debug.Print "Range(""A1"") On Error GoTo ErrHandler"
+  ' Range("A1").Value = 1
+  ' ErrHandler:
+End Sub
+`)
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, code := range []string{"VB015", "VB016"} {
+		if got := issuesByCode(issues, code); len(got) != 0 {
+			t.Fatalf("%s should ignore comments and strings: %+v", code, got)
+		}
+	}
+}
+
+func TestLinterSortsIssuesStably(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "B.bas", "Sub B()\nRange(\"A1\").Value = 1\nEnd Sub\n")
+	writeLintModule(t, dir, "A.bas", "Sub A()\nRange(\"A1\").Value = 1\nEnd Sub\n")
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) < 2 {
+		t.Fatalf("expected lint issues, got %+v", issues)
+	}
+	last := Issue{}
+	for i, issue := range issues {
+		if i > 0 && (last.File > issue.File ||
+			(last.File == issue.File && last.Line > issue.Line) ||
+			(last.File == issue.File && last.Line == issue.Line && last.Column > issue.Column) ||
+			(last.File == issue.File && last.Line == issue.Line && last.Column == issue.Column && last.Code > issue.Code)) {
+			t.Fatalf("issues not sorted: %+v", issues)
+		}
+		last = issue
+	}
+}
+
 func assertIssue(t *testing.T, issues []Issue, code string, line int) {
 	t.Helper()
 	findIssue(t, issues, code, line)
@@ -768,4 +929,15 @@ func issuesByCode(issues []Issue, code string) []Issue {
 		}
 	}
 	return filtered
+}
+
+func writeLintModule(t *testing.T, dir, name, body string) {
+	t.Helper()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -55,6 +55,7 @@
 - When spawning nested `powershell.exe -Command` helpers from PowerShell, escape every child-scope `$variable` reference with backticks in the command string. Otherwise the parent shell expands them before launch and the child helper can silently do nothing while UI state remains stuck.
 - Excel VBE compile automation should not assume the `CommandBars("Debug")` toolbar contains the compile command. In real Excel, `Compile VBAProject` can live only under `CommandBars("Menu Bar") -> Debug` (`Id = 578`), and `Enabled = false` should be treated as "no compile needed" rather than executed as a failure path.
 - `go test ./internal/excel/scripts` can take 2-3 minutes even when healthy. Do not infer success or failure from a short silent interval; use a generous timeout and wait for completion before treating the package as hung.
+- AST symbol ranges may describe declaration nodes rather than enclosing scopes. Lint rules that scan local references must derive the containing procedure bounds, and cleanup labels such as `Cleanup:` need explicit coverage because they can be normal fallthrough cleanup paths.
 
 # DialogWatcher
 

--- a/vitepress/commands/lint.md
+++ b/vitepress/commands/lint.md
@@ -48,8 +48,23 @@ Use `lint --json` in agent loops before `push` to catch source problems while Ex
 | `VB012` | error    | Mismatched procedure end statement.                                                                                        |
 | `VB013` | error    | Missing whitespace before a line-continuation underscore.                                                                  |
 | `VB014` | error    | `tree-sitter-vba` parser recovery found syntax errors or missing syntax nodes.                                             |
+| `VB015` | warning  | Unqualified Excel object access such as `Range(...)`, `Cells(...)`, `Rows(...)`, or `Columns(...)`.                        |
+| `VB016` | warning  | Normal execution can fall through into an error-handler label.                                                             |
+| `VB017` | warning  | `Application` state such as events, alerts, or screen updating is disabled without an obvious restore path.                |
+| `VB018` | warning  | Local declarations or parameters shadow module-level names, procedure names, or same-scope declarations.                   |
+| `VB019` | warning  | Multiple declarators mix typed and untyped names; in VBA each name needs its own `As <Type>`.                              |
+| `VB020` | warning  | Procedure-local variable is declared but never referenced.                                                                 |
+| `VB021` | warning  | Private procedure is not called from parsed source.                                                                        |
+| `VB022` | warning  | Confusing parenthesized call syntax such as `Foo (bar)`.                                                                   |
+| `VB023` | warning  | `For Each` control variable is undeclared or obviously incompatible.                                                       |
+| `VB024` | warning  | Active object dependency such as `ActiveWorkbook`, `ActiveSheet`, `ActiveCell`, or `Selection`.                            |
+| `VB025` | warning  | `Range.Find` result is dereferenced before a `Nothing` check.                                                              |
+| `VB026` | warning  | `Resume` is used outside a likely error-handler context.                                                                   |
+| `VB027` | warning  | Nested `With` blocks use implicit Excel members whose target can be ambiguous.                                             |
 
-Core declaration, member-access, and error-handling checks are AST-backed. They ignore comments and strings, distinguish module-level declarations from procedure-local declarations, and report individual declarators such as `a` in `Dim a, b As Long`.
+Core declaration, member-access, error-handling, Excel object, and procedure-scope checks are AST-backed. They ignore comments and strings, distinguish module-level declarations from procedure-local declarations, and report individual declarators such as `a` in `Dim a, b As Long`.
+
+Rules `VB015`, `VB016`, `VB017`, `VB019`, `VB022`, `VB023`, `VB024`, and `VB026` are enabled by default. Heavier project-wide or dataflow-sensitive rules stay conservative opt-ins through `[lint]` settings.
 
 ## JSON Output Example
 

--- a/vitepress/design/linter.md
+++ b/vitepress/design/linter.md
@@ -2,7 +2,7 @@
 
 The linter catches automation-hostile VBA and syntax patterns that can block agents or surface modal dialogs.
 
-Declaration, member-access, and error-handling checks are backed by `tree-sitter-vba`, so findings can distinguish comments and strings from executable code, module-level declarations from procedure-local declarations, and individual declarators in one `Dim` statement.
+Declaration, member-access, error-handling, Excel object, and procedure-scope checks are backed by `tree-sitter-vba`, so findings can distinguish comments and strings from executable code, module-level declarations from procedure-local declarations, and individual declarators in one `Dim` statement.
 
 Rules include:
 
@@ -11,6 +11,10 @@ Rules include:
 - Broad `On Error Resume Next`
 - Implicit `Variant` risks
 - Public module fields
+- Unqualified Excel object access
+- Error-handler fallthrough
+- Multiple declarator clarity
+- Optional cleanup, shadowing, unused symbol, callback, `Range.Find`, `Resume`, and nested `With` checks
 - GUI boundaries such as file pickers, modal dialogs, UserForms, message pumps, and external process launches
 - Syntax-safety findings that prevent VBE compile dialogs before `push` or `run`
 

--- a/vitepress/reference/error-codes.md
+++ b/vitepress/reference/error-codes.md
@@ -26,4 +26,4 @@ Common examples:
 - `wsl_path_translation_failed`
 - `windows_xlflow_execution_failed`
 
-Lint codes include `VB001` through `VB014`. Analyzer codes include `VBA101` and later runtime-risk findings.
+Lint codes include `VB001` through `VB027`. Analyzer codes include `VBA101` and later runtime-risk findings.


### PR DESCRIPTION
## Summary
- Add AST-backed static analysis rules to the linter
- Update config and error-code handling to support the new checks
- Refresh README, CLI contract, and design/reference docs
- Expand unit coverage for config and linter behavior

## Testing
- Unit tests updated for config and linter logic
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 13 new linting rules (VB015–VB027) covering unqualified Excel object access, error-handler fallthrough, unused variables/procedures, scope shadowing, confusing call syntax, and nested `With` ambiguity detection.
  * New configuration options in `xlflow.toml` to enable or disable individual linting rules, with sensible defaults.

* **Documentation**
  * Updated reference guides and design documentation describing all new linting rules and their configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->