### PR TITLE
Add AST-backed runtime risk checks to analyze.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
-- Refactored `xlflow lint` to use `tree-sitter-vba` AST-backed checks for core declaration, member-access, and error-handling rules, including per-declarator implicit `Variant` diagnostics and parser recovery findings.
+- Refactored `xlflow lint` to use `tree-sitter-vba` AST-backed checks for core declaration, member-access, and local code-shape rules, including per-declarator implicit `Variant` diagnostics and parser recovery findings.
+- Refactored `xlflow analyze` to use `tree-sitter-vba` AST-backed procedure context and added runtime-risk findings for `Range.Find` `Nothing` guards, object initialization, Application state restore, error-handler fallthrough, unqualified Excel object access, ByRef mismatch candidates, Dictionary/Collection guards, `ReDim Preserve`, object/array comparisons, function return paths, and expanded Excel member mismatches.
 - Documented the full `xlflow lint` rule list on the command page, including `VB001` through `VB014` codes and severity levels.
 - Added `xlflow inspect calls`, a source-only tree-sitter-vba call-site extractor for exported VBA files with caller context, argument summaries, source ranges, conservative project-symbol resolution, JSON output, and compact grouped text output.
 - Added `xlflow inspect symbols`, a source-only tree-sitter-vba symbol indexer for exported `.bas`, `.cls`, and `.frm` VBA files with JSON and compact outline output.

--- a/README.ja.md
+++ b/README.ja.md
@@ -600,12 +600,6 @@ detect_implicit_variant = true
 forbid_public_module_fields = true
 # ヘッドレス実行時の対話型入力（MsgBox、InputBoxなど）を禁止します。
 forbid_interactive_input = true
-# 修飾されていない Range/Cells/Rows/Columns アクセスを禁止します。
-forbid_unqualified_excel_objects = true
-# 通常実行が error handler label に落ちる procedure を検出します。
-detect_error_handler_fallthrough = true
-# 復元経路が明確でない Application state 変更を検出します。
-detect_application_state_restore = true
 # module 変数や procedure 名を隠す local 名を検出します。
 detect_scope_shadowing = false
 # 一部の declarator だけに型が付く Dim 文を説明します。
@@ -618,14 +612,34 @@ detect_unused_private_procedures = false
 detect_confusing_call_syntax = true
 # For Each control variable の宣言・型の問題を検出します。
 detect_for_each_control_type = true
-# ActiveWorkbook/ActiveSheet/ActiveCell/Selection 依存を禁止します。
-forbid_active_object_dependency = true
-# Nothing check 前に使われる Range.Find 結果を検出します。
-detect_range_find_nothing_check = false
 # error handler 外に見える Resume 文を検出します。
 detect_dangerous_resume = true
 # nested With 内の曖昧な implicit Excel member を検出します。
 detect_nested_with_ambiguity = false
+
+[analyze]
+# Nothing check 前に使われる Range.Find 結果を検出します。
+detect_range_find_nothing_check = true
+# 明確な Set 代入前に使われる object 変数を検出します。
+detect_object_use_before_set = true
+# 復元経路が明確でない Application state 変更を検出します。
+detect_application_state_restore = true
+# 通常実行が error handler label に落ちる procedure を検出します。
+detect_error_handler_fallthrough = true
+# 修飾されていない Range/Cells/Rows/Columns アクセスを禁止します。
+forbid_unqualified_excel_objects = true
+# ByRef 引数の型不一致候補を検出します。
+detect_byref_argument_mismatch = false
+# 明確な guard がない Dictionary/Collection access を検出します。
+detect_dictionary_collection_guard = false
+# 多次元配列での ReDim Preserve 使用を検出します。
+detect_redim_preserve_dimension = true
+# object または array の比較ミスを検出します。
+detect_object_array_comparison = true
+# return value を代入せずに抜ける可能性がある Function を検出します。
+detect_function_return_path = false
+# 既知の Excel object/member mismatch を検出します。
+detect_excel_object_member_mismatch = true
 ```
 
 `project.entry` は `xlflow run` の macro 名を省略した場合に使われます。

--- a/README.md
+++ b/README.md
@@ -600,12 +600,6 @@ detect_implicit_variant = true
 forbid_public_module_fields = true
 # Forbid interactive input (MsgBox, InputBox, etc.) in headless runs.
 forbid_interactive_input = true
-# Forbid unqualified Range/Cells/Rows/Columns access.
-forbid_unqualified_excel_objects = true
-# Detect procedures that can fall through into an error handler.
-detect_error_handler_fallthrough = true
-# Detect Application state changes without an obvious restore path.
-detect_application_state_restore = true
 # Detect local names that shadow module or procedure names.
 detect_scope_shadowing = false
 # Explain mixed Dim declarations where only some declarators are typed.
@@ -618,14 +612,34 @@ detect_unused_private_procedures = false
 detect_confusing_call_syntax = true
 # Detect For Each control variable declaration/type issues.
 detect_for_each_control_type = true
-# Forbid ActiveWorkbook/ActiveSheet/ActiveCell/Selection dependencies.
-forbid_active_object_dependency = true
-# Detect Range.Find results used without a Nothing check.
-detect_range_find_nothing_check = false
 # Detect Resume statements outside likely error handlers.
 detect_dangerous_resume = true
 # Detect nested With blocks with ambiguous implicit Excel members.
 detect_nested_with_ambiguity = false
+
+[analyze]
+# Detect Range.Find results used without a Nothing check.
+detect_range_find_nothing_check = true
+# Detect object variables used before an obvious Set assignment.
+detect_object_use_before_set = true
+# Detect Application state changes without an obvious restore path.
+detect_application_state_restore = true
+# Detect procedures that can fall through into an error handler.
+detect_error_handler_fallthrough = true
+# Forbid unqualified Range/Cells/Rows/Columns access.
+forbid_unqualified_excel_objects = true
+# Detect likely ByRef argument type mismatches.
+detect_byref_argument_mismatch = false
+# Detect Dictionary/Collection access without an obvious guard.
+detect_dictionary_collection_guard = false
+# Detect ReDim Preserve usage on multi-dimensional arrays.
+detect_redim_preserve_dimension = true
+# Detect object or array comparison mistakes.
+detect_object_array_comparison = true
+# Detect functions that may exit without assigning their return value.
+detect_function_return_path = false
+# Detect known Excel object/member mismatches.
+detect_excel_object_member_mismatch = true
 ```
 
 `project.entry` is used when `xlflow run` is invoked without a macro name.

--- a/docs/adr/ADR-0013-analyze-runtime-risk-ownership.md
+++ b/docs/adr/ADR-0013-analyze-runtime-risk-ownership.md
@@ -1,0 +1,55 @@
+# ADR-0013: Analyze Owns Semantic VBA Runtime-Risk Checks
+
+## Status
+
+`accepted`
+
+## Background
+
+xlflow has two source-only feedback commands:
+
+- `lint` reports syntax-safety, style, parser recovery, and local code-shape issues.
+- `analyze` reports likely runtime failures and source patterns that can explain or prevent Excel/VBA runtime errors.
+
+The AST-backed lint work temporarily included several runtime-risk checks, including unqualified Excel object access, error-handler fallthrough, Application state restore, and `Range.Find` results used without `Nothing` guards. Those checks need declaration, procedure, and flow context, and they overlap with analyzer diagnostics used by source preflight and runtime failure suggestions.
+
+The relevant lint/analyze rule set is still under `## Unreleased`, so xlflow does not need compatibility aliases or a migration period for the temporary lint placement.
+
+## Decision
+
+`xlflow analyze` owns semantic VBA runtime-risk checks that require declaration, procedure, call, assignment, label, member-access, or return-path context.
+
+`xlflow lint` remains focused on syntax-safety, parser recovery, local code-shape, and automation-hostile GUI boundaries. Runtime-risk checks previously staged in lint before release are moved to analyze without compatibility aliases.
+
+The analyzer uses `tree-sitter-vba` through `internal/vba/ast` and keeps the existing analysis finding contract: `code`, `severity`, `file`, `module`, `procedure`, `line`, `message`, `reason`, `suggestion`, and `nearby_code`, with `column` included only when reliable.
+
+Stable analyzer codes include existing `VBA101` through `VBA106` plus runtime-risk `VBA201` through `VBA211`.
+
+## Consequences
+
+Positive consequences:
+
+- `check` output separates local lint feedback from runtime-risk analysis more clearly.
+- Analyzer findings can be reused by source preflight and runtime failure suggestions without duplicating lint issues.
+- AST-backed analysis can ignore comments and strings while using procedure and declaration context.
+
+Negative consequences:
+
+- The analyzer becomes more complex and needs focused tests for conservative false-positive behavior.
+- Documentation and generated config must describe both `[lint]` and `[analyze]` rule families.
+- False-positive-prone analyzer rules need opt-in defaults until their behavior is proven.
+
+## Rationale
+
+- Specs: `docs/specs/cli-contract.md`, `docs/specs/runtime-debugging.md`.
+- Docs: `vitepress/commands/lint.md`, `vitepress/commands/analyze.md`, `vitepress/reference/config-file.md`.
+- Tests: analyzer regression tests for `VBA101` through `VBA106` and runtime-risk tests for `VBA201` through `VBA211`.
+- Code: `internal/analyze`, `internal/lint`, `internal/config`.
+
+## Supersedes
+
+- None
+
+## Superseded by
+
+- None

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -127,7 +127,7 @@ For GitHub Copilot, use `agents` because Copilot reads repository instructions f
 
 `pull` supports the `.NET` bridge in both explicit `--bridge dotnet` mode and Windows `auto` mode. In `auto`, xlflow prefers the `.NET` bridge and falls back to PowerShell only when `.NET` is unavailable, incompatible, or unsupported for the command. The command routes through the `.NET` Excel bridge executable (`xlflow-excel-bridge.exe`) and produces the same envelope fields (`target`, `session`, `workbook`, `source`, `logs`). The `.NET` bridge implementation handles standard modules, class modules, UserForms (`.frm` / `.frx`), document modules, Rubberduck folder annotations, and sidecar UserForm code-behind sidecars with the same behavior as the PowerShell path.
 
-`push` reads source-controlled `.bas`, `.cls`, and `.frm` files as UTF-8 without BOM, writes CP932 temporary import copies under `.xlflow/tmp/`, and imports those temporary files through VBIDE. `.frx` files are binary userform companions and are copied without text conversion. Source enumeration is recursive under each configured `[src]` root. In `sidecar` mode, `src/forms/code/*.bas` is reserved for UserForm code-behind sidecars: those files participate in source fingerprinting but are not imported as standalone standard modules. Instead, before Excel opens xlflow synchronizes tracked `.frm` embedded code from the sidecar so `src/forms/code/<FormName>.bas` remains authoritative, then after a `.frm` import succeeds it reapplies that sidecar to the imported UserForm `CodeModule`. If a sidecar contains exported UserForm header lines such as `Attribute VB_Name`, preflight fails with `source_preflight_failed` before Excel opens instead of synchronizing corrupted `.frm` content. In `sidecar` mode, push also validates `src/forms/specs/*.{yaml,yml,json}` against tracked `.frm` artifacts before Excel opens: the spec filename, `form.name`, `.frm` basename, and `.frm` `Attribute VB_Name` must agree, otherwise preflight fails with `source_preflight_failed` and issue code `FRM201` so xlflow cannot import the wrong Designer-backed form. In `frm` mode, `.frm` embedded code remains authoritative and `src/forms/code` is ignored. When `[vba].folder_annotation="update"`, xlflow rewrites `@Folder("A.B")` comments in temporary import copies from the file's relative directory below its configured root; the tracked source file itself is not rewritten during `push`. When `folder_annotation="preserve"`, existing annotations are kept as-is; `ignore` disables folder annotation read/write. Before starting Excel, `push` runs fatal source preflight checks for patterns that are known to surface as VBE modal dialogs instead of COM errors, including typographic quote characters, likely C-style quote escapes, statically-known object/member mismatches such as `Worksheet.DisplayGridlines`, removed legacy helper APIs such as `XlflowLog` / `XlflowSetTraceFile`, contaminated UserForm sidecars that still contain `Attribute VB_*` export headers, and spec/artifact mismatches that would cause a different UserForm name to be imported than the one declared in `src/forms/specs`. Recursive source trees are also validated for duplicate VBA component basenames; conflicts fail with `duplicate_module_name` before Excel opens. These failures return `lint_failed`, `analyze_failed`, `source_preflight_failed`, `duplicate_module_name`, or related environment failures, include top-level `issues` and/or `analysis` when applicable, and use validation exit code `1`. By default (or with `--backup=always`), `push` creates a timestamped workbook backup under `.xlflow/backups/<backup-id>/`, writes `metadata.json` beside the copied workbook file, replaces non-document VBA components, updates document modules, runs VBE Compile, saves the workbook, and writes source fingerprints to `.xlflow/state/push.json`. If VBE Compile fails after import, `push` returns `vba_compile_failed` with `error.phase = "compile_vba"` and validation exit code `1`; the workbook is not saved and source fingerprints are not updated. `.NET` bridge compile failures may include top-level `push_diagnostic.kind = "compile"` with dialog metadata, VBE selection location, and non-fatal `location_capture` attempts. When source mapping is verified, `location.line` and `location.end_line` are source-file line numbers, adjusted for exported metadata such as hidden `Attribute VB_*` lines. `column` and `end_column` are omitted unless the VBE selection exposes a source-column value that xlflow can treat as reliable. Session-backed compile failures also report `session.dirty = true` / `save_required = true` because the live workbook has already received the imported source.
+`push` reads source-controlled `.bas`, `.cls`, and `.frm` files as UTF-8 without BOM, writes CP932 temporary import copies under `.xlflow/tmp/`, and imports those temporary files through VBIDE. `.frx` files are binary userform companions and are copied without text conversion. Source enumeration is recursive under each configured `[src]` root. In `sidecar` mode, `src/forms/code/*.bas` is reserved for UserForm code-behind sidecars: those files participate in source fingerprinting but are not imported as standalone standard modules. Instead, before Excel opens xlflow synchronizes tracked `.frm` embedded code from the sidecar so `src/forms/code/<FormName>.bas` remains authoritative, then after a `.frm` import succeeds it reapplies that sidecar to the imported UserForm `CodeModule`. If a sidecar contains exported UserForm header lines such as `Attribute VB_Name`, preflight fails with `source_preflight_failed` and issue code `FRM202` before Excel opens instead of synchronizing corrupted `.frm` content. In `sidecar` mode, push also validates `src/forms/specs/*.{yaml,yml,json}` against tracked `.frm` artifacts before Excel opens: the spec filename, `form.name`, `.frm` basename, and `.frm` `Attribute VB_Name` must agree, otherwise preflight fails with `source_preflight_failed` and issue code `FRM201` so xlflow cannot import the wrong Designer-backed form. In `frm` mode, `.frm` embedded code remains authoritative and `src/forms/code` is ignored. When `[vba].folder_annotation="update"`, xlflow rewrites `@Folder("A.B")` comments in temporary import copies from the file's relative directory below its configured root; the tracked source file itself is not rewritten during `push`. When `folder_annotation="preserve"`, existing annotations are kept as-is; `ignore` disables folder annotation read/write. Before starting Excel, `push` runs fatal source preflight checks for patterns that are known to surface as VBE modal dialogs instead of COM errors, including typographic quote characters, likely C-style quote escapes, statically-known object/member mismatches such as `Worksheet.DisplayGridlines`, removed legacy helper APIs such as `XlflowLog` / `XlflowSetTraceFile`, contaminated UserForm sidecars that still contain `Attribute VB_*` export headers, and spec/artifact mismatches that would cause a different UserForm name to be imported than the one declared in `src/forms/specs`. Recursive source trees are also validated for duplicate VBA component basenames; conflicts fail with `duplicate_module_name` before Excel opens. These failures return `lint_failed`, `analyze_failed`, `source_preflight_failed`, `duplicate_module_name`, or related environment failures, include top-level `issues` and/or `analysis` when applicable, and use validation exit code `1`. By default (or with `--backup=always`), `push` creates a timestamped workbook backup under `.xlflow/backups/<backup-id>/`, writes `metadata.json` beside the copied workbook file, replaces non-document VBA components, updates document modules, runs VBE Compile, saves the workbook, and writes source fingerprints to `.xlflow/state/push.json`. If VBE Compile fails after import, `push` returns `vba_compile_failed` with `error.phase = "compile_vba"` and validation exit code `1`; the workbook is not saved and source fingerprints are not updated. `.NET` bridge compile failures may include top-level `push_diagnostic.kind = "compile"` with dialog metadata, VBE selection location, and non-fatal `location_capture` attempts. When source mapping is verified, `location.line` and `location.end_line` are source-file line numbers, adjusted for exported metadata such as hidden `Attribute VB_*` lines. `column` and `end_column` are omitted unless the VBE selection exposes a source-column value that xlflow can treat as reliable. Session-backed compile failures also report `session.dirty = true` / `save_required = true` because the live workbook has already received the imported source.
 
 `push` supports the `.NET` bridge in both explicit `--bridge dotnet` mode and Windows `auto` mode. In `auto`, xlflow prefers the `.NET` bridge and falls back to PowerShell only when `.NET` is unavailable, incompatible, or unsupported for the command. The command routes through the `.NET` Excel bridge executable (`xlflow-excel-bridge.exe`) and produces the same envelope fields (`target`, `session`, `workbook`, `backup`, `source`, `logs`). The `.NET` bridge implementation handles standard modules, class modules, UserForms (`.frm` / `.frx`), document modules, backup mode, changed-only fingerprinting, sidecar UserForm code-behind synchronization, and Rubberduck folder annotations with the same behavior as the PowerShell path.
 
@@ -253,19 +253,27 @@ forbid_on_error_resume_next = true
 detect_implicit_variant = true
 forbid_public_module_fields = true
 forbid_interactive_input = true
-forbid_unqualified_excel_objects = true
-detect_error_handler_fallthrough = true
-detect_application_state_restore = true
 detect_scope_shadowing = false
 detect_multiple_declarator_clarity = true
 detect_unused_local_variables = false
 detect_unused_private_procedures = false
 detect_confusing_call_syntax = true
 detect_for_each_control_type = true
-forbid_active_object_dependency = true
-detect_range_find_nothing_check = false
 detect_dangerous_resume = true
 detect_nested_with_ambiguity = false
+
+[analyze]
+detect_range_find_nothing_check = true
+detect_object_use_before_set = true
+detect_application_state_restore = true
+detect_error_handler_fallthrough = true
+forbid_unqualified_excel_objects = true
+detect_byref_argument_mismatch = false
+detect_dictionary_collection_guard = false
+detect_redim_preserve_dimension = true
+detect_object_array_comparison = true
+detect_function_return_path = false
+detect_excel_object_member_mismatch = true
 ```
 
 ## JSON Envelope
@@ -465,17 +473,12 @@ Core declaration, member-access, error-handling, Excel object, and procedure-sco
 - `VB012`: mismatched procedure end statement
 - `VB013`: missing whitespace before a line-continuation underscore
 - `VB014`: `tree-sitter-vba` parser recovery found syntax errors or missing syntax nodes
-- `VB015`: unqualified Excel object access such as `Range(...)`, `Cells(...)`, `Rows(...)`, or `Columns(...)`
-- `VB016`: normal execution can fall through into an error-handler label
-- `VB017`: `Application.EnableEvents`, `Application.DisplayAlerts`, or `Application.ScreenUpdating` is disabled without an obvious restore path
 - `VB018`: local declarations or parameters shadow module-level names, procedure names, or same-scope declarations
 - `VB019`: mixed multiple declarators where only some names have explicit `As <Type>`
 - `VB020`: unused procedure-local variable
 - `VB021`: unused private procedure, excluding known event/callback naming patterns
 - `VB022`: confusing parenthesized call syntax such as `Foo (bar)`
 - `VB023`: `For Each` control variable is undeclared or obviously incompatible
-- `VB024`: active object dependency such as `ActiveWorkbook`, `ActiveSheet`, `ActiveCell`, or `Selection`
-- `VB025`: `Range.Find` result is dereferenced before a `Nothing` check
 - `VB026`: `Resume` is used outside a likely error-handler context
 - `VB027`: nested `With` blocks use implicit Excel members whose target can be ambiguous
 
@@ -483,10 +486,26 @@ Projects that intentionally use interactive GUI entrypoints may set `[lint].forb
 
 Compile-dialog prevention findings `VB008` through `VB014` are always enabled and block source preflight before `push` or `run` opens Excel.
 
-Higher-signal rules `VB015`, `VB016`, `VB017`, `VB019`, `VB022`, `VB023`, `VB024`, and `VB026` are enabled by default. Heavier project-wide or dataflow-sensitive rules `VB018`, `VB020`, `VB021`, `VB025`, and `VB027` are disabled by default and can be enabled with their `[lint]` booleans.
+Higher-signal lint rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide lint rules `VB018`, `VB020`, `VB021`, and `VB027` are disabled by default and can be enabled with their `[lint]` booleans.
 
 ## Analysis Rules
 
 - `VBA101`: object variable assignment likely missing `Set`
 - `VBA102`: object-returning function assignment likely missing `Set`
 - `VBA103`: object-returning function body likely missing `Set <FunctionName> = ...`
+- `VBA104`: known Excel object/member mismatch such as `Worksheet.DisplayGridlines`
+- `VBA105`: removed `XlflowLog` trace helper call
+- `VBA106`: removed `XlflowSetTraceFile` trace helper call
+- `VBA201`: `Range.Find` result is dereferenced before a `Nothing` check
+- `VBA202`: object variable may be used before an obvious `Set` assignment
+- `VBA203`: `Application.EnableEvents`, `Application.DisplayAlerts`, `Application.ScreenUpdating`, or `Application.Calculation` is changed without an obvious restore path
+- `VBA204`: normal execution can fall through into an error-handler label
+- `VBA205`: unqualified Excel object access or active object dependency
+- `VBA206`: likely ByRef argument type mismatch candidate
+- `VBA207`: `Dictionary` or `Collection` access without an obvious existence guard
+- `VBA208`: `ReDim Preserve` is used on a multi-dimensional array
+- `VBA209`: object or array comparison mistake
+- `VBA210`: function may exit without assigning its return value
+- `VBA211`: expanded known Excel object/member mismatch
+
+Analyzer rules `VBA101` through `VBA106`, `VBA201` through `VBA205`, `VBA208`, `VBA209`, and `VBA211` are enabled by default. Rules `VBA206`, `VBA207`, and `VBA210` are disabled by default and can be enabled with their `[analyze]` booleans.

--- a/docs/specs/runtime-debugging.md
+++ b/docs/specs/runtime-debugging.md
@@ -78,7 +78,7 @@ Compile failures return `vba_compile_failed` with `error.phase = "compile_vba"` 
 
 ## Runtime Source Analysis
 
-`xlflow analyze` scans configured source directories without Excel COM. The v1 analyzer is deliberately pattern-based and detects likely missing `Set` assignments for object variables and object-returning functions, statically-known object/member mismatches such as `Worksheet.DisplayGridlines`, and removed legacy helper APIs when source-controlled VBA still calls `XlflowLog` or `XlflowSetTraceFile`. Stable analyzer codes are `VBA101`, `VBA102`, `VBA103`, `VBA104`, `VBA105`, and `VBA106`.
+`xlflow analyze` scans configured source directories without Excel COM. The analyzer uses `tree-sitter-vba` to build per-file and per-procedure context from declarations, parameters, function and property returns, labels, assignments, calls, and member access. It detects likely missing `Set` assignments for object variables and object-returning functions, statically-known Excel object/member mismatches, removed legacy helper APIs such as `XlflowLog` and `XlflowSetTraceFile`, `Range.Find` results used without `Nothing` guards, object variables used before obvious initialization, Application state leaks, error-handler fallthrough, unqualified Excel object access, and selected opt-in semantic risks. Stable analyzer codes are `VBA101` through `VBA106` and `VBA201` through `VBA211`.
 
 `xlflow check` aggregates `lint`, `analyze`, and `doctor`. It continues after lint/analyze findings and returns all cheap source feedback before reporting Excel COM doctor status.
 

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -288,18 +288,23 @@ func (a Analyzer) buildContext(files []parsedFile) analysisContext {
 func (a Analyzer) analyzeParsedFile(file parsedFile, ctx analysisContext) []Finding {
 	reportedMissingHelpers := map[string]bool{}
 	var findings []Finding
-	for _, proc := range sourceProceduresFromAST(file.Root, file.Result.Source) {
-		findings = append(findings, a.analyzeProcedure(file, proc, ctx, reportedMissingHelpers)...)
+	procedures := sourceProceduresFromAST(file.Root, file.Result.Source)
+	moduleDecls := moduleDeclarations(file.Lines, procedures)
+	for _, proc := range procedures {
+		findings = append(findings, a.analyzeProcedure(file, proc, moduleDecls, ctx, reportedMissingHelpers)...)
 	}
-	if len(sourceProceduresFromAST(file.Root, file.Result.Source)) == 0 {
+	if len(procedures) == 0 {
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		findings = append(findings, a.analyzeProcedure(file, proc, ctx, reportedMissingHelpers)...)
+		findings = append(findings, a.analyzeProcedure(file, proc, moduleDecls, ctx, reportedMissingHelpers)...)
 	}
 	return findings
 }
 
-func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, ctx analysisContext, reportedMissingHelpers map[string]bool) []Finding {
-	decls := procedureDeclarations(file.Lines, proc)
+func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, reportedMissingHelpers map[string]bool) []Finding {
+	decls := cloneDeclarations(moduleDecls)
+	for key, decl := range procedureDeclarations(file.Lines, proc) {
+		decls[key] = decl
+	}
 	for _, param := range proc.Params {
 		decls[strings.ToLower(param.Name)] = sourceDeclaration{Name: param.Name, Type: param.Type, Line: proc.StartLine, Object: isObjectType(param.Type), Parameter: true}
 	}
@@ -346,6 +351,9 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, ctx an
 			findings = append(findings, a.legacyMemberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)...)
 		}
 		if setAssignRe.MatchString(stmt) {
+			if a.Config.Analyze.DetectObjectUseBeforeSet {
+				findings = append(findings, a.objectUseBeforeSetFindings(file, proc, lineNo, stmt, decls, initialized, maybeInitializedByCall)...)
+			}
 			if m := setAssignRe.FindStringSubmatch(stmt); len(m) > 0 {
 				initialized[strings.ToLower(m[1])] = true
 				if strings.EqualFold(m[1], proc.Name) {
@@ -510,6 +518,50 @@ func procedureDeclarations(lines []string, proc sourceProcedure) map[string]sour
 		}
 	}
 	return decls
+}
+
+func moduleDeclarations(lines []string, procedures []sourceProcedure) map[string]sourceDeclaration {
+	decls := map[string]sourceDeclaration{}
+	for i := 0; i < len(lines); i++ {
+		lineNo := i + 1
+		if lineInAnyProcedure(lineNo, procedures) {
+			continue
+		}
+		stmt := normalizedCodeLine(lines[i])
+		lower := strings.ToLower(stmt)
+		if !strings.HasPrefix(lower, "dim ") && !strings.HasPrefix(lower, "static ") && !strings.HasPrefix(lower, "private ") && !strings.HasPrefix(lower, "public ") {
+			continue
+		}
+		m := declRe.FindStringSubmatch(stmt)
+		if len(m) == 0 {
+			continue
+		}
+		for _, part := range strings.Split(m[1], ",") {
+			name, typ, array, newExpr := declarationNameAndType(part)
+			if name == "" {
+				continue
+			}
+			decls[strings.ToLower(name)] = sourceDeclaration{Name: name, Type: typ, Line: lineNo, Object: isObjectType(typ), Array: array, NewExpression: newExpr}
+		}
+	}
+	return decls
+}
+
+func lineInAnyProcedure(line int, procedures []sourceProcedure) bool {
+	for _, proc := range procedures {
+		if proc.StartLine <= line && line <= proc.EndLine {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneDeclarations(decls map[string]sourceDeclaration) map[string]sourceDeclaration {
+	clone := make(map[string]sourceDeclaration, len(decls))
+	for key, decl := range decls {
+		clone[key] = decl
+	}
+	return clone
 }
 
 func declarationNameAndType(text string) (string, string, bool, bool) {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -1,14 +1,16 @@
 package analyze
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/gui"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 type Finding struct {
@@ -18,6 +20,7 @@ type Finding struct {
 	Module     string   `json:"module,omitempty"`
 	Procedure  string   `json:"procedure,omitempty"`
 	Line       int      `json:"line"`
+	Column     int      `json:"column,omitempty"`
 	Message    string   `json:"message"`
 	Reason     string   `json:"reason"`
 	Suggestion string   `json:"suggestion"`
@@ -31,27 +34,29 @@ type Analyzer struct {
 }
 
 var (
-	declRe            = regexp.MustCompile(`(?i)^\s*(?:dim|private|public|static)\s+([A-Za-z_][A-Za-z0-9_]*)\s+as\s+(?:new\s+)?([A-Za-z_][A-Za-z0-9_.]*)\b`)
-	procRe            = regexp.MustCompile(`(?i)^\s*(?:public\s+|private\s+|friend\s+)?(sub|function|property\s+get)\s+([A-Za-z_][A-Za-z0-9_]*)\b(?:[^']*?\bas\s+([A-Za-z_][A-Za-z0-9_.]*))?`)
-	publicProcDeclRe  = regexp.MustCompile(`(?i)^\s*public\s+(?:sub|function|property\s+get)\s+([A-Za-z_][A-Za-z0-9_]*)\b`)
-	assignRe          = regexp.MustCompile(`(?i)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=`)
-	setAssign         = regexp.MustCompile(`(?i)^\s*set\s+([A-Za-z_][A-Za-z0-9_]*)\s*=`)
-	callAssign        = regexp.MustCompile(`(?i)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_.]*)\s*(?:\(|$)`)
-	withRe            = regexp.MustCompile(`(?i)^\s*with\s+(.+)$`)
-	endWithRe         = regexp.MustCompile(`(?i)^\s*end\s+with\b`)
-	withMember        = regexp.MustCompile(`(?i)^\s*\.([A-Za-z_][A-Za-z0-9_]*)\b`)
-	memberRe          = regexp.MustCompile(`(?i)\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\b`)
-	traceHelperCallRe = regexp.MustCompile(`(?i)^\s*(?:call\s+)?(XlflowLog|XlflowSetTraceFile)\b`)
-	traceHelperQualRe = regexp.MustCompile(`(?i)\bXlflowTrace\s*\.\s*(XlflowLog|XlflowSetTraceFile)\b`)
+	declRe             = regexp.MustCompile(`(?i)^\s*(?:dim|private|public|static)\s+(.+)$`)
+	assignRe           = regexp.MustCompile(`(?i)^\s*(?:let\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=`)
+	setAssignRe        = regexp.MustCompile(`(?i)^\s*set\s+([A-Za-z_][A-Za-z0-9_]*)\s*=`)
+	callAssignRe       = regexp.MustCompile(`(?i)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_.]*)\s*(?:\(|$)`)
+	withRe             = regexp.MustCompile(`(?i)^\s*with\s+(.+)$`)
+	endWithRe          = regexp.MustCompile(`(?i)^\s*end\s+with\b`)
+	withMemberRe       = regexp.MustCompile(`(?i)^\s*\.([A-Za-z_][A-Za-z0-9_]*)\b`)
+	memberRe           = regexp.MustCompile(`(?i)\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\b`)
+	traceHelperCallRe  = regexp.MustCompile(`(?i)^\s*(?:call\s+)?(XlflowLog|XlflowSetTraceFile)\b`)
+	traceHelperQualRe  = regexp.MustCompile(`(?i)\bXlflowTrace\s*\.\s*(XlflowLog|XlflowSetTraceFile)\b`)
+	unqualifiedExcelRe = regexp.MustCompile(`(?i)(^|[^A-Za-z0-9_.$])\b(Range|Cells|Rows|Columns)\b\s*(?:\(|\.)`)
+	activeExcelRe      = regexp.MustCompile(`(?i)(^|[^A-Za-z0-9_.$])\b(ActiveWorkbook|ActiveSheet|ActiveCell|Selection)\b`)
+	redimPreserveRe    = regexp.MustCompile(`(?i)^\s*redim\s+preserve\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)`)
 )
 
 var objectTypes = map[string]bool{
 	"application": true, "workbook": true, "worksheet": true, "range": true,
 	"chart": true, "pivot table": true, "pivottable": true, "listobject": true,
-	"dictionary": true, "collection": true, "object": true,
+	"dictionary": true, "collection": true, "object": true, "window": true,
 }
 
 type invalidMemberRule struct {
+	Code       string
 	Reason     string
 	Suggestion string
 }
@@ -65,8 +70,36 @@ type helperDependencyRule struct {
 var invalidObjectMembers = map[string]map[string]invalidMemberRule{
 	"worksheet": {
 		"displaygridlines": {
+			Code:       "VBA104",
 			Reason:     "DisplayGridlines is a Window property, not a Worksheet member.",
 			Suggestion: "Set DisplayGridlines on ActiveWindow or another Window object instead of the Worksheet.",
+		},
+		"screenupdating": {
+			Code:       "VBA211",
+			Reason:     "ScreenUpdating is an Application property, not a Worksheet member.",
+			Suggestion: "Set Application.ScreenUpdating instead of a Worksheet member.",
+		},
+		"displayalerts": {
+			Code:       "VBA211",
+			Reason:     "DisplayAlerts is an Application property, not a Worksheet member.",
+			Suggestion: "Set Application.DisplayAlerts instead of a Worksheet member.",
+		},
+		"enableevents": {
+			Code:       "VBA211",
+			Reason:     "EnableEvents is an Application property, not a Worksheet member.",
+			Suggestion: "Set Application.EnableEvents instead of a Worksheet member.",
+		},
+	},
+	"workbook": {
+		"displaygridlines": {
+			Code:       "VBA211",
+			Reason:     "DisplayGridlines is a Window property, not a Workbook member.",
+			Suggestion: "Set DisplayGridlines on ActiveWindow or another Window object instead of the Workbook.",
+		},
+		"screenupdating": {
+			Code:       "VBA211",
+			Reason:     "ScreenUpdating is an Application property, not a Workbook member.",
+			Suggestion: "Set Application.ScreenUpdating instead of a Workbook member.",
 		},
 	},
 }
@@ -85,7 +118,52 @@ var traceHelperDependencies = map[string]helperDependencyRule{
 }
 
 type analysisContext struct {
-	standardModulePublicProcs map[string]bool
+	functionReturns map[string]string
+	procedures      map[string]procedureSignature
+}
+
+type procedureSignature struct {
+	Name       string
+	ReturnType string
+	Params     []parameterInfo
+}
+
+type parameterInfo struct {
+	Name    string
+	Type    string
+	Passing string
+}
+
+type parsedFile struct {
+	Path   string
+	Lines  []string
+	Module string
+	Root   *tree_sitter.Node
+	Result *vbaast.ParseResult
+}
+
+type sourceProcedure struct {
+	Kind       string
+	Name       string
+	ReturnType string
+	StartLine  int
+	EndLine    int
+	Params     []parameterInfo
+}
+
+type sourceDeclaration struct {
+	Name          string
+	Type          string
+	Line          int
+	Object        bool
+	Array         bool
+	NewExpression bool
+	Parameter     bool
+}
+
+type withInfo struct {
+	Target string
+	Type   string
 }
 
 func (a Analyzer) Run() ([]Finding, error) {
@@ -93,19 +171,43 @@ func (a Analyzer) Run() ([]Finding, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx, err := a.buildContext(files)
+	parser, err := vbaast.NewParser()
 	if err != nil {
 		return nil, err
 	}
-	var findings []Finding
+	defer parser.Close()
+	parsedFiles := make([]parsedFile, 0, len(files))
 	for _, file := range files {
-		items, err := a.analyzeFile(file, ctx)
+		parsed, err := parser.ParseFile(file)
 		if err != nil {
+			closeParsedFiles(parsedFiles)
 			return nil, err
 		}
-		findings = append(findings, items...)
+		parsedFiles = append(parsedFiles, parsedFile{
+			Path:   file,
+			Lines:  normalizedSourceLines(string(parsed.Source)),
+			Module: strings.TrimSuffix(filepath.Base(file), filepath.Ext(file)),
+			Root:   parsed.Root,
+			Result: parsed,
+		})
 	}
+	defer closeParsedFiles(parsedFiles)
+
+	ctx := a.buildContext(parsedFiles)
+	var findings []Finding
+	for _, file := range parsedFiles {
+		findings = append(findings, a.analyzeParsedFile(file, ctx)...)
+	}
+	sortFindings(findings)
 	return findings, nil
+}
+
+func closeParsedFiles(files []parsedFile) {
+	for _, file := range files {
+		if file.Result != nil {
+			file.Result.Close()
+		}
+	}
 }
 
 func (a Analyzer) files() ([]string, error) {
@@ -139,6 +241,7 @@ func (a Analyzer) files() ([]string, error) {
 			return nil, err
 		}
 	}
+	sort.Strings(files)
 	return files, nil
 }
 
@@ -154,8 +257,7 @@ func (a Analyzer) shouldIncludeFile(path string) bool {
 	}
 	formsRoot := filepath.Clean(filepath.Join(a.RootDir, a.Config.Src.Forms))
 	cleanPath := filepath.Clean(path)
-	if !strings.HasPrefix(strings.ToLower(cleanPath), strings.ToLower(formsRoot)+strings.ToLower(string(os.PathSeparator))) &&
-		!strings.EqualFold(cleanPath, formsRoot) {
+	if !isPathInsideRoot(cleanPath, formsRoot) {
 		return true
 	}
 	sidecarPath := filepath.Join(formsRoot, "code", strings.TrimSuffix(filepath.Base(cleanPath), filepath.Ext(cleanPath))+".bas")
@@ -165,133 +267,533 @@ func (a Analyzer) shouldIncludeFile(path string) bool {
 	return true
 }
 
-type procInfo struct {
-	Name       string
-	ReturnType string
-}
-
-type withInfo struct {
-	Target string
-	Type   string
-}
-
-func (a Analyzer) buildContext(files []string) (analysisContext, error) {
-	ctx := analysisContext{standardModulePublicProcs: map[string]bool{}}
-	modulesRoot := filepath.Clean(filepath.Join(a.RootDir, a.Config.Src.Modules))
-	for _, path := range files {
-		if !isStandardModuleFile(path, modulesRoot) {
-			continue
-		}
-		lines, err := readLines(path)
-		if err != nil {
-			return analysisContext{}, err
-		}
-		for _, raw := range lines {
-			code := strings.TrimSpace(gui.StripComment(raw))
-			if m := publicProcDeclRe.FindStringSubmatch(code); len(m) > 0 {
-				ctx.standardModulePublicProcs[strings.ToLower(m[1])] = true
+func (a Analyzer) buildContext(files []parsedFile) analysisContext {
+	ctx := analysisContext{functionReturns: map[string]string{}, procedures: map[string]procedureSignature{}}
+	for _, file := range files {
+		for _, proc := range sourceProceduresFromAST(file.Root, file.Result.Source) {
+			if isObjectType(proc.ReturnType) {
+				ctx.functionReturns[strings.ToLower(proc.Name)] = proc.ReturnType
 			}
+			ctx.procedures[strings.ToLower(proc.Name)] = procedureSignature{
+				Name:       proc.Name,
+				ReturnType: proc.ReturnType,
+				Params:     proc.Params,
+			}
+			ctx.procedures[strings.ToLower(file.Module+"."+proc.Name)] = ctx.procedures[strings.ToLower(proc.Name)]
 		}
 	}
-	return ctx, nil
+	return ctx
 }
 
-func (a Analyzer) analyzeFile(path string, ctx analysisContext) ([]Finding, error) {
-	lines, err := readLines(path)
-	if err != nil {
-		return nil, err
-	}
-	module := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-	decls := map[string]string{}
-	funcReturns := map[string]string{}
-	current := procInfo{}
-	withStack := make([]withInfo, 0)
+func (a Analyzer) analyzeParsedFile(file parsedFile, ctx analysisContext) []Finding {
 	reportedMissingHelpers := map[string]bool{}
 	var findings []Finding
+	for _, proc := range sourceProceduresFromAST(file.Root, file.Result.Source) {
+		findings = append(findings, a.analyzeProcedure(file, proc, ctx, reportedMissingHelpers)...)
+	}
+	if len(sourceProceduresFromAST(file.Root, file.Result.Source)) == 0 {
+		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
+		findings = append(findings, a.analyzeProcedure(file, proc, ctx, reportedMissingHelpers)...)
+	}
+	return findings
+}
 
-	for i, raw := range lines {
+func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, ctx analysisContext, reportedMissingHelpers map[string]bool) []Finding {
+	decls := procedureDeclarations(file.Lines, proc)
+	for _, param := range proc.Params {
+		decls[strings.ToLower(param.Name)] = sourceDeclaration{Name: param.Name, Type: param.Type, Line: proc.StartLine, Object: isObjectType(param.Type), Parameter: true}
+	}
+	handlerLabels := onErrorHandlerLabels(file.Lines, proc)
+	withStack := make([]withInfo, 0)
+	initialized := initialObjectState(decls)
+	maybeInitializedByCall := map[string]bool{}
+	findAssignments := map[string]int{}
+	guardedFinds := map[string]bool{}
+	functionAssigned := false
+	var findings []Finding
+
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(file.Lines); i++ {
 		lineNo := i + 1
-		code := strings.TrimSpace(gui.StripComment(raw))
-		if code == "" {
+		stmt := normalizedCodeLine(file.Lines[i])
+		if stmt == "" {
 			continue
 		}
-		isProcDecl := false
-		if m := procRe.FindStringSubmatch(code); len(m) > 0 {
-			current = procInfo{Name: m[2], ReturnType: m[3]}
-			isProcDecl = true
-			if strings.EqualFold(m[1], "function") || strings.Contains(strings.ToLower(m[1]), "property") {
-				if isObjectType(m[3]) {
-					funcReturns[strings.ToLower(m[2])] = m[3]
-				}
-			}
-		}
-		if strings.EqualFold(code, "end sub") || strings.EqualFold(code, "end function") || strings.EqualFold(code, "end property") {
-			current = procInfo{}
-			withStack = withStack[:0]
-			continue
-		}
-		if endWithRe.MatchString(code) {
+		lower := strings.ToLower(stmt)
+
+		if endWithRe.MatchString(stmt) {
 			if len(withStack) > 0 {
 				withStack = withStack[:len(withStack)-1]
 			}
 			continue
 		}
-		if m := withRe.FindStringSubmatch(code); len(m) > 0 {
+		if m := withRe.FindStringSubmatch(stmt); len(m) > 0 {
 			withStack = append(withStack, resolveWithInfo(m[1], decls))
 			continue
 		}
-		if m := declRe.FindStringSubmatch(code); len(m) > 0 {
-			decls[strings.ToLower(m[1])] = m[2]
-			continue
-		}
-		if !isProcDecl {
-			for _, helper := range referencedTraceHelpers(code) {
-				lower := strings.ToLower(helper)
-				if reportedMissingHelpers[lower] {
-					continue
-				}
-				if rule, ok := traceHelperDependencies[lower]; ok {
-					findings = append(findings, a.helperFinding(path, module, current.Name, lineNo, lines, helper, rule))
-					reportedMissingHelpers[lower] = true
-				}
-			}
-		}
-		if currentWith, ok := currentWithInfo(withStack); ok {
-			if m := withMember.FindStringSubmatch(code); len(m) > 0 {
-				if rule, ok := invalidMemberRuleFor(currentWith.Type, m[1]); ok {
-					findings = append(findings, a.memberFinding(path, module, current.Name, lineNo, lines, currentWith.Target, currentWith.Type, m[1], rule))
-				}
-			}
-		}
-		for _, m := range memberRe.FindAllStringSubmatch(code, -1) {
-			if typ, ok := decls[strings.ToLower(m[1])]; ok {
-				if rule, ok := invalidMemberRuleFor(typ, m[2]); ok {
-					findings = append(findings, a.memberFinding(path, module, current.Name, lineNo, lines, m[1], typ, m[2], rule))
-				}
-			}
-		}
-		if setAssign.MatchString(code) {
-			continue
-		}
-		if m := assignRe.FindStringSubmatch(code); len(m) > 0 {
-			target := strings.ToLower(m[1])
-			if current.Name != "" && strings.EqualFold(target, current.Name) && isObjectType(current.ReturnType) {
-				findings = append(findings, a.finding(path, module, current.Name, lineNo, lines, "VBA103", m[1], current.ReturnType))
+		for _, helper := range referencedTraceHelpers(stmt) {
+			key := strings.ToLower(helper)
+			if reportedMissingHelpers[key] {
 				continue
 			}
-			if cm := callAssign.FindStringSubmatch(code); len(cm) > 0 {
+			if rule, ok := traceHelperDependencies[key]; ok {
+				findings = append(findings, a.helperFinding(file, proc, lineNo, helper, rule))
+				reportedMissingHelpers[key] = true
+			}
+		}
+		if a.Config.Analyze.DetectExcelObjectMemberMismatch {
+			findings = append(findings, a.memberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)...)
+		} else {
+			findings = append(findings, a.legacyMemberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)...)
+		}
+		if setAssignRe.MatchString(stmt) {
+			if m := setAssignRe.FindStringSubmatch(stmt); len(m) > 0 {
+				initialized[strings.ToLower(m[1])] = true
+				if strings.EqualFold(m[1], proc.Name) {
+					functionAssigned = true
+				}
+			}
+			if name, ok := rangeFindAssignment(stmt); ok {
+				findAssignments[strings.ToLower(name)] = lineNo
+			}
+			if a.Config.Analyze.ForbidUnqualifiedExcelObjects {
+				findings = append(findings, a.unqualifiedExcelFindings(file, proc, lineNo, stmt)...)
+			}
+			continue
+		}
+		if m := assignRe.FindStringSubmatch(stmt); len(m) > 0 {
+			target := strings.ToLower(m[1])
+			if proc.Name != "" && strings.EqualFold(target, proc.Name) {
+				functionAssigned = true
+			}
+			if proc.Name != "" && strings.EqualFold(target, proc.Name) && isObjectType(proc.ReturnType) {
+				findings = append(findings, a.objectSetFinding(file, proc, lineNo, "VBA103", m[1], proc.ReturnType))
+				continue
+			}
+			if cm := callAssignRe.FindStringSubmatch(stmt); len(cm) > 0 {
 				callee := strings.ToLower(lastName(cm[2]))
-				if typ, ok := decls[target]; ok && isObjectType(typ) && isObjectType(funcReturns[callee]) {
-					findings = append(findings, a.finding(path, module, current.Name, lineNo, lines, "VBA102", m[1], funcReturns[callee]))
+				if typ, ok := decls[target]; ok && typ.Object && isObjectType(ctx.functionReturns[callee]) {
+					findings = append(findings, a.objectSetFinding(file, proc, lineNo, "VBA102", m[1], ctx.functionReturns[callee]))
 					continue
 				}
 			}
-			if typ, ok := decls[target]; ok && isObjectType(typ) {
-				findings = append(findings, a.finding(path, module, current.Name, lineNo, lines, "VBA101", m[1], typ))
+			if decl, ok := decls[target]; ok && decl.Object {
+				findings = append(findings, a.objectSetFinding(file, proc, lineNo, "VBA101", m[1], decl.Type))
+			}
+		}
+		if a.Config.Analyze.DetectRangeFindNothingCheck {
+			findings = append(findings, a.rangeFindFindings(file, proc, lineNo, stmt, findAssignments, guardedFinds)...)
+		}
+		if a.Config.Analyze.DetectObjectUseBeforeSet {
+			findings = append(findings, a.objectUseBeforeSetFindings(file, proc, lineNo, stmt, decls, initialized, maybeInitializedByCall)...)
+		}
+		if a.Config.Analyze.ForbidUnqualifiedExcelObjects {
+			findings = append(findings, a.unqualifiedExcelFindings(file, proc, lineNo, stmt)...)
+		}
+		if a.Config.Analyze.DetectByRefArgumentMismatch {
+			findings = append(findings, a.byRefMismatchFindings(file, proc, lineNo, stmt, ctx)...)
+		}
+		if a.Config.Analyze.DetectDictionaryCollectionGuard {
+			findings = append(findings, a.dictionaryCollectionFindings(file, proc, lineNo, stmt, decls)...)
+		}
+		if a.Config.Analyze.DetectRedimPreserveDimension {
+			findings = append(findings, a.redimPreserveFindings(file, proc, lineNo, stmt)...)
+		}
+		if a.Config.Analyze.DetectObjectArrayComparison {
+			findings = append(findings, a.objectArrayComparisonFindings(file, proc, lineNo, stmt, decls)...)
+		}
+		markCallInitialized(stmt, decls, maybeInitializedByCall)
+		_ = lower
+	}
+	if a.Config.Analyze.DetectApplicationStateRestore {
+		findings = append(findings, a.applicationStateFindings(file, proc)...)
+	}
+	if a.Config.Analyze.DetectErrorHandlerFallthrough {
+		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc, handlerLabels)...)
+	}
+	if a.Config.Analyze.DetectFunctionReturnPath && proc.Kind == "Function" && proc.Name != "" && !functionAssigned {
+		findings = append(findings, a.simpleFinding(file, proc, proc.StartLine, "VBA210", "warning", proc.Name+" may exit without assigning its return value.", "Functions return the default value when no assignment to the function name is reached.", "Assign "+proc.Name+" on every successful return path, or make the default return explicit."))
+	}
+	return findings
+}
+
+func sourceProceduresFromAST(root *tree_sitter.Node, source []byte) []sourceProcedure {
+	var procedures []sourceProcedure
+	collectSourceProcedures(root, source, &procedures)
+	sort.SliceStable(procedures, func(i, j int) bool {
+		return procedures[i].StartLine < procedures[j].StartLine
+	})
+	return procedures
+}
+
+func collectSourceProcedures(node *tree_sitter.Node, source []byte, procedures *[]sourceProcedure) {
+	if node == nil {
+		return
+	}
+	switch node.Kind() {
+	case "sub_declaration", "function_declaration", "property_declaration", "property_get_declaration", "property_let_declaration", "property_set_declaration":
+		r := vbaast.NodeRange(node)
+		kind := "Sub"
+		if strings.Contains(node.Kind(), "function") {
+			kind = "Function"
+		} else if strings.Contains(node.Kind(), "property") {
+			kind = "Property"
+		}
+		*procedures = append(*procedures, sourceProcedure{
+			Kind:       kind,
+			Name:       nodeProcedureName(node, source),
+			ReturnType: typeText(node, source),
+			StartLine:  r.StartLine,
+			EndLine:    r.EndLine,
+			Params:     parameters(node, source),
+		})
+		return
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		collectSourceProcedures(node.NamedChild(i), source, procedures)
+	}
+}
+
+func nodeProcedureName(node *tree_sitter.Node, source []byte) string {
+	if name := node.ChildByFieldName("name"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	if name := firstNamedChildKind(node, "identifier"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	return ""
+}
+
+func parameters(node *tree_sitter.Node, source []byte) []parameterInfo {
+	list := node.ChildByFieldName("parameters")
+	if list == nil {
+		list = firstNamedChildKind(node, "parameter_list")
+	}
+	if list == nil {
+		return nil
+	}
+	var params []parameterInfo
+	for i := uint(0); i < list.NamedChildCount(); i++ {
+		child := list.NamedChild(i)
+		if child == nil || child.Kind() != "parameter" {
+			continue
+		}
+		param := parameterInfo{Name: nodeName(child, source), Type: typeText(child, source)}
+		if hasWord(child.Utf8Text(source), "ByVal") {
+			param.Passing = "ByVal"
+		} else {
+			param.Passing = "ByRef"
+		}
+		params = append(params, param)
+	}
+	return params
+}
+
+func procedureDeclarations(lines []string, proc sourceProcedure) map[string]sourceDeclaration {
+	decls := map[string]sourceDeclaration{}
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		lineNo := i + 1
+		stmt := normalizedCodeLine(lines[i])
+		lower := strings.ToLower(stmt)
+		if !strings.HasPrefix(lower, "dim ") && !strings.HasPrefix(lower, "static ") && !strings.HasPrefix(lower, "private ") && !strings.HasPrefix(lower, "public ") {
+			continue
+		}
+		m := declRe.FindStringSubmatch(stmt)
+		if len(m) == 0 {
+			continue
+		}
+		for _, part := range strings.Split(m[1], ",") {
+			name, typ, array, newExpr := declarationNameAndType(part)
+			if name == "" {
+				continue
+			}
+			decls[strings.ToLower(name)] = sourceDeclaration{Name: name, Type: typ, Line: lineNo, Object: isObjectType(typ), Array: array, NewExpression: newExpr}
+		}
+	}
+	return decls
+}
+
+func declarationNameAndType(text string) (string, string, bool, bool) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", "", false, false
+	}
+	lower := strings.ToLower(text)
+	namePart := text
+	typ := ""
+	if idx := strings.Index(lower, " as "); idx >= 0 {
+		namePart = strings.TrimSpace(text[:idx])
+		typ = strings.TrimSpace(text[idx+4:])
+	}
+	newExpr := false
+	if strings.HasPrefix(strings.ToLower(typ), "new ") {
+		newExpr = true
+		typ = strings.TrimSpace(typ[4:])
+	}
+	array := strings.Contains(namePart, "(") || strings.Contains(strings.ToLower(typ), "()")
+	namePart = strings.TrimSpace(strings.TrimLeft(namePart, "()"))
+	nameFields := strings.FieldsFunc(namePart, func(r rune) bool {
+		return !isVBAIdentifierRune(r)
+	})
+	if len(nameFields) == 0 {
+		return "", typ, array, newExpr
+	}
+	return cleanIdentifier(nameFields[0]), typ, array, newExpr
+}
+
+func initialObjectState(decls map[string]sourceDeclaration) map[string]bool {
+	out := map[string]bool{}
+	for key, decl := range decls {
+		if decl.Object {
+			out[key] = decl.Parameter || decl.NewExpression
+		}
+	}
+	return out
+}
+
+func (a Analyzer) legacyMemberMismatchFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls map[string]sourceDeclaration, withStack []withInfo) []Finding {
+	all := a.memberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)
+	filtered := all[:0]
+	for _, finding := range all {
+		if finding.Code == "VBA104" {
+			filtered = append(filtered, finding)
+		}
+	}
+	return filtered
+}
+
+func (a Analyzer) memberMismatchFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls map[string]sourceDeclaration, withStack []withInfo) []Finding {
+	var findings []Finding
+	if currentWith, ok := currentWithInfo(withStack); ok {
+		if m := withMemberRe.FindStringSubmatch(stmt); len(m) > 0 {
+			if rule, ok := invalidMemberRuleFor(currentWith.Type, m[1]); ok {
+				findings = append(findings, a.memberFinding(file, proc, lineNo, currentWith.Target, currentWith.Type, m[1], rule))
 			}
 		}
 	}
-	return findings, nil
+	for _, m := range memberRe.FindAllStringSubmatch(stmt, -1) {
+		if decl, ok := decls[strings.ToLower(m[1])]; ok {
+			if rule, ok := invalidMemberRuleFor(decl.Type, m[2]); ok {
+				findings = append(findings, a.memberFinding(file, proc, lineNo, m[1], decl.Type, m[2], rule))
+			}
+		}
+	}
+	return findings
+}
+
+func (a Analyzer) rangeFindFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, findAssignments map[string]int, guarded map[string]bool) []Finding {
+	lower := strings.ToLower(stmt)
+	for name := range findAssignments {
+		if strings.Contains(lower, "if "+name+" is nothing") || strings.Contains(lower, "if not "+name+" is nothing") {
+			guarded[name] = true
+		}
+	}
+	if name, ok := rangeFindAssignment(stmt); ok {
+		findAssignments[strings.ToLower(name)] = lineNo
+		return nil
+	}
+	var findings []Finding
+	for name, assignLine := range findAssignments {
+		if guarded[name] {
+			continue
+		}
+		if strings.Contains(lower, name+".") {
+			suggestion := "Add If " + name + " Is Nothing Then handling after the Find assignment."
+			if assignLine == 0 {
+				suggestion = "Check the Find result for Nothing before dereferencing it."
+			}
+			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA201", "warning", "Range.Find result "+name+" is dereferenced before a Nothing check.", "Range.Find returns Nothing when no match is found, so dereferencing the result can raise runtime error 91.", suggestion))
+			guarded[name] = true
+		}
+	}
+	return findings
+}
+
+func (a Analyzer) objectUseBeforeSetFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls map[string]sourceDeclaration, initialized, maybeInitializedByCall map[string]bool) []Finding {
+	var findings []Finding
+	lower := strings.ToLower(stmt)
+	for key, decl := range decls {
+		if !decl.Object || initialized[key] || maybeInitializedByCall[key] || lineNo <= decl.Line {
+			continue
+		}
+		if strings.Contains(lower, key+".") {
+			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA202", "warning", decl.Name+" may be used before it is assigned with Set.", "Object variables are Nothing until assigned with Set; member access before initialization can raise runtime error 91.", "Assign `Set "+decl.Name+" = ...` before using members, or guard `If "+decl.Name+" Is Nothing Then`."))
+			initialized[key] = true
+		}
+	}
+	return findings
+}
+
+func markCallInitialized(stmt string, decls map[string]sourceDeclaration, maybeInitialized map[string]bool) {
+	if strings.Contains(stmt, "=") {
+		return
+	}
+	lower := strings.ToLower(stmt)
+	for _, prefix := range []string{"dim ", "static ", "private ", "public "} {
+		if strings.HasPrefix(lower, prefix) {
+			return
+		}
+	}
+	for key, decl := range decls {
+		if decl.Object && hasWord(lower, key) {
+			maybeInitialized[key] = true
+		}
+	}
+}
+
+func (a Analyzer) unqualifiedExcelFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string) []Finding {
+	var findings []Finding
+	for _, m := range unqualifiedExcelRe.FindAllStringSubmatch(stmt, -1) {
+		name := m[2]
+		findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA205", "warning", "Unqualified "+name+" access depends on the active worksheet.", "Unqualified Excel object access is resolved through the active sheet or selection at runtime.", "Qualify "+name+" with an explicit Worksheet or Range object."))
+	}
+	for _, m := range activeExcelRe.FindAllStringSubmatch(stmt, -1) {
+		name := m[2]
+		findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA205", "warning", name+" creates an active Excel object dependency.", "ActiveWorkbook, ActiveSheet, ActiveCell, and Selection depend on the user's current Excel state.", "Pass or capture explicit Workbook, Worksheet, or Range objects instead."))
+	}
+	return findings
+}
+
+func (a Analyzer) byRefMismatchFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, ctx analysisContext) []Finding {
+	name, args, ok := parseSimpleCall(stmt)
+	if !ok {
+		return nil
+	}
+	sig, ok := ctx.procedures[strings.ToLower(name)]
+	if !ok {
+		return nil
+	}
+	var findings []Finding
+	for i, arg := range args {
+		if i >= len(sig.Params) {
+			break
+		}
+		param := sig.Params[i]
+		if strings.EqualFold(param.Passing, "ByVal") || param.Type == "" {
+			continue
+		}
+		if obviousArgumentMismatch(arg, param.Type) {
+			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA206", "warning", "Argument for ByRef parameter "+param.Name+" may not match "+param.Type+".", "VBA ByRef arguments must be type-compatible with the declared parameter.", "Pass a variable of type "+param.Type+" or change the procedure parameter to ByVal when mutation is not required."))
+		}
+	}
+	return findings
+}
+
+func (a Analyzer) dictionaryCollectionFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls map[string]sourceDeclaration) []Finding {
+	lower := strings.ToLower(stmt)
+	if strings.Contains(lower, ".exists(") || strings.Contains(lower, "on error") {
+		return nil
+	}
+	var findings []Finding
+	for key, decl := range decls {
+		typ := strings.ToLower(cleanIdentifier(decl.Type))
+		if typ != "dictionary" && typ != "collection" && typ != "scripting.dictionary" {
+			continue
+		}
+		if strings.Contains(lower, key+"(") || strings.Contains(lower, key+".item(") {
+			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA207", "warning", decl.Name+" item access has no obvious existence guard.", "Dictionary and Collection item lookup can fail at runtime when the key is missing.", "Guard the access with Exists, explicit error handling, or a prior key validation path."))
+		}
+	}
+	return findings
+}
+
+func (a Analyzer) redimPreserveFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string) []Finding {
+	m := redimPreserveRe.FindStringSubmatch(stmt)
+	if len(m) == 0 || !strings.Contains(m[2], ",") {
+		return nil
+	}
+	return []Finding{a.simpleFinding(file, proc, lineNo, "VBA208", "warning", "ReDim Preserve is used on a multi-dimensional array.", "VBA can only Preserve the last dimension of an array; changing earlier dimensions raises a runtime error.", "Only change the last dimension, or copy values into a newly sized array explicitly.")}
+}
+
+func (a Analyzer) objectArrayComparisonFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls map[string]sourceDeclaration) []Finding {
+	lower := strings.ToLower(stmt)
+	var findings []Finding
+	for key, decl := range decls {
+		if decl.Object && strings.Contains(lower, key+" = nothing") {
+			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", decl.Name+" is compared to Nothing with =.", "Object references must be compared with Is Nothing, not the scalar equality operator.", "Use `If "+decl.Name+" Is Nothing Then` or `If Not "+decl.Name+" Is Nothing Then`."))
+		}
+		if decl.Array && (strings.Contains(lower, key+" = ") || strings.Contains(lower, " = "+key)) {
+			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", decl.Name+" appears to be compared as a scalar value.", "VBA arrays cannot be compared directly to scalar values.", "Compare explicit elements or bounds instead of the array variable itself."))
+		}
+	}
+	return findings
+}
+
+func (a Analyzer) applicationStateFindings(file parsedFile, proc sourceProcedure) []Finding {
+	props := []string{"enableevents", "displayalerts", "screenupdating", "calculation"}
+	var findings []Finding
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(file.Lines); i++ {
+		stmt := normalizedCodeLine(file.Lines[i])
+		lower := compactStatement(strings.ToLower(stmt))
+		for _, prop := range props {
+			prefix := "application." + prop + "="
+			if !strings.Contains(lower, prefix) {
+				continue
+			}
+			if prop != "calculation" && !strings.Contains(lower, prefix+"false") {
+				continue
+			}
+			if prop == "calculation" && strings.Contains(lower, prefix+"xlcalculationautomatic") {
+				continue
+			}
+			if hasLaterApplicationRestore(file.Lines, proc, i+1, prop) {
+				continue
+			}
+			name := applicationStateName(prop)
+			findings = append(findings, a.simpleFinding(file, proc, i+1, "VBA203", "warning", "Application."+name+" is changed without an obvious restore path.", "Macros that leave Excel application state changed can break later user or automation workflows after failure.", "Save the previous Application."+name+" value and restore it in a cleanup path."))
+		}
+	}
+	return findings
+}
+
+func hasLaterApplicationRestore(lines []string, proc sourceProcedure, start int, prop string) bool {
+	prefix := "application." + prop + "="
+	for i := start; i < proc.EndLine && i < len(lines); i++ {
+		lower := compactStatement(strings.ToLower(normalizedCodeLine(lines[i])))
+		if !strings.Contains(lower, prefix) {
+			continue
+		}
+		if prop == "calculation" || !strings.Contains(lower, prefix+"false") {
+			return true
+		}
+	}
+	return false
+}
+
+func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourceProcedure, handlerLabels map[string]bool) []Finding {
+	if len(handlerLabels) == 0 {
+		return nil
+	}
+	var findings []Finding
+	lastCode := ""
+	for i := proc.StartLine - 1; i < proc.EndLine-1 && i < len(file.Lines); i++ {
+		lineNo := i + 1
+		stmt := normalizedCodeLine(file.Lines[i])
+		if stmt == "" {
+			continue
+		}
+		if label, ok := labelName(stmt); ok && handlerLabels[strings.ToLower(label)] {
+			if !isCleanupFallthroughLabel(label) && !terminatesNormalFlow(lastCode) {
+				findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA204", "warning", "Normal execution can fall through into error handler "+label+".", "Without Exit Sub, Exit Function, or Exit Property before the handler label, successful execution can run error handling code.", "Add an Exit statement before "+label+" or rename the label as a cleanup path if fallthrough is intentional."))
+			}
+		}
+		lastCode = stmt
+	}
+	return findings
+}
+
+func onErrorHandlerLabels(lines []string, proc sourceProcedure) map[string]bool {
+	labels := map[string]bool{}
+	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+		stmt := normalizedCodeLine(lines[i])
+		lower := strings.ToLower(stmt)
+		if strings.HasPrefix(lower, "on error goto ") && lower != "on error goto 0" {
+			label := cleanIdentifier(strings.TrimSpace(stmt[len("on error goto "):]))
+			if label != "" {
+				labels[strings.ToLower(label)] = true
+			}
+		}
+	}
+	return labels
 }
 
 func BlockingFindings(findings []Finding) []Finding {
@@ -304,11 +806,7 @@ func BlockingFindings(findings []Finding) []Finding {
 	return blocking
 }
 
-func (a Analyzer) finding(path, module, procedure string, line int, lines []string, code, target, typ string) Finding {
-	file, err := filepath.Rel(a.RootDir, path)
-	if err != nil {
-		file = path
-	}
+func (a Analyzer) objectSetFinding(file parsedFile, proc sourceProcedure, line int, code, target, typ string) Finding {
 	msg := target + " is declared As " + typ + " and is assigned without Set."
 	reason := "VBA object references require `Set` when assigning an object value."
 	suggestion := "Use `Set " + target + " = ...` when the right-hand side returns an object."
@@ -317,82 +815,38 @@ func (a Analyzer) finding(path, module, procedure string, line int, lines []stri
 		reason = "Object-returning VBA functions must assign the function name with `Set` before returning."
 		suggestion = "Use `Set " + target + " = ...` inside this function body when returning a " + typ + "."
 	}
-	return Finding{
-		Code:       code,
-		Severity:   "warning",
-		File:       filepath.ToSlash(file),
-		Module:     module,
-		Procedure:  procedure,
-		Line:       line,
-		Message:    msg,
-		Reason:     reason,
-		Suggestion: suggestion,
-		NearbyCode: nearby(lines, line, 2),
-	}
+	return a.simpleFinding(file, proc, line, code, "warning", msg, reason, suggestion)
 }
 
-func (a Analyzer) memberFinding(path, module, procedure string, line int, lines []string, target, typ, member string, rule invalidMemberRule) Finding {
-	file, err := filepath.Rel(a.RootDir, path)
-	if err != nil {
-		file = path
-	}
+func (a Analyzer) memberFinding(file parsedFile, proc sourceProcedure, line int, target, typ, member string, rule invalidMemberRule) Finding {
 	targetLabel := target
 	if targetLabel == "" {
 		targetLabel = "This object"
 	}
-	return Finding{
-		Code:       "VBA104",
-		Severity:   "error",
-		File:       filepath.ToSlash(file),
-		Module:     module,
-		Procedure:  procedure,
-		Line:       line,
-		Message:    targetLabel + " is declared As " + typ + " but ." + member + " is not a member of " + typ + ".",
-		Reason:     rule.Reason,
-		Suggestion: rule.Suggestion,
-		NearbyCode: nearby(lines, line, 2),
-	}
+	return a.simpleFinding(file, proc, line, rule.Code, "error", targetLabel+" is declared As "+typ+" but ."+member+" is not a member of "+typ+".", rule.Reason, rule.Suggestion)
 }
 
-func (a Analyzer) helperFinding(path, module, procedure string, line int, lines []string, helper string, rule helperDependencyRule) Finding {
-	file, err := filepath.Rel(a.RootDir, path)
-	if err != nil {
-		file = path
-	}
-	return Finding{
-		Code:       rule.Code,
-		Severity:   "error",
-		File:       filepath.ToSlash(file),
-		Module:     module,
-		Procedure:  procedure,
-		Line:       line,
-		Message:    helper + " is a removed legacy trace API and should not appear in project VBA.",
-		Reason:     rule.Reason,
-		Suggestion: rule.Suggestion,
-		NearbyCode: nearby(lines, line, 2),
-	}
+func (a Analyzer) helperFinding(file parsedFile, proc sourceProcedure, line int, helper string, rule helperDependencyRule) Finding {
+	return a.simpleFinding(file, proc, line, rule.Code, "error", helper+" is a removed legacy trace API and should not appear in project VBA.", rule.Reason, rule.Suggestion)
 }
 
-func readLines(path string) ([]string, error) {
-	f, err := os.Open(path)
+func (a Analyzer) simpleFinding(file parsedFile, proc sourceProcedure, line int, code, severity, message, reason, suggestion string) Finding {
+	rel, err := filepath.Rel(a.RootDir, file.Path)
 	if err != nil {
-		return nil, err
+		rel = file.Path
 	}
-	var lines []string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
+	return Finding{
+		Code:       code,
+		Severity:   severity,
+		File:       filepath.ToSlash(rel),
+		Module:     file.Module,
+		Procedure:  proc.Name,
+		Line:       line,
+		Message:    message,
+		Reason:     reason,
+		Suggestion: suggestion,
+		NearbyCode: nearby(file.Lines, line, 2),
 	}
-	if err := scanner.Err(); err != nil {
-		if closeErr := f.Close(); closeErr != nil {
-			return nil, closeErr
-		}
-		return nil, err
-	}
-	if err := f.Close(); err != nil {
-		return nil, err
-	}
-	return lines, nil
 }
 
 func nearby(lines []string, line, radius int) []string {
@@ -415,12 +869,50 @@ func nearby(lines []string, line, radius int) []string {
 	return out
 }
 
+func normalizedSourceLines(source string) []string {
+	source = strings.ReplaceAll(source, "\r\n", "\n")
+	source = strings.ReplaceAll(source, "\r", "\n")
+	return strings.Split(source, "\n")
+}
+
+func normalizedCodeLine(line string) string {
+	return strings.Join(strings.Fields(maskStringLiterals(gui.StripComment(line))), " ")
+}
+
+func maskStringLiterals(line string) string {
+	var b strings.Builder
+	b.Grow(len(line))
+	inString := false
+	for i := 0; i < len(line); i++ {
+		if line[i] != '"' {
+			if inString {
+				b.WriteByte(' ')
+			} else {
+				b.WriteByte(line[i])
+			}
+			continue
+		}
+		b.WriteByte('"')
+		if inString && i+1 < len(line) && line[i+1] == '"' {
+			b.WriteByte('"')
+			i++
+			continue
+		}
+		inString = !inString
+	}
+	return b.String()
+}
+
+func compactStatement(stmt string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(stmt, " ", ""), "\t", "")
+}
+
 func isObjectType(typ string) bool {
-	typ = strings.ToLower(strings.TrimSpace(typ))
+	typ = strings.ToLower(cleanIdentifier(strings.TrimSpace(typ)))
 	if typ == "" {
 		return false
 	}
-	return objectTypes[typ] || strings.HasSuffix(typ, ".application") || strings.HasSuffix(typ, ".workbook") || strings.HasSuffix(typ, ".worksheet") || strings.HasSuffix(typ, ".range")
+	return objectTypes[typ] || strings.HasSuffix(typ, ".application") || strings.HasSuffix(typ, ".workbook") || strings.HasSuffix(typ, ".worksheet") || strings.HasSuffix(typ, ".range") || strings.HasSuffix(typ, ".dictionary")
 }
 
 func lastName(name string) string {
@@ -448,7 +940,7 @@ func referencedTraceHelpers(code string) []string {
 	return helpers
 }
 
-func resolveWithInfo(expr string, decls map[string]string) withInfo {
+func resolveWithInfo(expr string, decls map[string]sourceDeclaration) withInfo {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
 		return withInfo{}
@@ -457,9 +949,9 @@ func resolveWithInfo(expr string, decls map[string]string) withInfo {
 	if idx := strings.Index(base, "("); idx >= 0 {
 		base = base[:idx]
 	}
-	base = lastName(strings.TrimSpace(base))
-	if typ, ok := decls[strings.ToLower(base)]; ok {
-		return withInfo{Target: base, Type: typ}
+	base = lastName(strings.TrimSpace(strings.TrimPrefix(base, "Set ")))
+	if decl, ok := decls[strings.ToLower(base)]; ok {
+		return withInfo{Target: base, Type: decl.Type}
 	}
 	return withInfo{}
 }
@@ -474,28 +966,258 @@ func currentWithInfo(stack []withInfo) (withInfo, bool) {
 }
 
 func invalidMemberRuleFor(typ, member string) (invalidMemberRule, bool) {
-	rules, ok := invalidObjectMembers[strings.ToLower(strings.TrimSpace(typ))]
+	rules, ok := invalidObjectMembers[strings.ToLower(cleanIdentifier(strings.TrimSpace(typ)))]
 	if !ok {
 		return invalidMemberRule{}, false
 	}
-	rule, ok := rules[strings.ToLower(strings.TrimSpace(member))]
+	rule, ok := rules[strings.ToLower(cleanIdentifier(strings.TrimSpace(member)))]
 	if !ok {
 		return invalidMemberRule{}, false
 	}
 	return rule, true
 }
 
-func isStandardModuleFile(path, modulesRoot string) bool {
-	if !strings.EqualFold(filepath.Ext(path), ".bas") {
+func rangeFindAssignment(stmt string) (string, bool) {
+	lower := strings.ToLower(stmt)
+	if !strings.Contains(lower, ".find(") && !strings.Contains(lower, ".find ") {
+		return "", false
+	}
+	left, _, ok := strings.Cut(stmt, "=")
+	if !ok {
+		return "", false
+	}
+	left = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(left), "Set "))
+	fields := strings.FieldsFunc(left, func(r rune) bool {
+		return !isVBAIdentifierRune(r)
+	})
+	if len(fields) == 0 {
+		return "", false
+	}
+	return cleanIdentifier(fields[len(fields)-1]), true
+}
+
+func labelName(stmt string) (string, bool) {
+	stmt = strings.TrimSpace(stmt)
+	if !strings.HasSuffix(stmt, ":") || strings.Contains(stmt, " ") {
+		return "", false
+	}
+	name := cleanIdentifier(strings.TrimSuffix(stmt, ":"))
+	return name, name != ""
+}
+
+func isCleanupFallthroughLabel(label string) bool {
+	switch strings.ToLower(label) {
+	case "cleanup", "clean_up", "finally", "done":
+		return true
+	default:
 		return false
 	}
+}
+
+func terminatesNormalFlow(stmt string) bool {
+	lower := strings.ToLower(strings.TrimSpace(stmt))
+	return strings.HasPrefix(lower, "exit sub") ||
+		strings.HasPrefix(lower, "exit function") ||
+		strings.HasPrefix(lower, "exit property") ||
+		strings.HasPrefix(lower, "goto ") ||
+		lower == "end"
+}
+
+func applicationStateName(prop string) string {
+	switch strings.ToLower(prop) {
+	case "enableevents":
+		return "EnableEvents"
+	case "displayalerts":
+		return "DisplayAlerts"
+	case "screenupdating":
+		return "ScreenUpdating"
+	case "calculation":
+		return "Calculation"
+	default:
+		return prop
+	}
+}
+
+func parseSimpleCall(stmt string) (string, []string, bool) {
+	stmt = strings.TrimSpace(stmt)
+	if stmt == "" || strings.HasPrefix(strings.ToLower(stmt), "call ") {
+		stmt = strings.TrimSpace(strings.TrimPrefix(stmt, "Call "))
+	}
+	if strings.Contains(stmt, "=") || strings.HasPrefix(strings.ToLower(stmt), "if ") {
+		return "", nil, false
+	}
+	name := ""
+	argText := ""
+	if idx := strings.Index(stmt, "("); idx >= 0 && strings.HasSuffix(stmt, ")") {
+		name = strings.TrimSpace(stmt[:idx])
+		argText = strings.TrimSuffix(stmt[idx+1:], ")")
+	} else {
+		fields := strings.Fields(stmt)
+		if len(fields) < 2 {
+			return "", nil, false
+		}
+		name = fields[0]
+		argText = strings.TrimSpace(stmt[len(name):])
+	}
+	name = cleanIdentifier(lastName(name))
+	if name == "" {
+		return "", nil, false
+	}
+	return name, splitArgs(argText), true
+}
+
+func splitArgs(text string) []string {
+	var args []string
+	start := 0
+	inString := false
+	depth := 0
+	for i := 0; i < len(text); i++ {
+		switch text[i] {
+		case '"':
+			if inString && i+1 < len(text) && text[i+1] == '"' {
+				i++
+				continue
+			}
+			inString = !inString
+		case '(':
+			if !inString {
+				depth++
+			}
+		case ')':
+			if !inString && depth > 0 {
+				depth--
+			}
+		case ',':
+			if !inString && depth == 0 {
+				args = append(args, strings.TrimSpace(text[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if strings.TrimSpace(text[start:]) != "" {
+		args = append(args, strings.TrimSpace(text[start:]))
+	}
+	return args
+}
+
+func obviousArgumentMismatch(arg, typ string) bool {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return false
+	}
+	lowerType := strings.ToLower(cleanIdentifier(typ))
+	isStringLiteral := strings.HasPrefix(arg, `"`) && strings.HasSuffix(arg, `"`)
+	isNumericLiteral := true
+	for _, r := range arg {
+		if (r < '0' || r > '9') && r != '.' && r != '-' {
+			isNumericLiteral = false
+			break
+		}
+	}
+	if isStringLiteral {
+		return lowerType != "string" && lowerType != "variant"
+	}
+	if isNumericLiteral {
+		return lowerType == "string" || isObjectType(typ)
+	}
+	return false
+}
+
+func typeText(node *tree_sitter.Node, source []byte) string {
+	asType := node.ChildByFieldName("type")
+	if asType == nil {
+		asType = firstNamedChildKind(node, "as_type_clause")
+	}
+	if asType == nil {
+		return ""
+	}
+	if typeExpr := asType.ChildByFieldName("type"); typeExpr != nil {
+		return strings.TrimSpace(typeExpr.Utf8Text(source))
+	}
+	if asType.Kind() == "type_expression" {
+		return strings.TrimSpace(asType.Utf8Text(source))
+	}
+	text := strings.TrimSpace(asType.Utf8Text(source))
+	if strings.HasPrefix(strings.ToLower(text), "as ") {
+		return strings.TrimSpace(text[3:])
+	}
+	return text
+}
+
+func nodeName(node *tree_sitter.Node, source []byte) string {
+	if name := node.ChildByFieldName("name"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	if name := firstNamedChildKind(node, "identifier"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	return ""
+}
+
+func firstNamedChildKind(node *tree_sitter.Node, kind string) *tree_sitter.Node {
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child != nil && child.Kind() == kind {
+			return child
+		}
+	}
+	return nil
+}
+
+func cleanIdentifier(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.Trim(text, "[]")
+	text = strings.TrimRight(text, "$%&#@^!")
+	return text
+}
+
+func hasWord(text, word string) bool {
+	fields := strings.FieldsFunc(text, func(r rune) bool {
+		return !isVBAIdentifierRune(r)
+	})
+	for _, field := range fields {
+		if strings.EqualFold(field, word) {
+			return true
+		}
+	}
+	return false
+}
+
+func isVBAIdentifierRune(r rune) bool {
+	switch r {
+	case '_', '$', '%', '&', '!', '#', '@', '^':
+		return true
+	}
+	return r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z'
+}
+
+func isPathInsideRoot(path, root string) bool {
 	path = filepath.Clean(path)
-	modulesRoot = filepath.Clean(modulesRoot)
-	rel, err := filepath.Rel(modulesRoot, path)
+	root = filepath.Clean(root)
+	if strings.EqualFold(path, root) {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
 	if err != nil {
 		return false
 	}
-	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	return rel != "." && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)
+}
+
+func sortFindings(findings []Finding) {
+	sort.SliceStable(findings, func(i, j int) bool {
+		a, b := findings[i], findings[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		if a.Column != b.Column {
+			return a.Column < b.Column
+		}
+		return a.Code < b.Code
+	})
 }
 
 func strconvItoa(v int) string {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -182,6 +183,11 @@ func (a Analyzer) Run() ([]Finding, error) {
 		if err != nil {
 			closeParsedFiles(parsedFiles)
 			return nil, err
+		}
+		if parsed.HasError || parsed.HasMissing {
+			parsed.Close()
+			closeParsedFiles(parsedFiles)
+			return nil, fmt.Errorf("parse %s: VBA parser reported errors or missing nodes", file)
 		}
 		parsedFiles = append(parsedFiles, parsedFile{
 			Path:   file,
@@ -409,7 +415,7 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 		if a.Config.Analyze.DetectObjectArrayComparison {
 			findings = append(findings, a.objectArrayComparisonFindings(file, proc, lineNo, stmt, decls)...)
 		}
-		markCallInitialized(stmt, decls, maybeInitializedByCall)
+		markCallInitialized(stmt, decls, ctx, maybeInitializedByCall)
 		_ = lower
 	}
 	if a.Config.Analyze.DetectApplicationStateRestore {
@@ -675,18 +681,28 @@ func (a Analyzer) objectUseBeforeSetFindings(file parsedFile, proc sourceProcedu
 	return findings
 }
 
-func markCallInitialized(stmt string, decls map[string]sourceDeclaration, maybeInitialized map[string]bool) {
+func markCallInitialized(stmt string, decls map[string]sourceDeclaration, ctx analysisContext, maybeInitialized map[string]bool) {
 	if strings.Contains(stmt, "=") {
 		return
 	}
-	lower := strings.ToLower(stmt)
-	for _, prefix := range []string{"dim ", "static ", "private ", "public "} {
-		if strings.HasPrefix(lower, prefix) {
-			return
-		}
+	name, args, ok := parseSimpleCall(stmt)
+	if !ok {
+		return
 	}
-	for key, decl := range decls {
-		if decl.Object && hasWord(lower, key) {
+	sig, ok := ctx.procedures[strings.ToLower(name)]
+	if !ok {
+		return
+	}
+	for i, arg := range args {
+		if i >= len(sig.Params) {
+			break
+		}
+		param := sig.Params[i]
+		if strings.EqualFold(param.Passing, "ByVal") || !isObjectType(param.Type) {
+			continue
+		}
+		key := strings.ToLower(cleanIdentifier(arg))
+		if decl, ok := decls[key]; ok && decl.Object {
 			maybeInitialized[key] = true
 		}
 	}
@@ -763,11 +779,49 @@ func (a Analyzer) objectArrayComparisonFindings(file parsedFile, proc sourceProc
 		if decl.Object && strings.Contains(lower, key+" = nothing") {
 			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", decl.Name+" is compared to Nothing with =.", "Object references must be compared with Is Nothing, not the scalar equality operator.", "Use `If "+decl.Name+" Is Nothing Then` or `If Not "+decl.Name+" Is Nothing Then`."))
 		}
-		if decl.Array && (strings.Contains(lower, key+" = ") || strings.Contains(lower, " = "+key)) {
+		if decl.Array && identifierComparedAsOperand(lower, key) {
 			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", decl.Name+" appears to be compared as a scalar value.", "VBA arrays cannot be compared directly to scalar values.", "Compare explicit elements or bounds instead of the array variable itself."))
 		}
 	}
 	return findings
+}
+
+func identifierComparedAsOperand(stmt, name string) bool {
+	name = strings.ToLower(cleanIdentifier(name))
+	if name == "" {
+		return false
+	}
+	for _, op := range []string{"=", "<>", "<=", ">=", "<", ">"} {
+		parts := strings.Split(stmt, op)
+		if len(parts) < 2 {
+			continue
+		}
+		for i := 0; i < len(parts)-1; i++ {
+			if operandIsIdentifier(parts[i], name) || operandIsIdentifier(parts[i+1], name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func operandIsIdentifier(text, name string) bool {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return false
+	}
+	fields := strings.FieldsFunc(text, func(r rune) bool {
+		return !isVBAIdentifierRune(r)
+	})
+	if len(fields) == 0 {
+		return false
+	}
+	candidate := strings.ToLower(cleanIdentifier(fields[len(fields)-1]))
+	if candidate == name {
+		return true
+	}
+	candidate = strings.ToLower(cleanIdentifier(fields[0]))
+	return candidate == name
 }
 
 func (a Analyzer) applicationStateFindings(file parsedFile, proc sourceProcedure) []Finding {
@@ -1092,8 +1146,11 @@ func applicationStateName(prop string) string {
 
 func parseSimpleCall(stmt string) (string, []string, bool) {
 	stmt = strings.TrimSpace(stmt)
-	if stmt == "" || strings.HasPrefix(strings.ToLower(stmt), "call ") {
-		stmt = strings.TrimSpace(strings.TrimPrefix(stmt, "Call "))
+	if stmt == "" {
+		return "", nil, false
+	}
+	if strings.HasPrefix(strings.ToLower(stmt), "call ") {
+		stmt = strings.TrimSpace(stmt[len("call "):])
 	}
 	if strings.Contains(stmt, "=") || strings.HasPrefix(strings.ToLower(stmt), "if ") {
 		return "", nil, false

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -25,6 +25,22 @@ End Sub
 	assertFinding(t, findings, "VBA101", 4)
 }
 
+func TestAnalyzerFindsMissingSetForModuleLevelObjectVariable(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private ws As Worksheet
+Public Sub Run()
+  ws = ThisWorkbook.Worksheets("Sheet1")
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFinding(t, findings, "VBA101", 4)
+}
+
 func TestAnalyzerFindsMissingSetForObjectReturningFunction(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
@@ -114,6 +130,23 @@ func TestAnalyzerFindsWorksheetMemberAssignedOnVariable(t *testing.T) {
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
   Dim ws As Worksheet
+  Set ws = ThisWorkbook.Worksheets(1)
+  ws.DisplayGridlines = False
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFinding(t, findings, "VBA104", 5)
+}
+
+func TestAnalyzerFindsWorksheetMemberOnModuleLevelVariable(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private ws As Worksheet
+Public Sub Run()
   Set ws = ThisWorkbook.Worksheets(1)
   ws.DisplayGridlines = False
 End Sub
@@ -307,6 +340,23 @@ End Sub
 			t.Fatalf("%s should not trigger for guarded pattern: %+v", code, got)
 		}
 	}
+}
+
+func TestAnalyzerChecksObjectUseOnSetAssignmentRHS(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim ws As Worksheet
+  Dim rng As Range
+  Set rng = ws.Range("A1")
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFinding(t, findings, "VBA202", 5)
 }
 
 func TestAnalyzerOptInRuntimeRiskRules(t *testing.T) {

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -240,6 +240,142 @@ func TestAnalyzerSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
 	}
 }
 
+func TestAnalyzerFindsDefaultRuntimeRiskRules(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim found As Range
+  Dim ws As Worksheet
+  Set found = Range("A:A").Find("x")
+  Debug.Print found.Value
+  ws.Range("A1").Value = 1
+  Application.EnableEvents = False
+  On Error GoTo ErrHandler
+  Debug.Print "work"
+ErrHandler:
+  Debug.Print Err.Description
+  Dim values() As Variant
+  ReDim Preserve values(1 To 2, 1 To 3)
+  If ws = Nothing Then Debug.Print "missing"
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for code, line := range map[string]int{
+		"VBA201": 6,
+		"VBA202": 7,
+		"VBA203": 8,
+		"VBA204": 11,
+		"VBA205": 5,
+		"VBA208": 14,
+		"VBA209": 15,
+	} {
+		assertFinding(t, findings, code, line)
+	}
+}
+
+func TestAnalyzerRuntimeRiskRulesAllowGuardedPatterns(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Function Build() As Range
+  Set Build = Sheet1.Range("A1")
+End Function
+Public Sub Run()
+  Dim found As Range
+  Dim ws As Worksheet
+  Dim oldEvents As Boolean
+  oldEvents = Application.EnableEvents
+  Set ws = ThisWorkbook.Worksheets(1)
+  Set found = ws.Range("A:A").Find("x")
+  If found Is Nothing Then Exit Sub
+  Debug.Print found.Value
+  Application.EnableEvents = False
+Cleanup:
+  Application.EnableEvents = oldEvents
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, code := range []string{"VBA201", "VBA202", "VBA203", "VBA204", "VBA205", "VBA210"} {
+		if got := findingsByCode(findings, code); len(got) != 0 {
+			t.Fatalf("%s should not trigger for guarded pattern: %+v", code, got)
+		}
+	}
+}
+
+func TestAnalyzerOptInRuntimeRiskRules(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub NeedsLong(ByRef value As Long)
+End Sub
+Public Function MissingReturn() As Range
+End Function
+Public Sub Run()
+  Dim dict As Dictionary
+  Set dict = CreateObject("Scripting.Dictionary")
+  NeedsLong "abc"
+  Debug.Print dict("missing")
+End Sub
+`)
+	cfg := config.Default()
+	cfg.Analyze.DetectByRefArgumentMismatch = true
+	cfg.Analyze.DetectDictionaryCollectionGuard = true
+	cfg.Analyze.DetectFunctionReturnPath = true
+
+	findings, err := Analyzer{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFinding(t, findings, "VBA206", 9)
+	assertFinding(t, findings, "VBA207", 10)
+	assertFinding(t, findings, "VBA210", 4)
+}
+
+func TestAnalyzerExpandedExcelMemberMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim ws As Worksheet
+  Set ws = ThisWorkbook.Worksheets(1)
+  ws.ScreenUpdating = False
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFinding(t, findings, "VBA211", 5)
+}
+
+func TestAnalyzerRuntimeRiskRulesIgnoreCommentsAndStrings(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Debug.Print "Range(""A1"") On Error GoTo ErrHandler Application.EnableEvents = False"
+  ' Set found = Range("A:A").Find("x")
+  ' Debug.Print found.Value
+  ' ErrHandler:
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, code := range []string{"VBA201", "VBA203", "VBA204", "VBA205"} {
+		if got := findingsByCode(findings, code); len(got) != 0 {
+			t.Fatalf("%s should ignore comments and strings: %+v", code, got)
+		}
+	}
+}
+
 func writeModule(t *testing.T, dir, name, body string) {
 	t.Helper()
 	src := filepath.Join(dir, "src", "modules")
@@ -249,6 +385,16 @@ func writeModule(t *testing.T, dir, name, body string) {
 	if err := os.WriteFile(filepath.Join(src, name), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func findingsByCode(findings []Finding, code string) []Finding {
+	var matches []Finding
+	for _, finding := range findings {
+		if finding.Code == code {
+			matches = append(matches, finding)
+		}
+	}
+	return matches
 }
 
 func assertFinding(t *testing.T, findings []Finding, code string, line int) {

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -125,6 +125,22 @@ End Sub
 	}
 }
 
+func TestAnalyzerFailsOnParserRecovery(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Function Broken(ByVal value As String
+End Function
+`)
+
+	_, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err == nil {
+		t.Fatal("expected parser recovery error")
+	}
+	if !strings.Contains(err.Error(), "VBA parser reported errors or missing nodes") {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+}
+
 func TestAnalyzerFindsWorksheetMemberAssignedOnVariable(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
@@ -359,6 +375,45 @@ End Sub
 	assertFinding(t, findings, "VBA202", 5)
 }
 
+func TestAnalyzerDoesNotTreatAnyObjectMentionAsInitialization(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim ws As Worksheet
+  If ws Is Nothing Then Debug.Print "missing"
+  ws.Range("A1").Value = 1
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFinding(t, findings, "VBA202", 5)
+}
+
+func TestAnalyzerAllowsKnownByRefObjectInitializer(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Sub InitSheet(ByRef target As Worksheet)
+  Set target = ThisWorkbook.Worksheets(1)
+End Sub
+Public Sub Run()
+  Dim ws As Worksheet
+  InitSheet ws
+  ws.Range("A1").Value = 1
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA202"); len(got) != 0 {
+		t.Fatalf("known ByRef object initializer should suppress VBA202: %+v", got)
+	}
+}
+
 func TestAnalyzerOptInRuntimeRiskRules(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
@@ -385,6 +440,47 @@ End Sub
 	assertFinding(t, findings, "VBA206", 9)
 	assertFinding(t, findings, "VBA207", 10)
 	assertFinding(t, findings, "VBA210", 4)
+}
+
+func TestAnalyzerByRefMismatchHandlesLowercaseCallKeyword(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub NeedsLong(ByRef value As Long)
+End Sub
+Public Sub Run()
+  call NeedsLong("abc")
+End Sub
+`)
+	cfg := config.Default()
+	cfg.Analyze.DetectByRefArgumentMismatch = true
+
+	findings, err := Analyzer{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFinding(t, findings, "VBA206", 5)
+}
+
+func TestAnalyzerArrayComparisonUsesIdentifierBoundaries(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim a() As Variant
+  Dim total As Long
+  Dim amount As Long
+  If total = amount Then Debug.Print "ok"
+  If a = amount Then Debug.Print "bad"
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA209")
+	if len(got) != 1 || got[0].Line != 7 {
+		t.Fatalf("expected only array comparison on line 7, got %+v", got)
+	}
 }
 
 func TestAnalyzerExpandedExcelMemberMismatch(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4607,11 +4607,22 @@ func (a *app) runSourcePreflight(command string, cfg config.Config, action strin
 	if err != nil {
 		return a.writeFailure(command, output.ExitEnvironment, "lint_failed", err)
 	}
+	blockingIssues := lint.PushBlockingIssues(issues)
+	if len(blockingIssues) > 0 {
+		env := output.Failure(command, output.Error{
+			Code:    "lint_failed",
+			Message: fmt.Sprintf("%d source issue(s) must be fixed before %s to avoid a VBA editor dialog", len(blockingIssues), action),
+			Source:  "xlflow",
+			Phase:   "preflight",
+		})
+		env.Issues = blockingIssues
+		env.Logs = []string{"blocked before Excel automation to avoid a VBA editor dialog"}
+		return a.write(env, output.ExitValidation)
+	}
 	findings, err := analyze.Analyzer{RootDir: a.cwd, Config: cfg, PathFilter: pathFilter}.Run()
 	if err != nil {
 		return a.writeFailure(command, output.ExitEnvironment, "analyze_failed", err)
 	}
-	blockingIssues := lint.PushBlockingIssues(issues)
 	blockingFindings := filterAnalysisFindings(analyze.BlockingFindings(findings), ignoredAnalysisCodes)
 	if len(blockingIssues) == 0 && len(blockingFindings) == 0 {
 		return nil

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -3024,7 +3024,7 @@ code_source = "sidecar"
 	if got.Status != output.StatusFailed || got.Error.Code != "source_preflight_failed" || got.Error.Phase != "preflight" {
 		t.Fatalf("unexpected contaminated-sidecar preflight payload: %+v", got)
 	}
-	if len(got.Issues) != 1 || got.Issues[0].Code != "VBA201" || got.Issues[0].Line != 1 {
+	if len(got.Issues) != 1 || got.Issues[0].Code != "FRM202" || got.Issues[0].Line != 1 {
 		t.Fatalf("unexpected contaminated-sidecar issues: %+v", got.Issues)
 	}
 	if !strings.Contains(got.Issues[0].Suggestion, "Attribute VB_*") {
@@ -3387,7 +3387,7 @@ code_source = "sidecar"
 	if got.Status != output.StatusFailed || got.Error.Code != "source_preflight_failed" || got.Error.Phase != "preflight" {
 		t.Fatalf("unexpected push contaminated-sidecar payload: %+v", got)
 	}
-	if len(got.Issues) != 1 || got.Issues[0].Code != "VBA201" || got.Issues[0].Line != 1 {
+	if len(got.Issues) != 1 || got.Issues[0].Code != "FRM202" || got.Issues[0].Line != 1 {
 		t.Fatalf("unexpected push contaminated-sidecar issues: %+v", got.Issues)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	VBA      VBAConfig      `toml:"vba"`
 	UserForm UserFormConfig `toml:"userform"`
 	Lint     LintConfig     `toml:"lint"`
+	Analyze  AnalyzeConfig  `toml:"analyze"`
 }
 
 type ProjectConfig struct {
@@ -60,19 +61,28 @@ type LintConfig struct {
 	DetectImplicitVariant           bool `toml:"detect_implicit_variant"`
 	ForbidPublicModuleFields        bool `toml:"forbid_public_module_fields"`
 	ForbidInteractiveInput          bool `toml:"forbid_interactive_input"`
-	ForbidUnqualifiedExcelObjects   bool `toml:"forbid_unqualified_excel_objects"`
-	DetectErrorHandlerFallthrough   bool `toml:"detect_error_handler_fallthrough"`
-	DetectApplicationStateRestore   bool `toml:"detect_application_state_restore"`
 	DetectScopeShadowing            bool `toml:"detect_scope_shadowing"`
 	DetectMultipleDeclaratorClarity bool `toml:"detect_multiple_declarator_clarity"`
 	DetectUnusedLocalVariables      bool `toml:"detect_unused_local_variables"`
 	DetectUnusedPrivateProcedures   bool `toml:"detect_unused_private_procedures"`
 	DetectConfusingCallSyntax       bool `toml:"detect_confusing_call_syntax"`
 	DetectForEachControlType        bool `toml:"detect_for_each_control_type"`
-	ForbidActiveObjectDependency    bool `toml:"forbid_active_object_dependency"`
-	DetectRangeFindNothingCheck     bool `toml:"detect_range_find_nothing_check"`
 	DetectDangerousResume           bool `toml:"detect_dangerous_resume"`
 	DetectNestedWithAmbiguity       bool `toml:"detect_nested_with_ambiguity"`
+}
+
+type AnalyzeConfig struct {
+	DetectRangeFindNothingCheck     bool `toml:"detect_range_find_nothing_check"`
+	DetectObjectUseBeforeSet        bool `toml:"detect_object_use_before_set"`
+	DetectApplicationStateRestore   bool `toml:"detect_application_state_restore"`
+	DetectErrorHandlerFallthrough   bool `toml:"detect_error_handler_fallthrough"`
+	ForbidUnqualifiedExcelObjects   bool `toml:"forbid_unqualified_excel_objects"`
+	DetectByRefArgumentMismatch     bool `toml:"detect_byref_argument_mismatch"`
+	DetectDictionaryCollectionGuard bool `toml:"detect_dictionary_collection_guard"`
+	DetectRedimPreserveDimension    bool `toml:"detect_redim_preserve_dimension"`
+	DetectObjectArrayComparison     bool `toml:"detect_object_array_comparison"`
+	DetectFunctionReturnPath        bool `toml:"detect_function_return_path"`
+	DetectExcelObjectMemberMismatch bool `toml:"detect_excel_object_member_mismatch"`
 }
 
 func Default() Config {
@@ -109,14 +119,20 @@ func Default() Config {
 			DetectImplicitVariant:           true,
 			ForbidPublicModuleFields:        true,
 			ForbidInteractiveInput:          true,
-			ForbidUnqualifiedExcelObjects:   true,
-			DetectErrorHandlerFallthrough:   true,
-			DetectApplicationStateRestore:   true,
 			DetectMultipleDeclaratorClarity: true,
 			DetectConfusingCallSyntax:       true,
 			DetectForEachControlType:        true,
-			ForbidActiveObjectDependency:    true,
 			DetectDangerousResume:           true,
+		},
+		Analyze: AnalyzeConfig{
+			DetectRangeFindNothingCheck:     true,
+			DetectObjectUseBeforeSet:        true,
+			DetectApplicationStateRestore:   true,
+			DetectErrorHandlerFallthrough:   true,
+			ForbidUnqualifiedExcelObjects:   true,
+			DetectRedimPreserveDimension:    true,
+			DetectObjectArrayComparison:     true,
+			DetectExcelObjectMemberMismatch: true,
 		},
 	}
 }
@@ -291,12 +307,6 @@ detect_implicit_variant = %t
 forbid_public_module_fields = %t
 # Forbid interactive input (MsgBox, InputBox, etc.) in headless runs.
 forbid_interactive_input = %t
-# Forbid unqualified Range/Cells/Rows/Columns access.
-forbid_unqualified_excel_objects = %t
-# Detect procedures that can fall through into an error handler.
-detect_error_handler_fallthrough = %t
-# Detect Application state changes without an obvious restore path.
-detect_application_state_restore = %t
 # Detect local names that shadow module or procedure names.
 detect_scope_shadowing = %t
 # Explain mixed Dim declarations where only some declarators are typed.
@@ -309,14 +319,35 @@ detect_unused_private_procedures = %t
 detect_confusing_call_syntax = %t
 # Detect For Each control variable declaration/type issues.
 detect_for_each_control_type = %t
-# Forbid ActiveWorkbook/ActiveSheet/ActiveCell/Selection dependencies.
-forbid_active_object_dependency = %t
-# Detect Range.Find results used without a Nothing check.
-detect_range_find_nothing_check = %t
 # Detect Resume statements outside likely error handlers.
 detect_dangerous_resume = %t
 # Detect nested With blocks with ambiguous implicit Excel members.
 detect_nested_with_ambiguity = %t
+
+# Runtime-risk analysis rules.
+[analyze]
+# Detect Range.Find results used without a Nothing check.
+detect_range_find_nothing_check = %t
+# Detect object variables used before an obvious Set assignment.
+detect_object_use_before_set = %t
+# Detect Application state changes without an obvious restore path.
+detect_application_state_restore = %t
+# Detect procedures that can fall through into an error handler.
+detect_error_handler_fallthrough = %t
+# Forbid unqualified Range/Cells/Rows/Columns access.
+forbid_unqualified_excel_objects = %t
+# Detect likely ByRef argument type mismatches.
+detect_byref_argument_mismatch = %t
+# Detect Dictionary/Collection access without an obvious guard.
+detect_dictionary_collection_guard = %t
+# Detect ReDim Preserve usage on multi-dimensional arrays.
+detect_redim_preserve_dimension = %t
+# Detect object or array comparison mistakes.
+detect_object_array_comparison = %t
+# Detect functions that may exit without assigning their return value.
+detect_function_return_path = %t
+# Detect known Excel object/member mismatches.
+detect_excel_object_member_mismatch = %t
 `
 	_, err = fmt.Fprintf(f, tmpl,
 		cfg.Project.Name, cfg.Project.Entry,
@@ -327,13 +358,16 @@ detect_nested_with_ambiguity = %t
 		cfg.Lint.RequireOptionExplicit, cfg.Lint.ForbidSelect, cfg.Lint.ForbidActivate,
 		cfg.Lint.ForbidOnErrorResumeNext, cfg.Lint.DetectImplicitVariant,
 		cfg.Lint.ForbidPublicModuleFields, cfg.Lint.ForbidInteractiveInput,
-		cfg.Lint.ForbidUnqualifiedExcelObjects, cfg.Lint.DetectErrorHandlerFallthrough,
-		cfg.Lint.DetectApplicationStateRestore, cfg.Lint.DetectScopeShadowing,
-		cfg.Lint.DetectMultipleDeclaratorClarity, cfg.Lint.DetectUnusedLocalVariables,
+		cfg.Lint.DetectScopeShadowing, cfg.Lint.DetectMultipleDeclaratorClarity, cfg.Lint.DetectUnusedLocalVariables,
 		cfg.Lint.DetectUnusedPrivateProcedures, cfg.Lint.DetectConfusingCallSyntax,
-		cfg.Lint.DetectForEachControlType, cfg.Lint.ForbidActiveObjectDependency,
-		cfg.Lint.DetectRangeFindNothingCheck, cfg.Lint.DetectDangerousResume,
+		cfg.Lint.DetectForEachControlType, cfg.Lint.DetectDangerousResume,
 		cfg.Lint.DetectNestedWithAmbiguity,
+		cfg.Analyze.DetectRangeFindNothingCheck, cfg.Analyze.DetectObjectUseBeforeSet,
+		cfg.Analyze.DetectApplicationStateRestore, cfg.Analyze.DetectErrorHandlerFallthrough,
+		cfg.Analyze.ForbidUnqualifiedExcelObjects, cfg.Analyze.DetectByRefArgumentMismatch,
+		cfg.Analyze.DetectDictionaryCollectionGuard, cfg.Analyze.DetectRedimPreserveDimension,
+		cfg.Analyze.DetectObjectArrayComparison, cfg.Analyze.DetectFunctionReturnPath,
+		cfg.Analyze.DetectExcelObjectMemberMismatch,
 	)
 	return err
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,16 +43,25 @@ path = "build/Sales.xlsm"
 	if !cfg.Lint.ForbidInteractiveInput {
 		t.Fatalf("interactive input lint default was not applied")
 	}
-	if !cfg.Lint.ForbidUnqualifiedExcelObjects || !cfg.Lint.DetectErrorHandlerFallthrough ||
-		!cfg.Lint.DetectApplicationStateRestore || !cfg.Lint.DetectMultipleDeclaratorClarity ||
+	if !cfg.Lint.DetectMultipleDeclaratorClarity ||
 		!cfg.Lint.DetectConfusingCallSyntax || !cfg.Lint.DetectForEachControlType ||
-		!cfg.Lint.ForbidActiveObjectDependency || !cfg.Lint.DetectDangerousResume {
+		!cfg.Lint.DetectDangerousResume {
 		t.Fatalf("expected high-signal AST lint defaults to be enabled: %+v", cfg.Lint)
 	}
 	if cfg.Lint.DetectScopeShadowing || cfg.Lint.DetectUnusedLocalVariables ||
-		cfg.Lint.DetectUnusedPrivateProcedures || cfg.Lint.DetectRangeFindNothingCheck ||
+		cfg.Lint.DetectUnusedPrivateProcedures ||
 		cfg.Lint.DetectNestedWithAmbiguity {
 		t.Fatalf("expected false-positive-prone AST lint defaults to be opt-in: %+v", cfg.Lint)
+	}
+	if !cfg.Analyze.DetectRangeFindNothingCheck || !cfg.Analyze.DetectObjectUseBeforeSet ||
+		!cfg.Analyze.DetectApplicationStateRestore || !cfg.Analyze.DetectErrorHandlerFallthrough ||
+		!cfg.Analyze.ForbidUnqualifiedExcelObjects || !cfg.Analyze.DetectRedimPreserveDimension ||
+		!cfg.Analyze.DetectObjectArrayComparison || !cfg.Analyze.DetectExcelObjectMemberMismatch {
+		t.Fatalf("expected high-signal analyze defaults to be enabled: %+v", cfg.Analyze)
+	}
+	if cfg.Analyze.DetectByRefArgumentMismatch || cfg.Analyze.DetectDictionaryCollectionGuard ||
+		cfg.Analyze.DetectFunctionReturnPath {
+		t.Fatalf("expected false-positive-prone analyze defaults to be opt-in: %+v", cfg.Analyze)
 	}
 }
 
@@ -66,6 +75,9 @@ path = "build/Book.xlsm"
 
 [lint]
 forbid_interactive_input = false
+
+[analyze]
+detect_byref_argument_mismatch = true
 `)
 	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
 		t.Fatal(err)
@@ -76,6 +88,9 @@ forbid_interactive_input = false
 	}
 	if cfg.Lint.ForbidInteractiveInput {
 		t.Fatal("expected forbid_interactive_input=false to be honored")
+	}
+	if !cfg.Analyze.DetectByRefArgumentMismatch {
+		t.Fatal("expected analyze override to be honored")
 	}
 	if !cfg.Lint.RequireOptionExplicit {
 		t.Fatal("expected other lint defaults to remain enabled")
@@ -199,5 +214,8 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	}
 	if !loaded.Lint.RequireOptionExplicit {
 		t.Fatal("expected require_option_explicit=true")
+	}
+	if !loaded.Analyze.DetectRangeFindNothingCheck {
+		t.Fatal("expected analyze defaults to be written and loaded")
 	}
 }

--- a/internal/excel/forms/codebehind.go
+++ b/internal/excel/forms/codebehind.go
@@ -39,7 +39,7 @@ func (i UserFormCodeSourceIssue) LintIssue(formsDir string) lint.Issue {
 		}
 	}
 	return lint.Issue{
-		Code:       "VBA201",
+		Code:       "FRM202",
 		Severity:   "warning",
 		File:       relPath,
 		Line:       i.Line,

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -287,8 +287,6 @@ func (c *astLintContext) visit(node *tree_sitter.Node, inProcedure bool, inType 
 		inType = true
 	case "qualified_member_expression", "implicit_member_expression":
 		c.memberAccessIssue(node)
-	case "call_expression":
-		c.callExpressionIssue(node)
 	case "on_error_statement":
 		c.onErrorIssue(node)
 	case "variable_declaration":
@@ -318,34 +316,9 @@ func (c *astLintContext) memberAccessIssue(node *tree_sitter.Node) {
 	case c.linter.Config.Lint.ForbidActivate && strings.EqualFold(name, "Activate"):
 		c.issues = append(c.issues, c.linter.issueAt(c.path, vbaast.NodeRange(property), "VB003", "warning", "Avoid Activate. Use direct object references instead."))
 	}
-	if c.linter.Config.Lint.ForbidActiveObjectDependency {
-		if object := node.ChildByFieldName("object"); object != nil && isActiveObjectName(cleanIdentifier(object.Utf8Text(c.source))) {
-			issue := c.linter.issueAt(c.path, vbaast.NodeRange(object), "VB024", "warning", "Avoid active Excel objects; pass or capture explicit Workbook/Worksheet/Range objects.")
-			issue.Symbol = cleanIdentifier(object.Utf8Text(c.source))
-			c.issues = append(c.issues, issue)
-		}
-	}
 	if c.linter.Config.Lint.DetectNestedWithAmbiguity && node.Kind() == "implicit_member_expression" && c.withDepth >= 2 && isExcelObjectAccessName(name) {
 		issue := c.linter.issueAt(c.path, vbaast.NodeRange(property), "VB027", "warning", "Avoid implicit Excel members inside nested With blocks; qualify the target explicitly.")
 		issue.Symbol = "." + name
-		c.issues = append(c.issues, issue)
-	}
-}
-
-func (c *astLintContext) callExpressionIssue(node *tree_sitter.Node) {
-	fn := node.ChildByFieldName("function")
-	if fn == nil {
-		return
-	}
-	name := cleanIdentifier(fn.Utf8Text(c.source))
-	if c.linter.Config.Lint.ForbidUnqualifiedExcelObjects && fn.Kind() == "identifier" && isExcelObjectAccessName(name) {
-		issue := c.linter.issueAt(c.path, vbaast.NodeRange(fn), "VB015", "warning", "Qualify Excel object access with an explicit Worksheet or Workbook object.")
-		issue.Symbol = name
-		c.issues = append(c.issues, issue)
-	}
-	if c.linter.Config.Lint.ForbidActiveObjectDependency && fn.Kind() == "identifier" && isActiveObjectName(name) {
-		issue := c.linter.issueAt(c.path, vbaast.NodeRange(fn), "VB024", "warning", "Avoid active Excel objects; pass or capture explicit Workbook/Worksheet/Range objects.")
-		issue.Symbol = name
 		c.issues = append(c.issues, issue)
 	}
 }
@@ -424,12 +397,8 @@ func (c *astLintContext) parseIssue(root *tree_sitter.Node) Issue {
 
 func (l Linter) flowIssues(path string, source string, root *tree_sitter.Node) []Issue {
 	cfg := l.Config.Lint
-	if !cfg.DetectErrorHandlerFallthrough &&
-		!cfg.DetectApplicationStateRestore &&
-		!cfg.DetectConfusingCallSyntax &&
+	if !cfg.DetectConfusingCallSyntax &&
 		!cfg.DetectForEachControlType &&
-		!cfg.ForbidActiveObjectDependency &&
-		!cfg.DetectRangeFindNothingCheck &&
 		!cfg.DetectDangerousResume {
 		return nil
 	}
@@ -439,23 +408,11 @@ func (l Linter) flowIssues(path string, source string, root *tree_sitter.Node) [
 	for _, proc := range procedures {
 		decls := procedureDeclarations(lines, proc)
 		handlerLabels := onErrorHandlerLabels(lines, proc)
-		if cfg.DetectErrorHandlerFallthrough {
-			issues = append(issues, l.errorHandlerFallthroughIssues(path, lines, proc, handlerLabels)...)
-		}
-		if cfg.DetectApplicationStateRestore {
-			issues = append(issues, l.applicationStateIssues(path, lines, proc)...)
-		}
 		if cfg.DetectConfusingCallSyntax {
 			issues = append(issues, l.confusingCallIssues(path, lines, proc)...)
 		}
 		if cfg.DetectForEachControlType {
 			issues = append(issues, l.forEachIssues(path, lines, proc, decls)...)
-		}
-		if cfg.ForbidActiveObjectDependency {
-			issues = append(issues, l.activeObjectIssues(path, lines, proc)...)
-		}
-		if cfg.DetectRangeFindNothingCheck {
-			issues = append(issues, l.rangeFindIssues(path, lines, proc)...)
 		}
 		if cfg.DetectDangerousResume {
 			issues = append(issues, l.dangerousResumeIssues(path, lines, proc, handlerLabels)...)
@@ -584,72 +541,6 @@ func onErrorHandlerLabels(lines []string, proc sourceProcedure) map[string]bool 
 	return labels
 }
 
-func (l Linter) errorHandlerFallthroughIssues(path string, lines []string, proc sourceProcedure, handlerLabels map[string]bool) []Issue {
-	if len(handlerLabels) == 0 {
-		return nil
-	}
-	var issues []Issue
-	lastCode := ""
-	for i := proc.StartLine - 1; i < proc.EndLine-1 && i < len(lines); i++ {
-		lineNo := i + 1
-		stmt := normalizedCodeLine(lines[i])
-		if stmt == "" {
-			continue
-		}
-		if label, ok := labelName(stmt); ok && handlerLabels[strings.ToLower(label)] {
-			if !isCleanupFallthroughLabel(label) && !terminatesNormalFlow(lastCode) {
-				issue := l.issue(path, lineNo, "VB016", "warning", "Add Exit Sub/Function/Property before the error-handler label so normal execution cannot fall through.")
-				issue.Symbol = label
-				issues = append(issues, issue)
-			}
-		}
-		lastCode = stmt
-	}
-	return issues
-}
-
-func isCleanupFallthroughLabel(label string) bool {
-	switch strings.ToLower(label) {
-	case "cleanup", "clean_up", "finally", "done":
-		return true
-	default:
-		return false
-	}
-}
-
-func (l Linter) applicationStateIssues(path string, lines []string, proc sourceProcedure) []Issue {
-	props := []string{"enableevents", "displayalerts", "screenupdating"}
-	var issues []Issue
-	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
-		stmt := normalizedCodeLine(lines[i])
-		lower := compactStatement(strings.ToLower(stmt))
-		for _, prop := range props {
-			target := "application." + prop + "=false"
-			if !strings.Contains(lower, target) {
-				continue
-			}
-			if hasLaterApplicationRestore(lines, proc, i+1, prop) {
-				continue
-			}
-			issue := l.issue(path, i+1, "VB017", "warning", "Restore Application."+applicationStateName(prop)+" on a cleanup path after setting it to False.")
-			issue.Symbol = "Application." + applicationStateName(prop)
-			issues = append(issues, issue)
-		}
-	}
-	return issues
-}
-
-func hasLaterApplicationRestore(lines []string, proc sourceProcedure, start int, prop string) bool {
-	prefix := "application." + prop + "="
-	for i := start; i < proc.EndLine && i < len(lines); i++ {
-		lower := compactStatement(strings.ToLower(normalizedCodeLine(lines[i])))
-		if strings.Contains(lower, prefix) && !strings.Contains(lower, prefix+"false") {
-			return true
-		}
-	}
-	return false
-}
-
 func (l Linter) confusingCallIssues(path string, lines []string, proc sourceProcedure) []Issue {
 	var issues []Issue
 	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
@@ -707,79 +598,6 @@ func (l Linter) forEachIssues(path string, lines []string, proc sourceProcedure,
 	return issues
 }
 
-func (l Linter) activeObjectIssues(path string, lines []string, proc sourceProcedure) []Issue {
-	var issues []Issue
-	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
-		stmt := normalizedCodeLine(lines[i])
-		for _, name := range []string{"ActiveWorkbook", "ActiveSheet", "ActiveCell", "Selection"} {
-			if strings.Contains(strings.ToLower(stmt), strings.ToLower(name)+".") {
-				continue
-			}
-			if hasWord(stmt, name) {
-				issue := l.issue(path, i+1, "VB024", "warning", "Avoid active Excel objects; pass or capture explicit Workbook/Worksheet/Range objects.")
-				issue.Symbol = name
-				issues = append(issues, issue)
-			}
-		}
-	}
-	return issues
-}
-
-func (l Linter) rangeFindIssues(path string, lines []string, proc sourceProcedure) []Issue {
-	var issues []Issue
-	findAssignments := map[string]int{}
-	guarded := map[string]bool{}
-	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
-		lineNo := i + 1
-		stmt := normalizedCodeLine(lines[i])
-		lower := strings.ToLower(stmt)
-		for name := range findAssignments {
-			if strings.Contains(lower, "if "+strings.ToLower(name)+" is nothing") ||
-				strings.Contains(lower, "if not "+strings.ToLower(name)+" is nothing") {
-				guarded[strings.ToLower(name)] = true
-			}
-		}
-		if name, ok := rangeFindAssignment(stmt); ok {
-			findAssignments[strings.ToLower(name)] = lineNo
-			continue
-		}
-		for name, assignLine := range findAssignments {
-			if guarded[name] {
-				continue
-			}
-			if strings.Contains(lower, name+".") {
-				issue := l.issue(path, lineNo, "VB025", "warning", "Check the Range.Find result for Nothing before dereferencing it.")
-				issue.Symbol = name
-				if assignLine > 0 {
-					issue.Suggestion = "Add If " + name + " Is Nothing Then handling after the Find assignment."
-				}
-				issues = append(issues, issue)
-				guarded[name] = true
-			}
-		}
-	}
-	return issues
-}
-
-func rangeFindAssignment(stmt string) (string, bool) {
-	lower := strings.ToLower(stmt)
-	if !strings.Contains(lower, ".find(") && !strings.Contains(lower, ".find ") {
-		return "", false
-	}
-	left, _, ok := strings.Cut(stmt, "=")
-	if !ok {
-		return "", false
-	}
-	left = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(left), "Set "))
-	fields := strings.FieldsFunc(left, func(r rune) bool {
-		return !isVBAIdentifierRune(r)
-	})
-	if len(fields) == 0 {
-		return "", false
-	}
-	return cleanIdentifier(fields[len(fields)-1]), true
-}
-
 func (l Linter) dangerousResumeIssues(path string, lines []string, proc sourceProcedure, handlerLabels map[string]bool) []Issue {
 	var issues []Issue
 	inHandler := false
@@ -808,15 +626,6 @@ func labelName(stmt string) (string, bool) {
 	return name, name != ""
 }
 
-func terminatesNormalFlow(stmt string) bool {
-	lower := strings.ToLower(strings.TrimSpace(stmt))
-	return strings.HasPrefix(lower, "exit sub") ||
-		strings.HasPrefix(lower, "exit function") ||
-		strings.HasPrefix(lower, "exit property") ||
-		strings.HasPrefix(lower, "goto ") ||
-		lower == "end"
-}
-
 func normalizedSourceLines(source string) []string {
 	source = strings.ReplaceAll(source, "\r\n", "\n")
 	source = strings.ReplaceAll(source, "\r", "\n")
@@ -825,23 +634,6 @@ func normalizedSourceLines(source string) []string {
 
 func normalizedCodeLine(line string) string {
 	return strings.Join(strings.Fields(maskStringLiterals(gui.StripComment(line))), " ")
-}
-
-func compactStatement(stmt string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(stmt, " ", ""), "\t", "")
-}
-
-func applicationStateName(prop string) string {
-	switch strings.ToLower(prop) {
-	case "enableevents":
-		return "EnableEvents"
-	case "displayalerts":
-		return "DisplayAlerts"
-	case "screenupdating":
-		return "ScreenUpdating"
-	default:
-		return prop
-	}
 }
 
 func isStatementKeyword(name string) bool {
@@ -865,15 +657,6 @@ func isObviouslyScalarType(typ string) bool {
 func isExcelObjectAccessName(name string) bool {
 	switch strings.ToLower(cleanIdentifier(name)) {
 	case "range", "cells", "rows", "columns":
-		return true
-	default:
-		return false
-	}
-}
-
-func isActiveObjectName(name string) bool {
-	switch strings.ToLower(cleanIdentifier(name)) {
-	case "activeworkbook", "activesheet", "activecell", "selection":
 		return true
 	default:
 		return false

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -749,12 +749,6 @@ func TestLinterFindsDefaultASTBackedRules(t *testing.T) {
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
   Dim a, b As Long
-  Range("A1").Value = 1
-  Worksheets(1).Range("A1").Value = 2
-  On Error GoTo ErrHandler
-  Debug.Print "work"
-ErrHandler:
-  Debug.Print Err.Description
 End Sub
 `)
 
@@ -762,29 +756,7 @@ End Sub
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertIssue(t, issues, "VB015", 4)
-	assertIssue(t, issues, "VB016", 8)
 	assertIssue(t, issues, "VB019", 3)
-}
-
-func TestLinterAllowsCleanupLabelFallthrough(t *testing.T) {
-	dir := t.TempDir()
-	writeLintModule(t, dir, "Main.bas", `Option Explicit
-Public Sub Run()
-  On Error GoTo Cleanup
-  DoWork
-Cleanup:
-  CloseThing
-End Sub
-`)
-
-	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := issuesByCode(issues, "VB016"); len(got) != 0 {
-		t.Fatalf("VB016 should allow normal fallthrough into cleanup labels: %+v", got)
-	}
 }
 
 func TestLinterAllowsQualifiedExcelAccessAndNarrowResumeNext(t *testing.T) {
@@ -807,7 +779,7 @@ End Sub
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, code := range []string{"VB004", "VB015"} {
+	for _, code := range []string{"VB004"} {
 		if got := issuesByCode(issues, code); len(got) != 0 {
 			t.Fatalf("%s should not trigger for qualified/narrow pattern: %+v", code, got)
 		}
@@ -841,21 +813,17 @@ End Sub
 	cfg.Lint.DetectScopeShadowing = true
 	cfg.Lint.DetectUnusedLocalVariables = true
 	cfg.Lint.DetectUnusedPrivateProcedures = true
-	cfg.Lint.DetectRangeFindNothingCheck = true
 
 	issues, err := Linter{RootDir: dir, Config: cfg}.Run()
 	if err != nil {
 		t.Fatal(err)
 	}
 	for code, line := range map[string]int{
-		"VB017": 11,
 		"VB018": 8,
 		"VB020": 9,
 		"VB021": 5,
 		"VB022": 15,
 		"VB023": 16,
-		"VB024": 12,
-		"VB025": 14,
 		"VB026": 18,
 	} {
 		assertIssue(t, issues, code, line)
@@ -919,10 +887,8 @@ End Sub
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, code := range []string{"VB015", "VB016"} {
-		if got := issuesByCode(issues, code); len(got) != 0 {
-			t.Fatalf("%s should ignore comments and strings: %+v", code, got)
-		}
+	if len(issues) != 0 {
+		t.Fatalf("comments and strings should not trigger lint issues: %+v", issues)
 	}
 }
 

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -30,15 +30,53 @@ Use `analyze` for fast source-level feedback before opening Excel.
 > [!IMPORTANT]
 > Findings that block automation return a failure status and exit code `1`.
 
+## Rules
+
+| Code     | Severity | Description                                                               |
+| -------- | -------- | ------------------------------------------------------------------------- |
+| `VBA101` | warning  | Object variable assignment likely missing `Set`.                          |
+| `VBA102` | warning  | Object-returning project function assignment likely missing `Set`.        |
+| `VBA103` | warning  | Object-returning function body likely missing `Set <FunctionName> = ...`. |
+| `VBA104` | error    | Known Excel object/member mismatch such as `Worksheet.DisplayGridlines`.  |
+| `VBA105` | error    | Removed `XlflowLog` trace helper call.                                    |
+| `VBA106` | error    | Removed `XlflowSetTraceFile` trace helper call.                           |
+| `VBA201` | warning  | `Range.Find` result is dereferenced before a `Nothing` check.             |
+| `VBA202` | warning  | Object variable may be used before an obvious `Set` assignment.           |
+| `VBA203` | warning  | `Application` state is changed without an obvious restore path.           |
+| `VBA204` | warning  | Normal execution can fall through into an error-handler label.            |
+| `VBA205` | warning  | Unqualified or active Excel object access depends on runtime sheet state. |
+| `VBA206` | warning  | Likely ByRef argument type mismatch against a project-local procedure.    |
+| `VBA207` | warning  | `Dictionary` or `Collection` item access has no obvious existence guard.  |
+| `VBA208` | warning  | `ReDim Preserve` is used on a multi-dimensional array.                    |
+| `VBA209` | warning  | Object or array is compared with scalar equality.                         |
+| `VBA210` | warning  | Function may exit without assigning its return value.                     |
+| `VBA211` | error    | Expanded known Excel object/member mismatch.                              |
+
+Rules `VBA101` through `VBA106`, `VBA201` through `VBA205`, `VBA208`, `VBA209`, and `VBA211` are enabled by default. Rules `VBA206`, `VBA207`, and `VBA210` are opt-in through `[analyze]` because they are more dataflow-sensitive.
+
 ## JSON Output Example
 
-Successful `--json` output uses the xlflow envelope plus command-specific fields.
+Failed `--json` output uses the xlflow envelope plus command-specific fields.
 
 ```json
 {
-  "status": "error",
+  "status": "failed",
   "command": "analyze",
-  "findings": [{ "file": "src/modules/Main.bas", "line": 20, "code": "interactive_input" }]
+  "error": {
+    "code": "analyze_failed",
+    "message": "1 analysis finding(s) found"
+  },
+  "analysis": [
+    {
+      "code": "VBA201",
+      "severity": "warning",
+      "file": "src/modules/Main.bas",
+      "module": "Main",
+      "procedure": "Run",
+      "line": 12,
+      "message": "Range.Find result found is dereferenced before a Nothing check."
+    }
+  ]
 }
 ```
 

--- a/vitepress/commands/lint.md
+++ b/vitepress/commands/lint.md
@@ -48,23 +48,18 @@ Use `lint --json` in agent loops before `push` to catch source problems while Ex
 | `VB012` | error    | Mismatched procedure end statement.                                                                                        |
 | `VB013` | error    | Missing whitespace before a line-continuation underscore.                                                                  |
 | `VB014` | error    | `tree-sitter-vba` parser recovery found syntax errors or missing syntax nodes.                                             |
-| `VB015` | warning  | Unqualified Excel object access such as `Range(...)`, `Cells(...)`, `Rows(...)`, or `Columns(...)`.                        |
-| `VB016` | warning  | Normal execution can fall through into an error-handler label.                                                             |
-| `VB017` | warning  | `Application` state such as events, alerts, or screen updating is disabled without an obvious restore path.                |
 | `VB018` | warning  | Local declarations or parameters shadow module-level names, procedure names, or same-scope declarations.                   |
 | `VB019` | warning  | Multiple declarators mix typed and untyped names; in VBA each name needs its own `As <Type>`.                              |
 | `VB020` | warning  | Procedure-local variable is declared but never referenced.                                                                 |
 | `VB021` | warning  | Private procedure is not called from parsed source.                                                                        |
 | `VB022` | warning  | Confusing parenthesized call syntax such as `Foo (bar)`.                                                                   |
 | `VB023` | warning  | `For Each` control variable is undeclared or obviously incompatible.                                                       |
-| `VB024` | warning  | Active object dependency such as `ActiveWorkbook`, `ActiveSheet`, `ActiveCell`, or `Selection`.                            |
-| `VB025` | warning  | `Range.Find` result is dereferenced before a `Nothing` check.                                                              |
 | `VB026` | warning  | `Resume` is used outside a likely error-handler context.                                                                   |
 | `VB027` | warning  | Nested `With` blocks use implicit Excel members whose target can be ambiguous.                                             |
 
-Core declaration, member-access, error-handling, Excel object, and procedure-scope checks are AST-backed. They ignore comments and strings, distinguish module-level declarations from procedure-local declarations, and report individual declarators such as `a` in `Dim a, b As Long`.
+Core declaration, member-access, error-handling, and procedure-scope checks are AST-backed. They ignore comments and strings, distinguish module-level declarations from procedure-local declarations, and report individual declarators such as `a` in `Dim a, b As Long`.
 
-Rules `VB015`, `VB016`, `VB017`, `VB019`, `VB022`, `VB023`, `VB024`, and `VB026` are enabled by default. Heavier project-wide or dataflow-sensitive rules stay conservative opt-ins through `[lint]` settings.
+Rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide rules stay conservative opt-ins through `[lint]` settings. Use [`analyze`](./analyze) for semantic runtime-risk checks such as unqualified Excel access, error-handler fallthrough, Application state leaks, and `Range.Find` `Nothing` guards.
 
 ## JSON Output Example
 

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -71,6 +71,31 @@ detect_implicit_variant = true
 forbid_public_module_fields = true
 # Forbid interactive input (MsgBox, InputBox, etc.) in headless runs.
 forbid_interactive_input = true
+
+# Runtime-risk analysis rules.
+[analyze]
+# Detect Range.Find results used without a Nothing check.
+detect_range_find_nothing_check = true
+# Detect object variables used before an obvious Set assignment.
+detect_object_use_before_set = true
+# Detect Application state changes without an obvious restore path.
+detect_application_state_restore = true
+# Detect procedures that can fall through into an error handler.
+detect_error_handler_fallthrough = true
+# Forbid unqualified Range/Cells/Rows/Columns access.
+forbid_unqualified_excel_objects = true
+# Detect likely ByRef argument type mismatches.
+detect_byref_argument_mismatch = false
+# Detect Dictionary/Collection access without an obvious guard.
+detect_dictionary_collection_guard = false
+# Detect ReDim Preserve usage on multi-dimensional arrays.
+detect_redim_preserve_dimension = true
+# Detect object or array comparison mistakes.
+detect_object_array_comparison = true
+# Detect functions that may exit without assigning their return value.
+detect_function_return_path = false
+# Detect known Excel object/member mismatches.
+detect_excel_object_member_mismatch = true
 ```
 
 ## Section reference
@@ -128,6 +153,22 @@ When `[vba].folders = true`, files may be nested under these roots according to 
 | `detect_implicit_variant`     | bool | no       | `true`  | Detect implicitly typed `Variant` variables.                            |
 | `forbid_public_module_fields` | bool | no       | `true`  | Forbid public fields in standard modules.                               |
 | `forbid_interactive_input`    | bool | no       | `true`  | Forbid interactive input (`MsgBox`, `InputBox`, etc.) in headless runs. |
+
+### `[analyze]`
+
+| Key                                   | Type | Required | Default | Description                                                        |
+| ------------------------------------- | ---- | -------- | ------- | ------------------------------------------------------------------ |
+| `detect_range_find_nothing_check`     | bool | no       | `true`  | Detect `Range.Find` results used without a `Nothing` check.        |
+| `detect_object_use_before_set`        | bool | no       | `true`  | Detect object variables used before an obvious `Set` assignment.   |
+| `detect_application_state_restore`    | bool | no       | `true`  | Detect Application state changes without an obvious restore path.  |
+| `detect_error_handler_fallthrough`    | bool | no       | `true`  | Detect normal execution falling through into error-handler labels. |
+| `forbid_unqualified_excel_objects`    | bool | no       | `true`  | Detect unqualified `Range`, `Cells`, `Rows`, and `Columns` access. |
+| `detect_byref_argument_mismatch`      | bool | no       | `false` | Detect likely ByRef argument type mismatch candidates.             |
+| `detect_dictionary_collection_guard`  | bool | no       | `false` | Detect Dictionary/Collection lookup without an obvious guard.      |
+| `detect_redim_preserve_dimension`     | bool | no       | `true`  | Detect risky multi-dimensional `ReDim Preserve` usage.             |
+| `detect_object_array_comparison`      | bool | no       | `true`  | Detect object or array comparison mistakes.                        |
+| `detect_function_return_path`         | bool | no       | `false` | Detect functions that may exit without assigning a return value.   |
+| `detect_excel_object_member_mismatch` | bool | no       | `true`  | Detect known Excel object/member mismatches.                       |
 
 ## Defaults differ between `new` and `init`
 

--- a/vitepress/reference/error-codes.md
+++ b/vitepress/reference/error-codes.md
@@ -14,6 +14,7 @@ Common examples:
 - `output_file_exists`
 - `unsupported_image_format`
 - `form_not_found`
+- `FRM202`
 - `spec_validation_failed`
 - `fmt_failed`
 - `fmt_check_failed`
@@ -26,4 +27,4 @@ Common examples:
 - `wsl_path_translation_failed`
 - `windows_xlflow_execution_failed`
 
-Lint codes include `VB001` through `VB027`. Analyzer codes include `VBA101` and later runtime-risk findings.
+Lint codes include `VB001` through `VB014`, `VB018` through `VB023`, `VB026`, and `VB027`. Analyzer codes include `VBA101` through `VBA106` and runtime-risk findings `VBA201` through `VBA211`.


### PR DESCRIPTION
## Summary
- Introduced AST-based runtime risk assessment to `analyze` to improve the accuracy of analysis results.
- Updated documentation for CLI contracts, configuration, error codes, and debugging procedures.
- Added and updated related `lint` and analysis-related tests.

## Testing
- Added and updated unit tests to verify the behavior of AST-backed assessment and related configurations.
- Implemented tests covering regressions in analysis and lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `xlflow analyze` command with comprehensive runtime-risk detection (object initialization, Range.Find guarding, error-handler patterns, ByRef mismatches, and more).
  * New `[analyze]` configuration section for runtime-risk analysis options.

* **Changes**
  * Runtime-risk checks moved from `xlflow lint` to `xlflow analyze`.
  * `xlflow lint` now focuses on syntax, declarations, and code-shape checks.

* **Documentation**
  * Updated configuration examples and command documentation for the reorganized lint/analyze responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->