### PR TITLE
Migrate lint and analyze config to disabled_rules IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
-- Added `[lint].disabled_rules` for disabling configurable lint rules by stable diagnostic ID, with compatibility warnings for legacy per-rule booleans.
+- Added `[lint].disabled_rules` and `[analyze].disabled_rules` for disabling configurable source feedback rules by stable diagnostic ID, with compatibility warnings for legacy per-rule booleans.
 - Refactored `xlflow lint` to use `tree-sitter-vba` AST-backed checks for core declaration, member-access, and local code-shape rules, including per-declarator implicit `Variant` diagnostics and parser recovery findings.
 - Refactored `xlflow analyze` to use `tree-sitter-vba` AST-backed procedure context and added runtime-risk findings for `Range.Find` `Nothing` guards, object initialization, Application state restore, error-handler fallthrough, unqualified Excel object access, ByRef mismatch candidates, Dictionary/Collection guards, `ReDim Preserve`, object/array comparisons, function return paths, and expanded Excel member mismatches.
 - Documented the full `xlflow lint` rule list on the command page, including `VB001` through `VB014` codes and severity levels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added `[lint].disabled_rules` for disabling configurable lint rules by stable diagnostic ID, with compatibility warnings for legacy per-rule booleans.
 - Refactored `xlflow lint` to use `tree-sitter-vba` AST-backed checks for core declaration, member-access, and local code-shape rules, including per-declarator implicit `Variant` diagnostics and parser recovery findings.
 - Refactored `xlflow analyze` to use `tree-sitter-vba` AST-backed procedure context and added runtime-risk findings for `Range.Find` `Nothing` guards, object initialization, Application state restore, error-handler fallthrough, unqualified Excel object access, ByRef mismatch candidates, Dictionary/Collection guards, `ReDim Preserve`, object/array comparisons, function return paths, and expanded Excel member mismatches.
 - Documented the full `xlflow lint` rule list on the command page, including `VB001` through `VB014` codes and severity levels.

--- a/README.ja.md
+++ b/README.ja.md
@@ -586,36 +586,8 @@ code_source = "sidecar"
 
 # 静的解析ルール
 [lint]
-# すべてのモジュールで Option Explicit を必須にします。
-require_option_explicit = true
-# Select / Activate パターンの使用を禁止します。
-forbid_select = true
-# Activate の使用を禁止します。
-forbid_activate = true
-# On Error Resume Next の使用を禁止します。
-forbid_on_error_resume_next = true
-# 暗黙的に型指定された Variant 変数を検出します。
-detect_implicit_variant = true
-# 標準モジュール内でのパブリックフィールドの使用を禁止します。
-forbid_public_module_fields = true
-# ヘッドレス実行時の対話型入力（MsgBox、InputBoxなど）を禁止します。
-forbid_interactive_input = true
-# module 変数や procedure 名を隠す local 名を検出します。
-detect_scope_shadowing = false
-# 一部の declarator だけに型が付く Dim 文を説明します。
-detect_multiple_declarator_clarity = true
-# 未参照の procedure-local 変数を検出します。
-detect_unused_local_variables = false
-# 未参照の Private procedure を検出します。
-detect_unused_private_procedures = false
-# 紛らわしい parenthesized call syntax を検出します。
-detect_confusing_call_syntax = true
-# For Each control variable の宣言・型の問題を検出します。
-detect_for_each_control_type = true
-# error handler 外に見える Resume 文を検出します。
-detect_dangerous_resume = true
-# nested With 内の曖昧な implicit Excel member を検出します。
-detect_nested_with_ambiguity = false
+# 診断 ID で特定の lint ルールを無効化します。
+disabled_rules = []
 
 [analyze]
 # Nothing check 前に使われる Range.Find 結果を検出します。
@@ -644,7 +616,7 @@ detect_excel_object_member_mismatch = true
 
 `project.entry` は `xlflow run` の macro 名を省略した場合に使われます。
 
-対話前提の project で `UserForm` やダイアログを意図的に使う場合は、`forbid_interactive_input = false` にすると `VB007` 警告を抑止できます。これは lint だけに効き、`xlflow run --headless` の GUI 境界チェックは引き続きブロックします。
+対話前提の project で `UserForm` やダイアログを意図的に使う場合は、`[lint].disabled_rules = ["VB007"]` にすると `VB007` 警告を抑止できます。これは lint だけに効き、`xlflow run --headless` の GUI 境界チェックは引き続きブロックします。`forbid_interactive_input = false` のような従来の per-rule boolean も互換性のため受け付けますが、非推奨です。
 
 typographic quote、C-style quote escape、閉じられていないまたは対応がずれた procedure、行継続 `_` の空白不足を検出する構文安全 lint は常に有効です。`push` や `run` が Excel を開く前に VBE compile dialog を防ぐためのルールです。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -590,28 +590,8 @@ code_source = "sidecar"
 disabled_rules = []
 
 [analyze]
-# Nothing check 前に使われる Range.Find 結果を検出します。
-detect_range_find_nothing_check = true
-# 明確な Set 代入前に使われる object 変数を検出します。
-detect_object_use_before_set = true
-# 復元経路が明確でない Application state 変更を検出します。
-detect_application_state_restore = true
-# 通常実行が error handler label に落ちる procedure を検出します。
-detect_error_handler_fallthrough = true
-# 修飾されていない Range/Cells/Rows/Columns アクセスを禁止します。
-forbid_unqualified_excel_objects = true
-# ByRef 引数の型不一致候補を検出します。
-detect_byref_argument_mismatch = false
-# 明確な guard がない Dictionary/Collection access を検出します。
-detect_dictionary_collection_guard = false
-# 多次元配列での ReDim Preserve 使用を検出します。
-detect_redim_preserve_dimension = true
-# object または array の比較ミスを検出します。
-detect_object_array_comparison = true
-# return value を代入せずに抜ける可能性がある Function を検出します。
-detect_function_return_path = false
-# 既知の Excel object/member mismatch を検出します。
-detect_excel_object_member_mismatch = true
+# 診断 ID で特定の analyzer ルールを無効化します。
+disabled_rules = []
 ```
 
 `project.entry` は `xlflow run` の macro 名を省略した場合に使われます。
@@ -619,6 +599,8 @@ detect_excel_object_member_mismatch = true
 対話前提の project で `UserForm` やダイアログを意図的に使う場合は、`[lint].disabled_rules = ["VB007"]` にすると `VB007` 警告を抑止できます。これは lint だけに効き、`xlflow run --headless` の GUI 境界チェックは引き続きブロックします。`forbid_interactive_input = false` のような従来の per-rule boolean も互換性のため受け付けますが、非推奨です。
 
 typographic quote、C-style quote escape、閉じられていないまたは対応がずれた procedure、行継続 `_` の空白不足を検出する構文安全 lint は常に有効です。`push` や `run` が Excel を開く前に VBE compile dialog を防ぐためのルールです。
+
+analyzer ルールは `[analyze].disabled_rules = ["VBA205"]` のように無効化できます。`VBA101` から `VBA106` までの analyzer 診断は常に有効です。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -586,36 +586,8 @@ code_source = "sidecar"
 
 # Static analysis rules.
 [lint]
-# Require Option Explicit in every module.
-require_option_explicit = true
-# Forbid Select / Activate patterns.
-forbid_select = true
-# Forbid Activate usage.
-forbid_activate = true
-# Forbid On Error Resume Next.
-forbid_on_error_resume_next = true
-# Detect implicitly typed Variant variables.
-detect_implicit_variant = true
-# Forbid public fields in standard modules.
-forbid_public_module_fields = true
-# Forbid interactive input (MsgBox, InputBox, etc.) in headless runs.
-forbid_interactive_input = true
-# Detect local names that shadow module or procedure names.
-detect_scope_shadowing = false
-# Explain mixed Dim declarations where only some declarators are typed.
-detect_multiple_declarator_clarity = true
-# Detect unused procedure-local variables.
-detect_unused_local_variables = false
-# Detect unused Private procedures.
-detect_unused_private_procedures = false
-# Detect confusing parenthesized call syntax.
-detect_confusing_call_syntax = true
-# Detect For Each control variable declaration/type issues.
-detect_for_each_control_type = true
-# Detect Resume statements outside likely error handlers.
-detect_dangerous_resume = true
-# Detect nested With blocks with ambiguous implicit Excel members.
-detect_nested_with_ambiguity = false
+# Disable specific lint rules by diagnostic ID.
+disabled_rules = []
 
 [analyze]
 # Detect Range.Find results used without a Nothing check.
@@ -644,7 +616,7 @@ detect_excel_object_member_mismatch = true
 
 `project.entry` is used when `xlflow run` is invoked without a macro name.
 
-Set `forbid_interactive_input = false` when the project intentionally uses dialogs or UserForms and you want to suppress `VB007` warnings. This only affects lint output; `xlflow run --headless` still blocks GUI boundaries.
+Use `[lint].disabled_rules = ["VB007"]` when the project intentionally uses dialogs or UserForms and you want to suppress `VB007` warnings. This only affects lint output; `xlflow run --headless` still blocks GUI boundaries. Legacy per-rule booleans such as `forbid_interactive_input = false` are still accepted for compatibility, but are deprecated.
 
 Syntax safety lint rules for typographic quotes, C-style quote escapes, unclosed or mismatched procedures, and malformed line-continuation underscores are always enabled because they prevent VBE compile dialogs before `push` or `run` opens Excel.
 

--- a/README.md
+++ b/README.md
@@ -590,28 +590,8 @@ code_source = "sidecar"
 disabled_rules = []
 
 [analyze]
-# Detect Range.Find results used without a Nothing check.
-detect_range_find_nothing_check = true
-# Detect object variables used before an obvious Set assignment.
-detect_object_use_before_set = true
-# Detect Application state changes without an obvious restore path.
-detect_application_state_restore = true
-# Detect procedures that can fall through into an error handler.
-detect_error_handler_fallthrough = true
-# Forbid unqualified Range/Cells/Rows/Columns access.
-forbid_unqualified_excel_objects = true
-# Detect likely ByRef argument type mismatches.
-detect_byref_argument_mismatch = false
-# Detect Dictionary/Collection access without an obvious guard.
-detect_dictionary_collection_guard = false
-# Detect ReDim Preserve usage on multi-dimensional arrays.
-detect_redim_preserve_dimension = true
-# Detect object or array comparison mistakes.
-detect_object_array_comparison = true
-# Detect functions that may exit without assigning their return value.
-detect_function_return_path = false
-# Detect known Excel object/member mismatches.
-detect_excel_object_member_mismatch = true
+# Disable specific analyzer rules by diagnostic ID.
+disabled_rules = []
 ```
 
 `project.entry` is used when `xlflow run` is invoked without a macro name.
@@ -619,6 +599,8 @@ detect_excel_object_member_mismatch = true
 Use `[lint].disabled_rules = ["VB007"]` when the project intentionally uses dialogs or UserForms and you want to suppress `VB007` warnings. This only affects lint output; `xlflow run --headless` still blocks GUI boundaries. Legacy per-rule booleans such as `forbid_interactive_input = false` are still accepted for compatibility, but are deprecated.
 
 Syntax safety lint rules for typographic quotes, C-style quote escapes, unclosed or mismatched procedures, and malformed line-continuation underscores are always enabled because they prevent VBE compile dialogs before `push` or `run` opens Excel.
+
+Use `[analyze].disabled_rules = ["VBA205"]` to disable configurable analyzer rules. Analyzer diagnostics `VBA101` through `VBA106` are always enabled.
 
 ---
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -246,21 +246,7 @@ default_component_folders = true
 code_source = "sidecar"
 
 [lint]
-require_option_explicit = true
-forbid_select = true
-forbid_activate = true
-forbid_on_error_resume_next = true
-detect_implicit_variant = true
-forbid_public_module_fields = true
-forbid_interactive_input = true
-detect_scope_shadowing = false
-detect_multiple_declarator_clarity = true
-detect_unused_local_variables = false
-detect_unused_private_procedures = false
-detect_confusing_call_syntax = true
-detect_for_each_control_type = true
-detect_dangerous_resume = true
-detect_nested_with_ambiguity = false
+disabled_rules = []
 
 [analyze]
 detect_range_find_nothing_check = true
@@ -482,11 +468,15 @@ Core declaration, member-access, error-handling, Excel object, and procedure-sco
 - `VB026`: `Resume` is used outside a likely error-handler context
 - `VB027`: nested `With` blocks use implicit Excel members whose target can be ambiguous
 
-Projects that intentionally use interactive GUI entrypoints may set `[lint].forbid_interactive_input = false` to suppress `VB007`. This changes lint behavior only; `run --headless` still rejects GUI boundaries during preflight.
+Projects that intentionally use interactive GUI entrypoints may set `[lint].disabled_rules = ["VB007"]` to suppress `VB007`. This changes lint behavior only; `run --headless` still rejects GUI boundaries during preflight.
 
 Compile-dialog prevention findings `VB008` through `VB014` are always enabled and block source preflight before `push` or `run` opens Excel.
 
-Higher-signal lint rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide lint rules `VB018`, `VB020`, `VB021`, and `VB027` are disabled by default and can be enabled with their `[lint]` booleans.
+Projects should disable configurable lint rules with `[lint].disabled_rules` using stable diagnostic IDs, for example `disabled_rules = ["VB002", "VB006"]`. Legacy per-rule booleans remain accepted for compatibility, but emit deprecation warnings. If a legacy boolean enables a rule that is also listed in `disabled_rules`, `disabled_rules` takes precedence and xlflow emits a conflict warning.
+
+Configurable lint rule IDs map to legacy keys as follows: `VB001` = `require_option_explicit`, `VB002` = `forbid_select`, `VB003` = `forbid_activate`, `VB004` = `forbid_on_error_resume_next`, `VB005` = `detect_implicit_variant`, `VB006` = `forbid_public_module_fields`, `VB007` = `forbid_interactive_input`, `VB018` = `detect_scope_shadowing`, `VB019` = `detect_multiple_declarator_clarity`, `VB020` = `detect_unused_local_variables`, `VB021` = `detect_unused_private_procedures`, `VB022` = `detect_confusing_call_syntax`, `VB023` = `detect_for_each_control_type`, `VB026` = `detect_dangerous_resume`, and `VB027` = `detect_nested_with_ambiguity`.
+
+Higher-signal lint rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide lint rules `VB018`, `VB020`, `VB021`, and `VB027` are disabled by default and can still be enabled with their legacy `[lint]` booleans during the compatibility window.
 
 ## Analysis Rules
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -249,17 +249,7 @@ code_source = "sidecar"
 disabled_rules = []
 
 [analyze]
-detect_range_find_nothing_check = true
-detect_object_use_before_set = true
-detect_application_state_restore = true
-detect_error_handler_fallthrough = true
-forbid_unqualified_excel_objects = true
-detect_byref_argument_mismatch = false
-detect_dictionary_collection_guard = false
-detect_redim_preserve_dimension = true
-detect_object_array_comparison = true
-detect_function_return_path = false
-detect_excel_object_member_mismatch = true
+disabled_rules = []
 ```
 
 ## JSON Envelope
@@ -498,4 +488,8 @@ Higher-signal lint rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by d
 - `VBA210`: function may exit without assigning its return value
 - `VBA211`: expanded known Excel object/member mismatch
 
-Analyzer rules `VBA101` through `VBA106`, `VBA201` through `VBA205`, `VBA208`, `VBA209`, and `VBA211` are enabled by default. Rules `VBA206`, `VBA207`, and `VBA210` are disabled by default and can be enabled with their `[analyze]` booleans.
+Projects should disable configurable analyzer rules with `[analyze].disabled_rules` using stable diagnostic IDs, for example `disabled_rules = ["VBA205", "VBA211"]`. Legacy per-rule booleans remain accepted for compatibility, but emit deprecation warnings. If a legacy boolean enables a rule that is also listed in `disabled_rules`, `disabled_rules` takes precedence and xlflow emits a conflict warning.
+
+Configurable analyzer rule IDs map to legacy keys as follows: `VBA201` = `detect_range_find_nothing_check`, `VBA202` = `detect_object_use_before_set`, `VBA203` = `detect_application_state_restore`, `VBA204` = `detect_error_handler_fallthrough`, `VBA205` = `forbid_unqualified_excel_objects`, `VBA206` = `detect_byref_argument_mismatch`, `VBA207` = `detect_dictionary_collection_guard`, `VBA208` = `detect_redim_preserve_dimension`, `VBA209` = `detect_object_array_comparison`, `VBA210` = `detect_function_return_path`, and `VBA211` = `detect_excel_object_member_mismatch`.
+
+Analyzer rules `VBA201` through `VBA205`, `VBA208`, `VBA209`, and `VBA211` are enabled by default. Rules `VBA206`, `VBA207`, and `VBA210` are disabled by default and can still be enabled with their legacy `[analyze]` booleans during the compatibility window. Analyzer diagnostics `VBA101` through `VBA106` are always enabled.

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -326,6 +326,43 @@ End Sub
 	}
 }
 
+func TestAnalyzerHonorsDisabledRuleIDs(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim found As Range
+  Set found = Range("A:A").Find("x")
+  found.Value = 1
+End Sub
+`)
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[analyze]
+disabled_rules = ["VBA205"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, config.FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings, err := Analyzer{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA205"); len(got) != 0 {
+		t.Fatalf("VBA205 should be disabled: %+v", got)
+	}
+	if got := findingsByCode(findings, "VBA201"); len(got) == 0 {
+		t.Fatalf("VBA201 should remain enabled: %+v", findings)
+	}
+}
+
 func TestAnalyzerRuntimeRiskRulesAllowGuardedPatterns(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -50,6 +50,7 @@ type app struct {
 	stderr         io.Writer
 	stdoutTerminal func() bool
 	stderrTerminal func() bool
+	configWarnings []map[string]any
 	buildInfo      BuildInfo
 	updateChecker  releaseChecker
 }
@@ -4968,6 +4969,9 @@ func (a *app) loadConfig(command string) (config.Config, error) {
 	if err != nil {
 		return cfg, a.writeFailure(command, output.ExitConfig, "config_error", err)
 	}
+	if len(cfg.Warnings) > 0 {
+		a.configWarnings = append(a.configWarnings, cfg.Warnings...)
+	}
 	return cfg, nil
 }
 
@@ -5001,6 +5005,7 @@ func (a *app) writeScaffoldWelcome(command string, skipUpdateCheck bool) error {
 
 func (a *app) writeFailure(command string, code int, errCode string, err error) error {
 	env := output.Failure(command, output.Error{Code: errCode, Message: err.Error()})
+	a.addConfigWarnings(&env)
 	if writeErr := output.WriteWithOptions(a.stdoutWriter(), env, a.outputOptions()); writeErr != nil {
 		return output.WithExitCode(code, writeErr)
 	}
@@ -5009,6 +5014,7 @@ func (a *app) writeFailure(command string, code int, errCode string, err error) 
 
 func (a *app) writeFormSpecFailure(command string, specErr *forms.SpecError) error {
 	env := output.Failure(command, output.Error{Code: specErr.Code, Message: specErr.Message})
+	a.addConfigWarnings(&env)
 	spec := map[string]any{}
 	if specErr.Path != "" {
 		spec["path"] = specErr.Path
@@ -5042,6 +5048,7 @@ func (a *app) write(env output.Envelope, code int) error {
 }
 
 func (a *app) writeWithOutputOptions(env output.Envelope, code int, opts output.Options) error {
+	a.addConfigWarnings(&env)
 	if err := output.WriteWithOptions(a.stdoutWriter(), env, opts); err != nil {
 		return output.WithExitCode(code, err)
 	}
@@ -5049,6 +5056,17 @@ func (a *app) writeWithOutputOptions(env output.Envelope, code int, opts output.
 		return output.WithExitCode(code, fmt.Errorf("%s failed", env.Command))
 	}
 	return nil
+}
+
+func (a *app) addConfigWarnings(env *output.Envelope) {
+	if env == nil || len(a.configWarnings) == 0 {
+		return
+	}
+	warnings := anySlice(env.Warnings)
+	for _, warning := range a.configWarnings {
+		warnings = append(warnings, warning)
+	}
+	env.Warnings = warnings
 }
 
 func (a *app) outputOptions() output.Options {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -315,7 +315,7 @@ disabled_rules = ["VB006"]`)
 		t.Fatalf("lint command error = %v, exit = %d", err, output.ExitCode(err))
 	}
 	text := stdout.String()
-	for _, want := range []string{"Warnings:", "[lint].forbid_public_module_fields is deprecated", "lint rule VB006 is enabled", "[lint].disabled_rules takes precedence"} {
+	for _, want := range []string{"Warnings:", "[lint].forbid_public_module_fields=true is deprecated", "Remove [lint].forbid_public_module_fields", "lint rule VB006 is enabled", "[lint].disabled_rules takes precedence"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected lint output to contain %q:\n%s", want, text)
 		}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -322,6 +322,34 @@ disabled_rules = ["VB006"]`)
 	}
 }
 
+func TestAnalyzeCommandJSONIncludesConfigWarnings(t *testing.T) {
+	dir := writeCLIWarningAnalyzeProject(t, `detect_byref_argument_mismatch = true`)
+	var stdout bytes.Buffer
+	a := &app{
+		cwd:            dir,
+		stdout:         &stdout,
+		stderr:         &bytes.Buffer{},
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"--json", "analyze"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("analyze command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+
+	var got struct {
+		Warnings []map[string]any `json:"warnings"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCLIWarning(got.Warnings, "deprecated_analyze_rule_config", "VBA206") {
+		t.Fatalf("expected analyze config deprecation warning, got %+v", got.Warnings)
+	}
+}
+
 func writeCLIWarningLintProject(t *testing.T, lintConfig string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -340,6 +368,30 @@ path = "build/Book.xlsm"
 
 [lint]
 ` + lintConfig + "\n"
+	if err := os.WriteFile(filepath.Join(dir, config.FileName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func writeCLIWarningAnalyzeProject(t *testing.T, analyzeConfig string) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte("Option Explicit\nPublic Sub Run()\nEnd Sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := `[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[analyze]
+` + analyzeConfig + "\n"
 	if err := os.WriteFile(filepath.Join(dir, config.FileName), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -269,6 +269,92 @@ func TestVersionCommandUsesDefaultBuildInfo(t *testing.T) {
 	}
 }
 
+func TestLintCommandJSONIncludesConfigWarnings(t *testing.T) {
+	dir := writeCLIWarningLintProject(t, `forbid_select = false`)
+	var stdout bytes.Buffer
+	a := &app{
+		cwd:            dir,
+		stdout:         &stdout,
+		stderr:         &bytes.Buffer{},
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"--json", "lint"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("lint command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+
+	var got struct {
+		Warnings []map[string]any `json:"warnings"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCLIWarning(got.Warnings, "deprecated_lint_rule_config", "VB002") {
+		t.Fatalf("expected config deprecation warning, got %+v", got.Warnings)
+	}
+}
+
+func TestLintCommandPlainIncludesConfigWarnings(t *testing.T) {
+	dir := writeCLIWarningLintProject(t, `forbid_public_module_fields = true
+disabled_rules = ["VB006"]`)
+	var stdout bytes.Buffer
+	a := &app{
+		cwd:            dir,
+		stdout:         &stdout,
+		stderr:         &bytes.Buffer{},
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"lint"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("lint command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+	text := stdout.String()
+	for _, want := range []string{"Warnings:", "[lint].forbid_public_module_fields is deprecated", "lint rule VB006 is enabled", "[lint].disabled_rules takes precedence"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected lint output to contain %q:\n%s", want, text)
+		}
+	}
+}
+
+func writeCLIWarningLintProject(t *testing.T, lintConfig string) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "Main.bas"), []byte("Option Explicit\nPublic Sub Run()\nEnd Sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := `[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[lint]
+` + lintConfig + "\n"
+	if err := os.WriteFile(filepath.Join(dir, config.FileName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func hasCLIWarning(warnings []map[string]any, code string, rule string) bool {
+	for _, warning := range warnings {
+		if warning["code"] == code && warning["rule"] == rule {
+			return true
+		}
+	}
+	return false
+}
+
 func TestVersionCommandVerboseIncludesExecutableAndFeatures(t *testing.T) {
 	var stdout bytes.Buffer
 	a := &app{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
@@ -15,13 +16,14 @@ const FileName = "xlflow.toml"
 var ErrInvalidExcelBridge = errors.New("excel.bridge must be one of auto, powershell, dotnet")
 
 type Config struct {
-	Project  ProjectConfig  `toml:"project"`
-	Excel    ExcelConfig    `toml:"excel"`
-	Src      SourceConfig   `toml:"src"`
-	VBA      VBAConfig      `toml:"vba"`
-	UserForm UserFormConfig `toml:"userform"`
-	Lint     LintConfig     `toml:"lint"`
-	Analyze  AnalyzeConfig  `toml:"analyze"`
+	Project  ProjectConfig    `toml:"project"`
+	Excel    ExcelConfig      `toml:"excel"`
+	Src      SourceConfig     `toml:"src"`
+	VBA      VBAConfig        `toml:"vba"`
+	UserForm UserFormConfig   `toml:"userform"`
+	Lint     LintConfig       `toml:"lint"`
+	Analyze  AnalyzeConfig    `toml:"analyze"`
+	Warnings []map[string]any `toml:"-"`
 }
 
 type ProjectConfig struct {
@@ -54,21 +56,22 @@ type UserFormConfig struct {
 }
 
 type LintConfig struct {
-	RequireOptionExplicit           bool `toml:"require_option_explicit"`
-	ForbidSelect                    bool `toml:"forbid_select"`
-	ForbidActivate                  bool `toml:"forbid_activate"`
-	ForbidOnErrorResumeNext         bool `toml:"forbid_on_error_resume_next"`
-	DetectImplicitVariant           bool `toml:"detect_implicit_variant"`
-	ForbidPublicModuleFields        bool `toml:"forbid_public_module_fields"`
-	ForbidInteractiveInput          bool `toml:"forbid_interactive_input"`
-	DetectScopeShadowing            bool `toml:"detect_scope_shadowing"`
-	DetectMultipleDeclaratorClarity bool `toml:"detect_multiple_declarator_clarity"`
-	DetectUnusedLocalVariables      bool `toml:"detect_unused_local_variables"`
-	DetectUnusedPrivateProcedures   bool `toml:"detect_unused_private_procedures"`
-	DetectConfusingCallSyntax       bool `toml:"detect_confusing_call_syntax"`
-	DetectForEachControlType        bool `toml:"detect_for_each_control_type"`
-	DetectDangerousResume           bool `toml:"detect_dangerous_resume"`
-	DetectNestedWithAmbiguity       bool `toml:"detect_nested_with_ambiguity"`
+	DisabledRules                   []string `toml:"disabled_rules"`
+	RequireOptionExplicit           bool     `toml:"require_option_explicit"`
+	ForbidSelect                    bool     `toml:"forbid_select"`
+	ForbidActivate                  bool     `toml:"forbid_activate"`
+	ForbidOnErrorResumeNext         bool     `toml:"forbid_on_error_resume_next"`
+	DetectImplicitVariant           bool     `toml:"detect_implicit_variant"`
+	ForbidPublicModuleFields        bool     `toml:"forbid_public_module_fields"`
+	ForbidInteractiveInput          bool     `toml:"forbid_interactive_input"`
+	DetectScopeShadowing            bool     `toml:"detect_scope_shadowing"`
+	DetectMultipleDeclaratorClarity bool     `toml:"detect_multiple_declarator_clarity"`
+	DetectUnusedLocalVariables      bool     `toml:"detect_unused_local_variables"`
+	DetectUnusedPrivateProcedures   bool     `toml:"detect_unused_private_procedures"`
+	DetectConfusingCallSyntax       bool     `toml:"detect_confusing_call_syntax"`
+	DetectForEachControlType        bool     `toml:"detect_for_each_control_type"`
+	DetectDangerousResume           bool     `toml:"detect_dangerous_resume"`
+	DetectNestedWithAmbiguity       bool     `toml:"detect_nested_with_ambiguity"`
 }
 
 type AnalyzeConfig struct {
@@ -84,6 +87,45 @@ type AnalyzeConfig struct {
 	DetectFunctionReturnPath        bool `toml:"detect_function_return_path"`
 	DetectExcelObjectMemberMismatch bool `toml:"detect_excel_object_member_mismatch"`
 }
+
+type lintRuleConfig struct {
+	ID      string
+	Key     string
+	Default bool
+	Get     func(LintConfig) bool
+	Set     func(*LintConfig, bool)
+}
+
+var configurableLintRules = []lintRuleConfig{
+	{ID: "VB001", Key: "require_option_explicit", Default: true, Get: func(c LintConfig) bool { return c.RequireOptionExplicit }, Set: func(c *LintConfig, v bool) { c.RequireOptionExplicit = v }},
+	{ID: "VB002", Key: "forbid_select", Default: true, Get: func(c LintConfig) bool { return c.ForbidSelect }, Set: func(c *LintConfig, v bool) { c.ForbidSelect = v }},
+	{ID: "VB003", Key: "forbid_activate", Default: true, Get: func(c LintConfig) bool { return c.ForbidActivate }, Set: func(c *LintConfig, v bool) { c.ForbidActivate = v }},
+	{ID: "VB004", Key: "forbid_on_error_resume_next", Default: true, Get: func(c LintConfig) bool { return c.ForbidOnErrorResumeNext }, Set: func(c *LintConfig, v bool) { c.ForbidOnErrorResumeNext = v }},
+	{ID: "VB005", Key: "detect_implicit_variant", Default: true, Get: func(c LintConfig) bool { return c.DetectImplicitVariant }, Set: func(c *LintConfig, v bool) { c.DetectImplicitVariant = v }},
+	{ID: "VB006", Key: "forbid_public_module_fields", Default: true, Get: func(c LintConfig) bool { return c.ForbidPublicModuleFields }, Set: func(c *LintConfig, v bool) { c.ForbidPublicModuleFields = v }},
+	{ID: "VB007", Key: "forbid_interactive_input", Default: true, Get: func(c LintConfig) bool { return c.ForbidInteractiveInput }, Set: func(c *LintConfig, v bool) { c.ForbidInteractiveInput = v }},
+	{ID: "VB018", Key: "detect_scope_shadowing", Default: false, Get: func(c LintConfig) bool { return c.DetectScopeShadowing }, Set: func(c *LintConfig, v bool) { c.DetectScopeShadowing = v }},
+	{ID: "VB019", Key: "detect_multiple_declarator_clarity", Default: true, Get: func(c LintConfig) bool { return c.DetectMultipleDeclaratorClarity }, Set: func(c *LintConfig, v bool) { c.DetectMultipleDeclaratorClarity = v }},
+	{ID: "VB020", Key: "detect_unused_local_variables", Default: false, Get: func(c LintConfig) bool { return c.DetectUnusedLocalVariables }, Set: func(c *LintConfig, v bool) { c.DetectUnusedLocalVariables = v }},
+	{ID: "VB021", Key: "detect_unused_private_procedures", Default: false, Get: func(c LintConfig) bool { return c.DetectUnusedPrivateProcedures }, Set: func(c *LintConfig, v bool) { c.DetectUnusedPrivateProcedures = v }},
+	{ID: "VB022", Key: "detect_confusing_call_syntax", Default: true, Get: func(c LintConfig) bool { return c.DetectConfusingCallSyntax }, Set: func(c *LintConfig, v bool) { c.DetectConfusingCallSyntax = v }},
+	{ID: "VB023", Key: "detect_for_each_control_type", Default: true, Get: func(c LintConfig) bool { return c.DetectForEachControlType }, Set: func(c *LintConfig, v bool) { c.DetectForEachControlType = v }},
+	{ID: "VB026", Key: "detect_dangerous_resume", Default: true, Get: func(c LintConfig) bool { return c.DetectDangerousResume }, Set: func(c *LintConfig, v bool) { c.DetectDangerousResume = v }},
+	{ID: "VB027", Key: "detect_nested_with_ambiguity", Default: false, Get: func(c LintConfig) bool { return c.DetectNestedWithAmbiguity }, Set: func(c *LintConfig, v bool) { c.DetectNestedWithAmbiguity = v }},
+}
+
+var (
+	lintRuleByID               = indexLintRulesByID()
+	nonConfigurableLintRuleIDs = map[string]bool{
+		"VB008": true,
+		"VB009": true,
+		"VB010": true,
+		"VB011": true,
+		"VB012": true,
+		"VB013": true,
+		"VB014": true,
+	}
+)
 
 func Default() Config {
 	return Config{
@@ -154,10 +196,14 @@ func load(cwd string, allowInvalidExcelBridge bool) (Config, error) {
 		}
 		return cfg, err
 	}
-	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+	meta, err := toml.DecodeFile(path, &cfg)
+	if err != nil {
 		return cfg, err
 	}
 	applyDefaults(&cfg)
+	if err := applyLintRuleConfig(&cfg, meta); err != nil {
+		return cfg, err
+	}
 	if err := normalizeExcelBridge(&cfg, allowInvalidExcelBridge); err != nil {
 		return cfg, err
 	}
@@ -215,6 +261,79 @@ func validate(cfg Config) error {
 	return nil
 }
 
+func indexLintRulesByID() map[string]lintRuleConfig {
+	out := make(map[string]lintRuleConfig, len(configurableLintRules))
+	for _, rule := range configurableLintRules {
+		out[rule.ID] = rule
+	}
+	return out
+}
+
+func applyLintRuleConfig(cfg *Config, meta toml.MetaData) error {
+	disabled, disabledSet, err := normalizeDisabledLintRules(cfg.Lint.DisabledRules)
+	if err != nil {
+		return err
+	}
+	cfg.Lint.DisabledRules = disabled
+	warnings := make([]map[string]any, 0)
+	for _, rule := range configurableLintRules {
+		if !meta.IsDefined("lint", rule.Key) {
+			continue
+		}
+		warnings = append(warnings, map[string]any{
+			"code":    "deprecated_lint_rule_config",
+			"message": fmt.Sprintf("[lint].%s is deprecated. Use [lint].disabled_rules = [%q] instead.", rule.Key, rule.ID),
+			"rule":    rule.ID,
+			"key":     rule.Key,
+		})
+		if rule.Get(cfg.Lint) && disabledSet[rule.ID] {
+			warnings = append(warnings,
+				map[string]any{
+					"code":    "conflicting_lint_rule_config",
+					"message": fmt.Sprintf("lint rule %s is enabled by [lint].%s=true but also listed in [lint].disabled_rules.", rule.ID, rule.Key),
+					"rule":    rule.ID,
+					"key":     rule.Key,
+				},
+				map[string]any{
+					"code":    "disabled_rules_precedence",
+					"message": "[lint].disabled_rules takes precedence.",
+					"rule":    rule.ID,
+					"key":     rule.Key,
+				},
+			)
+		}
+	}
+	for id := range disabledSet {
+		rule := lintRuleByID[id]
+		rule.Set(&cfg.Lint, false)
+	}
+	cfg.Warnings = append(cfg.Warnings, warnings...)
+	return nil
+}
+
+func normalizeDisabledLintRules(ids []string) ([]string, map[string]bool, error) {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(ids))
+	for _, raw := range ids {
+		id := strings.ToUpper(strings.TrimSpace(raw))
+		if id == "" {
+			continue
+		}
+		if _, ok := lintRuleByID[id]; !ok {
+			if nonConfigurableLintRuleIDs[id] {
+				return nil, nil, fmt.Errorf("lint rule ID is not configurable in [lint].disabled_rules: %s", id)
+			}
+			return nil, nil, fmt.Errorf("unknown lint rule ID in [lint].disabled_rules: %s", id)
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out, seen, nil
+}
+
 func normalizeExcelBridge(cfg *Config, allowInvalid bool) error {
 	mode, err := excelbridge.ParseMode(cfg.Excel.Bridge)
 	if err != nil {
@@ -230,6 +349,70 @@ func normalizeExcelBridge(cfg *Config, allowInvalid bool) error {
 	return nil
 }
 
+func renderLintConfig(cfg LintConfig) string {
+	var b strings.Builder
+	b.WriteString("# Disable specific lint rules by diagnostic ID.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Example:\n")
+	b.WriteString("# disabled_rules = [\n")
+	b.WriteString("#   \"VB006\", # Allow public module-level fields in this legacy project.\n")
+	b.WriteString("# ]\n")
+	disabled := disabledLintRuleIDsForWrite(cfg)
+	if len(disabled) == 0 {
+		b.WriteString("disabled_rules = []\n")
+	} else {
+		b.WriteString("disabled_rules = [\n")
+		for _, id := range disabled {
+			b.WriteString("  \"")
+			b.WriteString(id)
+			b.WriteString("\",\n")
+		}
+		b.WriteString("]\n")
+	}
+	optIn := legacyOptInLintRulesForWrite(cfg)
+	if len(optIn) > 0 {
+		b.WriteString("\n")
+		b.WriteString("# Legacy opt-in lint settings. Prefer disabled_rules for disabling recommended rules.\n")
+		for _, rule := range optIn {
+			b.WriteString(rule.Key)
+			b.WriteString(" = true\n")
+		}
+	}
+	return b.String()
+}
+
+func disabledLintRuleIDsForWrite(cfg LintConfig) []string {
+	seen := map[string]bool{}
+	for _, raw := range cfg.DisabledRules {
+		id := strings.ToUpper(strings.TrimSpace(raw))
+		if _, ok := lintRuleByID[id]; ok {
+			seen[id] = true
+		}
+	}
+	for _, rule := range configurableLintRules {
+		if rule.Default && !rule.Get(cfg) {
+			seen[rule.ID] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for _, rule := range configurableLintRules {
+		if seen[rule.ID] {
+			out = append(out, rule.ID)
+		}
+	}
+	return out
+}
+
+func legacyOptInLintRulesForWrite(cfg LintConfig) []lintRuleConfig {
+	var out []lintRuleConfig
+	for _, rule := range configurableLintRules {
+		if !rule.Default && rule.Get(cfg) {
+			out = append(out, rule)
+		}
+	}
+	return out
+}
+
 func Write(path string, cfg Config) (err error) {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
@@ -240,6 +423,8 @@ func Write(path string, cfg Config) (err error) {
 			err = closeErr
 		}
 	}()
+
+	lintConfigText := renderLintConfig(cfg.Lint)
 
 	const tmpl = `# Project identity and entry point.
 [project]
@@ -293,36 +478,7 @@ code_source = %q
 
 # Static analysis rules.
 [lint]
-# Require Option Explicit in every module.
-require_option_explicit = %t
-# Forbid Select / Activate patterns.
-forbid_select = %t
-# Forbid Activate usage.
-forbid_activate = %t
-# Forbid On Error Resume Next.
-forbid_on_error_resume_next = %t
-# Detect implicitly typed Variant variables.
-detect_implicit_variant = %t
-# Forbid public fields in standard modules.
-forbid_public_module_fields = %t
-# Forbid interactive input (MsgBox, InputBox, etc.) in headless runs.
-forbid_interactive_input = %t
-# Detect local names that shadow module or procedure names.
-detect_scope_shadowing = %t
-# Explain mixed Dim declarations where only some declarators are typed.
-detect_multiple_declarator_clarity = %t
-# Detect unused procedure-local variables.
-detect_unused_local_variables = %t
-# Detect unused Private procedures.
-detect_unused_private_procedures = %t
-# Detect confusing parenthesized call syntax.
-detect_confusing_call_syntax = %t
-# Detect For Each control variable declaration/type issues.
-detect_for_each_control_type = %t
-# Detect Resume statements outside likely error handlers.
-detect_dangerous_resume = %t
-# Detect nested With blocks with ambiguous implicit Excel members.
-detect_nested_with_ambiguity = %t
+%s
 
 # Runtime-risk analysis rules.
 [analyze]
@@ -355,13 +511,7 @@ detect_excel_object_member_mismatch = %t
 		cfg.Src.Modules, cfg.Src.Classes, cfg.Src.Forms, cfg.Src.Workbook,
 		cfg.VBA.Folders, cfg.VBA.FolderAnnotation, cfg.VBA.DefaultComponentFolders,
 		cfg.UserForm.CodeSource,
-		cfg.Lint.RequireOptionExplicit, cfg.Lint.ForbidSelect, cfg.Lint.ForbidActivate,
-		cfg.Lint.ForbidOnErrorResumeNext, cfg.Lint.DetectImplicitVariant,
-		cfg.Lint.ForbidPublicModuleFields, cfg.Lint.ForbidInteractiveInput,
-		cfg.Lint.DetectScopeShadowing, cfg.Lint.DetectMultipleDeclaratorClarity, cfg.Lint.DetectUnusedLocalVariables,
-		cfg.Lint.DetectUnusedPrivateProcedures, cfg.Lint.DetectConfusingCallSyntax,
-		cfg.Lint.DetectForEachControlType, cfg.Lint.DetectDangerousResume,
-		cfg.Lint.DetectNestedWithAmbiguity,
+		lintConfigText,
 		cfg.Analyze.DetectRangeFindNothingCheck, cfg.Analyze.DetectObjectUseBeforeSet,
 		cfg.Analyze.DetectApplicationStateRestore, cfg.Analyze.DetectErrorHandlerFallthrough,
 		cfg.Analyze.ForbidUnqualifiedExcelObjects, cfg.Analyze.DetectByRefArgumentMismatch,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -323,7 +323,7 @@ func applyLintRuleConfig(cfg *Config, meta toml.MetaData) error {
 		}
 		warnings = append(warnings, map[string]any{
 			"code":    "deprecated_lint_rule_config",
-			"message": fmt.Sprintf("[lint].%s is deprecated. Use [lint].disabled_rules = [%q] instead.", rule.Key, rule.ID),
+			"message": deprecatedRuleConfigMessage("lint", rule.Key, rule.ID, rule.Get(cfg.Lint), rule.Default),
 			"rule":    rule.ID,
 			"key":     rule.Key,
 		})
@@ -388,7 +388,7 @@ func applyAnalyzeRuleConfig(cfg *Config, meta toml.MetaData) error {
 		}
 		warnings = append(warnings, map[string]any{
 			"code":    "deprecated_analyze_rule_config",
-			"message": fmt.Sprintf("[analyze].%s is deprecated. Use [analyze].disabled_rules = [%q] instead.", rule.Key, rule.ID),
+			"message": deprecatedRuleConfigMessage("analyze", rule.Key, rule.ID, rule.Get(cfg.Analyze), rule.Default),
 			"rule":    rule.ID,
 			"key":     rule.Key,
 		})
@@ -415,6 +415,21 @@ func applyAnalyzeRuleConfig(cfg *Config, meta toml.MetaData) error {
 	}
 	cfg.Warnings = append(cfg.Warnings, warnings...)
 	return nil
+}
+
+func deprecatedRuleConfigMessage(section, key, id string, enabled, defaultEnabled bool) string {
+	qualifiedKey := fmt.Sprintf("[%s].%s", section, key)
+	switch {
+	case !enabled:
+		if defaultEnabled {
+			return fmt.Sprintf("%s=false is deprecated. Use [%s].disabled_rules = [%q] instead.", qualifiedKey, section, id)
+		}
+		return fmt.Sprintf("%s=false is deprecated and redundant because %s is disabled by default. Remove %s.", qualifiedKey, id, qualifiedKey)
+	case defaultEnabled:
+		return fmt.Sprintf("%s=true is deprecated and redundant because %s is enabled by default. Remove %s.", qualifiedKey, id, qualifiedKey)
+	default:
+		return fmt.Sprintf("%s=true is deprecated but remains the compatibility opt-in for %s; keep it until an opt-in replacement is available.", qualifiedKey, id)
+	}
 }
 
 func normalizeDisabledAnalyzeRules(ids []string) ([]string, map[string]bool, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,17 +75,18 @@ type LintConfig struct {
 }
 
 type AnalyzeConfig struct {
-	DetectRangeFindNothingCheck     bool `toml:"detect_range_find_nothing_check"`
-	DetectObjectUseBeforeSet        bool `toml:"detect_object_use_before_set"`
-	DetectApplicationStateRestore   bool `toml:"detect_application_state_restore"`
-	DetectErrorHandlerFallthrough   bool `toml:"detect_error_handler_fallthrough"`
-	ForbidUnqualifiedExcelObjects   bool `toml:"forbid_unqualified_excel_objects"`
-	DetectByRefArgumentMismatch     bool `toml:"detect_byref_argument_mismatch"`
-	DetectDictionaryCollectionGuard bool `toml:"detect_dictionary_collection_guard"`
-	DetectRedimPreserveDimension    bool `toml:"detect_redim_preserve_dimension"`
-	DetectObjectArrayComparison     bool `toml:"detect_object_array_comparison"`
-	DetectFunctionReturnPath        bool `toml:"detect_function_return_path"`
-	DetectExcelObjectMemberMismatch bool `toml:"detect_excel_object_member_mismatch"`
+	DisabledRules                   []string `toml:"disabled_rules"`
+	DetectRangeFindNothingCheck     bool     `toml:"detect_range_find_nothing_check"`
+	DetectObjectUseBeforeSet        bool     `toml:"detect_object_use_before_set"`
+	DetectApplicationStateRestore   bool     `toml:"detect_application_state_restore"`
+	DetectErrorHandlerFallthrough   bool     `toml:"detect_error_handler_fallthrough"`
+	ForbidUnqualifiedExcelObjects   bool     `toml:"forbid_unqualified_excel_objects"`
+	DetectByRefArgumentMismatch     bool     `toml:"detect_byref_argument_mismatch"`
+	DetectDictionaryCollectionGuard bool     `toml:"detect_dictionary_collection_guard"`
+	DetectRedimPreserveDimension    bool     `toml:"detect_redim_preserve_dimension"`
+	DetectObjectArrayComparison     bool     `toml:"detect_object_array_comparison"`
+	DetectFunctionReturnPath        bool     `toml:"detect_function_return_path"`
+	DetectExcelObjectMemberMismatch bool     `toml:"detect_excel_object_member_mismatch"`
 }
 
 type lintRuleConfig struct {
@@ -94,6 +95,14 @@ type lintRuleConfig struct {
 	Default bool
 	Get     func(LintConfig) bool
 	Set     func(*LintConfig, bool)
+}
+
+type analyzeRuleConfig struct {
+	ID      string
+	Key     string
+	Default bool
+	Get     func(AnalyzeConfig) bool
+	Set     func(*AnalyzeConfig, bool)
 }
 
 var configurableLintRules = []lintRuleConfig{
@@ -114,16 +123,37 @@ var configurableLintRules = []lintRuleConfig{
 	{ID: "VB027", Key: "detect_nested_with_ambiguity", Default: false, Get: func(c LintConfig) bool { return c.DetectNestedWithAmbiguity }, Set: func(c *LintConfig, v bool) { c.DetectNestedWithAmbiguity = v }},
 }
 
+var configurableAnalyzeRules = []analyzeRuleConfig{
+	{ID: "VBA201", Key: "detect_range_find_nothing_check", Default: true, Get: func(c AnalyzeConfig) bool { return c.DetectRangeFindNothingCheck }, Set: func(c *AnalyzeConfig, v bool) { c.DetectRangeFindNothingCheck = v }},
+	{ID: "VBA202", Key: "detect_object_use_before_set", Default: true, Get: func(c AnalyzeConfig) bool { return c.DetectObjectUseBeforeSet }, Set: func(c *AnalyzeConfig, v bool) { c.DetectObjectUseBeforeSet = v }},
+	{ID: "VBA203", Key: "detect_application_state_restore", Default: true, Get: func(c AnalyzeConfig) bool { return c.DetectApplicationStateRestore }, Set: func(c *AnalyzeConfig, v bool) { c.DetectApplicationStateRestore = v }},
+	{ID: "VBA204", Key: "detect_error_handler_fallthrough", Default: true, Get: func(c AnalyzeConfig) bool { return c.DetectErrorHandlerFallthrough }, Set: func(c *AnalyzeConfig, v bool) { c.DetectErrorHandlerFallthrough = v }},
+	{ID: "VBA205", Key: "forbid_unqualified_excel_objects", Default: true, Get: func(c AnalyzeConfig) bool { return c.ForbidUnqualifiedExcelObjects }, Set: func(c *AnalyzeConfig, v bool) { c.ForbidUnqualifiedExcelObjects = v }},
+	{ID: "VBA206", Key: "detect_byref_argument_mismatch", Default: false, Get: func(c AnalyzeConfig) bool { return c.DetectByRefArgumentMismatch }, Set: func(c *AnalyzeConfig, v bool) { c.DetectByRefArgumentMismatch = v }},
+	{ID: "VBA207", Key: "detect_dictionary_collection_guard", Default: false, Get: func(c AnalyzeConfig) bool { return c.DetectDictionaryCollectionGuard }, Set: func(c *AnalyzeConfig, v bool) { c.DetectDictionaryCollectionGuard = v }},
+	{ID: "VBA208", Key: "detect_redim_preserve_dimension", Default: true, Get: func(c AnalyzeConfig) bool { return c.DetectRedimPreserveDimension }, Set: func(c *AnalyzeConfig, v bool) { c.DetectRedimPreserveDimension = v }},
+	{ID: "VBA209", Key: "detect_object_array_comparison", Default: true, Get: func(c AnalyzeConfig) bool { return c.DetectObjectArrayComparison }, Set: func(c *AnalyzeConfig, v bool) { c.DetectObjectArrayComparison = v }},
+	{ID: "VBA210", Key: "detect_function_return_path", Default: false, Get: func(c AnalyzeConfig) bool { return c.DetectFunctionReturnPath }, Set: func(c *AnalyzeConfig, v bool) { c.DetectFunctionReturnPath = v }},
+	{ID: "VBA211", Key: "detect_excel_object_member_mismatch", Default: true, Get: func(c AnalyzeConfig) bool { return c.DetectExcelObjectMemberMismatch }, Set: func(c *AnalyzeConfig, v bool) { c.DetectExcelObjectMemberMismatch = v }},
+}
+
 var (
-	lintRuleByID               = indexLintRulesByID()
-	nonConfigurableLintRuleIDs = map[string]bool{
-		"VB008": true,
-		"VB009": true,
-		"VB010": true,
-		"VB011": true,
-		"VB012": true,
-		"VB013": true,
-		"VB014": true,
+	lintRuleByID           = indexLintRulesByID()
+	analyzeRuleByID        = indexAnalyzeRulesByID()
+	nonConfigurableRuleIDs = map[string]bool{
+		"VB008":  true,
+		"VB009":  true,
+		"VB010":  true,
+		"VB011":  true,
+		"VB012":  true,
+		"VB013":  true,
+		"VB014":  true,
+		"VBA101": true,
+		"VBA102": true,
+		"VBA103": true,
+		"VBA104": true,
+		"VBA105": true,
+		"VBA106": true,
 	}
 )
 
@@ -204,6 +234,9 @@ func load(cwd string, allowInvalidExcelBridge bool) (Config, error) {
 	if err := applyLintRuleConfig(&cfg, meta); err != nil {
 		return cfg, err
 	}
+	if err := applyAnalyzeRuleConfig(&cfg, meta); err != nil {
+		return cfg, err
+	}
 	if err := normalizeExcelBridge(&cfg, allowInvalidExcelBridge); err != nil {
 		return cfg, err
 	}
@@ -269,6 +302,14 @@ func indexLintRulesByID() map[string]lintRuleConfig {
 	return out
 }
 
+func indexAnalyzeRulesByID() map[string]analyzeRuleConfig {
+	out := make(map[string]analyzeRuleConfig, len(configurableAnalyzeRules))
+	for _, rule := range configurableAnalyzeRules {
+		out[rule.ID] = rule
+	}
+	return out
+}
+
 func applyLintRuleConfig(cfg *Config, meta toml.MetaData) error {
 	disabled, disabledSet, err := normalizeDisabledLintRules(cfg.Lint.DisabledRules)
 	if err != nil {
@@ -320,10 +361,75 @@ func normalizeDisabledLintRules(ids []string) ([]string, map[string]bool, error)
 			continue
 		}
 		if _, ok := lintRuleByID[id]; !ok {
-			if nonConfigurableLintRuleIDs[id] {
+			if nonConfigurableRuleIDs[id] {
 				return nil, nil, fmt.Errorf("lint rule ID is not configurable in [lint].disabled_rules: %s", id)
 			}
 			return nil, nil, fmt.Errorf("unknown lint rule ID in [lint].disabled_rules: %s", id)
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out, seen, nil
+}
+
+func applyAnalyzeRuleConfig(cfg *Config, meta toml.MetaData) error {
+	disabled, disabledSet, err := normalizeDisabledAnalyzeRules(cfg.Analyze.DisabledRules)
+	if err != nil {
+		return err
+	}
+	cfg.Analyze.DisabledRules = disabled
+	warnings := make([]map[string]any, 0)
+	for _, rule := range configurableAnalyzeRules {
+		if !meta.IsDefined("analyze", rule.Key) {
+			continue
+		}
+		warnings = append(warnings, map[string]any{
+			"code":    "deprecated_analyze_rule_config",
+			"message": fmt.Sprintf("[analyze].%s is deprecated. Use [analyze].disabled_rules = [%q] instead.", rule.Key, rule.ID),
+			"rule":    rule.ID,
+			"key":     rule.Key,
+		})
+		if rule.Get(cfg.Analyze) && disabledSet[rule.ID] {
+			warnings = append(warnings,
+				map[string]any{
+					"code":    "conflicting_analyze_rule_config",
+					"message": fmt.Sprintf("analyze rule %s is enabled by [analyze].%s=true but also listed in [analyze].disabled_rules.", rule.ID, rule.Key),
+					"rule":    rule.ID,
+					"key":     rule.Key,
+				},
+				map[string]any{
+					"code":    "analyze_disabled_rules_precedence",
+					"message": "[analyze].disabled_rules takes precedence.",
+					"rule":    rule.ID,
+					"key":     rule.Key,
+				},
+			)
+		}
+	}
+	for id := range disabledSet {
+		rule := analyzeRuleByID[id]
+		rule.Set(&cfg.Analyze, false)
+	}
+	cfg.Warnings = append(cfg.Warnings, warnings...)
+	return nil
+}
+
+func normalizeDisabledAnalyzeRules(ids []string) ([]string, map[string]bool, error) {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(ids))
+	for _, raw := range ids {
+		id := strings.ToUpper(strings.TrimSpace(raw))
+		if id == "" {
+			continue
+		}
+		if _, ok := analyzeRuleByID[id]; !ok {
+			if nonConfigurableRuleIDs[id] {
+				return nil, nil, fmt.Errorf("analyze rule ID is not configurable in [analyze].disabled_rules: %s", id)
+			}
+			return nil, nil, fmt.Errorf("unknown analyze rule ID in [analyze].disabled_rules: %s", id)
 		}
 		if seen[id] {
 			continue
@@ -413,6 +519,70 @@ func legacyOptInLintRulesForWrite(cfg LintConfig) []lintRuleConfig {
 	return out
 }
 
+func renderAnalyzeConfig(cfg AnalyzeConfig) string {
+	var b strings.Builder
+	b.WriteString("# Disable specific analyzer rules by diagnostic ID.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Example:\n")
+	b.WriteString("# disabled_rules = [\n")
+	b.WriteString("#   \"VBA205\", # Allow active worksheet dependencies in this legacy project.\n")
+	b.WriteString("# ]\n")
+	disabled := disabledAnalyzeRuleIDsForWrite(cfg)
+	if len(disabled) == 0 {
+		b.WriteString("disabled_rules = []\n")
+	} else {
+		b.WriteString("disabled_rules = [\n")
+		for _, id := range disabled {
+			b.WriteString("  \"")
+			b.WriteString(id)
+			b.WriteString("\",\n")
+		}
+		b.WriteString("]\n")
+	}
+	optIn := legacyOptInAnalyzeRulesForWrite(cfg)
+	if len(optIn) > 0 {
+		b.WriteString("\n")
+		b.WriteString("# Legacy opt-in analyzer settings. Prefer disabled_rules for disabling recommended rules.\n")
+		for _, rule := range optIn {
+			b.WriteString(rule.Key)
+			b.WriteString(" = true\n")
+		}
+	}
+	return b.String()
+}
+
+func disabledAnalyzeRuleIDsForWrite(cfg AnalyzeConfig) []string {
+	seen := map[string]bool{}
+	for _, raw := range cfg.DisabledRules {
+		id := strings.ToUpper(strings.TrimSpace(raw))
+		if _, ok := analyzeRuleByID[id]; ok {
+			seen[id] = true
+		}
+	}
+	for _, rule := range configurableAnalyzeRules {
+		if rule.Default && !rule.Get(cfg) {
+			seen[rule.ID] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for _, rule := range configurableAnalyzeRules {
+		if seen[rule.ID] {
+			out = append(out, rule.ID)
+		}
+	}
+	return out
+}
+
+func legacyOptInAnalyzeRulesForWrite(cfg AnalyzeConfig) []analyzeRuleConfig {
+	var out []analyzeRuleConfig
+	for _, rule := range configurableAnalyzeRules {
+		if !rule.Default && rule.Get(cfg) {
+			out = append(out, rule)
+		}
+	}
+	return out
+}
+
 func Write(path string, cfg Config) (err error) {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
@@ -425,6 +595,7 @@ func Write(path string, cfg Config) (err error) {
 	}()
 
 	lintConfigText := renderLintConfig(cfg.Lint)
+	analyzeConfigText := renderAnalyzeConfig(cfg.Analyze)
 
 	const tmpl = `# Project identity and entry point.
 [project]
@@ -482,28 +653,7 @@ code_source = %q
 
 # Runtime-risk analysis rules.
 [analyze]
-# Detect Range.Find results used without a Nothing check.
-detect_range_find_nothing_check = %t
-# Detect object variables used before an obvious Set assignment.
-detect_object_use_before_set = %t
-# Detect Application state changes without an obvious restore path.
-detect_application_state_restore = %t
-# Detect procedures that can fall through into an error handler.
-detect_error_handler_fallthrough = %t
-# Forbid unqualified Range/Cells/Rows/Columns access.
-forbid_unqualified_excel_objects = %t
-# Detect likely ByRef argument type mismatches.
-detect_byref_argument_mismatch = %t
-# Detect Dictionary/Collection access without an obvious guard.
-detect_dictionary_collection_guard = %t
-# Detect ReDim Preserve usage on multi-dimensional arrays.
-detect_redim_preserve_dimension = %t
-# Detect object or array comparison mistakes.
-detect_object_array_comparison = %t
-# Detect functions that may exit without assigning their return value.
-detect_function_return_path = %t
-# Detect known Excel object/member mismatches.
-detect_excel_object_member_mismatch = %t
+%s
 `
 	_, err = fmt.Fprintf(f, tmpl,
 		cfg.Project.Name, cfg.Project.Entry,
@@ -512,12 +662,7 @@ detect_excel_object_member_mismatch = %t
 		cfg.VBA.Folders, cfg.VBA.FolderAnnotation, cfg.VBA.DefaultComponentFolders,
 		cfg.UserForm.CodeSource,
 		lintConfigText,
-		cfg.Analyze.DetectRangeFindNothingCheck, cfg.Analyze.DetectObjectUseBeforeSet,
-		cfg.Analyze.DetectApplicationStateRestore, cfg.Analyze.DetectErrorHandlerFallthrough,
-		cfg.Analyze.ForbidUnqualifiedExcelObjects, cfg.Analyze.DetectByRefArgumentMismatch,
-		cfg.Analyze.DetectDictionaryCollectionGuard, cfg.Analyze.DetectRedimPreserveDimension,
-		cfg.Analyze.DetectObjectArrayComparison, cfg.Analyze.DetectFunctionReturnPath,
-		cfg.Analyze.DetectExcelObjectMemberMismatch,
+		analyzeConfigText,
 	)
 	return err
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -94,6 +95,133 @@ detect_byref_argument_mismatch = true
 	}
 	if !cfg.Lint.RequireOptionExplicit {
 		t.Fatal("expected other lint defaults to remain enabled")
+	}
+}
+
+func TestLoadSupportsDisabledLintRules(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[lint]
+disabled_rules = ["VB002", "vb006", "VB002"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Lint.ForbidSelect {
+		t.Fatal("expected VB002/forbid_select to be disabled")
+	}
+	if cfg.Lint.ForbidPublicModuleFields {
+		t.Fatal("expected VB006/forbid_public_module_fields to be disabled")
+	}
+	if !cfg.Lint.ForbidActivate {
+		t.Fatal("expected unrelated lint rule to remain enabled")
+	}
+	if got := strings.Join(cfg.Lint.DisabledRules, ","); got != "VB002,VB006" {
+		t.Fatalf("disabled rules = %q, want VB002,VB006", got)
+	}
+}
+
+func TestLoadRejectsUnknownDisabledLintRule(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[lint]
+disabled_rules = ["VB999"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "unknown lint rule ID in [lint].disabled_rules: VB999") {
+		t.Fatalf("expected unknown lint rule error, got %v", err)
+	}
+}
+
+func TestLoadRejectsNonConfigurableDisabledLintRule(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[lint]
+disabled_rules = ["VB013"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "lint rule ID is not configurable in [lint].disabled_rules: VB013") {
+		t.Fatalf("expected non-configurable lint rule error, got %v", err)
+	}
+}
+
+func TestLoadWarnsForLegacyLintRuleConfig(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[lint]
+forbid_select = false
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Lint.ForbidSelect {
+		t.Fatal("expected legacy forbid_select=false to be honored")
+	}
+	if !hasConfigWarning(cfg.Warnings, "deprecated_lint_rule_config", "VB002") {
+		t.Fatalf("expected deprecated config warning, got %+v", cfg.Warnings)
+	}
+}
+
+func TestLoadDisabledRulesTakePrecedenceOverLegacyLintRuleConfig(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[lint]
+forbid_public_module_fields = true
+disabled_rules = ["VB006"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Lint.ForbidPublicModuleFields {
+		t.Fatal("expected disabled_rules to take precedence over legacy true")
+	}
+	if !hasConfigWarning(cfg.Warnings, "deprecated_lint_rule_config", "VB006") ||
+		!hasConfigWarning(cfg.Warnings, "conflicting_lint_rule_config", "VB006") ||
+		!hasConfigWarning(cfg.Warnings, "disabled_rules_precedence", "VB006") {
+		t.Fatalf("expected deprecation and conflict warnings, got %+v", cfg.Warnings)
 	}
 }
 
@@ -195,6 +323,17 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	if err := Write(p, cfg); err != nil {
 		t.Fatalf("Write failed: %v", err)
 	}
+	body, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "disabled_rules = [") || !strings.Contains(text, `"VB007"`) {
+		t.Fatalf("expected generated config to disable VB007 by ID:\n%s", text)
+	}
+	if strings.Contains(text, "forbid_interactive_input = false") || strings.Contains(text, "require_option_explicit = true") {
+		t.Fatalf("generated config should prefer disabled_rules over legacy lint booleans:\n%s", text)
+	}
 
 	loaded, err := Load(dir)
 	if err != nil {
@@ -218,4 +357,13 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	if !loaded.Analyze.DetectRangeFindNothingCheck {
 		t.Fatal("expected analyze defaults to be written and loaded")
 	}
+}
+
+func hasConfigWarning(warnings []map[string]any, code string, rule string) bool {
+	for _, warning := range warnings {
+		if warning["code"] == code && warning["rule"] == rule {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -266,6 +266,9 @@ forbid_select = false
 	if !hasConfigWarning(cfg.Warnings, "deprecated_lint_rule_config", "VB002") {
 		t.Fatalf("expected deprecated config warning, got %+v", cfg.Warnings)
 	}
+	if !hasConfigWarningMessage(cfg.Warnings, "deprecated_lint_rule_config", "VB002", `Use [lint].disabled_rules = ["VB002"] instead`) {
+		t.Fatalf("expected false legacy lint warning to suggest disabled_rules, got %+v", cfg.Warnings)
+	}
 }
 
 func TestLoadWarnsForLegacyAnalyzeRuleConfig(t *testing.T) {
@@ -291,6 +294,41 @@ detect_byref_argument_mismatch = true
 	}
 	if !hasConfigWarning(cfg.Warnings, "deprecated_analyze_rule_config", "VBA206") {
 		t.Fatalf("expected deprecated analyze config warning, got %+v", cfg.Warnings)
+	}
+	if !hasConfigWarningMessage(cfg.Warnings, "deprecated_analyze_rule_config", "VBA206", "compatibility opt-in") {
+		t.Fatalf("expected true opt-in analyze warning to avoid disabled_rules migration, got %+v", cfg.Warnings)
+	}
+	if hasConfigWarningMessage(cfg.Warnings, "deprecated_analyze_rule_config", "VBA206", "disabled_rules") {
+		t.Fatalf("true opt-in analyze warning must not suggest disabled_rules, got %+v", cfg.Warnings)
+	}
+}
+
+func TestLoadWarnsForRedundantLegacyTrueRuleConfig(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[lint]
+forbid_select = true
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Lint.ForbidSelect {
+		t.Fatal("expected legacy forbid_select=true to keep rule enabled")
+	}
+	if !hasConfigWarningMessage(cfg.Warnings, "deprecated_lint_rule_config", "VB002", "Remove [lint].forbid_select") {
+		t.Fatalf("expected true default-on lint warning to suggest removal, got %+v", cfg.Warnings)
+	}
+	if hasConfigWarningMessage(cfg.Warnings, "deprecated_lint_rule_config", "VB002", "disabled_rules") {
+		t.Fatalf("true default-on lint warning must not suggest disabled_rules, got %+v", cfg.Warnings)
 	}
 }
 
@@ -499,6 +537,19 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 func hasConfigWarning(warnings []map[string]any, code string, rule string) bool {
 	for _, warning := range warnings {
 		if warning["code"] == code && warning["rule"] == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func hasConfigWarningMessage(warnings []map[string]any, code string, rule string, text string) bool {
+	for _, warning := range warnings {
+		if warning["code"] != code || warning["rule"] != rule {
+			continue
+		}
+		message, _ := warning["message"].(string)
+		if strings.Contains(message, text) {
 			return true
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -130,6 +130,38 @@ disabled_rules = ["VB002", "vb006", "VB002"]
 	}
 }
 
+func TestLoadSupportsDisabledAnalyzeRules(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[analyze]
+disabled_rules = ["VBA201", "vba205", "VBA201"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Analyze.DetectRangeFindNothingCheck {
+		t.Fatal("expected VBA201/detect_range_find_nothing_check to be disabled")
+	}
+	if cfg.Analyze.ForbidUnqualifiedExcelObjects {
+		t.Fatal("expected VBA205/forbid_unqualified_excel_objects to be disabled")
+	}
+	if !cfg.Analyze.DetectObjectUseBeforeSet {
+		t.Fatal("expected unrelated analyze rule to remain enabled")
+	}
+	if got := strings.Join(cfg.Analyze.DisabledRules, ","); got != "VBA201,VBA205" {
+		t.Fatalf("disabled analyze rules = %q, want VBA201,VBA205", got)
+	}
+}
+
 func TestLoadRejectsUnknownDisabledLintRule(t *testing.T) {
 	dir := t.TempDir()
 	body := []byte(`[project]
@@ -150,6 +182,26 @@ disabled_rules = ["VB999"]
 	}
 }
 
+func TestLoadRejectsUnknownDisabledAnalyzeRule(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[analyze]
+disabled_rules = ["VBA999"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "unknown analyze rule ID in [analyze].disabled_rules: VBA999") {
+		t.Fatalf("expected unknown analyze rule error, got %v", err)
+	}
+}
+
 func TestLoadRejectsNonConfigurableDisabledLintRule(t *testing.T) {
 	dir := t.TempDir()
 	body := []byte(`[project]
@@ -167,6 +219,26 @@ disabled_rules = ["VB013"]
 	_, err := Load(dir)
 	if err == nil || !strings.Contains(err.Error(), "lint rule ID is not configurable in [lint].disabled_rules: VB013") {
 		t.Fatalf("expected non-configurable lint rule error, got %v", err)
+	}
+}
+
+func TestLoadRejectsNonConfigurableDisabledAnalyzeRule(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[analyze]
+disabled_rules = ["VBA104"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "analyze rule ID is not configurable in [analyze].disabled_rules: VBA104") {
+		t.Fatalf("expected non-configurable analyze rule error, got %v", err)
 	}
 }
 
@@ -196,6 +268,32 @@ forbid_select = false
 	}
 }
 
+func TestLoadWarnsForLegacyAnalyzeRuleConfig(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[analyze]
+detect_byref_argument_mismatch = true
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Analyze.DetectByRefArgumentMismatch {
+		t.Fatal("expected legacy detect_byref_argument_mismatch=true to be honored")
+	}
+	if !hasConfigWarning(cfg.Warnings, "deprecated_analyze_rule_config", "VBA206") {
+		t.Fatalf("expected deprecated analyze config warning, got %+v", cfg.Warnings)
+	}
+}
+
 func TestLoadDisabledRulesTakePrecedenceOverLegacyLintRuleConfig(t *testing.T) {
 	dir := t.TempDir()
 	body := []byte(`[project]
@@ -222,6 +320,35 @@ disabled_rules = ["VB006"]
 		!hasConfigWarning(cfg.Warnings, "conflicting_lint_rule_config", "VB006") ||
 		!hasConfigWarning(cfg.Warnings, "disabled_rules_precedence", "VB006") {
 		t.Fatalf("expected deprecation and conflict warnings, got %+v", cfg.Warnings)
+	}
+}
+
+func TestLoadAnalyzeDisabledRulesTakePrecedenceOverLegacyRuleConfig(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[analyze]
+forbid_unqualified_excel_objects = true
+disabled_rules = ["VBA205"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Analyze.ForbidUnqualifiedExcelObjects {
+		t.Fatal("expected analyze disabled_rules to take precedence over legacy true")
+	}
+	if !hasConfigWarning(cfg.Warnings, "deprecated_analyze_rule_config", "VBA205") ||
+		!hasConfigWarning(cfg.Warnings, "conflicting_analyze_rule_config", "VBA205") ||
+		!hasConfigWarning(cfg.Warnings, "analyze_disabled_rules_precedence", "VBA205") {
+		t.Fatalf("expected analyze deprecation and conflict warnings, got %+v", cfg.Warnings)
 	}
 }
 
@@ -318,6 +445,7 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	cfg.Excel.Bridge = "powershell"
 	cfg.UserForm.CodeSource = "frm"
 	cfg.Lint.ForbidInteractiveInput = false
+	cfg.Analyze.ForbidUnqualifiedExcelObjects = false
 
 	p := filepath.Join(dir, FileName)
 	if err := Write(p, cfg); err != nil {
@@ -331,8 +459,14 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	if !strings.Contains(text, "disabled_rules = [") || !strings.Contains(text, `"VB007"`) {
 		t.Fatalf("expected generated config to disable VB007 by ID:\n%s", text)
 	}
+	if !strings.Contains(text, `"VBA205"`) {
+		t.Fatalf("expected generated config to disable VBA205 by ID:\n%s", text)
+	}
 	if strings.Contains(text, "forbid_interactive_input = false") || strings.Contains(text, "require_option_explicit = true") {
 		t.Fatalf("generated config should prefer disabled_rules over legacy lint booleans:\n%s", text)
+	}
+	if strings.Contains(text, "forbid_unqualified_excel_objects = false") || strings.Contains(text, "detect_range_find_nothing_check = true") {
+		t.Fatalf("generated config should prefer disabled_rules over legacy analyze booleans:\n%s", text)
 	}
 
 	loaded, err := Load(dir)
@@ -356,6 +490,9 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	}
 	if !loaded.Analyze.DetectRangeFindNothingCheck {
 		t.Fatal("expected analyze defaults to be written and loaded")
+	}
+	if loaded.Analyze.ForbidUnqualifiedExcelObjects {
+		t.Fatal("expected forbid_unqualified_excel_objects=false")
 	}
 }
 

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -132,6 +132,42 @@ End Sub
 	}
 }
 
+func TestLinterHonorsDisabledRuleIDs(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Range("A1").Select
+  ActiveCell.Activate
+End Sub
+`)
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[lint]
+disabled_rules = ["VB002"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, config.FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Linter{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := issuesByCode(issues, "VB002"); len(got) != 0 {
+		t.Fatalf("VB002 should be disabled: %+v", got)
+	}
+	if got := issuesByCode(issues, "VB003"); len(got) == 0 {
+		t.Fatalf("VB003 should remain enabled: %+v", issues)
+	}
+}
+
 func TestLinterUsesASTForDeclaratorsAndColumns(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1022,6 +1022,7 @@ func (r renderer) renderLint(env Envelope) string {
 	b.WriteString("\n")
 	if len(issues) == 0 {
 		b.WriteString("No lint issues found.\n")
+		b.WriteString(r.renderWarningsAndHints(env))
 		return b.String()
 	}
 	b.WriteString(kv("Issues", fmt.Sprintf("%d", len(issues))))
@@ -1032,6 +1033,7 @@ func (r renderer) renderLint(env Envelope) string {
 		}
 		fmt.Fprintf(&b, "%s %s %s - %s\n", r.style("["+stringValue(issue, "severity")+"]", "214", true), stringValue(issue, "code"), loc, stringValue(issue, "message"))
 	}
+	b.WriteString(r.renderWarningsAndHints(env))
 	return b.String()
 }
 
@@ -1044,6 +1046,7 @@ func (r renderer) renderAnalysis(env Envelope) string {
 	b.WriteString("\n")
 	if len(findings) == 0 {
 		b.WriteString("No analysis findings found.\n")
+		b.WriteString(r.renderWarningsAndHints(env))
 		return b.String()
 	}
 	b.WriteString(kv("Findings", fmt.Sprintf("%d", len(findings))))
@@ -1059,6 +1062,7 @@ func (r renderer) renderAnalysis(env Envelope) string {
 			b.WriteString("\n")
 		}
 	}
+	b.WriteString(r.renderWarningsAndHints(env))
 	return b.String()
 }
 

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -52,7 +52,16 @@ Use `analyze` for fast source-level feedback before opening Excel.
 | `VBA210` | warning  | Function may exit without assigning its return value.                     |
 | `VBA211` | error    | Expanded known Excel object/member mismatch.                              |
 
-Rules `VBA101` through `VBA106`, `VBA201` through `VBA205`, `VBA208`, `VBA209`, and `VBA211` are enabled by default. Rules `VBA206`, `VBA207`, and `VBA210` are opt-in through `[analyze]` because they are more dataflow-sensitive.
+Disable configurable analyzer rules with `[analyze].disabled_rules`:
+
+```toml
+[analyze]
+disabled_rules = ["VBA205", "VBA211"]
+```
+
+Legacy per-rule booleans such as `forbid_unqualified_excel_objects = false` remain accepted for compatibility, but xlflow emits a deprecation warning. If both formats disagree, `disabled_rules` takes precedence and xlflow reports a conflict warning.
+
+Rules `VBA201` through `VBA205`, `VBA208`, `VBA209`, and `VBA211` are enabled by default. Rules `VBA206`, `VBA207`, and `VBA210` are opt-in through legacy `[analyze]` settings because they are more dataflow-sensitive. Diagnostics `VBA101` through `VBA106` are always enabled.
 
 ## JSON Output Example
 

--- a/vitepress/commands/lint.md
+++ b/vitepress/commands/lint.md
@@ -59,7 +59,18 @@ Use `lint --json` in agent loops before `push` to catch source problems while Ex
 
 Core declaration, member-access, error-handling, and procedure-scope checks are AST-backed. They ignore comments and strings, distinguish module-level declarations from procedure-local declarations, and report individual declarators such as `a` in `Dim a, b As Long`.
 
-Rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide rules stay conservative opt-ins through `[lint]` settings. Use [`analyze`](./analyze) for semantic runtime-risk checks such as unqualified Excel access, error-handler fallthrough, Application state leaks, and `Range.Find` `Nothing` guards.
+Disable configurable lint rules with `[lint].disabled_rules`:
+
+```toml
+[lint]
+disabled_rules = ["VB002", "VB006"]
+```
+
+Legacy per-rule booleans such as `forbid_select = false` remain accepted for compatibility, but xlflow emits a deprecation warning. If both formats disagree, `disabled_rules` takes precedence and xlflow reports a conflict warning.
+
+Safety diagnostics `VB008` through `VB014` are always enabled because they prevent VBE compile dialogs before `push` or `run` opens Excel.
+
+Rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide rules stay conservative opt-ins through legacy `[lint]` settings. Use [`analyze`](./analyze) for semantic runtime-risk checks such as unqualified Excel access, error-handler fallthrough, Application state leaks, and `Range.Find` `Nothing` guards.
 
 ## JSON Output Example
 

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -62,28 +62,8 @@ disabled_rules = []
 
 # Runtime-risk analysis rules.
 [analyze]
-# Detect Range.Find results used without a Nothing check.
-detect_range_find_nothing_check = true
-# Detect object variables used before an obvious Set assignment.
-detect_object_use_before_set = true
-# Detect Application state changes without an obvious restore path.
-detect_application_state_restore = true
-# Detect procedures that can fall through into an error handler.
-detect_error_handler_fallthrough = true
-# Forbid unqualified Range/Cells/Rows/Columns access.
-forbid_unqualified_excel_objects = true
-# Detect likely ByRef argument type mismatches.
-detect_byref_argument_mismatch = false
-# Detect Dictionary/Collection access without an obvious guard.
-detect_dictionary_collection_guard = false
-# Detect ReDim Preserve usage on multi-dimensional arrays.
-detect_redim_preserve_dimension = true
-# Detect object or array comparison mistakes.
-detect_object_array_comparison = true
-# Detect functions that may exit without assigning their return value.
-detect_function_return_path = false
-# Detect known Excel object/member mismatches.
-detect_excel_object_member_mismatch = true
+# Disable specific analyzer rules by diagnostic ID.
+disabled_rules = []
 ```
 
 ## Section reference
@@ -162,19 +142,29 @@ Safety diagnostics `VB008` through `VB014` are always enabled and cannot be disa
 
 ### `[analyze]`
 
-| Key                                   | Type | Required | Default | Description                                                        |
-| ------------------------------------- | ---- | -------- | ------- | ------------------------------------------------------------------ |
-| `detect_range_find_nothing_check`     | bool | no       | `true`  | Detect `Range.Find` results used without a `Nothing` check.        |
-| `detect_object_use_before_set`        | bool | no       | `true`  | Detect object variables used before an obvious `Set` assignment.   |
-| `detect_application_state_restore`    | bool | no       | `true`  | Detect Application state changes without an obvious restore path.  |
-| `detect_error_handler_fallthrough`    | bool | no       | `true`  | Detect normal execution falling through into error-handler labels. |
-| `forbid_unqualified_excel_objects`    | bool | no       | `true`  | Detect unqualified `Range`, `Cells`, `Rows`, and `Columns` access. |
-| `detect_byref_argument_mismatch`      | bool | no       | `false` | Detect likely ByRef argument type mismatch candidates.             |
-| `detect_dictionary_collection_guard`  | bool | no       | `false` | Detect Dictionary/Collection lookup without an obvious guard.      |
-| `detect_redim_preserve_dimension`     | bool | no       | `true`  | Detect risky multi-dimensional `ReDim Preserve` usage.             |
-| `detect_object_array_comparison`      | bool | no       | `true`  | Detect object or array comparison mistakes.                        |
-| `detect_function_return_path`         | bool | no       | `false` | Detect functions that may exit without assigning a return value.   |
-| `detect_excel_object_member_mismatch` | bool | no       | `true`  | Detect known Excel object/member mismatches.                       |
+| Key              | Type     | Required | Default | Description                                          |
+| ---------------- | -------- | -------- | ------- | ---------------------------------------------------- |
+| `disabled_rules` | string[] | no       | `[]`    | Disable configurable analyzer rules by diagnostic ID. |
+
+Legacy per-rule booleans such as `forbid_unqualified_excel_objects = false` remain accepted for compatibility, but xlflow emits a deprecation warning. Prefer `disabled_rules = ["VBA205"]`.
+
+Configurable analyzer rule IDs:
+
+| ID       | Legacy key                              |
+| -------- | --------------------------------------- |
+| `VBA201` | `detect_range_find_nothing_check`       |
+| `VBA202` | `detect_object_use_before_set`          |
+| `VBA203` | `detect_application_state_restore`      |
+| `VBA204` | `detect_error_handler_fallthrough`      |
+| `VBA205` | `forbid_unqualified_excel_objects`      |
+| `VBA206` | `detect_byref_argument_mismatch`        |
+| `VBA207` | `detect_dictionary_collection_guard`    |
+| `VBA208` | `detect_redim_preserve_dimension`       |
+| `VBA209` | `detect_object_array_comparison`        |
+| `VBA210` | `detect_function_return_path`           |
+| `VBA211` | `detect_excel_object_member_mismatch`   |
+
+Analyzer diagnostics `VBA101` through `VBA106` are always enabled and cannot be disabled with `disabled_rules`.
 
 ## Defaults differ between `new` and `init`
 

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -142,27 +142,27 @@ Safety diagnostics `VB008` through `VB014` are always enabled and cannot be disa
 
 ### `[analyze]`
 
-| Key              | Type     | Required | Default | Description                                          |
-| ---------------- | -------- | -------- | ------- | ---------------------------------------------------- |
+| Key              | Type     | Required | Default | Description                                           |
+| ---------------- | -------- | -------- | ------- | ----------------------------------------------------- |
 | `disabled_rules` | string[] | no       | `[]`    | Disable configurable analyzer rules by diagnostic ID. |
 
 Legacy per-rule booleans such as `forbid_unqualified_excel_objects = false` remain accepted for compatibility, but xlflow emits a deprecation warning. Prefer `disabled_rules = ["VBA205"]`.
 
 Configurable analyzer rule IDs:
 
-| ID       | Legacy key                              |
-| -------- | --------------------------------------- |
-| `VBA201` | `detect_range_find_nothing_check`       |
-| `VBA202` | `detect_object_use_before_set`          |
-| `VBA203` | `detect_application_state_restore`      |
-| `VBA204` | `detect_error_handler_fallthrough`      |
-| `VBA205` | `forbid_unqualified_excel_objects`      |
-| `VBA206` | `detect_byref_argument_mismatch`        |
-| `VBA207` | `detect_dictionary_collection_guard`    |
-| `VBA208` | `detect_redim_preserve_dimension`       |
-| `VBA209` | `detect_object_array_comparison`        |
-| `VBA210` | `detect_function_return_path`           |
-| `VBA211` | `detect_excel_object_member_mismatch`   |
+| ID       | Legacy key                            |
+| -------- | ------------------------------------- |
+| `VBA201` | `detect_range_find_nothing_check`     |
+| `VBA202` | `detect_object_use_before_set`        |
+| `VBA203` | `detect_application_state_restore`    |
+| `VBA204` | `detect_error_handler_fallthrough`    |
+| `VBA205` | `forbid_unqualified_excel_objects`    |
+| `VBA206` | `detect_byref_argument_mismatch`      |
+| `VBA207` | `detect_dictionary_collection_guard`  |
+| `VBA208` | `detect_redim_preserve_dimension`     |
+| `VBA209` | `detect_object_array_comparison`      |
+| `VBA210` | `detect_function_return_path`         |
+| `VBA211` | `detect_excel_object_member_mismatch` |
 
 Analyzer diagnostics `VBA101` through `VBA106` are always enabled and cannot be disabled with `disabled_rules`.
 

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -57,20 +57,8 @@ code_source = "sidecar"
 
 # Static analysis rules.
 [lint]
-# Require Option Explicit in every module.
-require_option_explicit = true
-# Forbid Select / Activate patterns.
-forbid_select = true
-# Forbid Activate usage.
-forbid_activate = true
-# Forbid On Error Resume Next.
-forbid_on_error_resume_next = true
-# Detect implicitly typed Variant variables.
-detect_implicit_variant = true
-# Forbid public fields in standard modules.
-forbid_public_module_fields = true
-# Forbid interactive input (MsgBox, InputBox, etc.) in headless runs.
-forbid_interactive_input = true
+# Disable specific lint rules by diagnostic ID.
+disabled_rules = []
 
 # Runtime-risk analysis rules.
 [analyze]
@@ -144,15 +132,33 @@ When `[vba].folders = true`, files may be nested under these roots according to 
 
 ### `[lint]`
 
-| Key                           | Type | Required | Default | Description                                                             |
-| ----------------------------- | ---- | -------- | ------- | ----------------------------------------------------------------------- |
-| `require_option_explicit`     | bool | no       | `true`  | Require `Option Explicit` in every module.                              |
-| `forbid_select`               | bool | no       | `true`  | Forbid `Select` / `Activate` patterns.                                  |
-| `forbid_activate`             | bool | no       | `true`  | Forbid `Activate` usage.                                                |
-| `forbid_on_error_resume_next` | bool | no       | `true`  | Forbid `On Error Resume Next`.                                          |
-| `detect_implicit_variant`     | bool | no       | `true`  | Detect implicitly typed `Variant` variables.                            |
-| `forbid_public_module_fields` | bool | no       | `true`  | Forbid public fields in standard modules.                               |
-| `forbid_interactive_input`    | bool | no       | `true`  | Forbid interactive input (`MsgBox`, `InputBox`, etc.) in headless runs. |
+| Key              | Type     | Required | Default | Description                                       |
+| ---------------- | -------- | -------- | ------- | ------------------------------------------------- |
+| `disabled_rules` | string[] | no       | `[]`    | Disable configurable lint rules by diagnostic ID. |
+
+Legacy per-rule booleans such as `forbid_select = false` remain accepted for compatibility, but xlflow emits a deprecation warning. Prefer `disabled_rules = ["VB002"]`.
+
+Configurable lint rule IDs:
+
+| ID      | Legacy key                           |
+| ------- | ------------------------------------ |
+| `VB001` | `require_option_explicit`            |
+| `VB002` | `forbid_select`                      |
+| `VB003` | `forbid_activate`                    |
+| `VB004` | `forbid_on_error_resume_next`        |
+| `VB005` | `detect_implicit_variant`            |
+| `VB006` | `forbid_public_module_fields`        |
+| `VB007` | `forbid_interactive_input`           |
+| `VB018` | `detect_scope_shadowing`             |
+| `VB019` | `detect_multiple_declarator_clarity` |
+| `VB020` | `detect_unused_local_variables`      |
+| `VB021` | `detect_unused_private_procedures`   |
+| `VB022` | `detect_confusing_call_syntax`       |
+| `VB023` | `detect_for_each_control_type`       |
+| `VB026` | `detect_dangerous_resume`            |
+| `VB027` | `detect_nested_with_ambiguity`       |
+
+Safety diagnostics `VB008` through `VB014` are always enabled and cannot be disabled with `disabled_rules`.
 
 ### `[analyze]`
 


### PR DESCRIPTION
## Summary
- Added `[analyze].disabled_rules` to enable disabling analyzer rules based on diagnostic IDs.
- The old individual boolean settings are retained for compatibility, but now deprecation and conflict warnings are issued.
- Updated the README, specifications, command documentation, and CHANGELOG to match the new configuration method.
- Added unit tests to cover regressions in config/analyzer/CLI.

## Testing
- Added and updated unit tests to verify the application of disabled_rules, warnings for old configurations, and conflict priority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `[lint].disabled_rules` and `[analyze].disabled_rules` configuration options to disable specific rules by diagnostic ID instead of per-rule booleans.

* **Documentation**
  * Updated configuration guides to explain the new disabled rules format, deprecation warnings for legacy boolean settings, and which rules are always enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->