### PR TITLE
Document COM cleanup best practices for VBA test hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Documented COM cleanup best practices for VBA tests that open external workbooks, including `Close` plus `Set ... = Nothing` to avoid file locks during test hooks.
 - Fixed test and macro discovery so Unicode VBA procedure names such as Japanese `Test*` and `*_Test` names are recognized by both PowerShell and `.NET` bridges.
 - Added experimental `xlflow pack`, a pure-Go, cross-platform command that builds an `.xlsm` artifact from the source tree plus a workbook template without Excel. It regenerates `xl/vbaProject.bin` from `.bas`/`.cls` sources and replaces only that single zip entry, leaving the rest of the workbook untouched. Gated behind `--experimental`; supports standard, class, and unambiguous document modules, carries existing UserForm designer streams through byte-for-byte, and performs no VBE compile or runtime validation (every run reports `pack.vbe_validation = "not_performed"` and a `vbe_validation_skipped` warning). Fails loudly on protected or signed projects, UserForm generation, ambiguous layouts, active sessions, and in-place overwrite of the template or configured workbook. See `docs/specs/pack-command.md` and ADR-0012.
 - Updated `tree-sitter-vba` to v0.7.0 and removed `xlflow fmt` parser-workaround fallback for legacy numbered comments, colon-separated block lines, and valid line-continuation forms now handled by the grammar.

--- a/internal/agentskill/templates/xlflow/references/testing.md
+++ b/internal/agentskill/templates/xlflow/references/testing.md
@@ -109,6 +109,54 @@ Public Sub Test_Setup_Ran()
 End Sub
 ```
 
+## COM Object Cleanup in Tests
+
+When a test opens an external workbook, always release the COM reference immediately after closing it. `GetObject(path)` and `Application.Workbooks.Open(path)` return workbook COM proxies that can keep the file locked even after `wb.Close False` if the VBA variable still holds the object reference.
+
+Required pattern:
+
+```vb
+Set wb = GetObject(path)
+wb.Close False
+Set wb = Nothing
+
+Set wb = Application.Workbooks.Open(path)
+wb.Close False
+Set wb = Nothing
+```
+
+Use a cleanup block when assertions or runtime errors can happen before the close:
+
+```vb
+Public Sub Test_ReadsExternalWorkbook()
+    Dim wb As Object
+    Dim errNumber As Long
+    Dim errSource As String
+    Dim errDescription As String
+
+    On Error GoTo Cleanup
+    Set wb = GetObject(outputPath)
+
+    ' assertions...
+
+Cleanup:
+    errNumber = Err.Number
+    errSource = Err.Source
+    errDescription = Err.Description
+
+    If Not wb Is Nothing Then
+        On Error Resume Next
+        wb.Close False
+        Set wb = Nothing
+        On Error GoTo 0
+    End If
+
+    If errNumber <> 0 Then Err.Raise errNumber, errSource, errDescription
+End Sub
+```
+
+Missing `Set wb = Nothing` often shows up away from the leaking test. Tests may pass individually but fail as a suite when `BeforeAll`, `AfterAll`, `BeforeEach`, or `AfterEach` later tries to delete or overwrite the same file. VBA error 70, `Permission denied`, or a localized write-denied message during cleanup is a strong signal to check for an unreleased workbook reference in an earlier test.
+
 ## Running Tests
 
 ### Basic usage

--- a/vitepress/commands/test.md
+++ b/vitepress/commands/test.md
@@ -64,6 +64,24 @@ xlflow recognizes these reserved procedure names in each test module:
 
 All hooks must be public parameterless `Sub` procedures. If a hook fails, the affected tests are recorded as failed with a dedicated error code.
 
+## COM Object Cleanup
+
+When test code opens another workbook with `GetObject(path)` or `Application.Workbooks.Open(path)`, close it and release the object reference immediately. Otherwise Excel can keep the file locked after `wb.Close False`, and later hooks may fail with VBA error 70 (`Permission denied`) while deleting or overwriting the file.
+
+```vb
+Public Sub Test_ReadsOutputWorkbook()
+    Dim wb As Object
+    Set wb = GetObject(outputPath)
+
+    ' assertions...
+
+    wb.Close False
+    Set wb = Nothing
+End Sub
+```
+
+Best-effort hook cleanup with `On Error Resume Next` can reduce cascading failures, but it does not replace releasing workbook references in the test that opened them.
+
 ## Examples
 
 ```bash

--- a/vitepress/commands/test.md
+++ b/vitepress/commands/test.md
@@ -71,12 +71,28 @@ When test code opens another workbook with `GetObject(path)` or `Application.Wor
 ```vb
 Public Sub Test_ReadsOutputWorkbook()
     Dim wb As Object
+    Dim errNumber As Long
+    Dim errSource As String
+    Dim errDescription As String
+
+    On Error GoTo Cleanup
     Set wb = GetObject(outputPath)
 
     ' assertions...
 
-    wb.Close False
-    Set wb = Nothing
+Cleanup:
+    errNumber = Err.Number
+    errSource = Err.Source
+    errDescription = Err.Description
+
+    If Not wb Is Nothing Then
+        On Error Resume Next
+        wb.Close False
+        Set wb = Nothing
+        On Error GoTo 0
+    End If
+
+    If errNumber <> 0 Then Err.Raise errNumber, errSource, errDescription
 End Sub
 ```
 


### PR DESCRIPTION
## Summary
- Document the required COM cleanup pattern for VBA tests that open external workbooks.
- Call out `Close` plus `Set ... = Nothing` to avoid lingering file locks during test hooks and cleanup.
- Add guidance to both the agent testing reference and the public test command docs.
- Note the failure mode where missing cleanup surfaces later as VBA error 70 during delete or overwrite steps.

## Testing
- Not run (not requested)