### PR TITLE
Use MSYS2 location for release workflow CGO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           cache: true
 
       - name: Set up MSYS2 UCRT64 GCC
+        id: msys2
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: UCRT64
@@ -39,10 +40,18 @@ jobs:
           install: >-
             mingw-w64-ucrt-x86_64-gcc
 
-      - name: Add MSYS2 UCRT64 to PATH
+      - name: Configure MSYS2 UCRT64 for CGO
+        id: cgo
         shell: pwsh
         run: |
-          "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
+          $ucrtBin = Join-Path "${{ steps.msys2.outputs.msys2-location }}" "ucrt64\bin"
+          $gcc = Join-Path $ucrtBin "gcc.exe"
+          if (-not (Test-Path -LiteralPath $gcc)) {
+            throw "MSYS2 UCRT64 gcc not found at $gcc"
+          }
+
+          $ucrtBin >> $env:GITHUB_PATH
+          "cc=$gcc" >> $env:GITHUB_OUTPUT
 
       - name: Set up .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
@@ -52,7 +61,7 @@ jobs:
       - name: Run tests
         env:
           CGO_ENABLED: "1"
-          CC: C:/msys64/ucrt64/bin/gcc.exe
+          CC: ${{ steps.cgo.outputs.cc }}
         run: go test ./...
 
       - name: Run .NET bridge tests
@@ -61,7 +70,7 @@ jobs:
       - name: Build
         env:
           CGO_ENABLED: "1"
-          CC: C:/msys64/ucrt64/bin/gcc.exe
+          CC: ${{ steps.cgo.outputs.cc }}
         run: go build ./...
 
       - name: Build .NET bridge
@@ -85,7 +94,7 @@ jobs:
           SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
           CGO_ENABLED: "1"
-          CC: C:/msys64/ucrt64/bin/gcc.exe
+          CC: ${{ steps.cgo.outputs.cc }}
 
       - name: Smoke test Windows archive
         shell: pwsh
@@ -100,8 +109,12 @@ jobs:
           Expand-Archive $zip.FullName -DestinationPath $extract -Force
 
           $oldPath = $env:Path
+          $msysRoot = "${{ steps.msys2.outputs.msys2-location }}"
           try {
-            $env:Path = ($env:Path -split ';' | Where-Object { $_ -notlike 'C:\msys64*' }) -join ';'
+            $env:Path = ($env:Path -split ';' | Where-Object {
+              -not $_.StartsWith($msysRoot, [StringComparison]::OrdinalIgnoreCase) -and
+              -not $_.StartsWith('C:\msys64', [StringComparison]::OrdinalIgnoreCase)
+            }) -join ';'
             & "$extract\xlflow.exe" --help
             & "$extract\xlflow.exe" version
           } finally {

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ builds:
     binary: xlflow
     env:
       - CGO_ENABLED=1
-      - CC=C:/msys64/ucrt64/bin/gcc.exe
+      - CC={{ .Env.CC }}
     flags:
       - -trimpath
     ldflags:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -56,6 +56,7 @@
 - Excel VBE compile automation should not assume the `CommandBars("Debug")` toolbar contains the compile command. In real Excel, `Compile VBAProject` can live only under `CommandBars("Menu Bar") -> Debug` (`Id = 578`), and `Enabled = false` should be treated as "no compile needed" rather than executed as a failure path.
 - `go test ./internal/excel/scripts` can take 2-3 minutes even when healthy. Do not infer success or failure from a short silent interval; use a generous timeout and wait for completion before treating the package as hung.
 - AST symbol ranges may describe declaration nodes rather than enclosing scopes. Lint rules that scan local references must derive the containing procedure bounds, and cleanup labels such as `Cleanup:` need explicit coverage because they can be normal fallthrough cleanup paths.
+- GitHub Actions workflows that use `msys2/setup-msys2` must not hardcode `C:\msys64`. Use the action's `msys2-location` output to derive UCRT64 tool paths because hosted runners can install MSYS2 under `$RUNNER_TEMP`.
 
 # DialogWatcher
 


### PR DESCRIPTION
Fixed an issue in the CI release workflow where failures were occurring due to missing GCC.
- release.yml
- Modified to resolve `ucrt64\bin\gcc.exe` from `steps.msys2.outputs.msys2-location` and pass it as the CC to `go test`, `go build`, and `GoReleaser`
- Also updated the smoke test logic to properly exclude MSYS2 from the PATH when testing
- lessons.md
- Added notes to prevent recurrence by ensuring C:\msys64 is not hardcoded in the workflow