### PR TITLE
fix(pack): detect protected projects via CMG ProjectProtectionState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Improved `xlflow pack` protected-project detection: it now reads the CMG `ProjectProtectionState` bits (MS-OVBA §2.3.1.15) instead of a DPB password-length heuristic, so protected and unprotected projects are classified by the spec-defined signal rather than a corpus-calibrated threshold.
+
 ## v0.14.0
 
 - Added inline VBA suppression comments for lint and analyze diagnostics, supporting `xlflow:disable-next-line <ID>` and `xlflow:disable-line <ID>` with stable IDs such as `VB002` and `VBA205`, plus warnings for unknown, unsupported, or unused suppressions. Preflight-blocking errors remain unsuppressible.

--- a/internal/pack/ovba/encryption.go
+++ b/internal/pack/ovba/encryption.go
@@ -65,6 +65,9 @@ func DecryptData(enc []byte) ([]byte, error) {
 		lenBuf[i] = b
 	}
 	dataLen := binary.LittleEndian.Uint32(lenBuf[:])
+	if remaining := len(enc) - pos; uint64(dataLen) > uint64(remaining) {
+		return nil, fmt.Errorf("ovba: declared data length %d exceeds %d remaining bytes", dataLen, remaining)
+	}
 
 	out := make([]byte, 0, dataLen)
 	for i := uint32(0); i < dataLen; i++ {

--- a/internal/pack/ovba/encryption.go
+++ b/internal/pack/ovba/encryption.go
@@ -1,0 +1,78 @@
+package ovba
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// DecryptData reverses the MS-OVBA "Data Encryption" scheme (§2.4.3.3 Decryption).
+// Despite the spec's name this is reversible obfuscation, not cryptography: the
+// key is derived from the data's own Seed byte, so no password is required.
+//
+// enc is the raw bytes of an Encrypted Data Structure (§2.4.3.1):
+//
+//	Seed(1) VersionEnc(1) ProjKeyEnc(1) IgnoredEnc(IgnoredLength) LengthEnc(4) DataEnc(Length)
+//
+// It returns the decrypted Data. A Version other than 2, a truncated structure,
+// or a Length that overruns the input is a fail-loud error rather than a silent
+// misread.
+func DecryptData(enc []byte) ([]byte, error) {
+	if len(enc) < 3 {
+		return nil, fmt.Errorf("ovba: encrypted data too short (%d bytes)", len(enc))
+	}
+	seed := enc[0]
+	versionEnc := enc[1]
+	projKeyEnc := enc[2]
+
+	if version := seed ^ versionEnc; version != 2 {
+		return nil, fmt.Errorf("ovba: unexpected encryption version %d (want 2)", version)
+	}
+	projKey := seed ^ projKeyEnc
+
+	// State per §2.4.3.3. Byte arithmetic wraps mod 256 (Go uint8).
+	unencByte1 := projKey
+	encByte1 := projKeyEnc
+	encByte2 := versionEnc
+
+	pos := 3
+	decryptNext := func() (byte, error) {
+		if pos >= len(enc) {
+			return 0, errors.New("ovba: encrypted data ended prematurely")
+		}
+		be := enc[pos]
+		pos++
+		b := be ^ (encByte2 + unencByte1)
+		encByte2 = encByte1
+		encByte1 = be
+		unencByte1 = b
+		return b, nil
+	}
+
+	ignoredLen := int((seed & 6) / 2)
+	for i := 0; i < ignoredLen; i++ {
+		if _, err := decryptNext(); err != nil {
+			return nil, err
+		}
+	}
+
+	var lenBuf [4]byte
+	for i := range lenBuf {
+		b, err := decryptNext()
+		if err != nil {
+			return nil, err
+		}
+		lenBuf[i] = b
+	}
+	dataLen := binary.LittleEndian.Uint32(lenBuf[:])
+
+	out := make([]byte, 0, dataLen)
+	for i := uint32(0); i < dataLen; i++ {
+		b, err := decryptNext()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}

--- a/internal/pack/ovba/encryption_test.go
+++ b/internal/pack/ovba/encryption_test.go
@@ -1,0 +1,84 @@
+package ovba
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// encryptData is the §2.4.3.2 inverse of DecryptData, used only to generate
+// valid Encrypted Data Structures for round-trip testing. Seed and projKey are
+// caller-chosen; ignored content is arbitrary (filled with 0x00).
+func encryptData(seed, projKey byte, data []byte) []byte {
+	const version = byte(2)
+	versionEnc := seed ^ version
+	projKeyEnc := seed ^ projKey
+
+	unencByte1 := projKey
+	encByte1 := projKeyEnc
+	encByte2 := versionEnc
+
+	out := []byte{seed, versionEnc, projKeyEnc}
+	encNext := func(b byte) byte {
+		be := b ^ (encByte2 + unencByte1)
+		encByte2 = encByte1
+		encByte1 = be
+		unencByte1 = b
+		return be
+	}
+
+	ignoredLen := int((seed & 6) / 2)
+	for i := 0; i < ignoredLen; i++ {
+		out = append(out, encNext(0x00))
+	}
+	var lenBuf [4]byte
+	binary.LittleEndian.PutUint32(lenBuf[:], uint32(len(data)))
+	for _, b := range lenBuf {
+		out = append(out, encNext(b))
+	}
+	for _, b := range data {
+		out = append(out, encNext(b))
+	}
+	return out
+}
+
+func TestDecryptDataRoundTrip(t *testing.T) {
+	cases := []struct {
+		name          string
+		seed, projKey byte
+		data          []byte
+	}{
+		// Vary seed so (seed & 6)/2 exercises IgnoredLength 0..3.
+		{"ignored0", 0x00, 0x7B, []byte{0x01, 0x00, 0x00, 0x00}},
+		{"ignored1", 0x02, 0x10, []byte{0x00, 0x00, 0x00, 0x00}},
+		{"ignored2", 0x04, 0xAB, []byte{0x04, 0x00, 0x00, 0x00}},
+		{"ignored3", 0x06, 0xFF, []byte("hello world")},
+		{"empty", 0x06, 0x01, []byte{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			enc := encryptData(c.seed, c.projKey, c.data)
+			got, err := DecryptData(enc)
+			if err != nil {
+				t.Fatalf("DecryptData: %v", err)
+			}
+			if !bytes.Equal(got, c.data) {
+				t.Errorf("round-trip mismatch: got %x want %x", got, c.data)
+			}
+		})
+	}
+}
+
+func TestDecryptDataRejectsBadVersion(t *testing.T) {
+	// Seed=0x00 so VersionEnc must be 0x02 for Version==2; use 0x03 to force a mismatch.
+	enc := []byte{0x00, 0x03, 0x10}
+	if _, err := DecryptData(enc); err == nil {
+		t.Fatal("expected error for Version != 2, got nil")
+	}
+}
+
+func TestDecryptDataRejectsShort(t *testing.T) {
+	if _, err := DecryptData([]byte{0x00, 0x02}); err == nil {
+		t.Fatal("expected error for input shorter than 3 bytes, got nil")
+	}
+}

--- a/internal/pack/ovba/encryption_test.go
+++ b/internal/pack/ovba/encryption_test.go
@@ -82,3 +82,28 @@ func TestDecryptDataRejectsShort(t *testing.T) {
 		t.Fatal("expected error for input shorter than 3 bytes, got nil")
 	}
 }
+
+func TestDecryptDataRejectsOversizedLength(t *testing.T) {
+	// Craft a structure whose decrypted Length is ~4 GiB but with no data bytes,
+	// so DecryptData must fail loudly on the length check rather than attempt a
+	// multi-gigabyte allocation before discovering the input is too short.
+	const seed, projKey = byte(0), byte(0x10) // seed=0 => IgnoredLength 0
+	versionEnc := seed ^ 2
+	projKeyEnc := seed ^ projKey
+	unencByte1, encByte1, encByte2 := projKey, projKeyEnc, versionEnc
+	enc := []byte{seed, versionEnc, projKeyEnc}
+	encNext := func(b byte) byte {
+		be := b ^ (encByte2 + unencByte1)
+		encByte2, encByte1, unencByte1 = encByte1, be, b
+		return be
+	}
+	var lenBuf [4]byte
+	binary.LittleEndian.PutUint32(lenBuf[:], 0xFFFFFFFF)
+	for _, b := range lenBuf {
+		enc = append(enc, encNext(b))
+	}
+	// No data bytes follow.
+	if _, err := DecryptData(enc); err == nil {
+		t.Fatal("expected error for declared length exceeding input, got nil")
+	}
+}

--- a/internal/pack/vbaproject/codepage_test.go
+++ b/internal/pack/vbaproject/codepage_test.go
@@ -60,4 +60,9 @@ func TestEncodeMBCSErrors(t *testing.T) {
 	if _, err := encodeMBCS("\u65e5\u672c\u8a9e", 1252); err == nil {
 		t.Error("characters not representable in CP1252 should return an error")
 	}
+	// cp932 is the primary VBA codepage; it must also fail loudly on a character
+	// it cannot represent (an emoji) rather than emit silent mojibake.
+	if _, err := encodeMBCS("x \U0001F600 y", 932); err == nil {
+		t.Error("characters not representable in CP932 should return an error")
+	}
 }

--- a/internal/pack/vbaproject/read.go
+++ b/internal/pack/vbaproject/read.go
@@ -142,6 +142,18 @@ func isProtected(cmg string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("vbaproject: CMG hex decode: %w", err)
 	}
+	// CMG always decrypts to a 4-byte ProjectProtectionState (§2.3.1.15), so the
+	// encrypted structure has a fixed size: Seed+VersionEnc+ProjKeyEnc (3) +
+	// IgnoredEnc + LengthEnc (4) + DataEnc (4). Validate that up front so a large
+	// but internally consistent CMG cannot force O(size) decrypt work before the
+	// 4-byte state check rejects it.
+	if len(raw) < 11 {
+		return false, fmt.Errorf("vbaproject: CMG too short (%d bytes)", len(raw))
+	}
+	ignoredLen := int((raw[0] & 0x06) >> 1)
+	if want := 3 + ignoredLen + 4 + 4; len(raw) != want {
+		return false, fmt.Errorf("vbaproject: CMG length is %d bytes (want %d)", len(raw), want)
+	}
 	state, err := ovba.DecryptData(raw)
 	if err != nil {
 		return false, fmt.Errorf("vbaproject: CMG decrypt: %w", err)

--- a/internal/pack/vbaproject/read.go
+++ b/internal/pack/vbaproject/read.go
@@ -1,6 +1,8 @@
 package vbaproject
 
 import (
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -30,6 +32,10 @@ func Read(data []byte) (*Project, error) {
 	}
 	di := ovba.ParseDir(dirPlain)
 
+	protected, err := isProtected(pt.CMG)
+	if err != nil {
+		return nil, err
+	}
 	p := &Project{
 		Props: ProjectProps{
 			ProjectID: pt.ID, Name: pt.Name,
@@ -37,7 +43,7 @@ func Read(data []byte) (*Project, error) {
 		},
 		Protection: Protection{
 			CMG: pt.CMG, DPB: pt.DPB, GC: pt.GC,
-			IsProtected: isProtected(pt.DPB),
+			IsProtected: protected,
 		},
 	}
 	for _, name := range di.RefNames {
@@ -110,12 +116,42 @@ func classify(name, projectKey string, c *cfb.Container) ModuleType {
 	return ModuleClass
 }
 
-// isProtected determines whether a project is protected. The spec-compliant check decrypts
-// CMG/ProjectProtectionState ([MS-OVBA] §2.4.3), but this library does not decrypt the DPB, so it uses a
-// heuristic: an unprotected DPB is a short obfuscated value (~16-20 chars measured in the corpus), while a
-// protected one contains a key hash and is longer (over 60 chars in the protected sample). The threshold 28
-// is the valley between them. Protected projects are treated as an edge case in v1 (see DESIGN.md).
-func isProtected(dpb string) bool { return len(dpb) > 28 }
+// ProjectProtectionState bits (MS-OVBA §2.3.1.15). The decrypted CMG Data is a
+// 4-byte little-endian value; any of these bits means the project's VBA is locked
+// for viewing, which pack cannot regenerate from source, so such projects are
+// rejected (see write.go / pack.go).
+const (
+	fUserProtected uint32 = 1 << 0
+	fHostProtected uint32 = 1 << 1
+	fVBAProtected  uint32 = 1 << 2
+)
+
+// isProtected reports whether the project's CMG (ProjectProtectionState, §2.3.1.15)
+// marks it as protected. cmg is the unquoted hex string from the PROJECT stream.
+// An earlier heuristic measured DPB (password) length; this reads the actual
+// protection bits by decrypting CMG (reversible obfuscation, no password needed).
+//
+// An empty CMG means the project has no protection record and is unprotected. A
+// CMG that cannot be hex-decoded or decrypted, or whose state is not 4 bytes, is a
+// fail-loud error rather than a silent misclassification in either direction.
+func isProtected(cmg string) (bool, error) {
+	if cmg == "" {
+		return false, nil
+	}
+	raw, err := hex.DecodeString(cmg)
+	if err != nil {
+		return false, fmt.Errorf("vbaproject: CMG hex decode: %w", err)
+	}
+	state, err := ovba.DecryptData(raw)
+	if err != nil {
+		return false, fmt.Errorf("vbaproject: CMG decrypt: %w", err)
+	}
+	if len(state) != 4 {
+		return false, fmt.Errorf("vbaproject: CMG protection state is %d bytes (want 4)", len(state))
+	}
+	bits := binary.LittleEndian.Uint32(state)
+	return bits&(fUserProtected|fHostProtected|fVBAProtected) != 0, nil
+}
 
 // firstSegment returns the first "/"-separated component of a CFB stream path
 // (e.g. "VBA" for "VBA/dir", "UserForm1" for "UserForm1/\x03VBFrame", and

--- a/internal/pack/vbaproject/read_test.go
+++ b/internal/pack/vbaproject/read_test.go
@@ -158,6 +158,13 @@ func TestIsProtectedEdgeCases(t *testing.T) {
 	if _, err := isProtected("zz"); err == nil {
 		t.Error("non-hex CMG: expected error, got nil")
 	}
+	// A CMG whose structure size is wrong (20 bytes; a valid CMG is 11-14) must be
+	// rejected up front, before decryption does O(size) work. Seed byte 0x00 here
+	// implies an expected length of 11.
+	oversized := "0002000000000000000000000000000000000000" // 20 bytes
+	if _, err := isProtected(oversized); err == nil {
+		t.Error("oversized CMG: expected error, got nil")
+	}
 }
 
 func TestReadPreservationRawSpans(t *testing.T) {

--- a/internal/pack/vbaproject/read_test.go
+++ b/internal/pack/vbaproject/read_test.go
@@ -120,6 +120,46 @@ func TestProtectedAndForm(t *testing.T) {
 	}
 }
 
+func TestIsProtectedClassifiesCorpus(t *testing.T) {
+	// p3 is the protected sample; the rest are unprotected. CMG comes straight
+	// from the PROJECT stream of each real fixture, so this is the external
+	// oracle for the decryption + bit interpretation.
+	cases := []struct {
+		book string
+		want bool
+	}{
+		{"p1_compiled", false},
+		{"p2_refs", false},
+		{"p3_protected", true},
+		{"p5_mbcs", false},
+		{"p6_nested_form", false},
+	}
+	for _, c := range cases {
+		t.Run(c.book, func(t *testing.T) {
+			p, err := Read(loadCorpus(t, c.book))
+			if err != nil {
+				t.Fatalf("Read(%s): %v", c.book, err)
+			}
+			if p.Protection.IsProtected != c.want {
+				t.Errorf("%s: IsProtected=%v want %v (CMG=%q)",
+					c.book, p.Protection.IsProtected, c.want, p.Protection.CMG)
+			}
+		})
+	}
+}
+
+func TestIsProtectedEdgeCases(t *testing.T) {
+	// Empty CMG => no protection record => unprotected, no error.
+	got, err := isProtected("")
+	if err != nil || got {
+		t.Fatalf("empty CMG: got (%v, %v), want (false, nil)", got, err)
+	}
+	// Non-hex CMG => fail-loud.
+	if _, err := isProtected("zz"); err == nil {
+		t.Error("non-hex CMG: expected error, got nil")
+	}
+}
+
 func TestReadPreservationRawSpans(t *testing.T) {
 	bin, err := os.ReadFile("testdata/corpus/p1_compiled.bin")
 	if err != nil {


### PR DESCRIPTION
## Summary

Pre-stable hardening for the experimental `xlflow pack` command, following the
staged scope in ADR-0012 ("before non-experimental status"). This is the
Linux-complete subset; the Windows/Excel smoke milestone is intentionally left
to a separate change.

`pack` previously detected protected VBA projects with a heuristic on the DPB
(password) string length (`len > 28`), a corpus-calibrated magic number that
keys off the wrong record. This replaces it with the spec-defined signal:
decrypt the CMG record and read the `ProjectProtectionState` bits.

## Changes

- Add a pure-Go MS-OVBA Data Decryption primitive (`internal/pack/ovba`,
  §2.4.3.3). It is reversible obfuscation, not cryptography (no password needed).
- Detect protected projects from the decrypted CMG `ProjectProtectionState`
  bits (`fUserProtected`/`fHostProtected`/`fVBAProtected`, §2.3.1.15) instead of
  DPB length. Misclassification in either direction is now fail-loud.
- Bound the declared data length before allocation, so a corrupt CMG fails loudly
  instead of attempting a multi-GiB allocation.
- Add a cp932 negative test: an unrepresentable character must fail loudly rather
  than emit silent mojibake.

## Validation

- Validated against the existing corpus (p3 protected; p1/p2/p5/p6 not) — the
  real-world oracle for the decryption.
- Fully Linux-testable: `go test ./internal/pack/...` green, `go vet` clean,
  golangci-lint clean. No new dependencies, no new ADR (implements ADR-0012).

## Out of scope

- Windows/Excel smoke tests (a separate pre-stable milestone).
- The UserForm strategy and "no VBE validation" docs are already present in
  `docs/specs/pack-command.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of VBA project protection detection to correctly identify protected and unprotected projects using specification-compliant methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->