### PR TITLE
Report doctor failures when the Excel bridge cannot access a valid desktop session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.14.1
+
 - Improved `xlflow pack` protected-project detection: it now reads the CMG `ProjectProtectionState` bits (MS-OVBA §2.3.1.15) instead of a DPB password-length heuristic, so protected and unprotected projects are classified by the spec-defined signal rather than a corpus-calibrated threshold.
+- Added `.NET doctor` diagnostics for the Windows systemprofile Desktop directories required by non-interactive Excel COM workbook automation. Missing directories now return `systemprofile_desktop_missing` with instructions to create both `System32` and `SysWOW64` Desktop paths, while permission-denied inspection results are reported as warnings instead of false missing-directory failures. `xlflow doctor` remains lightweight by default, while the new `--workbook` option opens the configured workbook and reports `workbook_openable`.
 
 ## v0.14.0
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -276,6 +276,8 @@ curl -fsSL https://harumiweb.github.io/xlflow/install.sh | sh
 xlflow doctor --json
 ```
 
+Windows Excel が設定済み workbook を開けることまで確認したい場合は `xlflow doctor --workbook --json` を使います。
+
 WSL から Windows 側の executable を見つけられない場合は、明示的に指定できます。
 
 ```bash
@@ -332,7 +334,9 @@ xlflow doctor --json
 ```
 
 > [!TIP]
-> `pull` / `push` / `run` / `test` が Excel、COM、bridge、VBIDE 設定の問題で失敗する場合は、まず `doctor` を実行してください。
+> `doctor` はデフォルトでは軽量診断です。設定済み workbook を開けることまで確認したい場合は `xlflow doctor --workbook --json` を実行してください。
+>
+> `pull` / `push` / `run` / `test` が Excel、COM、bridge、VBIDE、または workbook open 設定の問題で失敗する場合は、まず `doctor` を実行してください。
 
 ### 3. VBA をソースファイルとして取り出す
 
@@ -486,7 +490,7 @@ End If
 | ------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | `new`               | 新しい xlflow プロジェクトと `.xlsm` workbook を作成              | `xlflow new Book.xlsm`                                                       |
 | `init`              | 既存 workbook から xlflow プロジェクトを初期化                    | `xlflow init Book.xlsm`                                                      |
-| `doctor`            | Excel、COM、PowerShell、VBIDE access を診断                       | `xlflow doctor --json`                                                       |
+| `doctor`            | Excel、COM、PowerShell、VBIDE access、任意の workbook open を診断 | `xlflow doctor --workbook --json`                                            |
 | `attach`            | Excel で現在 active な workbook を検証                            | `xlflow attach --active --json`                                              |
 | `backup list`       | rollback 用 workbook backup を一覧表示                            | `xlflow backup list --json`                                                  |
 | `pull`              | VBA component を `src/` へエクスポート                            | `xlflow pull --json`                                                         |

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Run diagnostics from WSL before starting work:
 xlflow doctor --json
 ```
 
+Use `xlflow doctor --workbook --json` when you also want to verify that Windows Excel can open the configured workbook.
+
 If the Windows executable is not discoverable from WSL, point xlflow at it explicitly:
 
 ```bash
@@ -334,7 +336,9 @@ xlflow doctor --json
 ```
 
 > [!TIP]
-> If `pull`, `push`, `run`, or `test` fails because of Excel, COM, bridge, or VBIDE settings, run `doctor` first.
+> `doctor` is lightweight by default. If you need to prove the configured workbook can be opened, run `xlflow doctor --workbook --json`.
+>
+> If `pull`, `push`, `run`, or `test` fails because of Excel, COM, bridge, VBIDE, or workbook-open settings, run `doctor` first.
 
 ### 3. Export VBA into source files
 
@@ -483,39 +487,39 @@ End If
 
 ## Command map
 
-| Command             | Purpose                                                         | Typical usage                                                                |
-| ------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `new`               | Create a new xlflow project and `.xlsm` workbook                | `xlflow new Book.xlsm`                                                       |
-| `init`              | Initialize xlflow from an existing workbook                     | `xlflow init Book.xlsm`                                                      |
-| `doctor`            | Diagnose Excel, COM, PowerShell, and VBIDE access               | `xlflow doctor --json`                                                       |
-| `attach`            | Validate the workbook currently active in Excel                 | `xlflow attach --active --json`                                              |
-| `backup list`       | List rollback-capable workbook backups                          | `xlflow backup list --json`                                                  |
-| `pull`              | Export VBA components into `src/`                               | `xlflow pull --json`                                                         |
-| `push`              | Import VBA source back into the workbook                        | `xlflow push --json`                                                         |
-| `rollback`          | Restore the workbook from a saved backup                        | `xlflow rollback --latest --json`                                            |
-| `session`           | Keep the configured workbook open for fast loops                | `xlflow session start`                                                       |
-| `status`            | Show project, source, workbook, and session state               | `xlflow status --json`                                                       |
-| `save`              | Save the workbook held by a session                             | `xlflow save --session --json`                                               |
-| `runner`            | Manage the persistent xlflow runner marker module               | `xlflow runner install --json`                                               |
-| `process`           | Manage local Excel processes (list, cleanup)                    | `xlflow process list --json`                                                 |
-| `macros`            | Discover runnable macro entrypoints                             | `xlflow macros --json`                                                       |
-| `list forms`        | Discover workbook UserForms and expected source paths           | `xlflow list forms --json`                                                   |
-| `form snapshot`     | Persist Designer UserForm state as JSON or YAML spec            | `xlflow form snapshot UserForm1 --out src/forms/specs/UserForm1.yaml --json` |
-| `form build`        | Create a Designer-backed UserForm from a saved spec             | `xlflow form build src/forms/specs/UserForm1.yaml --json`                    |
-| `form export-image` | Export a runtime UserForm to a PNG image                        | `xlflow form export-image UserForm1 --out artifacts/UserForm1.png --json`    |
-| `run`               | Execute a macro from the CLI                                    | `xlflow run Main.Run --json`                                                 |
-| `export-image`      | Export a worksheet range to a PNG image                         | `xlflow export-image --sheet QR --range A1:AE31 --json`                      |
-| `edit`              | Mutate a live session workbook for setup and tuning             | `xlflow edit cell --sheet Input --cell B2 --value ABC123 --session --json`   |
-| `test`              | Run VBA tests                                                   | `xlflow test --json`                                                         |
-| `diff`              | Compare workbook content and optional VBA source                | `xlflow diff before.xlsm after.xlsm --json`                                  |
-| `inspect`           | Inspect saved workbook snapshots or explicit live session state | `xlflow inspect range --sheet Result --address A1:F20 --session --json`      |
-| `lint`              | Lint VBA source                                                 | `xlflow lint --json`                                                         |
-| `fmt`               | Format VBA source conservatively                                | `xlflow fmt --write --json`                                                  |
-| `analyze`           | Analyze runtime-risk patterns without opening Excel             | `xlflow analyze --json`                                                      |
-| `check`             | Run `lint`, `analyze`, and `doctor` as a preflight              | `xlflow check --keepalive --json`                                            |
-| `inspect-gui`       | Detect GUI interaction boundaries                               | `xlflow inspect-gui --json`                                                  |
-| `skill install`     | Install the bundled xlflow Skill for AI agents                  | `xlflow skill install --agent codex`                                         |
-| `version`           | Show the installed xlflow build metadata                        | `xlflow version`                                                             |
+| Command             | Purpose                                                              | Typical usage                                                                |
+| ------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `new`               | Create a new xlflow project and `.xlsm` workbook                     | `xlflow new Book.xlsm`                                                       |
+| `init`              | Initialize xlflow from an existing workbook                          | `xlflow init Book.xlsm`                                                      |
+| `doctor`            | Diagnose Excel, COM, PowerShell, VBIDE, and optional workbook access | `xlflow doctor --workbook --json`                                            |
+| `attach`            | Validate the workbook currently active in Excel                      | `xlflow attach --active --json`                                              |
+| `backup list`       | List rollback-capable workbook backups                               | `xlflow backup list --json`                                                  |
+| `pull`              | Export VBA components into `src/`                                    | `xlflow pull --json`                                                         |
+| `push`              | Import VBA source back into the workbook                             | `xlflow push --json`                                                         |
+| `rollback`          | Restore the workbook from a saved backup                             | `xlflow rollback --latest --json`                                            |
+| `session`           | Keep the configured workbook open for fast loops                     | `xlflow session start`                                                       |
+| `status`            | Show project, source, workbook, and session state                    | `xlflow status --json`                                                       |
+| `save`              | Save the workbook held by a session                                  | `xlflow save --session --json`                                               |
+| `runner`            | Manage the persistent xlflow runner marker module                    | `xlflow runner install --json`                                               |
+| `process`           | Manage local Excel processes (list, cleanup)                         | `xlflow process list --json`                                                 |
+| `macros`            | Discover runnable macro entrypoints                                  | `xlflow macros --json`                                                       |
+| `list forms`        | Discover workbook UserForms and expected source paths                | `xlflow list forms --json`                                                   |
+| `form snapshot`     | Persist Designer UserForm state as JSON or YAML spec                 | `xlflow form snapshot UserForm1 --out src/forms/specs/UserForm1.yaml --json` |
+| `form build`        | Create a Designer-backed UserForm from a saved spec                  | `xlflow form build src/forms/specs/UserForm1.yaml --json`                    |
+| `form export-image` | Export a runtime UserForm to a PNG image                             | `xlflow form export-image UserForm1 --out artifacts/UserForm1.png --json`    |
+| `run`               | Execute a macro from the CLI                                         | `xlflow run Main.Run --json`                                                 |
+| `export-image`      | Export a worksheet range to a PNG image                              | `xlflow export-image --sheet QR --range A1:AE31 --json`                      |
+| `edit`              | Mutate a live session workbook for setup and tuning                  | `xlflow edit cell --sheet Input --cell B2 --value ABC123 --session --json`   |
+| `test`              | Run VBA tests                                                        | `xlflow test --json`                                                         |
+| `diff`              | Compare workbook content and optional VBA source                     | `xlflow diff before.xlsm after.xlsm --json`                                  |
+| `inspect`           | Inspect saved workbook snapshots or explicit live session state      | `xlflow inspect range --sheet Result --address A1:F20 --session --json`      |
+| `lint`              | Lint VBA source                                                      | `xlflow lint --json`                                                         |
+| `fmt`               | Format VBA source conservatively                                     | `xlflow fmt --write --json`                                                  |
+| `analyze`           | Analyze runtime-risk patterns without opening Excel                  | `xlflow analyze --json`                                                      |
+| `check`             | Run `lint`, `analyze`, and `doctor` as a preflight                   | `xlflow check --keepalive --json`                                            |
+| `inspect-gui`       | Detect GUI interaction boundaries                                    | `xlflow inspect-gui --json`                                                  |
+| `skill install`     | Install the bundled xlflow Skill for AI agents                       | `xlflow skill install --agent codex`                                         |
+| `version`           | Show the installed xlflow build metadata                             | `xlflow version`                                                             |
 
 ---
 

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/DoctorCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/DoctorCommand.cs
@@ -74,7 +74,7 @@ public sealed class DoctorCommand : ICommandHandler
         {
             return FailedWithDiagnostics(request, diagnostics, new BridgeError(
                 Code: "systemprofile_desktop_missing",
-                Message: MissingSystemProfileDesktopMessage(),
+                Message: MissingSystemProfileDesktopMessage(systemProfileDesktop),
                 Phase: "doctor",
                 Source: "xlflow-excel-bridge",
                 Details: new Dictionary<string, object?>
@@ -211,13 +211,13 @@ public sealed class DoctorCommand : ICommandHandler
         }
     }
 
-    private static string MissingSystemProfileDesktopMessage()
+    private static string MissingSystemProfileDesktopMessage(SystemProfileDesktopDiagnostics systemProfileDesktop)
     {
-        return """
+        return $"""
             systemprofile Desktop directories are missing.
             Create both directories:
-            - C:\Windows\System32\config\systemprofile\Desktop
-            - C:\Windows\SysWOW64\config\systemprofile\Desktop
+            - {systemProfileDesktop.System32.Path}
+            - {systemProfileDesktop.SysWow64.Path}
 
             This is required for Excel COM automation in non-interactive sessions such as SSH, services, or CI.
             """;

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/DoctorCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/DoctorCommand.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Xlflow.ExcelBridge.Contract;
 using Xlflow.ExcelBridge.Diagnostics;
+using Xlflow.ExcelBridge.Services;
 
 namespace Xlflow.ExcelBridge.Commands;
 
@@ -27,10 +28,14 @@ public sealed class DoctorCommand : ICommandHandler
         cancellationToken.ThrowIfCancellationRequested();
 
         var excelProbe = (_probeExcel ?? ExcelDiagnostics.Probe)();
+        var diagnostics = BuildDiagnostics(excelProbe);
+        var checkWorkbook = BridgePayload.GetBool(request.Payload, "CheckWorkbook");
+        var workbookPath = BridgePayload.GetString(request.Payload, "WorkbookPath") ?? "";
+        var visible = BridgePayload.GetBool(request.Payload, "Visible");
 
         if (!excelProbe.ComActivation)
         {
-            return BridgeResponse.Failed(request, new BridgeError(
+            return FailedWithDiagnostics(request, diagnostics, new BridgeError(
                 Code: "excel_com_failure",
                 Message: excelProbe.Error ?? "Excel COM activation failed",
                 Phase: "doctor",
@@ -40,6 +45,67 @@ public sealed class DoctorCommand : ICommandHandler
                 Details: excelProbe.ComDetails));
         }
 
+        var extensions = new Dictionary<string, object?>
+        {
+            ["diagnostics"] = diagnostics,
+        };
+
+        WorkbookOpenDiagnostics? workbookProbe = null;
+        if (checkWorkbook)
+        {
+            if (string.IsNullOrWhiteSpace(workbookPath))
+            {
+                return FailedWithDiagnostics(request, diagnostics, new BridgeError(
+                    Code: "doctor_args_invalid",
+                    Message: "WorkbookPath is required when CheckWorkbook is true",
+                    Phase: "doctor",
+                    Source: "xlflow-excel-bridge"));
+            }
+
+            extensions["workbook"] = new Dictionary<string, object?>
+            {
+                ["path"] = ExcelBridgeSupport.NormalizePath(workbookPath),
+            };
+            workbookProbe = ProbeWorkbookOpen(workbookPath, visible);
+            diagnostics["workbook_openable"] = workbookProbe.Openable;
+        }
+
+        if (excelProbe.SystemProfileDesktop is { Missing: true } systemProfileDesktop)
+        {
+            return FailedWithDiagnostics(request, diagnostics, new BridgeError(
+                Code: "systemprofile_desktop_missing",
+                Message: MissingSystemProfileDesktopMessage(),
+                Phase: "doctor",
+                Source: "xlflow-excel-bridge",
+                Details: new Dictionary<string, object?>
+                {
+                    ["system32"] = BuildSystemProfileDesktopPathPayload(systemProfileDesktop.System32),
+                    ["syswow64"] = BuildSystemProfileDesktopPathPayload(systemProfileDesktop.SysWow64),
+                }),
+                extensions);
+        }
+
+        if (workbookProbe is { Openable: false })
+        {
+            return FailedWithDiagnostics(request, diagnostics, new BridgeError(
+                Code: "workbook_open_failed",
+                Message: "Configured workbook could not be opened: " + workbookProbe.Message,
+                Phase: "doctor.open_workbook",
+                Source: "xlflow-excel-bridge",
+                Number: workbookProbe.Number,
+                HResult: workbookProbe.HResult,
+                Details: new Dictionary<string, object?>
+                {
+                    ["path"] = ExcelBridgeSupport.NormalizePath(workbookPath),
+                }),
+                extensions);
+        }
+
+        return BridgeResponse.Ok(request, extensions);
+    }
+
+    private static Dictionary<string, object?> BuildDiagnostics(ExcelDiagnosticsResult excelProbe)
+    {
         var excel = new Dictionary<string, object?>
         {
             ["com_activation"] = excelProbe.ComActivation,
@@ -53,24 +119,113 @@ public sealed class DoctorCommand : ICommandHandler
         {
             excel["error"] = excelProbe.Error;
         }
-
-        return BridgeResponse.Ok(request, new Dictionary<string, object?>
+        if (excelProbe.SystemProfileDesktop is not null)
         {
-            ["diagnostics"] = new Dictionary<string, object?>
+            excel["systemprofile_desktop"] = new Dictionary<string, object?>
             {
-                ["requested_bridge"] = "dotnet",
-                ["selected_bridge"] = "dotnet",
-                ["fallback"] = false,
-                ["legacy"] = false,
-                ["protocol_version"] = ProtocolVersion.Current,
-                ["runtime"] = new Dictionary<string, object?>
-                {
-                    ["os"] = Environment.OSVersion.ToString(),
-                    ["process_architecture"] = RuntimeInformation.ProcessArchitecture.ToString(),
-                    ["dotnet_runtime"] = RuntimeInformation.FrameworkDescription,
-                },
-                ["excel"] = excel,
+                ["system32"] = BuildSystemProfileDesktopPathPayload(excelProbe.SystemProfileDesktop.System32),
+                ["syswow64"] = BuildSystemProfileDesktopPathPayload(excelProbe.SystemProfileDesktop.SysWow64),
+                ["ok"] = excelProbe.SystemProfileDesktop.Ok,
+                ["missing"] = excelProbe.SystemProfileDesktop.Missing,
+                ["access_denied"] = excelProbe.SystemProfileDesktop.AccessDenied,
+            };
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["requested_bridge"] = "dotnet",
+            ["selected_bridge"] = "dotnet",
+            ["fallback"] = false,
+            ["legacy"] = false,
+            ["protocol_version"] = ProtocolVersion.Current,
+            ["runtime"] = new Dictionary<string, object?>
+            {
+                ["os"] = Environment.OSVersion.ToString(),
+                ["process_architecture"] = RuntimeInformation.ProcessArchitecture.ToString(),
+                ["dotnet_runtime"] = RuntimeInformation.FrameworkDescription,
             },
-        });
+            ["excel"] = excel,
+        };
     }
+
+    private static BridgeResponse FailedWithDiagnostics(
+        BridgeRequest request,
+        Dictionary<string, object?> diagnostics,
+        BridgeError error,
+        Dictionary<string, object?>? extensions = null)
+    {
+        return new BridgeResponse
+        {
+            RequestId = request.RequestId,
+            Command = request.Command,
+            Status = BridgeStatus.Failed,
+            Error = error,
+            Extensions = extensions ?? new Dictionary<string, object?>
+            {
+                ["diagnostics"] = diagnostics,
+            },
+        };
+    }
+
+    private static Dictionary<string, object?> BuildSystemProfileDesktopPathPayload(SystemProfileDesktopPathDiagnostics path)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["path"] = path.Path,
+            ["status"] = path.Status,
+        };
+        if (!string.IsNullOrWhiteSpace(path.Message))
+        {
+            payload["message"] = path.Message;
+        }
+        return payload;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Workbook doctor diagnostics normalize all open/close failures into structured output.")]
+    private static WorkbookOpenDiagnostics ProbeWorkbookOpen(string workbookPath, bool visible)
+    {
+        ExcelSessionAttachment? attachment = null;
+        try
+        {
+            attachment = ExcelBridgeSupport.OpenWorkbookDirect(workbookPath, visible);
+            return new WorkbookOpenDiagnostics(Openable: true, Message: null, Number: null, HResult: null);
+        }
+        catch (Exception ex)
+        {
+            var failure = ExcelBridgeSupport.ClassifyComFailure(ex);
+            return new WorkbookOpenDiagnostics(
+                Openable: false,
+                Message: failure.Message,
+                Number: failure.Number,
+                HResult: failure.HResult);
+        }
+        finally
+        {
+            if (attachment is not null)
+            {
+                try { ExcelBridgeSupport.InvokeViaDynamic(attachment.Workbook, "Close", false); } catch { }
+                try { ExcelBridgeSupport.InvokeViaDynamic(attachment.Excel, "Quit"); } catch { }
+                ExcelBridgeSupport.ReleaseComObject(attachment.Workbook);
+                ExcelBridgeSupport.ReleaseComObject(attachment.Excel);
+            }
+        }
+    }
+
+    private static string MissingSystemProfileDesktopMessage()
+    {
+        return """
+            systemprofile Desktop directories are missing.
+            Create both directories:
+            - C:\Windows\System32\config\systemprofile\Desktop
+            - C:\Windows\SysWOW64\config\systemprofile\Desktop
+
+            This is required for Excel COM automation in non-interactive sessions such as SSH, services, or CI.
+            """;
+    }
+
+    private sealed record WorkbookOpenDiagnostics(
+        bool Openable,
+        string? Message,
+        int? Number,
+        string? HResult);
 }

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Diagnostics/ExcelDiagnostics.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Diagnostics/ExcelDiagnostics.cs
@@ -15,7 +15,37 @@ public sealed record ExcelDiagnosticsResult(
     string? Error,
     int? ComErrorNumber = null,
     string? ComHResult = null,
-    IReadOnlyDictionary<string, object?>? ComDetails = null);
+    IReadOnlyDictionary<string, object?>? ComDetails = null,
+    SystemProfileDesktopDiagnostics? SystemProfileDesktop = null);
+
+public sealed record SystemProfileDesktopDiagnostics(
+    SystemProfileDesktopPathDiagnostics System32,
+    SystemProfileDesktopPathDiagnostics SysWow64)
+{
+    public SystemProfileDesktopDiagnostics(bool System32, bool SysWow64)
+        : this(
+            new SystemProfileDesktopPathDiagnostics("C:\\Windows\\System32\\config\\systemprofile\\Desktop", System32 ? SystemProfileDesktopStatus.Exists : SystemProfileDesktopStatus.Missing),
+            new SystemProfileDesktopPathDiagnostics("C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop", SysWow64 ? SystemProfileDesktopStatus.Exists : SystemProfileDesktopStatus.Missing))
+    {
+    }
+
+    public bool Ok => System32.Status == SystemProfileDesktopStatus.Exists && SysWow64.Status == SystemProfileDesktopStatus.Exists;
+    public bool Missing => System32.Status == SystemProfileDesktopStatus.Missing || SysWow64.Status == SystemProfileDesktopStatus.Missing;
+    public bool AccessDenied => System32.Status == SystemProfileDesktopStatus.AccessDenied || SysWow64.Status == SystemProfileDesktopStatus.AccessDenied;
+}
+
+public sealed record SystemProfileDesktopPathDiagnostics(
+    string Path,
+    string Status,
+    string? Message = null);
+
+public static class SystemProfileDesktopStatus
+{
+    public const string Exists = "exists";
+    public const string Missing = "missing";
+    public const string AccessDenied = "access_denied";
+    public const string Unknown = "unknown";
+}
 
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "This bridge only runs on Windows where Excel COM is available.")]
 public static class ExcelDiagnostics
@@ -24,6 +54,7 @@ public static class ExcelDiagnostics
     public static ExcelDiagnosticsResult Probe()
     {
         object? app = null;
+        var systemProfileDesktop = ProbeSystemProfileDesktop();
         try
         {
             var excelType = Type.GetTypeFromProgID("Excel.Application");
@@ -36,7 +67,8 @@ public static class ExcelDiagnostics
                     VbideAccess: null,
                     AutomationSecurity: null,
                     TrustVbaAccess: null,
-                    Error: "Excel.Application ProgID not registered");
+                    Error: "Excel.Application ProgID not registered",
+                    SystemProfileDesktop: systemProfileDesktop);
             }
 
             try
@@ -59,7 +91,8 @@ public static class ExcelDiagnostics
                     {
                         ["source"] = ex.Source,
                         ["stack_trace"] = ex.StackTrace,
-                    });
+                    },
+                    SystemProfileDesktop: systemProfileDesktop);
             }
             catch (Exception ex)
             {
@@ -70,7 +103,8 @@ public static class ExcelDiagnostics
                     VbideAccess: null,
                     AutomationSecurity: null,
                     TrustVbaAccess: null,
-                    Error: $"COM activation failed: {ex.Message}");
+                    Error: $"COM activation failed: {ex.Message}",
+                    SystemProfileDesktop: systemProfileDesktop);
             }
 
             if (app is null)
@@ -82,7 +116,8 @@ public static class ExcelDiagnostics
                     VbideAccess: null,
                     AutomationSecurity: null,
                     TrustVbaAccess: null,
-                    Error: "COM activation returned null");
+                    Error: "COM activation returned null",
+                    SystemProfileDesktop: systemProfileDesktop);
             }
 
             string? version = null;
@@ -136,7 +171,8 @@ public static class ExcelDiagnostics
                 VbideAccess: vbideAccess,
                 AutomationSecurity: automationSecurity,
                 TrustVbaAccess: trustVbaAccess,
-                Error: null);
+                Error: null,
+                SystemProfileDesktop: systemProfileDesktop);
         }
         finally
         {
@@ -161,6 +197,53 @@ public static class ExcelDiagnostics
                     // best-effort cleanup
                 }
             }
+        }
+    }
+
+    private static SystemProfileDesktopDiagnostics ProbeSystemProfileDesktop()
+    {
+        var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        if (string.IsNullOrWhiteSpace(windows))
+        {
+            windows = "C:\\Windows";
+        }
+
+        var system32 = Path.Combine(windows, "System32", "config", "systemprofile", "Desktop");
+        var sysWow64 = Path.Combine(windows, "SysWOW64", "config", "systemprofile", "Desktop");
+
+        return new SystemProfileDesktopDiagnostics(
+            System32: ProbeSystemProfileDesktopPath(system32),
+            SysWow64: ProbeSystemProfileDesktopPath(sysWow64));
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Systemprofile Desktop diagnostics must classify inaccessible or unusual filesystem states without failing doctor.")]
+    private static SystemProfileDesktopPathDiagnostics ProbeSystemProfileDesktopPath(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
+            {
+                return new SystemProfileDesktopPathDiagnostics(path, SystemProfileDesktopStatus.Exists);
+            }
+
+            return new SystemProfileDesktopPathDiagnostics(path, SystemProfileDesktopStatus.Missing, "Path exists but is not a directory.");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return new SystemProfileDesktopPathDiagnostics(path, SystemProfileDesktopStatus.AccessDenied, ex.Message);
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            return new SystemProfileDesktopPathDiagnostics(path, SystemProfileDesktopStatus.Missing, ex.Message);
+        }
+        catch (FileNotFoundException ex)
+        {
+            return new SystemProfileDesktopPathDiagnostics(path, SystemProfileDesktopStatus.Missing, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return new SystemProfileDesktopPathDiagnostics(path, SystemProfileDesktopStatus.Unknown, ex.Message);
         }
     }
 

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeHostTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeHostTests.cs
@@ -64,7 +64,8 @@ public sealed class BridgeHostTests
             VbideAccess: true,
             AutomationSecurity: 1,
             TrustVbaAccess: null,
-            Error: null);
+            Error: null,
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(System32: true, SysWow64: true));
 
         const string request = """
             {
@@ -100,6 +101,10 @@ public sealed class BridgeHostTests
         Assert.True(excel.GetProperty("vbide_access").GetBoolean());
         Assert.Equal(1, excel.GetProperty("automation_security").GetInt32());
         Assert.Equal(JsonValueKind.Null, excel.GetProperty("trust_vba_access").ValueKind);
+        var systemProfileDesktop = excel.GetProperty("systemprofile_desktop");
+        Assert.Equal("exists", systemProfileDesktop.GetProperty("system32").GetProperty("status").GetString());
+        Assert.Equal("exists", systemProfileDesktop.GetProperty("syswow64").GetProperty("status").GetString());
+        Assert.True(systemProfileDesktop.GetProperty("ok").GetBoolean());
     }
 
     [Fact]

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/DoctorCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/DoctorCommandTests.cs
@@ -18,7 +18,8 @@ public sealed class DoctorCommandTests
             VbideAccess: true,
             AutomationSecurity: 1,
             TrustVbaAccess: null,
-            Error: null);
+            Error: null,
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(System32: true, SysWow64: true));
 
         var command = new DoctorCommand(() => probeResult);
         var request = new BridgeRequest
@@ -51,6 +52,10 @@ public sealed class DoctorCommandTests
         Assert.Equal("16.0", excel.GetProperty("version").GetString());
         Assert.Equal("17726.20160", excel.GetProperty("build").GetString());
         Assert.True(excel.GetProperty("vbide_access").GetBoolean());
+        var systemProfileDesktop = excel.GetProperty("systemprofile_desktop");
+        Assert.Equal("exists", systemProfileDesktop.GetProperty("system32").GetProperty("status").GetString());
+        Assert.Equal("exists", systemProfileDesktop.GetProperty("syswow64").GetProperty("status").GetString());
+        Assert.True(systemProfileDesktop.GetProperty("ok").GetBoolean());
     }
 
     [Fact]
@@ -70,7 +75,8 @@ public sealed class DoctorCommandTests
             {
                 ["source"] = "test",
                 ["stack_trace"] = "at TestMethod",
-            });
+            },
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(System32: true, SysWow64: true));
 
         var command = new DoctorCommand(() => probeResult);
         var request = new BridgeRequest
@@ -94,6 +100,8 @@ public sealed class DoctorCommandTests
         Assert.Equal(-2147221164, error.GetProperty("number").GetInt32());
         Assert.Equal("0x80040154", error.GetProperty("h_result").GetString());
         Assert.Equal(JsonValueKind.Object, error.GetProperty("details").ValueKind);
+        var systemProfileDesktop = json.RootElement.GetProperty("diagnostics").GetProperty("excel").GetProperty("systemprofile_desktop");
+        Assert.True(systemProfileDesktop.GetProperty("ok").GetBoolean());
     }
 
     [Fact]
@@ -106,7 +114,8 @@ public sealed class DoctorCommandTests
             VbideAccess: false,
             AutomationSecurity: 1,
             TrustVbaAccess: null,
-            Error: "VBIDE access unavailable");
+            Error: "VBIDE access unavailable",
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(System32: true, SysWow64: true));
 
         var command = new DoctorCommand(() => probeResult);
         var request = new BridgeRequest
@@ -125,6 +134,158 @@ public sealed class DoctorCommandTests
         Assert.True(excel.GetProperty("com_activation").GetBoolean());
         Assert.False(excel.GetProperty("vbide_access").GetBoolean());
         Assert.Equal("VBIDE access unavailable", excel.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void HandleReturnsFailedResponseWhenSystemProfileDesktopDirectoriesAreMissing()
+    {
+        var probeResult = new ExcelDiagnosticsResult(
+            ComActivation: true,
+            Version: "16.0",
+            Build: "17726.20160",
+            VbideAccess: true,
+            AutomationSecurity: 1,
+            TrustVbaAccess: null,
+            Error: null,
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(System32: false, SysWow64: true));
+
+        var command = new DoctorCommand(() => probeResult);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-doctor-systemprofile",
+            Command = "doctor",
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        var error = json.RootElement.GetProperty("error");
+        Assert.Equal("systemprofile_desktop_missing", error.GetProperty("code").GetString());
+        Assert.Equal("doctor", error.GetProperty("phase").GetString());
+        Assert.Contains("systemprofile Desktop directories are missing", error.GetProperty("message").GetString());
+        Assert.Contains(@"C:\Windows\System32\config\systemprofile\Desktop", error.GetProperty("message").GetString());
+
+        var systemProfileDesktop = json.RootElement.GetProperty("diagnostics").GetProperty("excel").GetProperty("systemprofile_desktop");
+        Assert.Equal("missing", systemProfileDesktop.GetProperty("system32").GetProperty("status").GetString());
+        Assert.Equal("exists", systemProfileDesktop.GetProperty("syswow64").GetProperty("status").GetString());
+        Assert.False(systemProfileDesktop.GetProperty("ok").GetBoolean());
+    }
+
+    [Fact]
+    public void HandleDoesNotFailWhenSystemProfileDesktopCannotBeInspected()
+    {
+        var probeResult = new ExcelDiagnosticsResult(
+            ComActivation: true,
+            Version: "16.0",
+            Build: "17726.20160",
+            VbideAccess: true,
+            AutomationSecurity: 1,
+            TrustVbaAccess: null,
+            Error: null,
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(
+                System32: new SystemProfileDesktopPathDiagnostics(@"C:\Windows\System32\config\systemprofile\Desktop", SystemProfileDesktopStatus.Exists),
+                SysWow64: new SystemProfileDesktopPathDiagnostics(@"C:\Windows\SysWOW64\config\systemprofile\Desktop", SystemProfileDesktopStatus.AccessDenied, "Access is denied.")));
+
+        var command = new DoctorCommand(() => probeResult);
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-doctor-systemprofile-access-denied",
+            Command = "doctor",
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("ok", json.RootElement.GetProperty("status").GetString());
+        var systemProfileDesktop = json.RootElement.GetProperty("diagnostics").GetProperty("excel").GetProperty("systemprofile_desktop");
+        Assert.Equal("exists", systemProfileDesktop.GetProperty("system32").GetProperty("status").GetString());
+        Assert.Equal("access_denied", systemProfileDesktop.GetProperty("syswow64").GetProperty("status").GetString());
+        Assert.True(systemProfileDesktop.GetProperty("access_denied").GetBoolean());
+        Assert.False(systemProfileDesktop.GetProperty("missing").GetBoolean());
+    }
+
+    [Fact]
+    public void HandleChecksWorkbookWhenRequested()
+    {
+        var probeResult = new ExcelDiagnosticsResult(
+            ComActivation: true,
+            Version: "16.0",
+            Build: "17726.20160",
+            VbideAccess: true,
+            AutomationSecurity: 1,
+            TrustVbaAccess: null,
+            Error: null,
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(System32: true, SysWow64: true));
+
+        var command = new DoctorCommand(() => probeResult);
+        var missingWorkbookPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "Book.xlsm");
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-doctor-workbook",
+            Command = "doctor",
+            Payload = JsonSerializer.SerializeToElement(new Dictionary<string, string>
+            {
+                ["CheckWorkbook"] = "true",
+                ["WorkbookPath"] = missingWorkbookPath,
+            }),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        var error = json.RootElement.GetProperty("error");
+        Assert.Equal("workbook_open_failed", error.GetProperty("code").GetString());
+        Assert.Equal("doctor.open_workbook", error.GetProperty("phase").GetString());
+        Assert.Contains("Configured workbook could not be opened", error.GetProperty("message").GetString());
+
+        var diagnostics = json.RootElement.GetProperty("diagnostics");
+        Assert.False(diagnostics.GetProperty("workbook_openable").GetBoolean());
+        Assert.Equal(Path.GetFullPath(missingWorkbookPath), json.RootElement.GetProperty("workbook").GetProperty("path").GetString());
+    }
+
+    [Fact]
+    public void HandleStillChecksWorkbookWhenSystemProfileDesktopDirectoriesAreMissing()
+    {
+        var probeResult = new ExcelDiagnosticsResult(
+            ComActivation: true,
+            Version: "16.0",
+            Build: "17726.20160",
+            VbideAccess: true,
+            AutomationSecurity: 1,
+            TrustVbaAccess: null,
+            Error: null,
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(System32: false, SysWow64: false));
+
+        var command = new DoctorCommand(() => probeResult);
+        var missingWorkbookPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "Book.xlsm");
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-doctor-systemprofile-workbook",
+            Command = "doctor",
+            Payload = JsonSerializer.SerializeToElement(new Dictionary<string, string>
+            {
+                ["CheckWorkbook"] = "true",
+                ["WorkbookPath"] = missingWorkbookPath,
+            }),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        var json = JsonSerializer.SerializeToDocument(response, JsonOptions.Default);
+
+        Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("systemprofile_desktop_missing", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+        Assert.Equal(Path.GetFullPath(missingWorkbookPath), json.RootElement.GetProperty("workbook").GetProperty("path").GetString());
+
+        var diagnostics = json.RootElement.GetProperty("diagnostics");
+        Assert.False(diagnostics.GetProperty("workbook_openable").GetBoolean());
+        var systemProfileDesktop = diagnostics.GetProperty("excel").GetProperty("systemprofile_desktop");
+        Assert.False(systemProfileDesktop.GetProperty("ok").GetBoolean());
     }
 
     [Fact]

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/DoctorCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/DoctorCommandTests.cs
@@ -147,7 +147,9 @@ public sealed class DoctorCommandTests
             AutomationSecurity: 1,
             TrustVbaAccess: null,
             Error: null,
-            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(System32: false, SysWow64: true));
+            SystemProfileDesktop: new SystemProfileDesktopDiagnostics(
+                System32: new SystemProfileDesktopPathDiagnostics(@"D:\Windows\System32\config\systemprofile\Desktop", SystemProfileDesktopStatus.Missing),
+                SysWow64: new SystemProfileDesktopPathDiagnostics(@"D:\Windows\SysWOW64\config\systemprofile\Desktop", SystemProfileDesktopStatus.Exists)));
 
         var command = new DoctorCommand(() => probeResult);
         var request = new BridgeRequest
@@ -165,7 +167,8 @@ public sealed class DoctorCommandTests
         Assert.Equal("systemprofile_desktop_missing", error.GetProperty("code").GetString());
         Assert.Equal("doctor", error.GetProperty("phase").GetString());
         Assert.Contains("systemprofile Desktop directories are missing", error.GetProperty("message").GetString());
-        Assert.Contains(@"C:\Windows\System32\config\systemprofile\Desktop", error.GetProperty("message").GetString());
+        Assert.Contains(@"D:\Windows\System32\config\systemprofile\Desktop", error.GetProperty("message").GetString());
+        Assert.Contains(@"D:\Windows\SysWOW64\config\systemprofile\Desktop", error.GetProperty("message").GetString());
 
         var systemProfileDesktop = json.RootElement.GetProperty("diagnostics").GetProperty("excel").GetProperty("systemprofile_desktop");
         Assert.Equal("missing", systemProfileDesktop.GetProperty("system32").GetProperty("status").GetString());

--- a/docs/bridge/dotnet-bridge.md
+++ b/docs/bridge/dotnet-bridge.md
@@ -47,13 +47,26 @@ The Go CLI remains responsible for command parsing, config loading, source-tree 
       "build": "12345",
       "vbide_access": true,
       "automation_security": 1,
-      "trust_vba_access": null
+      "trust_vba_access": null,
+      "systemprofile_desktop": {
+        "system32": {
+          "path": "C:\\Windows\\System32\\config\\systemprofile\\Desktop",
+          "status": "exists"
+        },
+        "syswow64": {
+          "path": "C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop",
+          "status": "exists"
+        },
+        "ok": true
+      }
     }
   }
 }
 ```
 
-When Excel COM activation fails, the bridge returns a structured error with `code`, `message`, `phase`, `source`, `number`, `h_result`, and `details` fields. The `h_result` field is a hex HRESULT string (e.g. `"0x80040154"`).
+When Excel COM activation fails, the bridge returns a structured error with `code`, `message`, `phase`, `source`, `number`, `h_result`, and `details` fields. The `h_result` field is a hex HRESULT string (e.g. `"0x80040154"`). When either systemprofile Desktop directory is definitely missing, the bridge returns `systemprofile_desktop_missing` with the same `diagnostics.excel.systemprofile_desktop` payload and an actionable message to create both directories. If a path cannot be inspected because the current user lacks permission, its status is `access_denied`; this is reported as a warning, not as a missing-directory failure.
+
+By default, `doctor` does not open the configured workbook. When the CLI sends `CheckWorkbook=true` for `xlflow doctor --workbook`, the bridge opens and closes the configured workbook and reports `diagnostics.workbook_openable`. A failed workbook open returns `workbook_open_failed` with `phase = "doctor.open_workbook"` and keeps the diagnostic payload in the response.
 
 Fields:
 
@@ -71,6 +84,14 @@ Fields:
 - `excel.vbide_access` — `true` when the VBA project object model is accessible.
 - `excel.automation_security` — observed `AutomationSecurity` value.
 - `excel.trust_vba_access` — observed Trust access state; `null` when not determinable.
+- `excel.systemprofile_desktop.system32.path` — `C:\Windows\System32\config\systemprofile\Desktop`.
+- `excel.systemprofile_desktop.system32.status` — `exists`, `missing`, `access_denied`, or `unknown`.
+- `excel.systemprofile_desktop.syswow64.path` — `C:\Windows\SysWOW64\config\systemprofile\Desktop`.
+- `excel.systemprofile_desktop.syswow64.status` — `exists`, `missing`, `access_denied`, or `unknown`.
+- `excel.systemprofile_desktop.ok` — `true` when both systemprofile Desktop directories are known to exist. These directories are required for reliable Excel COM workbook automation in non-interactive sessions such as SSH, services, and CI.
+- `excel.systemprofile_desktop.missing` — `true` when either path is definitely missing.
+- `excel.systemprofile_desktop.access_denied` — `true` when either path could not be inspected without elevated permissions.
+- `workbook_openable` — present only when workbook checking was requested; `true` when the configured workbook was opened and closed successfully.
 - `excel.error` — present only when a non-fatal diagnostic warning occurred.
 
 ### `inspect`

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -11,7 +11,7 @@ xlflow is a Windows-first Go CLI that treats Excel VBA projects as source-contro
 ```text
 xlflow [--json] [--bridge <auto|powershell|dotnet>] new [workbook] [--with-skill] [--agent <provider>] [--no-update-check]
 xlflow [--json] [--bridge <auto|powershell|dotnet>] init <workbook> [--with-module] [--with-skill] [--agent <provider>] [--no-update-check]
-xlflow [--json] [--bridge <auto|powershell|dotnet>] doctor
+xlflow [--json] [--bridge <auto|powershell|dotnet>] doctor [--workbook]
 xlflow [--json] [--bridge <auto|powershell|dotnet>] attach --active
 xlflow [--json] backup list
 xlflow [--json] list forms [--session]
@@ -83,7 +83,7 @@ Excel COM-backed commands report progress on stderr. Interactive stderr terminal
 
 Excel COM-backed commands also include top-level `bridge` metadata identifying the xlflow Excel bridge process. The fields vary by bridge provider. The PowerShell bridge returns `host` (process name, e.g. `pwsh.exe`), `edition` (e.g. `Core` or `Desktop`), and `version` (PowerShell version). The .NET bridge returns `name`, `version`, `protocol_version`, `runtime`, `architecture`, and may also include `commit`. If workbook VBA launches its own external PowerShell process, that workbook-side host may differ and must be inspected separately.
 
-`doctor --json` adds a top-level `diagnostics` object. Provider-specific `bridge` metadata and `diagnostics` serve different purposes: `bridge` identifies the bridge process itself, while `diagnostics` describes the probed Excel/runtime environment. `diagnostics.requested_bridge` records the requested mode, `diagnostics.selected_bridge` records the resolved provider, `diagnostics.fallback` reports whether `auto` fell back to PowerShell, and `diagnostics.legacy` reports whether the final provider is the legacy PowerShell bridge. With `.NET`, successful output also includes `diagnostics.protocol_version`, nested `runtime`, and nested `excel` probe fields. With PowerShell, callers must not assume the same nested shape unless the provider contract explicitly documents it for that bridge. Under WSL, the delegated Windows result is preserved and augmented with `diagnostics.host`, `diagnostics.windows`, and `diagnostics.path_translation`. These report WSL/distro detection, Windows xlflow path/version, bridge and Excel availability, and the translated project working directory. A WSL/Windows xlflow version mismatch is a warning rather than a hard failure.
+`doctor --json` adds a top-level `diagnostics` object. Provider-specific `bridge` metadata and `diagnostics` serve different purposes: `bridge` identifies the bridge process itself, while `diagnostics` describes the probed Excel/runtime environment. `diagnostics.requested_bridge` records the requested mode, `diagnostics.selected_bridge` records the resolved provider, `diagnostics.fallback` reports whether `auto` fell back to PowerShell, and `diagnostics.legacy` reports whether the final provider is the legacy PowerShell bridge. With `.NET`, successful output also includes `diagnostics.protocol_version`, nested `runtime`, and nested `excel` probe fields. Default `doctor` does not open the configured workbook; `doctor --workbook` opens and closes it and reports `diagnostics.workbook_openable`. With PowerShell, callers must not assume the same nested shape unless the provider contract explicitly documents it for that bridge. Under WSL, the delegated Windows result is preserved and augmented with `diagnostics.host`, `diagnostics.windows`, and `diagnostics.path_translation`. These report WSL/distro detection, Windows xlflow path/version, bridge and Excel availability, and the translated project working directory. A WSL/Windows xlflow version mismatch is a warning rather than a hard failure.
 
 `new` creates a fresh macro-enabled workbook under `build/`, scaffolds the same project layout as `init`, and then automatically `push`es the scaffolded VBA source into that workbook so the initial workbook and `src/` tree start in sync. Without an argument it creates `build/Book.xlsm`; when the argument has no extension, `.xlsm` is appended. Any other extension is rejected because workbook creation always uses Excel macro-enabled format `52`. New projects write `[userform].code_source = "sidecar"` into `xlflow.toml`.
 
@@ -269,7 +269,7 @@ All JSON output uses a stable top-level envelope.
 
 Command-specific fields are added at the top level:
 
-- `diagnostics` for `doctor` (includes `excel.com_activation` which indicates successful `Excel.Application` creation on the STA thread; WSL adds `host`, `windows`, and `path_translation`)
+- `diagnostics` for `doctor` (includes `excel.com_activation` which indicates successful `Excel.Application` creation on the STA thread, plus `.NET` bridge `excel.systemprofile_desktop` readiness with per-path `status` values of `exists`, `missing`, `access_denied`, or `unknown`; `doctor --workbook` additionally opens the configured workbook and reports `workbook_openable`; WSL adds `host`, `windows`, and `path_translation`)
 - `workbook` and `backup` for Excel file commands
 - `source` for commands that write project source files
 - `macro` for `run`

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1117,6 +1117,7 @@ func (a *app) bootstrapScaffoldPull(keepaliveOpts excel.CommandOptions) (output.
 }
 
 func (a *app) doctorCommand() *cobra.Command {
+	var checkWorkbook bool
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Diagnose Excel COM and VBIDE access",
@@ -1131,7 +1132,10 @@ func (a *app) doctorCommand() *cobra.Command {
 			var code int
 			err = a.withExcelProgress("Checking Excel automation", commandOpts, func() error {
 				var runErr error
-				env, code, runErr = a.excelRunnerForConfig(cfg).Doctor(cfg, commandOpts)
+				env, code, runErr = a.excelRunnerForConfig(cfg).DoctorWithOptions(cfg, excel.DoctorOptions{
+					CheckWorkbook: checkWorkbook,
+					Keepalive:     commandOpts,
+				})
 				return runErr
 			})
 			if err != nil {
@@ -1146,6 +1150,7 @@ func (a *app) doctorCommand() *cobra.Command {
 			return a.write(env, code)
 		},
 	}
+	cmd.Flags().BoolVar(&checkWorkbook, "workbook", false, "open the configured workbook as part of doctor diagnostics")
 	return cmd
 }
 

--- a/internal/excel/bridge.go
+++ b/internal/excel/bridge.go
@@ -481,11 +481,28 @@ type UIButtonRemoveOptions struct {
 	Session bool
 }
 
+type DoctorOptions struct {
+	CheckWorkbook bool
+	Keepalive     CommandOptions
+}
+
 func (r Runner) Doctor(cfg config.Config, opts ...CommandOptions) (output.Envelope, int, error) {
-	return r.run("doctor", map[string]string{
-		"WorkbookPath": workbookPath(r.RootDir, cfg.Excel.Path),
-		"Visible":      strconv.FormatBool(cfg.Excel.Visible),
-	}, opts...)
+	doctorOpts := DoctorOptions{}
+	if len(opts) > 0 {
+		doctorOpts.Keepalive = opts[0]
+	}
+	return r.DoctorWithOptions(cfg, doctorOpts)
+}
+
+func (r Runner) DoctorWithOptions(cfg config.Config, opts DoctorOptions) (output.Envelope, int, error) {
+	args := map[string]string{
+		"Visible":       strconv.FormatBool(cfg.Excel.Visible),
+		"CheckWorkbook": strconv.FormatBool(opts.CheckWorkbook),
+	}
+	if opts.CheckWorkbook {
+		args["WorkbookPath"] = workbookPath(r.RootDir, cfg.Excel.Path)
+	}
+	return r.run("doctor", args, opts.Keepalive)
 }
 
 func (r Runner) New(workbook string, opts ...CommandOptions) (output.Envelope, int, error) {

--- a/internal/excel/bridge_test.go
+++ b/internal/excel/bridge_test.go
@@ -884,6 +884,46 @@ func TestRunnerRejectsDotNetProtocolMismatch(t *testing.T) {
 	}
 }
 
+func TestRunnerDoctorChecksWorkbookOnlyWhenRequested(t *testing.T) {
+	original := bridgeProviderForMode
+	t.Cleanup(func() { bridgeProviderForMode = original })
+
+	var requests []excelbridge.Request
+	bridgeProviderForMode = func(root string, mode excelbridge.Mode) excelbridge.Provider {
+		return trackingBridgeProvider{
+			name:     string(excelbridge.ModeDotNet),
+			supports: true,
+			requests: &requests,
+			response: excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"doctor","logs":[],"error":null,"diagnostics":{"excel":{"com_activation":true,"vbide_access":true}}}`)},
+		}
+	}
+
+	root := t.TempDir()
+	cfg := config.Default()
+	if _, _, err := (Runner{RootDir: root, BridgeMode: "dotnet"}).Doctor(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := (Runner{RootDir: root, BridgeMode: "dotnet"}).DoctorWithOptions(cfg, DoctorOptions{CheckWorkbook: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
+	}
+	if got := requests[0].Args["CheckWorkbook"]; got != "false" {
+		t.Fatalf("default CheckWorkbook = %q, want false", got)
+	}
+	if _, ok := requests[0].Args["WorkbookPath"]; ok {
+		t.Fatalf("default doctor unexpectedly sent WorkbookPath: %#v", requests[0].Args)
+	}
+	if got := requests[1].Args["CheckWorkbook"]; got != "true" {
+		t.Fatalf("opt-in CheckWorkbook = %q, want true", got)
+	}
+	if got := requests[1].Args["WorkbookPath"]; got != filepath.Join(root, cfg.Excel.Path) {
+		t.Fatalf("opt-in WorkbookPath = %q, want %q", got, filepath.Join(root, cfg.Excel.Path))
+	}
+}
+
 func TestRunnerDoctorPreservesDotNetBridgeMetadataAndDiagnostics(t *testing.T) {
 	original := bridgeProviderForMode
 	t.Cleanup(func() { bridgeProviderForMode = original })

--- a/internal/excel/scripts/doctor.ps1
+++ b/internal/excel/scripts/doctor.ps1
@@ -31,6 +31,12 @@ try {
     }
   } else {
     Set-XlflowExcelAutomationDefaults -Excel $excel -DisplayAlerts $false
+    try {
+      $null = $excel.VBE
+      $diagnostics.vbide_access = $true
+    } catch {
+      $diagnostics.fix = "Enable 'Trust access to the VBA project object model' in Excel Trust Center."
+    }
   }
 
   $result.diagnostics = $diagnostics

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -601,12 +601,17 @@ func (r renderer) renderDoctor(env Envelope) string {
 		default:
 			b.WriteString(r.checkLine(false, "Systemprofile Desktop", systemProfileDetail))
 		}
-		if systemProfileStatus == "failed" && (env.Error == nil || !strings.Contains(env.Error.Message, "Create both directories:")) {
+		if systemProfileStatus == "failed" && (env.Error == nil || env.Error.Code != "systemprofile_desktop_missing") {
+			system32Path, syswow64Path := systemProfileDesktopPaths(systemProfileDesktop)
 			b.WriteString("\n")
 			b.WriteString("systemprofile Desktop directories are missing.\n")
 			b.WriteString("Create both directories:\n")
-			b.WriteString("- C:\\Windows\\System32\\config\\systemprofile\\Desktop\n")
-			b.WriteString("- C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop\n\n")
+			b.WriteString("- ")
+			b.WriteString(system32Path)
+			b.WriteString("\n")
+			b.WriteString("- ")
+			b.WriteString(syswow64Path)
+			b.WriteString("\n\n")
 			b.WriteString("This is required for Excel COM automation in non-interactive sessions such as SSH, services, or CI.\n")
 		}
 	}
@@ -645,6 +650,20 @@ func summarizeSystemProfileDesktop(systemProfileDesktop map[string]any) (string,
 	default:
 		return "warning", "systemprofile Desktop readiness could not be fully inspected"
 	}
+}
+
+func systemProfileDesktopPaths(systemProfileDesktop map[string]any) (string, string) {
+	system32 := objectMap(systemProfileDesktop["system32"])
+	syswow64 := objectMap(systemProfileDesktop["syswow64"])
+	system32Path := stringValue(system32, "path")
+	if system32Path == "" {
+		system32Path = "C:\\Windows\\System32\\config\\systemprofile\\Desktop"
+	}
+	syswow64Path := stringValue(syswow64, "path")
+	if syswow64Path == "" {
+		syswow64Path = "C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop"
+	}
+	return system32Path, syswow64Path
 }
 
 func (r renderer) doctorBool(diag map[string]any, excel map[string]any, flatKey string, nestedKey string) bool {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -590,10 +590,30 @@ func (r renderer) renderDoctor(env Envelope) string {
 		b.WriteString(kv("Bridge role", role))
 	}
 	b.WriteString(r.checkLine(r.doctorBool(diag, excel, "excel_installed", "com_activation"), "Excel automation", "Excel COM can be created"))
+	systemProfileDesktop := objectMap(excel["systemprofile_desktop"])
+	if len(systemProfileDesktop) > 0 {
+		systemProfileStatus, systemProfileDetail := summarizeSystemProfileDesktop(systemProfileDesktop)
+		switch systemProfileStatus {
+		case "ok":
+			b.WriteString(r.checkLine(true, "Systemprofile Desktop", systemProfileDetail))
+		case "warning":
+			b.WriteString(r.warnLine("Systemprofile Desktop", systemProfileDetail))
+		default:
+			b.WriteString(r.checkLine(false, "Systemprofile Desktop", systemProfileDetail))
+		}
+		if systemProfileStatus == "failed" && (env.Error == nil || !strings.Contains(env.Error.Message, "Create both directories:")) {
+			b.WriteString("\n")
+			b.WriteString("systemprofile Desktop directories are missing.\n")
+			b.WriteString("Create both directories:\n")
+			b.WriteString("- C:\\Windows\\System32\\config\\systemprofile\\Desktop\n")
+			b.WriteString("- C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop\n\n")
+			b.WriteString("This is required for Excel COM automation in non-interactive sessions such as SSH, services, or CI.\n")
+		}
+	}
 	if path := stringValue(workbook, "path"); path != "" {
 		b.WriteString(r.checkLine(boolValue(diag, "workbook_openable"), "Workbook", path))
 	} else {
-		b.WriteString(r.checkLine(false, "Workbook", "No configured workbook was checked"))
+		b.WriteString(r.skipLine("Workbook", "Not checked; run xlflow doctor --workbook to open the configured workbook"))
 	}
 	b.WriteString(r.checkLine(r.doctorBool(diag, excel, "vbide_access", ""), "VBIDE access", "VBA project object model is available"))
 	if fix := stringValue(diag, "fix"); fix != "" {
@@ -604,6 +624,27 @@ func (r renderer) renderDoctor(env Envelope) string {
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+func summarizeSystemProfileDesktop(systemProfileDesktop map[string]any) (string, string) {
+	system32 := objectMap(systemProfileDesktop["system32"])
+	syswow64 := objectMap(systemProfileDesktop["syswow64"])
+	system32Status := stringValue(system32, "status")
+	syswow64Status := stringValue(syswow64, "status")
+	switch {
+	case system32Status == "exists" && syswow64Status == "exists":
+		return "ok", "systemprofile Desktop directories are available"
+	case system32Status == "missing" || syswow64Status == "missing":
+		return "failed", "systemprofile Desktop directories are missing"
+	case system32Status == "access_denied" && syswow64Status == "access_denied":
+		return "warning", "systemprofile Desktop paths could not be inspected without elevated permissions"
+	case system32Status == "access_denied":
+		return "warning", "System32 path could not be inspected without elevated permissions"
+	case syswow64Status == "access_denied":
+		return "warning", "SysWOW64 path could not be inspected without elevated permissions"
+	default:
+		return "warning", "systemprofile Desktop readiness could not be fully inspected"
+	}
 }
 
 func (r renderer) doctorBool(diag map[string]any, excel map[string]any, flatKey string, nestedKey string) bool {
@@ -686,6 +727,14 @@ func (r renderer) checkLine(ok bool, name, detail string) string {
 		marker = r.style("[ok]", "42", true)
 	}
 	return fmt.Sprintf("%s %s - %s\n", marker, r.style(name, "", true), detail)
+}
+
+func (r renderer) skipLine(name, detail string) string {
+	return fmt.Sprintf("%s %s - %s\n", r.style("[-]", "244", true), r.style(name, "", true), detail)
+}
+
+func (r renderer) warnLine(name, detail string) string {
+	return fmt.Sprintf("%s %s - %s\n", r.style("[!]", "214", true), r.style(name, "", true), detail)
 }
 
 func summarizeRuntime(runtime map[string]any) string {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -635,6 +635,11 @@ func TestWriteWithOptionsRendersDoctorChecklistFromDotNetBridge(t *testing.T) {
 			"vbide_access":        true,
 			"automation_security": float64(1),
 			"trust_vba_access":    nil,
+			"systemprofile_desktop": map[string]any{
+				"system32": map[string]any{"path": `C:\Windows\System32\config\systemprofile\Desktop`, "status": "exists"},
+				"syswow64": map[string]any{"path": `C:\Windows\SysWOW64\config\systemprofile\Desktop`, "status": "exists"},
+				"ok":       true,
+			},
 		},
 	}
 	env.Status = StatusOK
@@ -643,13 +648,95 @@ func TestWriteWithOptionsRendersDoctorChecklistFromDotNetBridge(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := buf.String()
-	for _, want := range []string{"xlflow doctor", "Selected bridge:", "dotnet", "Requested bridge:", "auto", "Fallback:", "no", "Bridge role:", "primary", "Excel automation", "VBIDE access"} {
+	for _, want := range []string{"xlflow doctor", "Selected bridge:", "dotnet", "Requested bridge:", "auto", "Fallback:", "no", "Bridge role:", "primary", "Excel automation", "Systemprofile Desktop", "Workbook", "Not checked", "VBIDE access"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, got)
 		}
 	}
 	if strings.Contains(got, "FAILED") {
 		t.Fatalf("doctor output should not contain FAILED for dotnet bridge:\n%s", got)
+	}
+}
+
+func TestWriteWithOptionsRendersMissingSystemProfileDesktopFix(t *testing.T) {
+	env := New("doctor")
+	env.Status = StatusFailed
+	env.Error = &Error{
+		Code:    "systemprofile_desktop_missing",
+		Message: "systemprofile Desktop directories are missing.\nCreate both directories:\n- C:\\Windows\\System32\\config\\systemprofile\\Desktop\n- C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop\n\nThis is required for Excel COM automation in non-interactive sessions such as SSH, services, or CI.",
+		Source:  "xlflow-excel-bridge",
+		Phase:   "doctor",
+	}
+	env.Diagnostics = map[string]any{
+		"selected_bridge": "dotnet",
+		"excel": map[string]any{
+			"com_activation": true,
+			"vbide_access":   true,
+			"systemprofile_desktop": map[string]any{
+				"system32": map[string]any{"path": `C:\Windows\System32\config\systemprofile\Desktop`, "status": "missing"},
+				"syswow64": map[string]any{"path": `C:\Windows\SysWOW64\config\systemprofile\Desktop`, "status": "exists"},
+				"ok":       false,
+				"missing":  true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteWithOptions(&buf, env, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, want := range []string{
+		"FAILED",
+		"systemprofile Desktop directories are missing.",
+		"Create both directories:",
+		`C:\Windows\System32\config\systemprofile\Desktop`,
+		`C:\Windows\SysWOW64\config\systemprofile\Desktop`,
+		"non-interactive sessions such as SSH, services, or CI",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, got)
+		}
+	}
+	if count := strings.Count(got, "Create both directories:"); count != 1 {
+		t.Fatalf("doctor output repeated systemprofile fix %d times:\n%s", count, got)
+	}
+}
+
+func TestWriteWithOptionsRendersSystemProfileDesktopAccessDeniedWarning(t *testing.T) {
+	env := New("doctor")
+	env.Diagnostics = map[string]any{
+		"selected_bridge": "dotnet",
+		"excel": map[string]any{
+			"com_activation": true,
+			"vbide_access":   true,
+			"systemprofile_desktop": map[string]any{
+				"system32":      map[string]any{"path": `C:\Windows\System32\config\systemprofile\Desktop`, "status": "exists"},
+				"syswow64":      map[string]any{"path": `C:\Windows\SysWOW64\config\systemprofile\Desktop`, "status": "access_denied", "message": "Access is denied."},
+				"ok":            false,
+				"access_denied": true,
+			},
+		},
+		"workbook_openable": true,
+	}
+	env.Workbook = map[string]any{"path": `C:\dev\go\xlflow\example\calendar-pick\build\Book.xlsm`}
+
+	var buf bytes.Buffer
+	if err := WriteWithOptions(&buf, env, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, want := range []string{
+		"OK xlflow doctor",
+		"[!] Systemprofile Desktop - SysWOW64 path could not be inspected without elevated permissions",
+		`[ok] Workbook - C:\dev\go\xlflow\example\calendar-pick\build\Book.xlsm`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "systemprofile_desktop_missing") {
+		t.Fatalf("doctor output should not fail on access_denied:\n%s", got)
 	}
 }
 

--- a/internal/pack/vbaproject/modulekind_test.go
+++ b/internal/pack/vbaproject/modulekind_test.go
@@ -8,7 +8,7 @@ import "testing"
 // rebuilt PROJECTMODULES (driven by Type) can diverge from PROJECT text.
 func TestCheckModuleSetDetectsKindMismatch(t *testing.T) {
 	p := &Project{
-		ProjectStreamRaw: []byte("Class=Foo\r\n"),         // PROJECT says Foo is a Class
+		ProjectStreamRaw: []byte("Class=Foo\r\n"),                  // PROJECT says Foo is a Class
 		Modules:          []Module{{Name: "Foo", Type: ModuleStd}}, // model says standard module
 	}
 	if err := checkModuleSet(p); err == nil {

--- a/vitepress/commands/doctor.md
+++ b/vitepress/commands/doctor.md
@@ -1,11 +1,11 @@
 # xlflow doctor
 
-Diagnose Excel, COM, PowerShell, VBIDE access, workbook access, and GUI-boundary prerequisites.
+Diagnose Excel, COM, PowerShell, VBIDE access, systemprofile Desktop readiness, optional workbook access, and GUI-boundary prerequisites.
 
 ## Usage
 
 ```bash
-xlflow doctor [--bridge <auto|powershell|dotnet>]
+xlflow doctor [--bridge <auto|powershell|dotnet>] [--workbook]
 ```
 
 ## Options and Arguments
@@ -14,18 +14,24 @@ xlflow doctor [--bridge <auto|powershell|dotnet>]
 | --------------------- | ------------------------------------------------------------------ | ------- |
 | `--json`              | Return structured diagnostics for agents and CI logs.              | false   |
 | `--bridge <provider>` | Select the Excel bridge provider (`auto`, `powershell`, `dotnet`). | `auto`  |
+| `--workbook`          | Open and close the configured workbook as part of diagnostics.     | false   |
 
 ## Examples
 
 ```bash
 xlflow doctor
 xlflow doctor --bridge dotnet --json
+xlflow doctor --workbook
 ```
 
 ## Notes
 
 ::: tip
 Run `doctor` before debugging workbook behavior on a new Windows or Excel installation.
+:::
+
+::: tip
+By default, `doctor` performs lightweight Excel COM, VBIDE, and systemprofile Desktop checks without opening the configured workbook. Use `--workbook` when you need to prove that the configured workbook can be opened by the selected bridge.
 :::
 
 ::: warning
@@ -67,11 +73,24 @@ A version mismatch between WSL and Windows xlflow is reported as a warning but d
       "build": "12345",
       "vbide_access": true,
       "automation_security": 1,
-      "trust_vba_access": null
+      "trust_vba_access": null,
+      "systemprofile_desktop": {
+        "system32": {
+          "path": "C:\\Windows\\System32\\config\\systemprofile\\Desktop",
+          "status": "exists"
+        },
+        "syswow64": {
+          "path": "C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop",
+          "status": "exists"
+        },
+        "ok": true
+      }
     }
   }
 }
 ```
+
+With `--workbook`, successful output also includes the configured workbook path and `diagnostics.workbook_openable: true`.
 
 WSL output includes the same Windows diagnostics plus the delegation boundary:
 
@@ -139,6 +158,40 @@ When Excel COM activation fails with `--bridge dotnet`, the response uses the st
   }
 }
 ```
+
+When the Windows systemprofile Desktop directories are missing, `doctor` fails with an actionable environment error. These directories are required for Excel COM workbook automation in non-interactive sessions such as SSH, services, and CI.
+
+```json
+{
+  "status": "failed",
+  "command": "doctor",
+  "error": {
+    "code": "systemprofile_desktop_missing",
+    "message": "systemprofile Desktop directories are missing.\nCreate both directories:\n- C:\\Windows\\System32\\config\\systemprofile\\Desktop\n- C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop\n\nThis is required for Excel COM automation in non-interactive sessions such as SSH, services, or CI.",
+    "phase": "doctor",
+    "source": "xlflow-excel-bridge"
+  },
+  "diagnostics": {
+    "excel": {
+      "com_activation": true,
+      "systemprofile_desktop": {
+        "system32": {
+          "path": "C:\\Windows\\System32\\config\\systemprofile\\Desktop",
+          "status": "missing"
+        },
+        "syswow64": {
+          "path": "C:\\Windows\\SysWOW64\\config\\systemprofile\\Desktop",
+          "status": "missing"
+        },
+        "ok": false,
+        "missing": true
+      }
+    }
+  }
+}
+```
+
+If a systemprofile Desktop path exists but cannot be inspected by the current user, `status` is `access_denied`. That condition is reported as a warning in human output; it does not by itself make `doctor` fail.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Tighten `doctor` so it reports the bridge as unhealthy when Excel operations fail with the `0x800a03ec` missing `systemprofile\Desktop` condition.
- Surface clearer diagnostics from the .NET bridge and CLI output so the failure mode is distinguishable from a healthy environment.
- Update bridge tests, CLI tests, and docs to cover the new contract.
- Record the behavior change in the changelog and command/spec docs.

## Testing
- Added and updated unit tests around doctor diagnostics, bridge host behavior, and CLI output.
- Verified the new failure classification and messaging through the existing automated test suite for the affected areas.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--workbook` flag to `xlflow doctor` to verify the configured workbook can be opened during diagnostics.
  * Enhanced diagnostics for Windows systemprofile Desktop directories, distinguishing between missing and permission-denied cases.

* **Documentation**
  * Updated `xlflow doctor` documentation with new flag and diagnostic output details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->