### PR TITLE
docs(pack): document release-gate Excel smoke for packed artifacts

### DIFF
--- a/.agents/skills/xlflow-tmp-workspace-e2e/SKILL.md
+++ b/.agents/skills/xlflow-tmp-workspace-e2e/SKILL.md
@@ -234,13 +234,16 @@ Open the produced artifact, run the packed macro, and assert the sentinel cell:
 ```powershell
 $path = 'C:\dev\go\xlflow\tmp_workspaces\<topic>-e2e\dist\Book.xlsm'
 $excel = New-Object -ComObject Excel.Application
-$excel.Visible = $false
+$excel.Visible = $true   # keep Excel visible: a hidden VBE compile-error dialog otherwise looks like a hang
 $excel.DisplayAlerts = $false
 $excel.AutomationSecurity = 1  # msoAutomationSecurityLow: allow the packed macros to run
 $wb = $excel.Workbooks.Open($path)
 try {
   $excel.Run('Main.Run')                      # forces a VBE compile, then runs the packed macro
-  $wb.Worksheets.Item(1).Range('A1').Value2   # expect the sentinel written by Main.Run, e.g. "xlflow ok"
+  $sentinel = $wb.Worksheets.Item(1).Range('A1').Value2
+  if ($sentinel -ne 'xlflow ok') {            # the value Main.Run writes in section 3
+    throw "pack smoke failed: A1 was '$sentinel', expected 'xlflow ok'"
+  }
 } finally {
   $wb.Close($false)
   $excel.Quit()
@@ -257,7 +260,7 @@ The smoke passes only when:
 - the packed workbook opens in Excel without a compile error
 - `Run` executes the packed macro and the sentinel cell holds the expected value
 
-A compile error on open, a missing or wrong sentinel value, or a non-zero `pack` exit is a release blocker. Record the `pack` JSON output and the observed sentinel value in the release-gate report.
+A compile error on open, a missing or wrong sentinel value, or a non-zero `pack` exit is a release blocker. If `Run` appears to hang, bring the (visible) Excel window to the foreground — a VBE compile-error dialog is the usual hidden cause. Record the `pack` JSON output and the observed sentinel value in the release-gate report.
 
 ## Failure Handling
 

--- a/.agents/skills/xlflow-tmp-workspace-e2e/SKILL.md
+++ b/.agents/skills/xlflow-tmp-workspace-e2e/SKILL.md
@@ -244,6 +244,7 @@ try {
   if ($sentinel -ne 'xlflow ok') {            # the value Main.Run writes in section 3
     throw "pack smoke failed: A1 was '$sentinel', expected 'xlflow ok'"
   }
+  "pack smoke OK: A1 = $sentinel"             # surface the observed value for the release-gate report
 } finally {
   $wb.Close($false)
   $excel.Quit()
@@ -260,7 +261,7 @@ The smoke passes only when:
 - the packed workbook opens in Excel without a compile error
 - `Run` executes the packed macro and the sentinel cell holds the expected value
 
-A compile error on open, a missing or wrong sentinel value, or a non-zero `pack` exit is a release blocker. If `Run` appears to hang, bring the (visible) Excel window to the foreground — a VBE compile-error dialog is the usual hidden cause. Record the `pack` JSON output and the observed sentinel value in the release-gate report.
+A compile error on open, a missing or wrong sentinel value, or a non-zero `pack` exit is a release blocker. If `Run` appears to hang, a modal VBE compile-error dialog is the usual cause — bring the Excel window to the foreground to read and dismiss it. Record the `pack` JSON output and the observed sentinel value in the release-gate report.
 
 ## Failure Handling
 

--- a/.agents/skills/xlflow-tmp-workspace-e2e/SKILL.md
+++ b/.agents/skills/xlflow-tmp-workspace-e2e/SKILL.md
@@ -194,6 +194,12 @@ Release-gate verification must cover:
 - UserForm round-trip, including `.frm` and `.frx`
 - `init` from an existing workbook
 
+When the release includes `pack` changes, also cover the pack artifact smoke described in section 7:
+
+- produce a `.xlsm` with `xlflow pack` (file-level, no Excel)
+- open the produced artifact in Excel and run a packed macro
+- assert an observable effect, such as a sentinel cell value, to confirm the packed VBA compiled and ran
+
 When the release includes session-related changes, also cover:
 
 - `session start`
@@ -206,6 +212,52 @@ When the release includes session-related changes, also cover:
 Even when the change is not primarily about session state, prefer the same session-backed execution pattern for multi-step Excel COM release checks unless a specific saved-file reopen path is itself under test.
 
 Do not report release readiness if one of these paths was skipped without calling it out explicitly.
+
+### 7. pack artifact smoke
+
+Use this section when the release includes changes to the experimental `pack` command (`docs/specs/pack-command.md`, ADR-0012).
+
+`pack` is a pure-Go, file-level path: it regenerates `xl/vbaProject.bin` from source without opening Excel, so it always reports `pack.vbe_validation = "not_performed"`. This smoke exists to confirm, at the release gate, that a representative packed artifact actually compiles and runs in real Excel. It is release-gate evidence only; it does not run in PR CI and it does not change `pack`'s permanent no-validation contract.
+
+Keep the automated PR path Linux/pure-Go only. Do not add Excel or COM steps to PR CI; the smoke is performed here, in the release gate, on Windows with Excel.
+
+In the primary workspace, make the standard `src/modules/Main.bas` macro from section 3 write a known sentinel value to `A1`. Keep the sentinel in a module that already exists in the template (for example `Main`): the experimental `pack` MVP updates existing modules only and rejects a brand-new module with `pack_ambiguous_layout`. Produce the artifact at the file level:
+
+```powershell
+xlflow pack --out dist/Book.xlsm --experimental --json
+```
+
+Confirm the JSON envelope reports `status = "ok"`, `pack.backend = "pure-go"`, and `pack.vbe_validation = "not_performed"`.
+
+Open the produced artifact, run the packed macro, and assert the sentinel cell:
+
+```powershell
+$path = 'C:\dev\go\xlflow\tmp_workspaces\<topic>-e2e\dist\Book.xlsm'
+$excel = New-Object -ComObject Excel.Application
+$excel.Visible = $false
+$excel.DisplayAlerts = $false
+$excel.AutomationSecurity = 1  # msoAutomationSecurityLow: allow the packed macros to run
+$wb = $excel.Workbooks.Open($path)
+try {
+  $excel.Run('Main.Run')                      # forces a VBE compile, then runs the packed macro
+  $wb.Worksheets.Item(1).Range('A1').Value2   # expect the sentinel written by Main.Run, e.g. "xlflow ok"
+} finally {
+  $wb.Close($false)
+  $excel.Quit()
+  [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($wb)
+  [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($excel)
+  [gc]::Collect()
+  [gc]::WaitForPendingFinalizers()
+}
+```
+
+The smoke passes only when:
+
+- `pack` exits `0` and produces the `.xlsm`
+- the packed workbook opens in Excel without a compile error
+- `Run` executes the packed macro and the sentinel cell holds the expected value
+
+A compile error on open, a missing or wrong sentinel value, or a non-zero `pack` exit is a release blocker. Record the `pack` JSON output and the observed sentinel value in the release-gate report.
 
 ## Failure Handling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ root: .
 
 - Windows + Excel COM / VBIDE access が関わる変更をリリースする前には、repo-local の `xlflow-tmp-workspace-e2e` skill を使って実機 E2E を実施すること
 - 少なくとも blank workbook、standard module round-trip、class module round-trip、UserForm + `.frx` round-trip、`init` の各経路を確認すること
+- `pack` を含むリリースでは、生成した `.xlsm` を実 Excel で開いて最小マクロを compile/run し、sentinel セル値などの観測可能な効果を確認する pack artifact smoke も実施すること（手順は `docs/specs/pack-command.md` の Release-gate Excel smoke と `xlflow-tmp-workspace-e2e` skill のセクション7）。自動 PR CI は Linux/pure-Go のみに保つこと
 - session-aware workflow を変更した場合は、`session start -> push --fast --session --no-save -> run/test -> save -> session stop` も release gate に含めること
 - Windows + Excel の実機 E2E で workbook-backed command を複数回組み合わせる場合は、session-aware workflow を変更していなくても、まず `session start -> push --fast --session --no-save -> run/test --session -> save --session -> session stop` を優先すること
 - 検証に使った `tmp_workspaces` の絶対パス、実行コマンド、結果、未検証項目を最終報告へ残すこと

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,7 @@ Run the repo-local `xlflow-tmp-workspace-e2e` skill against fresh `tmp_workspace
 - class module round-trip
 - UserForm round-trip including `.frm` and `.frx`
 - `init` from an existing workbook
+- pack artifact smoke (when the release touches `pack`): produce a `.xlsm` with `pack --experimental`, open it in Excel, run a packed macro, and assert a sentinel cell value; keep the automated PR path Linux/pure-Go only
 
 If the release changes session behavior, also verify the session loop:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ Run the repo-local `xlflow-tmp-workspace-e2e` skill against fresh `tmp_workspace
 - class module round-trip
 - UserForm round-trip including `.frm` and `.frx`
 - `init` from an existing workbook
-- pack artifact smoke (when the release touches `pack`): produce a `.xlsm` with `pack --experimental`, open it in Excel, run a packed macro, and assert a sentinel cell value; keep the automated PR path Linux/pure-Go only
+- pack artifact smoke (when the release touches `pack`): see `docs/specs/pack-command.md` ("Release-gate Excel smoke"); produce a `.xlsm` with `pack --experimental`, open it in Excel, run a packed macro, and assert a sentinel cell value; keep the automated PR path Linux/pure-Go only
 
 If the release changes session behavior, also verify the session loop:
 

--- a/docs/specs/pack-command.md
+++ b/docs/specs/pack-command.md
@@ -107,7 +107,21 @@ The backend identifier `pack.backend = "pure-go"` is deliberately distinct from 
 - **Source cross-checks**: decompress the regenerated module streams and compare against expected source text (and, where available, against `olevba` output) to confirm MS-OVBA correctness.
 - **Negative tests**: each unsupported case asserts the documented error code and exit code.
 
-These run on the existing Linux PR CI lane; no Windows runner is required for the `pack` path. Windows/Excel smoke tests that open the artifact and run a macro are a pre-stable milestone, not part of the MVP CI.
+These run on the existing Linux PR CI lane; no Windows runner is required for the `pack` path, and the automated PR path stays Linux/pure-Go only. Windows/Excel smoke tests that open the artifact and run a macro are a pre-stable milestone performed in the release gate, not in PR CI; see _Release-gate Excel smoke_ below.
+
+## Release-gate Excel smoke (pre-stable)
+
+The pure-Go path cannot tell whether a generated workbook actually compiles and runs (see _No VBE validation contract_). To close that gap before `pack` leaves experimental status, a representative packed artifact is smoke-tested in real Excel at the release gate — not in PR CI.
+
+This smoke is part of the repository's manual release-gate flow (the `xlflow-tmp-workspace-e2e` skill, "pack artifact smoke" section); the automated PR path remains Linux/pure-Go only. The procedure:
+
+1. Build a workspace with a known sentinel macro — a standard module that writes a fixed value to a cell.
+2. Produce the artifact at the file level: `xlflow pack --out dist/Book.xlsm --experimental`. Confirm the JSON reports `pack.vbe_validation = "not_performed"`.
+3. Open the produced `.xlsm` in Excel via COM, run the packed macro (which forces a VBE compile), and assert that the sentinel cell holds the expected value.
+
+The smoke passes only if `pack` exits `0`, the workbook opens without a compile error, and the macro's observable effect (the sentinel cell) matches. A compile error, a wrong sentinel value, or a non-zero exit blocks the release.
+
+This is release-gate evidence for a representative build. It does not change `pack`'s permanent `vbe_validation = "not_performed"` contract: `pack` itself never validates, and artifacts produced in the field remain unvalidated until opened in Excel.
 
 ## Staged UserForm plan
 


### PR DESCRIPTION
Closes #173

## What

Documents the release-gate Excel smoke for `pack` artifacts, as discussed in #173. `pack` is a pure-Go, file-level path that never opens Excel, so it cannot tell whether a generated workbook actually compiles and runs. This adds a manual release-gate smoke that opens a packed `.xlsm` in real Excel, compiles and runs a packed macro, and asserts an observable sentinel cell value.

This details ADR-0012's existing pre-stable milestone; no new ADR is needed.

## Changes

- **`.agents/skills/xlflow-tmp-workspace-e2e/SKILL.md`**: new section 7 "pack artifact smoke", referenced from the release-gate coverage list.
- **`docs/specs/pack-command.md`**: documents the procedure; states the automated PR path stays Linux/pure-Go only.
- **`AGENTS.md`, `CONTRIBUTING.md`**: add the smoke to the release preflight coverage lists.

No `.github/workflows` changes: the Excel smoke is a manual release-gate step, never part of PR CI. The automated PR path remains Linux/pure-Go only.

## Verification

Ran the documented procedure end-to-end (packed with the pure-Go path on Linux, opened in real Excel on Windows — the cross-platform path `pack` exists for):

1. `xlflow new` scaffolded a workspace; `Main.Run` set to write a sentinel to `A1`.
2. `xlflow pack --out dist/Book.xlsm --experimental --json` produced the artifact: `status=ok, backend=pure-go, vbe_validation=not_performed, modules: standard 8 / document 2 / carried_streams 1`.
3. Opened the packed `.xlsm` in Excel 16.0, `Application.Run "Main.Run"` (forces a VBE compile), read back `A1`:

```
RESULT: PASS
OBSERVED: PACK_SMOKE_SENTINEL_OK
```

The packed artifact compiled and ran in real Excel with the expected observable effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release validation procedures to add a Windows Excel “pack artifact smoke” step for releases that include experimental `pack` changes.
  * Added end-to-end guidance to produce a packed `.xlsm`, open it in real Excel, run a minimal macro, and verify an observable sentinel result.
  * Clarified that automated PR checks stay Linux/pure-Go only, while the Excel validation remains a release-gate responsibility with defined success/failure criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->