### PR TITLE
Fix VBA false positives for array assignments and paired Application state restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed `xlflow analyze` false positives for `VBA209` array element and UDT-array member assignments, clarified `VBA204` fallthrough guidance, and recognized paired Push/Pop `Application` state restore helpers for `VBA203`.
+
 ## v0.14.1
 
 - Improved `xlflow pack` protected-project detection: it now reads the CMG `ProjectProtectionState` bits (MS-OVBA §2.3.1.15) instead of a DPB password-length heuristic, so protected and unprotected projects are classified by the spec-defined signal rather than a corpus-calibrated threshold.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -168,6 +168,11 @@ type sourceDeclaration struct {
 	Parameter     bool
 }
 
+type applicationStateProcedureSummary struct {
+	Disables map[string]bool
+	Restores map[string]bool
+}
+
 type withInfo struct {
 	Target string
 	Type   string
@@ -316,17 +321,18 @@ func (a Analyzer) analyzeParsedFile(file parsedFile, ctx analysisContext) []Find
 	var findings []Finding
 	procedures := sourceProceduresFromAST(file.Root, file.Result.Source)
 	moduleDecls := moduleDeclarations(file.Lines, procedures)
+	appStateProcedures := applicationStateProcedureSummaries(file.Lines, procedures)
 	for _, proc := range procedures {
-		findings = append(findings, a.analyzeProcedure(file, proc, moduleDecls, ctx, reportedMissingHelpers)...)
+		findings = append(findings, a.analyzeProcedure(file, proc, moduleDecls, ctx, appStateProcedures, reportedMissingHelpers)...)
 	}
 	if len(procedures) == 0 {
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		findings = append(findings, a.analyzeProcedure(file, proc, moduleDecls, ctx, reportedMissingHelpers)...)
+		findings = append(findings, a.analyzeProcedure(file, proc, moduleDecls, ctx, appStateProcedures, reportedMissingHelpers)...)
 	}
 	return findings
 }
 
-func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, reportedMissingHelpers map[string]bool) []Finding {
+func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, appStateProcedures map[string]applicationStateProcedureSummary, reportedMissingHelpers map[string]bool) []Finding {
 	decls := cloneDeclarations(moduleDecls)
 	for key, decl := range procedureDeclarations(file.Lines, proc) {
 		decls[key] = decl
@@ -439,7 +445,7 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 		_ = lower
 	}
 	if a.Config.Analyze.DetectApplicationStateRestore {
-		findings = append(findings, a.applicationStateFindings(file, proc)...)
+		findings = append(findings, a.applicationStateFindings(file, proc, appStateProcedures)...)
 	}
 	if a.Config.Analyze.DetectErrorHandlerFallthrough {
 		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc, handlerLabels)...)
@@ -931,24 +937,20 @@ func nextNonSpace(text string, index int) byte {
 	return 0
 }
 
-func (a Analyzer) applicationStateFindings(file parsedFile, proc sourceProcedure) []Finding {
-	props := []string{"enableevents", "displayalerts", "screenupdating", "calculation"}
+func (a Analyzer) applicationStateFindings(file parsedFile, proc sourceProcedure, summaries map[string]applicationStateProcedureSummary) []Finding {
 	var findings []Finding
 	for i := proc.StartLine - 1; i < proc.EndLine && i < len(file.Lines); i++ {
 		stmt := normalizedCodeLine(file.Lines[i])
 		lower := compactStatement(strings.ToLower(stmt))
-		for _, prop := range props {
-			prefix := "application." + prop + "="
-			if !strings.Contains(lower, prefix) {
-				continue
-			}
-			if prop != "calculation" && !strings.Contains(lower, prefix+"false") {
-				continue
-			}
-			if prop == "calculation" && strings.Contains(lower, prefix+"xlcalculationautomatic") {
+		for _, prop := range applicationStateProperties() {
+			disables, _ := applicationStateAssignmentKind(lower, prop)
+			if !disables {
 				continue
 			}
 			if hasLaterApplicationRestore(file.Lines, proc, i+1, prop) {
+				continue
+			}
+			if hasPairedApplicationRestoreProcedure(proc.Name, prop, summaries) {
 				continue
 			}
 			name := applicationStateName(prop)
@@ -958,14 +960,77 @@ func (a Analyzer) applicationStateFindings(file parsedFile, proc sourceProcedure
 	return findings
 }
 
-func hasLaterApplicationRestore(lines []string, proc sourceProcedure, start int, prop string) bool {
+func applicationStateProcedureSummaries(lines []string, procedures []sourceProcedure) map[string]applicationStateProcedureSummary {
+	summaries := map[string]applicationStateProcedureSummary{}
+	for _, proc := range procedures {
+		summary := applicationStateProcedureSummary{Disables: map[string]bool{}, Restores: map[string]bool{}}
+		for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
+			lower := compactStatement(strings.ToLower(normalizedCodeLine(lines[i])))
+			for _, prop := range applicationStateProperties() {
+				disables, restores := applicationStateAssignmentKind(lower, prop)
+				if disables {
+					summary.Disables[prop] = true
+				}
+				if restores {
+					summary.Restores[prop] = true
+				}
+			}
+		}
+		summaries[strings.ToLower(proc.Name)] = summary
+	}
+	return summaries
+}
+
+func applicationStateProperties() []string {
+	return []string{"enableevents", "displayalerts", "screenupdating", "calculation"}
+}
+
+func applicationStateAssignmentKind(lower, prop string) (bool, bool) {
 	prefix := "application." + prop + "="
+	if !strings.Contains(lower, prefix) {
+		return false, false
+	}
+	rhs := lower[strings.Index(lower, prefix)+len(prefix):]
+	if prop != "calculation" {
+		if strings.HasPrefix(rhs, "false") {
+			return true, false
+		}
+		return false, true
+	}
+	if strings.HasPrefix(rhs, "xlcalculationautomatic") {
+		return false, true
+	}
+	if strings.HasPrefix(rhs, "xlcalculationmanual") || strings.HasPrefix(rhs, "xlcalculationsemiautomatic") {
+		return true, false
+	}
+	return false, true
+}
+
+func hasPairedApplicationRestoreProcedure(procName, prop string, summaries map[string]applicationStateProcedureSummary) bool {
+	if procName == "" {
+		return false
+	}
+	lowerName := strings.ToLower(procName)
+	if !strings.HasPrefix(lowerName, "push") {
+		return false
+	}
+	current, ok := summaries[lowerName]
+	if !ok || !current.Disables[prop] {
+		return false
+	}
+	for _, restoreName := range []string{"pop" + strings.TrimPrefix(lowerName, "push"), "restore" + strings.TrimPrefix(lowerName, "push")} {
+		if summary, ok := summaries[restoreName]; ok && summary.Restores[prop] {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLaterApplicationRestore(lines []string, proc sourceProcedure, start int, prop string) bool {
 	for i := start; i < proc.EndLine && i < len(lines); i++ {
 		lower := compactStatement(strings.ToLower(normalizedCodeLine(lines[i])))
-		if !strings.Contains(lower, prefix) {
-			continue
-		}
-		if prop == "calculation" || !strings.Contains(lower, prefix+"false") {
+		_, restores := applicationStateAssignmentKind(lower, prop)
+		if restores {
 			return true
 		}
 	}

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -528,6 +528,9 @@ func procedureDeclarations(lines []string, proc sourceProcedure) map[string]sour
 		lineNo := i + 1
 		stmt := normalizedCodeLine(lines[i])
 		lower := strings.ToLower(stmt)
+		if lineNo == proc.StartLine && isProcedureHeaderLine(lower) {
+			continue
+		}
 		if !strings.HasPrefix(lower, "dim ") && !strings.HasPrefix(lower, "static ") && !strings.HasPrefix(lower, "private ") && !strings.HasPrefix(lower, "public ") {
 			continue
 		}
@@ -544,6 +547,16 @@ func procedureDeclarations(lines []string, proc sourceProcedure) map[string]sour
 		}
 	}
 	return decls
+}
+
+func isProcedureHeaderLine(lower string) bool {
+	lower = strings.TrimSpace(lower)
+	for _, prefix := range []string{"sub ", "function ", "property ", "private sub ", "private function ", "private property ", "public sub ", "public function ", "public property ", "friend sub ", "friend function ", "friend property "} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func moduleDeclarations(lines []string, procedures []sourceProcedure) map[string]sourceDeclaration {
@@ -811,37 +824,111 @@ func identifierComparedAsOperand(stmt, name string) bool {
 	if name == "" {
 		return false
 	}
-	for _, op := range []string{"=", "<>", "<=", ">=", "<", ">"} {
-		parts := strings.Split(stmt, op)
-		if len(parts) < 2 {
+	for i := 0; i < len(stmt); i++ {
+		opLen := comparisonOperatorLength(stmt, i)
+		if opLen == 0 {
 			continue
 		}
-		for i := 0; i < len(parts)-1; i++ {
-			if operandIsIdentifier(parts[i], name) || operandIsIdentifier(parts[i+1], name) {
-				return true
-			}
+		left := stmt[:i]
+		right := stmt[i+opLen:]
+		if operandEndsWithBareIdentifier(left, name) || operandStartsWithBareIdentifier(right, name) {
+			return true
 		}
+		i += opLen - 1
 	}
 	return false
 }
 
-func operandIsIdentifier(text, name string) bool {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return false
+func comparisonOperatorLength(stmt string, index int) int {
+	if index < 0 || index >= len(stmt) {
+		return 0
 	}
-	fields := strings.FieldsFunc(text, func(r rune) bool {
-		return !isVBAIdentifierRune(r)
-	})
+	if index+1 < len(stmt) {
+		switch stmt[index : index+2] {
+		case "<>", "<=", ">=":
+			return 2
+		}
+	}
+	switch stmt[index] {
+	case '=', '<', '>':
+		return 1
+	default:
+		return 0
+	}
+}
+
+func operandEndsWithBareIdentifier(text, name string) bool {
+	fields := identifierFields(text)
 	if len(fields) == 0 {
 		return false
 	}
-	candidate := strings.ToLower(cleanIdentifier(fields[len(fields)-1]))
-	if candidate == name {
-		return true
+	return fieldMatchesBareIdentifier(text, fields[len(fields)-1], name)
+}
+
+func operandStartsWithBareIdentifier(text, name string) bool {
+	fields := identifierFields(text)
+	if len(fields) == 0 {
+		return false
 	}
-	candidate = strings.ToLower(cleanIdentifier(fields[0]))
-	return candidate == name
+	return fieldMatchesBareIdentifier(text, fields[0], name)
+}
+
+type identifierField struct {
+	Text       string
+	Start, End int
+}
+
+func identifierFields(text string) []identifierField {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	var fields []identifierField
+	start := -1
+	for i, r := range text {
+		if isVBAIdentifierRune(r) {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			fields = append(fields, identifierField{Text: text[start:i], Start: start, End: i})
+			start = -1
+		}
+	}
+	if start >= 0 {
+		fields = append(fields, identifierField{Text: text[start:], Start: start, End: len(text)})
+	}
+	return fields
+}
+
+func fieldMatchesBareIdentifier(text string, field identifierField, name string) bool {
+	if strings.ToLower(cleanIdentifier(field.Text)) != name {
+		return false
+	}
+	if previousNonSpace(text, field.Start) == '.' {
+		return false
+	}
+	next := nextNonSpace(text, field.End)
+	return next != '(' && next != '.'
+}
+
+func previousNonSpace(text string, index int) byte {
+	for i := index - 1; i >= 0; i-- {
+		if text[i] != ' ' && text[i] != '\t' {
+			return text[i]
+		}
+	}
+	return 0
+}
+
+func nextNonSpace(text string, index int) byte {
+	for i := index; i < len(text); i++ {
+		if text[i] != ' ' && text[i] != '\t' {
+			return text[i]
+		}
+	}
+	return 0
 }
 
 func (a Analyzer) applicationStateFindings(file parsedFile, proc sourceProcedure) []Finding {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -986,7 +986,7 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 		}
 		if label, ok := labelName(stmt); ok && handlerLabels[strings.ToLower(label)] {
 			if !isCleanupFallthroughLabel(label) && !terminatesNormalFlow(lastCode) {
-				findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA204", "warning", "Normal execution can fall through into error handler "+label+".", "Without Exit Sub, Exit Function, or Exit Property before the handler label, successful execution can run error handling code.", "Add an Exit statement before "+label+" or rename the label as a cleanup path if fallthrough is intentional."))
+				findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA204", "warning", "Normal execution can fall through into error handler "+label+".", "Without Exit Sub, Exit Function, or Exit Property before the handler label, successful execution can run error handling code.", errorHandlerFallthroughSuggestion(proc, label)))
 			}
 		}
 		lastCode = stmt
@@ -1225,6 +1225,17 @@ func isCleanupFallthroughLabel(label string) bool {
 	default:
 		return false
 	}
+}
+
+func errorHandlerFallthroughSuggestion(proc sourceProcedure, label string) string {
+	exitStmt := "Exit Sub"
+	switch strings.ToLower(proc.Kind) {
+	case "function":
+		exitStmt = "Exit Function"
+	case "property":
+		exitStmt = "Exit Property"
+	}
+	return "Add `" + exitStmt + "` before `" + label + ":`, or rename the label to Cleanup if normal fallthrough is intentional."
 }
 
 func terminatesNormalFlow(stmt string) bool {

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -588,6 +588,45 @@ End Sub
 	}
 }
 
+func TestAnalyzerArrayComparisonIgnoresElementsAndProcedureHeaders(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private fastModeDepth As Long
+Private Type DownloadItem
+  Filename As String
+End Type
+Private C_Down() As DownloadItem
+Private TestArray() As Variant
+
+Private Sub PopFastMode()
+  If fastModeDepth <= 0 Then Exit Sub
+  fastModeDepth = fastModeDepth - 1
+End Sub
+
+Public Sub Run()
+  Dim values() As Variant
+  Dim dataMatrix() As Variant
+  Dim stepData() As Variant
+  Dim columnIndex As Long
+  Dim stepIndex As Long
+  Dim outputColumn As Long
+  Dim rowIndex As Long
+  Dim i As Long
+  values(1, columnIndex) = i
+  dataMatrix(stepIndex, outputColumn) = stepData(rowIndex, 1)
+  C_Down(i).Filename = TestArray(i, 0)
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA209"); len(got) != 0 {
+		t.Fatalf("VBA209 should ignore array element and UDT-array member assignments: %+v", got)
+	}
+}
+
 func TestAnalyzerExpandedExcelMemberMismatch(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -463,6 +463,69 @@ End Sub
 	}
 }
 
+func TestAnalyzerApplicationStateAllowsPushPopRestorePattern(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private fastModeDepth As Long
+Private savedCalculation As XlCalculation
+Private savedEnableEvents As Boolean
+Private savedScreenUpdating As Boolean
+
+Private Sub PushFastMode()
+  If fastModeDepth = 0 Then
+    savedCalculation = Application.Calculation
+    savedEnableEvents = Application.EnableEvents
+    savedScreenUpdating = Application.ScreenUpdating
+    Application.ScreenUpdating = False
+    Application.EnableEvents = False
+    Application.Calculation = xlCalculationManual
+  End If
+  fastModeDepth = fastModeDepth + 1
+End Sub
+
+Private Sub PopFastMode()
+  If fastModeDepth <= 0 Then Exit Sub
+  fastModeDepth = fastModeDepth - 1
+  If fastModeDepth = 0 Then
+    Application.Calculation = savedCalculation
+    Application.EnableEvents = savedEnableEvents
+    Application.ScreenUpdating = savedScreenUpdating
+  End If
+End Sub
+
+Public Sub Run()
+  Call PushFastMode
+  On Error GoTo Cleanup
+  Debug.Print "work"
+Cleanup:
+  Call PopFastMode
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA203"); len(got) != 0 {
+		t.Fatalf("VBA203 should allow paired Push/Pop Application state restore: %+v", got)
+	}
+}
+
+func TestAnalyzerApplicationStateStillFlagsUnpairedPushPattern(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Sub PushFastMode()
+  Application.ScreenUpdating = False
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFinding(t, findings, "VBA203", 3)
+}
+
 func TestAnalyzerErrorHandlerFallthroughSuggestsConcreteExitStatement(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -463,6 +463,26 @@ End Sub
 	}
 }
 
+func TestAnalyzerErrorHandlerFallthroughSuggestsConcreteExitStatement(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  On Error GoTo ExitSub
+  Debug.Print "work"
+ExitSub:
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	finding := findFinding(t, findings, "VBA204", 5)
+	if !containsAll(finding.Suggestion, "`Exit Sub`", "`ExitSub:`") {
+		t.Fatalf("unexpected VBA204 suggestion: %q", finding.Suggestion)
+	}
+}
+
 func TestAnalyzerChecksObjectUseOnSetAssignmentRHS(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit


### PR DESCRIPTION
## Summary
- Suppress `VBA209` on array element assignments and UDT-array member assignments.
- Refine `VBA204` guidance to suggest the correct `Exit Sub` / `Exit Function` / `Exit Property` form.
- Recognize paired `Push` / `Pop` Application state helpers so legitimate restore patterns do not trigger `VBA203`.
- Document the analyzer behavior change in `CHANGELOG.md`.

## Testing
- Added analyzer tests covering array/UDT assignment cases, paired Application state restore helpers, and fallthrough suggestion text.
- Existing analyzer checks continue to pass for the unpaired push-pattern case.