### PR TITLE
Report unknown CLI commands with suggestions and JSON failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to xlflow will be documented in this file.
 
 - Removed the legacy PowerShell Excel bridge for v0.16.0. The only supported bridge modes are now `auto` and `dotnet`; `--bridge powershell`, `XLFLOW_EXCEL_BRIDGE=powershell`, and `[excel].bridge = "powershell"` now fail with bridge-mode/configuration errors instead of emitting a deprecation warning.
 - Added source-only `xlflow module new` and `xlflow form new` scaffolding commands for standard modules, class modules, and sidecar UserForms.
+- Added explicit unknown-command reporting so mistyped commands print a stderr error with help/suggestions, and `xlflow --json <unknown-command>` returns a structured `unknown_command` failure.
 - Added LSP CodeLens support for runnable no-argument VBA `Sub` procedures, including `Run` and `Run Test` actions backed by in-memory editor buffers.
 - Added `xlflow test list --json` for source-only VBA test discovery, enabling editor integrations to discover tests without parsing VBA in TypeScript or opening Excel.
 - Clarified the CLI JSON contract for editor integrations, including single-document stdout output and inactive `session status --json` payloads with `session.active=false`.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -68,6 +68,8 @@ xlflow [--json] version [--verbose]
 
 `--json` is a persistent global flag and can be used with every command, including `new` and `init`. With `--json`, stdout must contain exactly one complete JSON document for the final command result. Progress, human-readable logs, UI/debug streams, and warnings that are not part of the final JSON payload must go to stderr so editor integrations and agents can safely parse stdout with a single JSON decoder.
 
+Unknown top-level commands fail loudly before any workbook or project configuration is loaded. In text mode, `xlflow <unknown-command>` writes an error to stderr, includes close command suggestions when Cobra finds them, points to `xlflow --help`, and exits with code `2`. With `xlflow --json <unknown-command>`, stdout contains a structured failure envelope with `error.code = "unknown_command"` and optional `error.suggestions`.
+
 `--bridge` is also a persistent global flag for Excel bridge-backed commands. Supported values are `auto` and `dotnet`. Resolution order is `--bridge`, then `XLFLOW_EXCEL_BRIDGE`, then `[excel].bridge`, then the default `auto`. On Windows, `auto` selects the `.NET` bridge. Explicit `--bridge dotnet` is strict. The removed value `powershell` is rejected with a bridge-mode/configuration error.
 
 Under WSL, Excel-related top-level commands are delegated to Windows `xlflow.exe`: `new`, `init`, `doctor`, `attach`, `list`, `form`, `pull`, `push`, `rollback`, `session`, `save`, `status`, `runner`, `run`, `export-image`, `edit`, `macros`, `ui`, `test`, `inspect`, `check`, and `process`. Source-oriented commands remain in WSL: `backup`, `diff`, `inspect-gui`, `lint`, `lsp`, `fmt`, `analyze`, `generate`, `module`, `skill`, `version`, and completion/help. Source-only subcommands under delegated groups also remain local when explicitly documented, currently `test list` and `form new`. Delegation preserves stdin, stdout, stderr, JSON envelopes, and the Windows process exit code.
@@ -282,7 +284,7 @@ All JSON output uses a stable top-level envelope.
 }
 ```
 
-`status` is either `ok` or `failed`. `error` is `null` on success and a structured object on failure. Error objects contain `code`, `message`, `source`, `number`, `line`, `phase`, `h_result`, and `details`. `h_result` is a hex string (e.g. `"0x80040154"`) populated for COM-origin failures. `details` is an object with additional context such as `source` and `stack_trace`. All error fields except `message` are optional and omitted when empty or zero.
+`status` is either `ok` or `failed`. `error` is `null` on success and a structured object on failure. Error objects contain `code`, `message`, `source`, `number`, `line`, `phase`, `h_result`, `details`, and `suggestions`. `h_result` is a hex string (e.g. `"0x80040154"`) populated for COM-origin failures. `details` is an object with additional context such as `source` and `stack_trace`. `suggestions` is an array of command names for CLI parse failures such as `unknown_command`. All error fields except `message` are optional and omitted when empty or zero.
 
 Command-specific fields are added at the top level:
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -114,7 +114,7 @@ func ExecuteWithBuildInfo(info BuildInfo) error {
 	}
 	a := &app{cwd: cwd, rawArgs: append([]string{}, os.Args[1:]...), buildInfo: info.withDefaults()}
 	root := a.rootCommand()
-	return root.Execute()
+	return a.executeRoot(root)
 }
 
 func (info BuildInfo) withDefaults() BuildInfo {
@@ -183,6 +183,109 @@ func (a *app) rootCommand() *cobra.Command {
 		a.processCommand(),
 	)
 	return root
+}
+
+func (a *app) executeRoot(root *cobra.Command) error {
+	err := root.Execute()
+	if err == nil {
+		return nil
+	}
+	if name, ok := unknownCommandName(err); ok {
+		return a.writeUnknownCommandFailure(root, name, err)
+	}
+	return err
+}
+
+func unknownCommandName(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	const prefix = "unknown command "
+	message := err.Error()
+	if !strings.HasPrefix(message, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(message, prefix)
+	quoted, _, ok := strings.Cut(rest, " for ")
+	if !ok {
+		return "", false
+	}
+	name, quoteErr := strconv.Unquote(quoted)
+	if quoteErr != nil || name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+func (a *app) writeUnknownCommandFailure(root *cobra.Command, name string, err error) error {
+	suggestions := root.SuggestionsFor(name)
+	env := output.Failure("xlflow", output.Error{
+		Code:        "unknown_command",
+		Message:     fmt.Sprintf("unknown command %q", name),
+		Suggestions: suggestions,
+	})
+	if jsonOutput := a.json || rawArgsRequestJSON(a.rawArgs); jsonOutput {
+		opts := a.outputOptions()
+		opts.JSON = true
+		if writeErr := output.WriteWithOptions(a.stdoutWriter(), env, opts); writeErr != nil {
+			return output.WithExitCode(output.ExitConfig, writeErr)
+		}
+		return output.WithExitCode(output.ExitConfig, err)
+	}
+	if writeErr := writeUnknownCommandText(a.stderrWriter(), root.CommandPath(), name, suggestions); writeErr != nil {
+		return output.WithExitCode(output.ExitConfig, writeErr)
+	}
+	return output.WithExitCode(output.ExitConfig, err)
+}
+
+func writeUnknownCommandText(w io.Writer, commandPath string, name string, suggestions []string) error {
+	if commandPath == "" {
+		commandPath = "xlflow"
+	}
+	if _, err := fmt.Fprintf(w, "Error: unknown command %q for %q\n", name, commandPath); err != nil {
+		return err
+	}
+	if len(suggestions) > 0 {
+		if _, err := fmt.Fprintln(w, "\nDid you mean this?"); err != nil {
+			return err
+		}
+		for _, suggestion := range suggestions {
+			if _, err := fmt.Fprintf(w, "  %s\n", suggestion); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(w, "Run %q for usage.\n", commandPath+" --help")
+	return err
+}
+
+func rawArgsRequestJSON(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--json" {
+			return true
+		}
+		if strings.HasPrefix(arg, "--json=") {
+			value := strings.TrimPrefix(arg, "--json=")
+			parsed, err := strconv.ParseBool(value)
+			return err == nil && parsed
+		}
+		if arg == "--bridge" {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "--bridge=") {
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		return false
+	}
+	return false
 }
 
 func (a *app) versionCommand() *cobra.Command {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -791,6 +791,171 @@ func TestRootCommandRejectsRemovedTraceCommand(t *testing.T) {
 	}
 }
 
+func TestExecuteRootUnknownCommandWritesTextErrorToStderr(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	a := &app{
+		stdout:         &stdout,
+		stderr:         &stderr,
+		cwd:            t.TempDir(),
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"pussh"})
+
+	err := a.executeRoot(root)
+	if err == nil {
+		t.Fatal("expected unknown command error")
+	}
+	if code := output.ExitCode(err); code != output.ExitConfig {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitConfig)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	got := stderr.String()
+	for _, want := range []string{
+		`Error: unknown command "pussh" for "xlflow"`,
+		"Did you mean this?",
+		"  push",
+		`Run "xlflow --help" for usage.`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestExecuteRootUnknownCommandWithoutSuggestionOmitsSuggestionBlock(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	a := &app{
+		stdout:         &stdout,
+		stderr:         &stderr,
+		cwd:            t.TempDir(),
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"xyznotclose"})
+
+	err := a.executeRoot(root)
+	if err == nil {
+		t.Fatal("expected unknown command error")
+	}
+	if code := output.ExitCode(err); code != output.ExitConfig {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitConfig)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	got := stderr.String()
+	for _, want := range []string{
+		`Error: unknown command "xyznotclose" for "xlflow"`,
+		`Run "xlflow --help" for usage.`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Did you mean this?") {
+		t.Fatalf("stderr should not include suggestion block:\n%s", got)
+	}
+}
+
+func TestExecuteRootUnknownCommandJSONWritesStructuredError(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	a := &app{
+		stdout:         &stdout,
+		stderr:         &stderr,
+		cwd:            t.TempDir(),
+		rawArgs:        []string{"--json", "pussh"},
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"--json", "pussh"})
+
+	err := a.executeRoot(root)
+	if err == nil {
+		t.Fatal("expected unknown command error")
+	}
+	if code := output.ExitCode(err); code != output.ExitConfig {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitConfig)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("json output should be valid: %v\n%s", decodeErr, stdout.String())
+	}
+	if env.Status != output.StatusFailed || env.Command != "xlflow" {
+		t.Fatalf("unexpected envelope: %+v", env)
+	}
+	if env.Error == nil {
+		t.Fatal("expected structured error")
+	}
+	if env.Error.Code != "unknown_command" {
+		t.Fatalf("error code = %q, want unknown_command", env.Error.Code)
+	}
+	if env.Error.Message != `unknown command "pussh"` {
+		t.Fatalf("error message = %q", env.Error.Message)
+	}
+	if !reflect.DeepEqual(env.Error.Suggestions, []string{"push"}) {
+		t.Fatalf("suggestions = %#v, want push", env.Error.Suggestions)
+	}
+}
+
+func TestExecuteRootHelpStillSucceeds(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	a := &app{
+		stdout:         &stdout,
+		stderr:         &stderr,
+		cwd:            t.TempDir(),
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"--help"})
+
+	if err := a.executeRoot(root); err != nil {
+		t.Fatalf("help returned error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Agent-ready VBA development framework") {
+		t.Fatalf("help output missing root summary:\n%s", stdout.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRawArgsRequestJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "json before command", args: []string{"--json", "pussh"}, want: true},
+		{name: "json true before command", args: []string{"--json=true", "pussh"}, want: true},
+		{name: "json false before command", args: []string{"--json=false", "pussh"}, want: false},
+		{name: "bridge value before json", args: []string{"--bridge", "dotnet", "--json", "pussh"}, want: true},
+		{name: "json after command ignored", args: []string{"pussh", "--json"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rawArgsRequestJSON(tt.args); got != tt.want {
+				t.Fatalf("rawArgsRequestJSON(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRootCommandIncludesAnalyzeAndCheckCommands(t *testing.T) {
 	a := &app{}
 	root := a.rootCommand()

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -23,14 +23,15 @@ const (
 )
 
 type Error struct {
-	Code    string `json:"code,omitempty"`
-	Message string `json:"message"`
-	Source  string `json:"source,omitempty"`
-	Number  int    `json:"number,omitempty"`
-	Line    int    `json:"line,omitempty"`
-	Phase   string `json:"phase,omitempty"`
-	HResult string `json:"h_result,omitempty"`
-	Details any    `json:"details,omitempty"`
+	Code        string   `json:"code,omitempty"`
+	Message     string   `json:"message"`
+	Source      string   `json:"source,omitempty"`
+	Number      int      `json:"number,omitempty"`
+	Line        int      `json:"line,omitempty"`
+	Phase       string   `json:"phase,omitempty"`
+	HResult     string   `json:"h_result,omitempty"`
+	Details     any      `json:"details,omitempty"`
+	Suggestions []string `json:"suggestions,omitempty"`
 }
 
 type Envelope struct {

--- a/vitepress/reference/json-output.md
+++ b/vitepress/reference/json-output.md
@@ -26,6 +26,21 @@ Failures set `status` to `failed` and populate `error`:
 }
 ```
 
+Unknown commands are also structured when `--json` appears before the invalid command:
+
+```json
+{
+  "status": "failed",
+  "command": "xlflow",
+  "error": {
+    "code": "unknown_command",
+    "message": "unknown command \"pussh\"",
+    "suggestions": ["push"]
+  },
+  "logs": []
+}
+```
+
 Command-specific fields are top-level fields such as `issues`, `analysis`, `macro`, `macros`, `tests`, `diff`, `inspect`, `ui`, `debug`, `backups`, `rollback`, `target`, `session`, `warnings`, `hints`, `output`, `forms`, `edit`, `runner`, and `version`. `output` carries `fmt` result summaries, `export-image` output paths, and `form` command artifacts.
 
 `xlflow run --json` uses a compact failure payload by default. This keeps the fields that are usually relevant for fixing user VBA code and hides xlflow-internal diagnostic detail unless `--verbose` is specified.


### PR DESCRIPTION
## Summary
- Added explicit handling for mistyped top-level commands so `xlflow pussh` now reports a clear stderr error, suggested commands, and a help hint.
- Preserved JSON mode by returning a structured `unknown_command` failure with optional `suggestions` when `--json` is provided before the invalid command.
- Updated the CLI contract, JSON reference, changelog, and tests to cover text and JSON error paths.

## Testing
- Added unit coverage for unknown-command text output, suggestion handling, JSON envelopes, help behavior, and raw `--json` detection.
- Not run (not requested)