### PR TITLE
Add safe remove and rename commands for source/module operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to xlflow will be documented in this file.
 
 - Removed the legacy PowerShell Excel bridge for v0.16.0. The only supported bridge modes are now `auto` and `dotnet`; `--bridge powershell`, `XLFLOW_EXCEL_BRIDGE=powershell`, and `[excel].bridge = "powershell"` now fail with bridge-mode/configuration errors instead of emitting a deprecation warning.
 - Added source-only `xlflow module new` and `xlflow form new` scaffolding commands for standard modules, class modules, and sidecar UserForms.
+- Added source-only `xlflow module remove` and `xlflow module rename` commands for safe standard-module, class-module, and UserForm source mutations before the next `xlflow push`.
 - Added explicit unknown-command reporting so mistyped commands print a stderr error with help/suggestions, and `xlflow --json <unknown-command>` returns a structured `unknown_command` failure.
 - Added LSP CodeLens support for runnable no-argument VBA `Sub` procedures, including `Run` and `Run Test` actions backed by in-memory editor buffers.
 - Added `xlflow test list --json` for source-only VBA test discovery, enabling editor integrations to discover tests without parsing VBA in TypeScript or opening Excel.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -57,6 +57,8 @@ xlflow [--json] analyze
 xlflow [--json] check
 xlflow [--json] generate test <module-name>
 xlflow [--json] module new <name> --type standard|class
+xlflow [--json] module remove <module-name>
+xlflow [--json] module rename <old-name> <new-name>
 xlflow [--json] module install [--push]
 xlflow [--json] process list
 xlflow [--json] process cleanup <pid>
@@ -97,6 +99,10 @@ Excel COM-backed commands also include top-level `bridge` metadata identifying t
 `new` and `init` create or update a project-local `.gitignore`. The managed entries ignore Excel temporary files (`~$*.xls*`, `*.tmp`) and xlflow-generated state (`.xlflow/`, `build/`). Existing `.gitignore` content is preserved; missing managed entries are appended without duplicating entries that are already present.
 
 `module new <name> --type standard|class` is a source-only scaffold command. It requires an initialized project, validates `<name>` as a bare VBA component name without path separators or extensions, and refuses to overwrite existing files. `--type standard` writes `[src].modules/<Name>.bas` with `Attribute VB_Name = "<Name>"` and `Option Explicit`. `--type class` writes `[src].classes/<Name>.cls` with the minimal exported class header, `Attribute VB_Name = "<Name>"`, and `Option Explicit`. `--type` is required; missing or unsupported values fail with `module_new_args_invalid`, and filesystem/configuration failures use `module_new_failed`. Successful JSON uses `command="module new"` and `source.created[]`, `source.kind`, `source.name`, and `source.path`.
+
+`module remove <module-name>` is a source-only mutation command. It resolves source modules case-insensitively by basename across configured standard-module, class, form, and workbook document-module roots. Standard modules remove the matching `.bas`; class modules remove the matching `.cls`; UserForms remove the matching `.frm` plus any same-name `.frx`, `src/forms/code/<Name>.bas`, and `src/forms/specs/<Name>.yaml|yml|json` artifacts. Document modules under `[src].workbook` are protected and fail with `protected_module`. Missing, ambiguous, invalid, duplicate, or unsafe targets fail explicitly and return a non-zero status. Successful text output states that `xlflow push` is required to apply the source deletion to the workbook. Successful JSON uses `command="module remove"` and `source.operation="module.remove"`, `source.module`, `source.kind`, `source.removed[]`, and `source.requires_push=true`.
+
+`module rename <old-name> <new-name>` is a source-only mutation command. It validates `<new-name>` as a bare VBA component name, rejects collisions across all configured source roots, refuses document modules under `[src].workbook`, renames the source file, and updates `Attribute VB_Name` where present. UserForm renames also update the top-level `.frm` `Begin ... <Name>` declaration and move same-name `.frx`, sidecar code, and persisted spec artifacts; for specs, `form.name` is updated while other spec fields such as captions and controls are preserved. Successful text output states that `xlflow push` is required to apply the source rename to the workbook. Successful JSON uses `command="module rename"` and `source.operation="module.rename"`, `source.old_name`, `source.new_name`, `source.kind`, `source.renamed[]`, and `source.requires_push=true`.
 
 `module install` installs the bundled helper modules `XlflowAssert.bas`, `XlflowRuntime.bas`, `XlflowUI.bas`, and `XlflowDebug.bas` into the configured `[src].modules` root of an existing xlflow project without changing the workbook by default. `module install --push` additionally imports those helper modules into the configured workbook through the normal `push` path. The command refuses to overwrite any existing target helper source file.
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1507,9 +1507,9 @@ func (a *app) generateTestCommand() *cobra.Command {
 func (a *app) moduleCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "module",
-		Short: "Manage bundled xlflow helper modules",
+		Short: "Manage VBA source modules",
 	}
-	cmd.AddCommand(a.moduleNewCommand(), a.moduleInstallCommand())
+	cmd.AddCommand(a.moduleNewCommand(), a.moduleRemoveCommand(), a.moduleRenameCommand(), a.moduleInstallCommand())
 	return cmd
 }
 
@@ -1550,6 +1550,88 @@ func (a *app) moduleNewCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&moduleType, "type", "", "module type: standard or class")
 	return cmd
+}
+
+func (a *app) moduleRemoveCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <module-name>",
+		Short: "Remove a source module from the project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := a.loadConfig("module remove")
+			if err != nil {
+				return err
+			}
+			result, err := project.RemoveModule(a.cwd, args[0], cfg.Src)
+			if err != nil {
+				return a.writeModuleMutationFailure("module remove", err)
+			}
+			env := output.New("module remove")
+			env.Source = map[string]any{
+				"operation":     result.Operation,
+				"module":        result.Module,
+				"kind":          result.Kind,
+				"removed":       result.Removed,
+				"requires_push": result.RequiresPush,
+			}
+			env.Logs = []string{
+				fmt.Sprintf("Removed module %q.", result.Module),
+				`Run "xlflow push" to apply the change to the workbook.`,
+			}
+			return a.write(env, output.ExitSuccess)
+		},
+	}
+	return cmd
+}
+
+func (a *app) moduleRenameCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rename <old-name> <new-name>",
+		Short: "Rename a source module in the project",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := a.loadConfig("module rename")
+			if err != nil {
+				return err
+			}
+			result, err := project.RenameModule(a.cwd, args[0], args[1], cfg.Src)
+			if err != nil {
+				return a.writeModuleMutationFailure("module rename", err)
+			}
+			env := output.New("module rename")
+			env.Source = map[string]any{
+				"operation":     result.Operation,
+				"old_name":      result.OldName,
+				"new_name":      result.NewName,
+				"kind":          result.Kind,
+				"renamed":       result.Renamed,
+				"requires_push": result.RequiresPush,
+			}
+			env.Logs = []string{
+				fmt.Sprintf("Renamed module %q to %q.", result.OldName, result.NewName),
+				`Run "xlflow push" to apply the change to the workbook.`,
+			}
+			return a.write(env, output.ExitSuccess)
+		},
+	}
+	return cmd
+}
+
+func (a *app) writeModuleMutationFailure(command string, err error) error {
+	switch {
+	case errors.Is(err, project.ErrInvalidComponentName):
+		return a.writeFailure(command, output.ExitValidation, "module_name_invalid", err)
+	case errors.Is(err, project.ErrProtectedModule):
+		return a.writeFailure(command, output.ExitValidation, "protected_module", err)
+	case errors.Is(err, project.ErrModuleNotFound):
+		return a.writeFailure(command, output.ExitValidation, "module_not_found", err)
+	case errors.Is(err, project.ErrModuleAlreadyExists):
+		return a.writeFailure(command, output.ExitValidation, "module_already_exists", err)
+	case errors.Is(err, project.ErrModuleAmbiguous):
+		return a.writeFailure(command, output.ExitValidation, "module_ambiguous", err)
+	default:
+		return a.writeFailure(command, output.ExitEnvironment, "module_mutation_failed", err)
+	}
 }
 
 func (a *app) moduleInstallCommand() *cobra.Command {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -535,6 +535,28 @@ path = "build/Book.xlsm"
 	return dir
 }
 
+func writeCLIModuleMutationProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.Excel.Path = filepath.Join("build", "Book.xlsm")
+	if err := config.Write(filepath.Join(dir, config.FileName), cfg); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func writeCLIModuleFile(t *testing.T, root string, relPath string, body string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func writeCLIWarningAnalyzeProject(t *testing.T, analyzeConfig string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -2348,6 +2370,143 @@ func TestRootCommandIncludesModuleNewCommand(t *testing.T) {
 	}
 	if cmd.Flags().Lookup("type") == nil {
 		t.Fatal("expected module new command to define --type")
+	}
+}
+
+func TestRootCommandIncludesModuleRemoveAndRenameCommands(t *testing.T) {
+	a := &app{}
+	root := a.rootCommand()
+
+	removeCmd, _, err := root.Find([]string{"module", "remove", "InvoiceProcessor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removeCmd == nil || removeCmd.Name() != "remove" {
+		t.Fatalf("expected module remove command, got %#v", removeCmd)
+	}
+
+	renameCmd, _, err := root.Find([]string{"module", "rename", "OldName", "NewName"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if renameCmd == nil || renameCmd.Name() != "rename" {
+		t.Fatalf("expected module rename command, got %#v", renameCmd)
+	}
+}
+
+func TestModuleRemoveCommandWritesTextPushInstruction(t *testing.T) {
+	dir := writeCLIModuleMutationProject(t)
+	writeCLIModuleFile(t, dir, "src/modules/InvoiceProcessor.bas", `Attribute VB_Name = "InvoiceProcessor"`+"\n")
+
+	var stdout bytes.Buffer
+	a := &app{
+		cwd:            dir,
+		stdout:         &stdout,
+		stderr:         &bytes.Buffer{},
+		stdoutTerminal: func() bool { return false },
+		stderrTerminal: func() bool { return false },
+	}
+	root := a.rootCommand()
+	root.SetArgs([]string{"module", "remove", "InvoiceProcessor"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("module remove command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+	text := stdout.String()
+	for _, want := range []string{`Removed module "InvoiceProcessor".`, `Run "xlflow push" to apply the change to the workbook.`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected output to contain %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestModuleRenameCommandWritesJSON(t *testing.T) {
+	dir := writeCLIModuleMutationProject(t)
+	writeCLIModuleFile(t, dir, "src/modules/OldName.bas", `Attribute VB_Name = "OldName"`+"\n")
+
+	var stdout bytes.Buffer
+	a := &app{cwd: dir, stdout: &stdout, stderr: &bytes.Buffer{}}
+	root := a.rootCommand()
+	root.SetArgs([]string{"--json", "module", "rename", "OldName", "NewName"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("module rename command error = %v, exit = %d", err, output.ExitCode(err))
+	}
+
+	var env output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("json output should be valid: %v\n%s", err, stdout.String())
+	}
+	source := env.Source.(map[string]any)
+	if env.Command != "module rename" || source["operation"] != "module.rename" || source["old_name"] != "OldName" || source["new_name"] != "NewName" || source["requires_push"] != true {
+		t.Fatalf("unexpected module rename payload: command=%q source=%#v", env.Command, source)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "src", "modules", "NewName.bas")); err != nil {
+		t.Fatalf("expected renamed module file: %v", err)
+	}
+}
+
+func TestModuleRemoveCommandReturnsProtectedModuleCode(t *testing.T) {
+	dir := writeCLIModuleMutationProject(t)
+	writeCLIModuleFile(t, dir, "src/workbook/ThisWorkbook.bas", "Option Explicit\n")
+
+	var stdout bytes.Buffer
+	a := &app{cwd: dir, stdout: &stdout, stderr: &bytes.Buffer{}}
+	root := a.rootCommand()
+	root.SetArgs([]string{"--json", "module", "remove", "ThisWorkbook"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected module remove to fail for protected document module")
+	}
+	if output.ExitCode(err) != output.ExitValidation {
+		t.Fatalf("exit code = %d, want %d", output.ExitCode(err), output.ExitValidation)
+	}
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("json output should be valid: %v\n%s", decodeErr, stdout.String())
+	}
+	if env.Error == nil || env.Error.Code != "protected_module" {
+		t.Fatalf("unexpected error: %+v", env.Error)
+	}
+}
+
+func TestModuleRenameCommandReturnsStableValidationCodes(t *testing.T) {
+	dir := writeCLIModuleMutationProject(t)
+	writeCLIModuleFile(t, dir, "src/modules/Existing.bas", `Attribute VB_Name = "Existing"`+"\n")
+	writeCLIModuleFile(t, dir, "src/classes/Collision.cls", `Attribute VB_Name = "Collision"`+"\n")
+
+	tests := []struct {
+		name string
+		args []string
+		code string
+	}{
+		{name: "invalid", args: []string{"--json", "module", "rename", "Existing", "123Bad"}, code: "module_name_invalid"},
+		{name: "missing", args: []string{"--json", "module", "rename", "Missing", "NewName"}, code: "module_not_found"},
+		{name: "duplicate", args: []string{"--json", "module", "rename", "Existing", "Collision"}, code: "module_already_exists"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			a := &app{cwd: dir, stdout: &stdout, stderr: &bytes.Buffer{}}
+			root := a.rootCommand()
+			root.SetArgs(tt.args)
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected command to fail")
+			}
+			if output.ExitCode(err) != output.ExitValidation {
+				t.Fatalf("exit code = %d, want %d", output.ExitCode(err), output.ExitValidation)
+			}
+			var env output.Envelope
+			if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+				t.Fatalf("json output should be valid: %v\n%s", decodeErr, stdout.String())
+			}
+			if env.Error == nil || env.Error.Code != tt.code {
+				t.Fatalf("error code = %+v, want %s", env.Error, tt.code)
+			}
+		})
 	}
 }
 

--- a/internal/project/source_module.go
+++ b/internal/project/source_module.go
@@ -1,0 +1,458 @@
+package project
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+type ModuleRemoveResult struct {
+	Operation    string   `json:"operation"`
+	Module       string   `json:"module"`
+	Kind         string   `json:"kind"`
+	Removed      []string `json:"removed"`
+	RequiresPush bool     `json:"requires_push"`
+}
+
+type ModuleRenameResult struct {
+	Operation    string              `json:"operation"`
+	OldName      string              `json:"old_name"`
+	NewName      string              `json:"new_name"`
+	Kind         string              `json:"kind"`
+	Renamed      []ModuleRenameEntry `json:"renamed"`
+	RequiresPush bool                `json:"requires_push"`
+}
+
+type ModuleRenameEntry struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+var (
+	ErrModuleNotFound      = errors.New("module not found")
+	ErrModuleAmbiguous     = errors.New("module name is ambiguous")
+	ErrProtectedModule     = errors.New("protected module")
+	ErrModuleAlreadyExists = errors.New("module already exists")
+)
+
+type sourceModule struct {
+	Name      string
+	Kind      string
+	Path      string
+	Protected bool
+}
+
+type sourceRoot struct {
+	Path       string
+	Kind       string
+	Exts       map[string]bool
+	Protected  bool
+	SkipSubdir map[string]bool
+}
+
+type renameOp struct {
+	OldPath     string
+	NewPath     string
+	OldContent  []byte
+	NewContent  []byte
+	UpdateBytes bool
+}
+
+func RemoveModule(cwd, name string, src config.SourceConfig) (ModuleRemoveResult, error) {
+	var result ModuleRemoveResult
+	module, err := resolveSourceModule(cwd, src, name)
+	if err != nil {
+		return result, err
+	}
+	if module.Protected {
+		return result, fmt.Errorf("%w: document module %q cannot be removed", ErrProtectedModule, module.Name)
+	}
+	paths, err := moduleArtifactPaths(cwd, src, module)
+	if err != nil {
+		return result, err
+	}
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return result, err
+		}
+		result.Removed = append(result.Removed, filepath.ToSlash(rel(cwd, path)))
+	}
+	result.Operation = "module.remove"
+	result.Module = module.Name
+	result.Kind = module.Kind
+	result.RequiresPush = true
+	return result, nil
+}
+
+func RenameModule(cwd, oldName, newName string, src config.SourceConfig) (ModuleRenameResult, error) {
+	var result ModuleRenameResult
+	module, err := resolveSourceModule(cwd, src, oldName)
+	if err != nil {
+		return result, err
+	}
+	if module.Protected {
+		return result, fmt.Errorf("%w: document module %q cannot be renamed", ErrProtectedModule, module.Name)
+	}
+	cleanNewName, err := cleanComponentName(newName)
+	if err != nil {
+		return result, err
+	}
+	if strings.EqualFold(module.Name, cleanNewName) && module.Name == cleanNewName {
+		return result, fmt.Errorf("%w: module %q already exists", ErrModuleAlreadyExists, cleanNewName)
+	}
+	if err := rejectRenameCollision(cwd, src, module, cleanNewName); err != nil {
+		return result, err
+	}
+	ops, err := moduleRenameOps(cwd, src, module, cleanNewName)
+	if err != nil {
+		return result, err
+	}
+	if err := applyRenameOps(ops); err != nil {
+		return result, err
+	}
+	result.Operation = "module.rename"
+	result.OldName = module.Name
+	result.NewName = cleanNewName
+	result.Kind = module.Kind
+	result.RequiresPush = true
+	for _, op := range ops {
+		result.Renamed = append(result.Renamed, ModuleRenameEntry{
+			From: filepath.ToSlash(rel(cwd, op.OldPath)),
+			To:   filepath.ToSlash(rel(cwd, op.NewPath)),
+		})
+	}
+	return result, nil
+}
+
+func ResolveWorkbookRoot(cwd string, src config.SourceConfig) string {
+	workbookRoot := strings.TrimSpace(src.Workbook)
+	if workbookRoot == "" {
+		workbookRoot = config.Default().Src.Workbook
+	}
+	if !filepath.IsAbs(workbookRoot) {
+		workbookRoot = filepath.Join(cwd, filepath.FromSlash(workbookRoot))
+	}
+	return workbookRoot
+}
+
+func resolveSourceModule(cwd string, src config.SourceConfig, name string) (sourceModule, error) {
+	cleanName, err := cleanComponentName(name)
+	if err != nil {
+		return sourceModule{}, err
+	}
+	var matches []sourceModule
+	for _, root := range sourceRoots(cwd, src) {
+		found, err := modulesUnderRoot(root)
+		if err != nil {
+			return sourceModule{}, err
+		}
+		for _, module := range found {
+			if strings.EqualFold(module.Name, cleanName) {
+				matches = append(matches, module)
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return sourceModule{}, fmt.Errorf("%w: module %q was not found", ErrModuleNotFound, cleanName)
+	}
+	if len(matches) > 1 {
+		return sourceModule{}, fmt.Errorf("%w: module %q matched multiple source files", ErrModuleAmbiguous, cleanName)
+	}
+	return matches[0], nil
+}
+
+func sourceRoots(cwd string, src config.SourceConfig) []sourceRoot {
+	return []sourceRoot{
+		{Path: ResolveModuleRoot(cwd, src), Kind: "standard", Exts: map[string]bool{".bas": true}},
+		{Path: ResolveClassRoot(cwd, src), Kind: "class", Exts: map[string]bool{".cls": true}},
+		{
+			Path:       ResolveFormRoot(cwd, src),
+			Kind:       "form",
+			Exts:       map[string]bool{".frm": true},
+			SkipSubdir: map[string]bool{"code": true, "specs": true},
+		},
+		{
+			Path:      ResolveWorkbookRoot(cwd, src),
+			Kind:      "document",
+			Exts:      map[string]bool{".bas": true, ".cls": true, ".frm": true},
+			Protected: true,
+		},
+	}
+}
+
+func modulesUnderRoot(root sourceRoot) ([]sourceModule, error) {
+	var modules []sourceModule
+	err := filepath.WalkDir(root.Path, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			if !strings.EqualFold(path, root.Path) && root.SkipSubdir[strings.ToLower(d.Name())] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if !root.Exts[ext] {
+			return nil
+		}
+		modules = append(modules, sourceModule{
+			Name:      strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)),
+			Kind:      root.Kind,
+			Path:      path,
+			Protected: root.Protected,
+		})
+		return nil
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return modules, nil
+	}
+	return modules, err
+}
+
+func moduleArtifactPaths(cwd string, src config.SourceConfig, module sourceModule) ([]string, error) {
+	paths := []string{module.Path}
+	if module.Kind != "form" {
+		return paths, nil
+	}
+	formRoot := ResolveFormRoot(cwd, src)
+	for _, path := range []string{
+		filepath.Join(filepath.Dir(module.Path), module.Name+".frx"),
+		filepath.Join(formRoot, "code", module.Name+".bas"),
+		filepath.Join(formRoot, "specs", module.Name+".yaml"),
+		filepath.Join(formRoot, "specs", module.Name+".yml"),
+		filepath.Join(formRoot, "specs", module.Name+".json"),
+	} {
+		if _, err := os.Stat(path); err == nil {
+			paths = append(paths, path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+	return paths, nil
+}
+
+func rejectRenameCollision(cwd string, src config.SourceConfig, module sourceModule, newName string) error {
+	for _, root := range sourceRoots(cwd, src) {
+		found, err := modulesUnderRoot(root)
+		if err != nil {
+			return err
+		}
+		for _, candidate := range found {
+			if samePath(candidate.Path, module.Path) {
+				continue
+			}
+			if strings.EqualFold(candidate.Name, newName) {
+				return fmt.Errorf("%w: module %q already exists at %s", ErrModuleAlreadyExists, newName, candidate.Path)
+			}
+		}
+	}
+	if module.Kind != "form" {
+		return nil
+	}
+	formRoot := ResolveFormRoot(cwd, src)
+	for _, path := range []string{
+		filepath.Join(formRoot, "code", newName+".bas"),
+		filepath.Join(formRoot, "specs", newName+".yaml"),
+		filepath.Join(formRoot, "specs", newName+".yml"),
+		filepath.Join(formRoot, "specs", newName+".json"),
+	} {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("%w: module %q already exists at %s", ErrModuleAlreadyExists, newName, path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func moduleRenameOps(cwd string, src config.SourceConfig, module sourceModule, newName string) ([]renameOp, error) {
+	oldArtifacts, err := moduleArtifactPaths(cwd, src, module)
+	if err != nil {
+		return nil, err
+	}
+	ops := make([]renameOp, 0, len(oldArtifacts))
+	for _, oldPath := range oldArtifacts {
+		newPath := renamedArtifactPath(cwd, src, module, oldPath, newName)
+		op := renameOp{OldPath: oldPath, NewPath: newPath}
+		if !samePath(oldPath, newPath) {
+			if _, err := os.Stat(newPath); err == nil {
+				return nil, fmt.Errorf("%w: module %q already exists at %s", ErrModuleAlreadyExists, newName, newPath)
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return nil, err
+			}
+		}
+		if shouldRewriteArtifact(module, oldPath) {
+			body, err := os.ReadFile(oldPath)
+			if err != nil {
+				return nil, err
+			}
+			rewritten, err := rewriteModuleArtifact(module, oldPath, body, newName)
+			if err != nil {
+				return nil, err
+			}
+			op.OldContent = body
+			op.NewContent = rewritten
+			op.UpdateBytes = true
+		}
+		ops = append(ops, op)
+	}
+	return ops, nil
+}
+
+func renamedArtifactPath(cwd string, src config.SourceConfig, module sourceModule, oldPath string, newName string) string {
+	ext := filepath.Ext(oldPath)
+	if module.Kind == "form" {
+		formRoot := ResolveFormRoot(cwd, src)
+		if samePath(filepath.Dir(oldPath), filepath.Join(formRoot, "code")) {
+			return filepath.Join(formRoot, "code", newName+ext)
+		}
+		if samePath(filepath.Dir(oldPath), filepath.Join(formRoot, "specs")) {
+			return filepath.Join(formRoot, "specs", newName+ext)
+		}
+	}
+	return filepath.Join(filepath.Dir(oldPath), newName+ext)
+}
+
+func shouldRewriteArtifact(module sourceModule, path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch module.Kind {
+	case "standard", "class":
+		return samePath(path, module.Path)
+	case "form":
+		return samePath(path, module.Path) || ext == ".yaml" || ext == ".yml" || ext == ".json"
+	default:
+		return false
+	}
+}
+
+func rewriteModuleArtifact(module sourceModule, path string, body []byte, newName string) ([]byte, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	if module.Kind == "form" && (ext == ".yaml" || ext == ".yml" || ext == ".json") {
+		return rewriteFormSpecName(path, body, newName)
+	}
+	rewritten := rewriteVBNameAttribute(string(body), newName)
+	if module.Kind == "form" {
+		rewritten = rewriteFormBeginName(rewritten, module.Name, newName)
+	}
+	return []byte(rewritten), nil
+}
+
+var vbNameAttributePattern = regexp.MustCompile(`(?im)^Attribute\s+VB_Name\s*=\s*"[^"]*"`)
+
+func rewriteVBNameAttribute(source string, newName string) string {
+	return vbNameAttributePattern.ReplaceAllString(source, fmt.Sprintf("Attribute VB_Name = %q", newName))
+}
+
+func rewriteFormBeginName(source string, oldName string, newName string) string {
+	pattern := regexp.MustCompile(`(?im)^(\s*Begin\s+\S+\s+)` + regexp.QuoteMeta(oldName) + `(\s*)$`)
+	return pattern.ReplaceAllString(source, "${1}"+newName+"${2}")
+}
+
+func rewriteFormSpecName(path string, body []byte, newName string) ([]byte, error) {
+	var spec map[string]any
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".json":
+		if err := json.Unmarshal(body, &spec); err != nil {
+			return nil, err
+		}
+	case ".yaml", ".yml":
+		if err := yaml.Unmarshal(body, &spec); err != nil {
+			return nil, err
+		}
+	default:
+		return body, nil
+	}
+	form, _ := spec["form"].(map[string]any)
+	if form == nil {
+		form = map[string]any{}
+		spec["form"] = form
+	}
+	form["name"] = newName
+	switch ext {
+	case ".json":
+		out, err := json.MarshalIndent(spec, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return append(out, '\n'), nil
+	default:
+		out, err := yaml.Marshal(spec)
+		if err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
+func applyRenameOps(ops []renameOp) error {
+	var applied []renameOp
+	for _, op := range ops {
+		if err := renamePathCaseAware(op.OldPath, op.NewPath); err != nil {
+			rollbackRenameOps(applied)
+			return err
+		}
+		applied = append(applied, op)
+	}
+	for i, op := range applied {
+		if !op.UpdateBytes {
+			continue
+		}
+		if err := os.WriteFile(op.NewPath, op.NewContent, 0o644); err != nil {
+			rollbackContentAndRename(applied[:i+1])
+			return err
+		}
+	}
+	return nil
+}
+
+func renamePathCaseAware(oldPath string, newPath string) error {
+	if !samePath(oldPath, newPath) {
+		return os.Rename(oldPath, newPath)
+	}
+	if oldPath == newPath {
+		return nil
+	}
+	tmp := filepath.Join(filepath.Dir(oldPath), "."+filepath.Base(oldPath)+".xlflow-rename-tmp")
+	if err := os.Rename(oldPath, tmp); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, newPath); err != nil {
+		_ = os.Rename(tmp, oldPath)
+		return err
+	}
+	return nil
+}
+
+func rollbackRenameOps(ops []renameOp) {
+	for i := len(ops) - 1; i >= 0; i-- {
+		_ = os.Rename(ops[i].NewPath, ops[i].OldPath)
+	}
+}
+
+func rollbackContentAndRename(ops []renameOp) {
+	for i := len(ops) - 1; i >= 0; i-- {
+		if ops[i].UpdateBytes {
+			_ = os.WriteFile(ops[i].NewPath, ops[i].OldContent, 0o644)
+		}
+		_ = os.Rename(ops[i].NewPath, ops[i].OldPath)
+	}
+}
+
+func samePath(a string, b string) bool {
+	return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+}

--- a/internal/project/source_module_test.go
+++ b/internal/project/source_module_test.go
@@ -1,0 +1,235 @@
+package project
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRemoveModuleRemovesStandardClassAndFormArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default().Src
+	writeProjectFile(t, dir, "src/modules/InvoiceAggregator.bas", `Attribute VB_Name = "InvoiceAggregator"`+"\n")
+	writeProjectFile(t, dir, "src/classes/InvoiceService.cls", `Attribute VB_Name = "InvoiceService"`+"\n")
+	writeProjectFile(t, dir, "src/forms/CustomerForm.frm", `Begin VB.Form CustomerForm
+Attribute VB_Name = "CustomerForm"
+`)
+	writeProjectFile(t, dir, "src/forms/CustomerForm.frx", "binary")
+	writeProjectFile(t, dir, "src/forms/code/CustomerForm.bas", "Option Explicit\n")
+	writeProjectFile(t, dir, "src/forms/specs/CustomerForm.yaml", "form:\n  name: CustomerForm\n")
+
+	standard, err := RemoveModule(dir, "InvoiceAggregator", cfg)
+	if err != nil {
+		t.Fatalf("RemoveModule standard error = %v", err)
+	}
+	if standard.Kind != "standard" || !containsString(standard.Removed, "src/modules/InvoiceAggregator.bas") || !standard.RequiresPush {
+		t.Fatalf("unexpected standard result: %+v", standard)
+	}
+	if pathExists(filepath.Join(dir, "src", "modules", "InvoiceAggregator.bas")) {
+		t.Fatal("standard module should be removed")
+	}
+
+	class, err := RemoveModule(dir, "InvoiceService", cfg)
+	if err != nil {
+		t.Fatalf("RemoveModule class error = %v", err)
+	}
+	if class.Kind != "class" || !containsString(class.Removed, "src/classes/InvoiceService.cls") {
+		t.Fatalf("unexpected class result: %+v", class)
+	}
+
+	form, err := RemoveModule(dir, "CustomerForm", cfg)
+	if err != nil {
+		t.Fatalf("RemoveModule form error = %v", err)
+	}
+	for _, want := range []string{
+		"src/forms/CustomerForm.frm",
+		"src/forms/CustomerForm.frx",
+		"src/forms/code/CustomerForm.bas",
+		"src/forms/specs/CustomerForm.yaml",
+	} {
+		if !containsString(form.Removed, want) {
+			t.Fatalf("expected removed %s in %+v", want, form)
+		}
+		if pathExists(filepath.Join(dir, filepath.FromSlash(want))) {
+			t.Fatalf("%s should be removed", want)
+		}
+	}
+}
+
+func TestRenameModuleUpdatesStandardAndClassVBName(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default().Src
+	writeProjectFile(t, dir, "src/modules/OldStandard.bas", `Attribute VB_Name = "OldStandard"
+Option Explicit
+`)
+	writeProjectFile(t, dir, "src/classes/OldClass.cls", `VERSION 1.0 CLASS
+BEGIN
+END
+Attribute VB_Name = "OldClass"
+Option Explicit
+`)
+
+	standard, err := RenameModule(dir, "OldStandard", "NewStandard", cfg)
+	if err != nil {
+		t.Fatalf("RenameModule standard error = %v", err)
+	}
+	if standard.Kind != "standard" || standard.OldName != "OldStandard" || standard.NewName != "NewStandard" || !standard.RequiresPush {
+		t.Fatalf("unexpected standard result: %+v", standard)
+	}
+	assertFileContains(t, filepath.Join(dir, "src", "modules", "NewStandard.bas"), `Attribute VB_Name = "NewStandard"`)
+	if pathExists(filepath.Join(dir, "src", "modules", "OldStandard.bas")) {
+		t.Fatal("old standard path should be gone")
+	}
+
+	class, err := RenameModule(dir, "OldClass", "NewClass", cfg)
+	if err != nil {
+		t.Fatalf("RenameModule class error = %v", err)
+	}
+	if class.Kind != "class" {
+		t.Fatalf("unexpected class result: %+v", class)
+	}
+	assertFileContains(t, filepath.Join(dir, "src", "classes", "NewClass.cls"), `Attribute VB_Name = "NewClass"`)
+}
+
+func TestRenameModuleUpdatesFormArtifactsAndSpecName(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default().Src
+	writeProjectFile(t, dir, "src/forms/CustomerForm.frm", `VERSION 5.00
+Begin VB.Form CustomerForm
+   Caption = "Keep Caption"
+End
+Attribute VB_Name = "CustomerForm"
+Option Explicit
+`)
+	writeProjectFile(t, dir, "src/forms/CustomerForm.frx", "binary")
+	writeProjectFile(t, dir, "src/forms/code/CustomerForm.bas", "Option Explicit\nPrivate Sub UserForm_Initialize()\nEnd Sub\n")
+	writeProjectFile(t, dir, "src/forms/specs/CustomerForm.yaml", `schemaVersion: 1
+kind: xlflow.userform
+form:
+  name: CustomerForm
+  caption: Keep Caption
+controls:
+  - name: txtName
+    type: TextBox
+`)
+
+	result, err := RenameModule(dir, "CustomerForm", "RegistrationForm", cfg)
+	if err != nil {
+		t.Fatalf("RenameModule form error = %v", err)
+	}
+	if result.Kind != "form" || len(result.Renamed) != 4 {
+		t.Fatalf("unexpected form result: %+v", result)
+	}
+	frmPath := filepath.Join(dir, "src", "forms", "RegistrationForm.frm")
+	assertFileContains(t, frmPath, "Begin VB.Form RegistrationForm")
+	assertFileContains(t, frmPath, `Attribute VB_Name = "RegistrationForm"`)
+	assertFileContains(t, filepath.Join(dir, "src", "forms", "code", "RegistrationForm.bas"), "UserForm_Initialize")
+	if !pathExists(filepath.Join(dir, "src", "forms", "RegistrationForm.frx")) {
+		t.Fatal("renamed .frx should exist")
+	}
+	specBody, err := os.ReadFile(filepath.Join(dir, "src", "forms", "specs", "RegistrationForm.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var spec map[string]any
+	if err := yaml.Unmarshal(specBody, &spec); err != nil {
+		t.Fatal(err)
+	}
+	form := spec["form"].(map[string]any)
+	if form["name"] != "RegistrationForm" || form["caption"] != "Keep Caption" {
+		t.Fatalf("unexpected spec form: %+v", form)
+	}
+}
+
+func TestRenameModuleUpdatesJSONFormSpecName(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default().Src
+	writeProjectFile(t, dir, "src/forms/UserForm1.frm", `Begin VB.Form UserForm1
+Attribute VB_Name = "UserForm1"
+`)
+	writeProjectFile(t, dir, "src/forms/specs/UserForm1.json", `{"form":{"name":"UserForm1","caption":"Keep"},"controls":[{"name":"txtName"}]}`)
+
+	if _, err := RenameModule(dir, "UserForm1", "OrderForm", cfg); err != nil {
+		t.Fatalf("RenameModule error = %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "src", "forms", "specs", "OrderForm.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(body, &spec); err != nil {
+		t.Fatal(err)
+	}
+	form := spec["form"].(map[string]any)
+	if form["name"] != "OrderForm" || form["caption"] != "Keep" {
+		t.Fatalf("unexpected JSON spec form: %+v", form)
+	}
+}
+
+func TestModuleMutationsRejectProtectedDocumentModules(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default().Src
+	writeProjectFile(t, dir, "src/workbook/ThisWorkbook.bas", "Option Explicit\n")
+
+	if _, err := RemoveModule(dir, "ThisWorkbook", cfg); !errors.Is(err, ErrProtectedModule) {
+		t.Fatalf("RemoveModule protected error = %v, want ErrProtectedModule", err)
+	}
+	if _, err := RenameModule(dir, "ThisWorkbook", "BookHost", cfg); !errors.Is(err, ErrProtectedModule) {
+		t.Fatalf("RenameModule protected error = %v, want ErrProtectedModule", err)
+	}
+}
+
+func TestModuleMutationsRejectInvalidMissingDuplicateAndAmbiguousNames(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default().Src
+	writeProjectFile(t, dir, "src/modules/Existing.bas", `Attribute VB_Name = "Existing"`+"\n")
+	writeProjectFile(t, dir, "src/classes/Collision.cls", `Attribute VB_Name = "Collision"`+"\n")
+	writeProjectFile(t, dir, "src/modules/Ambiguous.bas", `Attribute VB_Name = "Ambiguous"`+"\n")
+	writeProjectFile(t, dir, "src/classes/Ambiguous.cls", `Attribute VB_Name = "Ambiguous"`+"\n")
+
+	if _, err := RemoveModule(dir, "Missing", cfg); !errors.Is(err, ErrModuleNotFound) {
+		t.Fatalf("RemoveModule missing error = %v, want ErrModuleNotFound", err)
+	}
+	if _, err := RenameModule(dir, "Existing", "123Bad", cfg); !errors.Is(err, ErrInvalidComponentName) {
+		t.Fatalf("RenameModule invalid error = %v, want ErrInvalidComponentName", err)
+	}
+	if _, err := RenameModule(dir, "Existing", "Collision", cfg); !errors.Is(err, ErrModuleAlreadyExists) {
+		t.Fatalf("RenameModule collision error = %v, want ErrModuleAlreadyExists", err)
+	}
+	if _, err := RemoveModule(dir, "Ambiguous", cfg); !errors.Is(err, ErrModuleAmbiguous) {
+		t.Fatalf("RemoveModule ambiguous error = %v, want ErrModuleAmbiguous", err)
+	}
+}
+
+func writeProjectFile(t *testing.T, root string, relPath string, body string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFileContains(t *testing.T, path string, want string) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), want) {
+		t.Fatalf("%s missing %q:\n%s", path, want, string(body))
+	}
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/vitepress/commands/module.md
+++ b/vitepress/commands/module.md
@@ -1,29 +1,35 @@
 # xlflow module
 
-Create VBA module source files or install bundled xlflow helper modules into an existing project.
+Create, remove, rename, or install VBA module source files in an existing project.
 
 ## Usage
 
 ```bash
 xlflow module new <name> --type standard
 xlflow module new <name> --type class
+xlflow module remove <module-name>
+xlflow module rename <old-name> <new-name>
 xlflow module install [--push]
 ```
 
 ## Options and Arguments
 
-| Option / argument | Description                                                                                | Default  |
-| ----------------- | ------------------------------------------------------------------------------------------ | -------- |
-| `new <name>`      | Create a new standard or class module source file.                                         | -        |
-| `--type`          | Required for `new`; must be `standard` or `class`.                                         | required |
-| `install`         | Install the bundled helper modules into the configured module source root.                 | required |
-| `--push`          | Push the installed helper modules into the configured workbook after writing source files. | false    |
+| Option / argument              | Description                                                                                | Default  |
+| ------------------------------ | ------------------------------------------------------------------------------------------ | -------- |
+| `new <name>`                   | Create a new standard or class module source file.                                         | -        |
+| `--type`                       | Required for `new`; must be `standard` or `class`.                                         | required |
+| `remove <module-name>`         | Remove a standard, class, or UserForm source module from the project.                      | -        |
+| `rename <old-name> <new-name>` | Rename a standard, class, or UserForm source module in the project.                        | -        |
+| `install`                      | Install the bundled helper modules into the configured module source root.                 | required |
+| `--push`                       | Push the installed helper modules into the configured workbook after writing source files. | false    |
 
 ## Examples
 
 ```bash
 xlflow module new InvoiceProcessor --type standard
 xlflow module new InvoiceService --type class --json
+xlflow module remove InvoiceAggregator
+xlflow module rename OldInvoiceService InvoiceService --json
 xlflow module install
 xlflow module install --push --json
 ```
@@ -42,6 +48,18 @@ xlflow module install --push --json
 `module new` and `module install` refuse to overwrite existing source files. Remove or rename colliding files before retrying.
 :::
 
+::: warning
+`module remove` and `module rename` change source files only. Run `xlflow push` afterward to apply the change to the workbook.
+:::
+
+::: tip
+UserForm remove/rename handles related source artifacts together: `.frm`, `.frx`, `src/forms/code/<Name>.bas`, and `src/forms/specs/<Name>.yaml|yml|json` when present.
+:::
+
+::: warning
+Workbook document modules such as `ThisWorkbook` and sheet modules are protected from `module remove` and `module rename`.
+:::
+
 ## JSON Output Example
 
 Successful `--json` output uses the xlflow envelope plus command-specific fields.
@@ -55,6 +73,40 @@ Successful `--json` output uses the xlflow envelope plus command-specific fields
     "kind": "standard",
     "name": "InvoiceProcessor",
     "path": "src/modules/InvoiceProcessor.bas"
+  }
+}
+```
+
+```json
+{
+  "status": "ok",
+  "command": "module remove",
+  "source": {
+    "operation": "module.remove",
+    "module": "InvoiceAggregator",
+    "kind": "standard",
+    "removed": ["src/modules/InvoiceAggregator.bas"],
+    "requires_push": true
+  }
+}
+```
+
+```json
+{
+  "status": "ok",
+  "command": "module rename",
+  "source": {
+    "operation": "module.rename",
+    "old_name": "OldInvoiceService",
+    "new_name": "InvoiceService",
+    "kind": "class",
+    "renamed": [
+      {
+        "from": "src/classes/OldInvoiceService.cls",
+        "to": "src/classes/InvoiceService.cls"
+      }
+    ],
+    "requires_push": true
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Implement safety-enhanced `remove` and `rename` commands for both `source` and `module` functionalities
- Update CLI contract specifications in `docs/specs/cli-contract.md` and refresh user documentation accordingly
- Add functionality for operating on source modules within `internal/project` along with corresponding test cases to verify its behavior
- Document all changes in `CHANGELOG.md`

## Testing
- Verify implementation behavior through existing CLI tests and unit tests in `internal/project`
- Ensure consistency between documentation and contract specifications