### PR TITLE
Add VS Code tree view context menu actions for xlflow modules

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,7 @@ tasks:
     cmds:
       - golangci-lint run
       - task ps-lint
+      - pnpm lint
 
   test:
     cmds:

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added CodeLens and save-before-run settings forwarded to `xlflow lsp --stdio` at startup.
 - Added command palette actions for `xlflow skill install` and `xlflow module install`.
 - Added Modules TreeView context menu actions for opening, renaming, deleting, revealing, copying, and running module/procedure items.
+- Added UserForms TreeView context menu actions for opening, renaming, deleting, revealing, and copying UserForm source artifacts.
 
 ## 0.1.0
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added CodeLens commands for running no-argument VBA procedures and tests through `xlflow.runProcedure` and `xlflow.runTestProcedure`.
 - Added CodeLens and save-before-run settings forwarded to `xlflow lsp --stdio` at startup.
 - Added command palette actions for `xlflow skill install` and `xlflow module install`.
+- Added Modules TreeView context menu actions for opening, renaming, deleting, revealing, copying, and running module/procedure items.
 
 ## 0.1.0
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -29,7 +29,11 @@ When `xlflow.toml` exists, the sidebar switches to project mode:
 
 Project view title actions refresh state, pull workbook source, push source changes, and start or stop the managed session. `Push Sources` asks for confirmation before running.
 
-Modules view title actions can create standard or class modules through `xlflow module new`, then refresh discovered symbols. UserForms view title actions can create sidecar UserForm source through `xlflow form new`, then refresh discovered form artifacts.
+Modules view title actions can create standard or class modules through `xlflow module new`, then refresh discovered symbols. Module item context menus can open, rename, delete, reveal, and copy source details for standard and class modules. Document modules can be opened, revealed, and copied, but destructive actions are hidden. Rename and delete delegate to `xlflow module rename` and `xlflow module remove`; the extension does not delete or rename source files directly.
+
+Procedure item context menus can open runnable procedures, run no-argument procedures through `xlflow run <ModuleName.ProcedureName>`, and copy procedure or qualified names.
+
+UserForms view title actions can create sidecar UserForm source through `xlflow form new`, then refresh discovered form artifacts. UserForms are managed in the UserForms view, not the Modules view.
 
 `UserForms` follows `[userform].code_source` from `xlflow.toml`. In `sidecar` mode it groups each form with its `src/forms/code/<FormName>.bas` code-behind file and `src/forms/specs/<FormName>.yaml` designer spec. In `frm` mode it shows the `.frm` file only. Binary `.frx` companion files are intentionally hidden.
 
@@ -107,14 +111,21 @@ The command palette includes:
 - `xlflow: Run Doctor`
 - `xlflow: Toggle Session`
 - `xlflow: Open Documentation`
+- `xlflow: Rename Module`
+- `xlflow: Delete Module`
+- `xlflow: Reveal Source File`
+- `xlflow: Copy Module Name`
+- `xlflow: Copy Relative Path`
+- `xlflow: Copy Procedure Name`
+- `xlflow: Copy Qualified Name`
 
-Workbook commands run from the resolved workspace folder. `New Project` runs `xlflow new`, `Initialize Project` runs `xlflow init <workbook>`, `Install Agent Skill` runs `xlflow skill install --agent <provider>`, `Install Helper Modules` runs `xlflow module install` or `xlflow module install --push`, `New Module` runs `xlflow module new <name> --type standard|class`, `New UserForm` runs `xlflow form new <name>`, `Pull Workbook` runs `xlflow pull`, `Push Sources` runs `xlflow push`, `Run Macro` runs `xlflow run`, `Run Tests` runs `xlflow test`, `Lint Workspace` runs `xlflow lint`, `Format Project` runs `xlflow fmt --write`, and `Save Workbook` runs `xlflow save`.
+Workbook commands run from the resolved workspace folder. `New Project` runs `xlflow new`, `Initialize Project` runs `xlflow init <workbook>`, `Install Agent Skill` runs `xlflow skill install --agent <provider>`, `Install Helper Modules` runs `xlflow module install` or `xlflow module install --push`, `New Module` runs `xlflow module new <name> --type standard|class`, `Rename Module` runs `xlflow --json module rename <old> <new>`, `Delete Module` runs `xlflow --json module remove <name>`, `New UserForm` runs `xlflow form new <name>`, `Pull Workbook` runs `xlflow pull`, `Push Sources` runs `xlflow push`, `Run Macro` runs `xlflow run`, `Run Tests` runs `xlflow test`, `Lint Workspace` runs `xlflow lint`, `Format Project` runs `xlflow fmt --write`, and `Save Workbook` runs `xlflow save`.
 
 `Install Agent Skill` prompts for one of the bundled provider targets: `codex`, `claude`, `cursor`, `gemini`, or `agents`. It also asks whether to pass `--force` before replacing an existing skill installation. `Install Helper Modules` prompts before using `--push` because that mode imports the helper modules into the configured workbook.
 
 `New UserForm` delegates sidecar validation to the CLI. It works for projects with `[userform].code_source = "sidecar"`; `frm` mode projects should use the existing snapshot/build workflow or migrate intentionally.
 
-The language server supplies CodeLens actions for no-argument VBA `Sub` procedures. `$(play) Run` invokes `xlflow run <qualifiedName>`, and `$(beaker) Run Test` invokes `xlflow --json test --module <moduleName> --filter <name>`. VS Code renders the `$(...)` prefixes as codicons. Dirty VBA documents are saved first when `xlflow.run.saveBeforeRun` is enabled.
+The language server supplies CodeLens actions for no-argument VBA `Sub` procedures. `$(play) Run` invokes `xlflow run <qualifiedName>`, and `$(beaker) Run Test` invokes `xlflow --json test --module <moduleName> --filter <name>`. The Modules TreeView uses the same run commands for procedure items. VS Code renders the `$(...)` prefixes as codicons. Dirty VBA documents are saved first when `xlflow.run.saveBeforeRun` is enabled.
 
 `Format Document` invokes VS Code document formatting for the active editor. For VBA files, formatting is provided by `xlflow lsp --stdio`.
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -33,7 +33,7 @@ Modules view title actions can create standard or class modules through `xlflow 
 
 Procedure item context menus can open runnable procedures, run no-argument procedures through `xlflow run <ModuleName.ProcedureName>`, and copy procedure or qualified names.
 
-UserForms view title actions can create sidecar UserForm source through `xlflow form new`, then refresh discovered form artifacts. UserForms are managed in the UserForms view, not the Modules view.
+UserForms view title actions can create sidecar UserForm source through `xlflow form new`, then refresh discovered form artifacts. UserForm item context menus can open the primary source artifact, rename, delete, reveal, and copy source details. Rename and delete delegate to `xlflow module rename` and `xlflow module remove` because UserForms may include `.frm`, `.frx`, sidecar code, and designer spec artifacts. Artifact item context menus can open, reveal, and copy paths for existing artifacts; missing artifacts do not expose file actions.
 
 `UserForms` follows `[userform].code_source` from `xlflow.toml`. In `sidecar` mode it groups each form with its `src/forms/code/<FormName>.bas` code-behind file and `src/forms/specs/<FormName>.yaml` designer spec. In `frm` mode it shows the `.frm` file only. Binary `.frx` companion files are intentionally hidden.
 
@@ -118,8 +118,13 @@ The command palette includes:
 - `xlflow: Copy Relative Path`
 - `xlflow: Copy Procedure Name`
 - `xlflow: Copy Qualified Name`
+- `xlflow: Rename UserForm`
+- `xlflow: Delete UserForm`
+- `xlflow: Reveal UserForm Source`
+- `xlflow: Copy UserForm Name`
+- `xlflow: Copy UserForm Relative Path`
 
-Workbook commands run from the resolved workspace folder. `New Project` runs `xlflow new`, `Initialize Project` runs `xlflow init <workbook>`, `Install Agent Skill` runs `xlflow skill install --agent <provider>`, `Install Helper Modules` runs `xlflow module install` or `xlflow module install --push`, `New Module` runs `xlflow module new <name> --type standard|class`, `Rename Module` runs `xlflow --json module rename <old> <new>`, `Delete Module` runs `xlflow --json module remove <name>`, `New UserForm` runs `xlflow form new <name>`, `Pull Workbook` runs `xlflow pull`, `Push Sources` runs `xlflow push`, `Run Macro` runs `xlflow run`, `Run Tests` runs `xlflow test`, `Lint Workspace` runs `xlflow lint`, `Format Project` runs `xlflow fmt --write`, and `Save Workbook` runs `xlflow save`.
+Workbook commands run from the resolved workspace folder. `New Project` runs `xlflow new`, `Initialize Project` runs `xlflow init <workbook>`, `Install Agent Skill` runs `xlflow skill install --agent <provider>`, `Install Helper Modules` runs `xlflow module install` or `xlflow module install --push`, `New Module` runs `xlflow module new <name> --type standard|class`, `Rename Module` and `Rename UserForm` run `xlflow --json module rename <old> <new>`, `Delete Module` and `Delete UserForm` run `xlflow --json module remove <name>`, `New UserForm` runs `xlflow form new <name>`, `Pull Workbook` runs `xlflow pull`, `Push Sources` runs `xlflow push`, `Run Macro` runs `xlflow run`, `Run Tests` runs `xlflow test`, `Lint Workspace` runs `xlflow lint`, `Format Project` runs `xlflow fmt --write`, and `Save Workbook` runs `xlflow save`.
 
 `Install Agent Skill` prompts for one of the bundled provider targets: `codex`, `claude`, `cursor`, `gemini`, or `agents`. It also asks whether to pass `--force` before replacing an existing skill installation. `Install Helper Modules` prompts before using `--push` because that mode imports the helper modules into the configured workbook.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -416,6 +416,31 @@
         "command": "xlflow.openUserFormArtifact",
         "title": "xlflow: Open UserForm Artifact",
         "category": "xlflow"
+      },
+      {
+        "command": "xlflow.renameUserForm",
+        "title": "xlflow: Rename UserForm",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.deleteUserForm",
+        "title": "xlflow: Delete UserForm",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.revealUserFormSource",
+        "title": "xlflow: Reveal UserForm Source",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.copyUserFormName",
+        "title": "xlflow: Copy UserForm Name",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.copyUserFormRelativePath",
+        "title": "xlflow: Copy UserForm Relative Path",
+        "category": "xlflow"
       }
     ],
     "menus": {
@@ -574,6 +599,46 @@
           "command": "xlflow.copyQualifiedName",
           "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.(procedure|testProcedure|procedureStatic)$/",
           "group": "4_copy@2"
+        },
+        {
+          "command": "xlflow.renameUserForm",
+          "when": "view == xlflow.userForms && viewItem =~ /^xlflow\\.userForm\\./",
+          "group": "2_workspace@1"
+        },
+        {
+          "command": "xlflow.deleteUserForm",
+          "when": "view == xlflow.userForms && viewItem =~ /^xlflow\\.userForm\\./",
+          "group": "2_workspace@2"
+        },
+        {
+          "command": "xlflow.revealUserFormSource",
+          "when": "view == xlflow.userForms && viewItem =~ /^xlflow\\.userForm\\./",
+          "group": "3_file@1"
+        },
+        {
+          "command": "xlflow.copyUserFormName",
+          "when": "view == xlflow.userForms && viewItem =~ /^xlflow\\.userForm\\./",
+          "group": "4_copy@1"
+        },
+        {
+          "command": "xlflow.copyUserFormRelativePath",
+          "when": "view == xlflow.userForms && viewItem =~ /^xlflow\\.userForm\\./",
+          "group": "4_copy@2"
+        },
+        {
+          "command": "xlflow.openUserFormArtifact",
+          "when": "view == xlflow.userForms && viewItem =~ /^xlflow\\.userFormArtifact\\./",
+          "group": "navigation@1"
+        },
+        {
+          "command": "xlflow.revealUserFormSource",
+          "when": "view == xlflow.userForms && viewItem =~ /^xlflow\\.userFormArtifact\\./",
+          "group": "3_file@1"
+        },
+        {
+          "command": "xlflow.copyUserFormRelativePath",
+          "when": "view == xlflow.userForms && viewItem =~ /^xlflow\\.userFormArtifact\\./",
+          "group": "4_copy@1"
         }
       ]
     },
@@ -677,7 +742,10 @@
     "onCommand:xlflow.copyProcedureName",
     "onCommand:xlflow.copyQualifiedName",
     "onCommand:xlflow.copyRelativePath",
+    "onCommand:xlflow.copyUserFormName",
+    "onCommand:xlflow.copyUserFormRelativePath",
     "onCommand:xlflow.deleteModule",
+    "onCommand:xlflow.deleteUserForm",
     "onCommand:xlflow.formatDocument",
     "onCommand:xlflow.formatProject",
     "onCommand:xlflow.initProject",
@@ -700,8 +768,10 @@
     "onCommand:xlflow.refreshTests",
     "onCommand:xlflow.refreshUserForms",
     "onCommand:xlflow.renameModule",
+    "onCommand:xlflow.renameUserForm",
     "onCommand:xlflow.restartLanguageServer",
     "onCommand:xlflow.revealSourceFile",
+    "onCommand:xlflow.revealUserFormSource",
     "onCommand:xlflow.runAllTests",
     "onCommand:xlflow.runDoctor",
     "onCommand:xlflow.runMacro",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -373,6 +373,41 @@
         "category": "xlflow"
       },
       {
+        "command": "xlflow.renameModule",
+        "title": "xlflow: Rename Module",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.deleteModule",
+        "title": "xlflow: Delete Module",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.revealSourceFile",
+        "title": "xlflow: Reveal Source File",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.copyModuleName",
+        "title": "xlflow: Copy Module Name",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.copyRelativePath",
+        "title": "xlflow: Copy Relative Path",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.copyProcedureName",
+        "title": "xlflow: Copy Procedure Name",
+        "category": "xlflow"
+      },
+      {
+        "command": "xlflow.copyQualifiedName",
+        "title": "xlflow: Copy Qualified Name",
+        "category": "xlflow"
+      },
+      {
         "command": "xlflow.openProcedure",
         "title": "xlflow: Open Procedure",
         "category": "xlflow"
@@ -471,6 +506,36 @@
       ],
       "view/item/context": [
         {
+          "command": "xlflow.openModule",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.module\\.(standard|class|document)$/",
+          "group": "navigation@1"
+        },
+        {
+          "command": "xlflow.renameModule",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.module\\.(standard|class)$/",
+          "group": "2_workspace@1"
+        },
+        {
+          "command": "xlflow.deleteModule",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.module\\.(standard|class)$/",
+          "group": "2_workspace@2"
+        },
+        {
+          "command": "xlflow.revealSourceFile",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.module\\.(standard|class|document)$/",
+          "group": "3_file@1"
+        },
+        {
+          "command": "xlflow.copyModuleName",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.module\\.(standard|class|document)$/",
+          "group": "4_copy@1"
+        },
+        {
+          "command": "xlflow.copyRelativePath",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.module\\.(standard|class|document)$/",
+          "group": "4_copy@2"
+        },
+        {
           "command": "xlflow.runProcedure",
           "when": "view == xlflow.modules && viewItem == xlflow.procedure",
           "group": "inline@1"
@@ -484,6 +549,31 @@
           "command": "xlflow.runTestProcedure",
           "when": "view == xlflow.tests && viewItem == xlflow.testWithSource",
           "group": "inline@1"
+        },
+        {
+          "command": "xlflow.openProcedure",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.(procedure|testProcedure|procedureStatic)$/",
+          "group": "navigation@1"
+        },
+        {
+          "command": "xlflow.runProcedure",
+          "when": "view == xlflow.modules && viewItem == xlflow.procedure",
+          "group": "2_run@1"
+        },
+        {
+          "command": "xlflow.runTestProcedure",
+          "when": "view == xlflow.modules && viewItem == xlflow.testProcedure",
+          "group": "2_run@1"
+        },
+        {
+          "command": "xlflow.copyProcedureName",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.(procedure|testProcedure|procedureStatic)$/",
+          "group": "4_copy@1"
+        },
+        {
+          "command": "xlflow.copyQualifiedName",
+          "when": "view == xlflow.modules && viewItem =~ /^xlflow\\.(procedure|testProcedure|procedureStatic)$/",
+          "group": "4_copy@2"
         }
       ]
     },
@@ -583,6 +673,11 @@
     "onCommand:xlflow.checkEnvironment",
     "onCommand:xlflow.collapseModules",
     "onCommand:xlflow.collapseUserForms",
+    "onCommand:xlflow.copyModuleName",
+    "onCommand:xlflow.copyProcedureName",
+    "onCommand:xlflow.copyQualifiedName",
+    "onCommand:xlflow.copyRelativePath",
+    "onCommand:xlflow.deleteModule",
     "onCommand:xlflow.formatDocument",
     "onCommand:xlflow.formatProject",
     "onCommand:xlflow.initProject",
@@ -604,7 +699,9 @@
     "onCommand:xlflow.refreshProject",
     "onCommand:xlflow.refreshTests",
     "onCommand:xlflow.refreshUserForms",
+    "onCommand:xlflow.renameModule",
     "onCommand:xlflow.restartLanguageServer",
+    "onCommand:xlflow.revealSourceFile",
     "onCommand:xlflow.runAllTests",
     "onCommand:xlflow.runDoctor",
     "onCommand:xlflow.runMacro",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -31,7 +31,8 @@
     "check": "tsc -p ./ --noEmit",
     "bundle": "node esbuild.js",
     "package": "vsce package --no-dependencies",
-    "test": "pnpm run compile && node ./dist/test/runTest.js"
+    "test": "pnpm run compile && node ./dist/test/runTest.js",
+    "lint": "oxlint ."
   },
   "dependencies": {
     "vscode-languageclient": "^10.0.0"
@@ -42,6 +43,7 @@
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.1",
+    "oxlint": "^1.71.0",
     "typescript": "^5.9.0"
   },
   "contributes": {

--- a/editors/vscode/pnpm-lock.yaml
+++ b/editors/vscode/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
+      oxlint:
+        specifier: ^1.71.0
+        version: 1.71.0
       typescript:
         specifier: ^5.9.0
         version: 5.9.3
@@ -258,6 +261,128 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxlint/binding-android-arm-eabi@1.71.0':
+    resolution: {integrity: sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.71.0':
+    resolution: {integrity: sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.71.0':
+    resolution: {integrity: sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.71.0':
+    resolution: {integrity: sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.71.0':
+    resolution: {integrity: sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.71.0':
+    resolution: {integrity: sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.71.0':
+    resolution: {integrity: sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.71.0':
+    resolution: {integrity: sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.71.0':
+    resolution: {integrity: sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.71.0':
+    resolution: {integrity: sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.71.0':
+    resolution: {integrity: sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.71.0':
+    resolution: {integrity: sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.71.0':
+    resolution: {integrity: sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.71.0':
+    resolution: {integrity: sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.71.0':
+    resolution: {integrity: sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.71.0':
+    resolution: {integrity: sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.71.0':
+    resolution: {integrity: sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.71.0':
+    resolution: {integrity: sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.71.0':
+    resolution: {integrity: sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@secretlint/config-creator@10.2.2':
     resolution: {integrity: sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==}
@@ -1012,6 +1137,19 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  oxlint@1.71.0:
+    resolution: {integrity: sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
@@ -1569,6 +1707,63 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oxlint/binding-android-arm-eabi@1.71.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.71.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.71.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.71.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.71.0':
+    optional: true
 
   '@secretlint/config-creator@10.2.2':
     dependencies:
@@ -2432,6 +2627,28 @@ snapshots:
       stdin-discarder: 0.2.2
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  oxlint@1.71.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.71.0
+      '@oxlint/binding-android-arm64': 1.71.0
+      '@oxlint/binding-darwin-arm64': 1.71.0
+      '@oxlint/binding-darwin-x64': 1.71.0
+      '@oxlint/binding-freebsd-x64': 1.71.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.71.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.71.0
+      '@oxlint/binding-linux-arm64-gnu': 1.71.0
+      '@oxlint/binding-linux-arm64-musl': 1.71.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.71.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.71.0
+      '@oxlint/binding-linux-riscv64-musl': 1.71.0
+      '@oxlint/binding-linux-s390x-gnu': 1.71.0
+      '@oxlint/binding-linux-x64-gnu': 1.71.0
+      '@oxlint/binding-linux-x64-musl': 1.71.0
+      '@oxlint/binding-openharmony-arm64': 1.71.0
+      '@oxlint/binding-win32-arm64-msvc': 1.71.0
+      '@oxlint/binding-win32-ia32-msvc': 1.71.0
+      '@oxlint/binding-win32-x64-msvc': 1.71.0
 
   p-map@7.0.4: {}
 

--- a/editors/vscode/src/commands.ts
+++ b/editors/vscode/src/commands.ts
@@ -290,7 +290,7 @@ export function registerCommands(
       await deleteUserForm(value, channels, hooks);
     }),
     vscode.commands.registerCommand("xlflow.revealUserFormSource", async (value: unknown) => {
-      const uri = treeUri(value);
+      const uri = userFormSourceUri(value);
       if (uri !== undefined) {
         await vscode.commands.executeCommand("revealInExplorer", uri);
       }
@@ -299,7 +299,10 @@ export function registerCommands(
       await copyText("UserForm name", treeName(value));
     }),
     vscode.commands.registerCommand("xlflow.copyUserFormRelativePath", async (value: unknown) => {
-      await copyText("Relative path", treeRelativePath(value) ?? relativePathFromTreeUri(value));
+      await copyText(
+        "Relative path",
+        userFormRelativePath(value) ?? relativePathFromUri(userFormSourceUri(value)),
+      );
     }),
     vscode.commands.registerCommand("xlflow.openProcedure", async (value: unknown) => {
       const uri = treeUri(value);
@@ -514,7 +517,7 @@ async function renameUserForm(
   hooks: CommandRefreshHooks,
 ): Promise<void> {
   const name = treeName(value);
-  const uri = treeUri(value);
+  const uri = userFormSourceUri(value);
   if (name === undefined) {
     vscode.window.showWarningMessage("xlflow rename UserForm received invalid UserForm arguments.");
     return;
@@ -524,10 +527,7 @@ async function renameUserForm(
     return;
   }
 
-  const workspaceFolder =
-    uri === undefined
-      ? await resolveWorkspaceRoot({ prompt: true, fallbackToFirst: true })
-      : await workspaceFolderForUri(uri);
+  const workspaceFolder = await workspaceFolderForUserForm(value, uri);
   const wasOpen =
     uri !== undefined &&
     vscode.workspace.textDocuments.some((document) => document.uri.toString() === uri.toString());
@@ -557,7 +557,7 @@ async function deleteUserForm(
   hooks: CommandRefreshHooks,
 ): Promise<void> {
   const name = treeName(value);
-  const uri = treeUri(value);
+  const uri = userFormSourceUri(value);
   if (name === undefined) {
     vscode.window.showWarningMessage("xlflow delete UserForm received invalid UserForm arguments.");
     return;
@@ -572,10 +572,7 @@ async function deleteUserForm(
     return;
   }
 
-  const workspaceFolder =
-    uri === undefined
-      ? await resolveWorkspaceRoot({ prompt: true, fallbackToFirst: true })
-      : await workspaceFolderForUri(uri);
+  const workspaceFolder = await workspaceFolderForUserForm(value, uri);
   const result = await runModuleMutation(
     ["remove", name],
     `xlflow module remove ${name}`,
@@ -834,6 +831,23 @@ async function workspaceFolderForUri(uri: vscode.Uri): Promise<vscode.WorkspaceF
   );
 }
 
+async function workspaceFolderForUserForm(
+  value: unknown,
+  sourceUri: vscode.Uri | undefined,
+): Promise<vscode.WorkspaceFolder | undefined> {
+  if (sourceUri !== undefined) {
+    return workspaceFolderForUri(sourceUri);
+  }
+  const workspaceUri = treeWorkspaceUri(value);
+  if (workspaceUri !== undefined) {
+    const folder = vscode.workspace.getWorkspaceFolder(workspaceUri);
+    if (folder !== undefined) {
+      return folder;
+    }
+  }
+  return resolveWorkspaceRoot({ prompt: true, fallbackToFirst: true });
+}
+
 async function runModuleMutation(
   args: string[],
   label: string,
@@ -903,8 +917,7 @@ function relativePathForUri(uri: vscode.Uri): string {
   return path.relative(folder.uri.fsPath, uri.fsPath).replace(/\\/g, "/");
 }
 
-function relativePathFromTreeUri(value: unknown): string | undefined {
-  const uri = treeUri(value);
+function relativePathFromUri(uri: vscode.Uri | undefined): string | undefined {
   return uri === undefined ? undefined : relativePathForUri(uri);
 }
 
@@ -930,11 +943,32 @@ function treeQualifiedName(value: unknown): string | undefined {
   return readNonEmpty((value as Record<string, unknown>).qualifiedName);
 }
 
-function treeRelativePath(value: unknown): string | undefined {
+function userFormRelativePath(value: unknown): string | undefined {
   if (typeof value !== "object" || value === null) {
     return undefined;
   }
-  return readNonEmpty((value as Record<string, unknown>).relativePath);
+  const obj = value as Record<string, unknown>;
+  return readNonEmpty(obj.primaryRelativePath) ?? readNonEmpty(obj.relativePath);
+}
+
+function userFormSourceUri(value: unknown): vscode.Uri | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const obj = value as Record<string, unknown>;
+  const primaryUri = obj.primaryUri;
+  if (primaryUri instanceof vscode.Uri) {
+    return primaryUri;
+  }
+  return treeUri(value);
+}
+
+function treeWorkspaceUri(value: unknown): vscode.Uri | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const workspaceUri = (value as Record<string, unknown>).workspaceUri;
+  return workspaceUri instanceof vscode.Uri ? workspaceUri : undefined;
 }
 
 function treeModuleKind(value: unknown): string | undefined {

--- a/editors/vscode/src/commands.ts
+++ b/editors/vscode/src/commands.ts
@@ -1,10 +1,11 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import { XlflowLanguageClientManager } from "./client";
 import { readConfig } from "./config";
 import { XlflowChannels } from "./logging";
 import { XlflowProjectStateService } from "./projectState";
 import { SessionManager } from "./session";
-import { resolveWorkspaceRoot, runXlflowCommand } from "./xlflow";
+import { resolveWorkspaceRoot, runXlflowCommand, runXlflowJsonCommand } from "./xlflow";
 
 type RunProcedureArgs = {
   uri: string;
@@ -14,6 +15,18 @@ type RunProcedureArgs = {
   kind?: "sub" | "test";
   line?: number;
 };
+
+interface XlflowMutationEnvelope {
+  status?: string;
+  error?: {
+    message?: string;
+    code?: string;
+  };
+  source?: {
+    renamed?: string[];
+    removed?: string[];
+  };
+}
 
 interface CommandRefreshHooks {
   refreshAll(): Promise<void>;
@@ -144,7 +157,7 @@ export function registerCommands(
       await runXlflowCommand(["run"], "xlflow run", channels.output, { requireWorkspace: true });
     }),
     vscode.commands.registerCommand("xlflow.runProcedure", async (args: unknown) => {
-      await runProcedureFromCodeLens(args, channels);
+      await runProcedure(args, channels);
     }),
     vscode.commands.registerCommand("xlflow.runTestProcedure", async (args: unknown) => {
       await runTestProcedureFromCodeLens(args, channels);
@@ -244,6 +257,31 @@ export function registerCommands(
       if (uri !== undefined) {
         await vscode.window.showTextDocument(uri);
       }
+    }),
+    vscode.commands.registerCommand("xlflow.renameModule", async (value: unknown) => {
+      await renameModule(value, channels, hooks);
+    }),
+    vscode.commands.registerCommand("xlflow.deleteModule", async (value: unknown) => {
+      await deleteModule(value, channels, hooks);
+    }),
+    vscode.commands.registerCommand("xlflow.revealSourceFile", async (value: unknown) => {
+      const uri = treeUri(value);
+      if (uri !== undefined) {
+        await vscode.commands.executeCommand("revealInExplorer", uri);
+      }
+    }),
+    vscode.commands.registerCommand("xlflow.copyModuleName", async (value: unknown) => {
+      await copyText("Module name", treeName(value));
+    }),
+    vscode.commands.registerCommand("xlflow.copyRelativePath", async (value: unknown) => {
+      const uri = treeUri(value);
+      await copyText("Relative path", uri === undefined ? undefined : relativePathForUri(uri));
+    }),
+    vscode.commands.registerCommand("xlflow.copyProcedureName", async (value: unknown) => {
+      await copyText("Procedure name", treeName(value));
+    }),
+    vscode.commands.registerCommand("xlflow.copyQualifiedName", async (value: unknown) => {
+      await copyText("Qualified name", treeQualifiedName(value));
     }),
     vscode.commands.registerCommand("xlflow.openProcedure", async (value: unknown) => {
       const uri = treeUri(value);
@@ -452,6 +490,97 @@ async function newUserForm(channels: XlflowChannels, hooks: CommandRefreshHooks)
   }
 }
 
+async function renameModule(
+  value: unknown,
+  channels: XlflowChannels,
+  hooks: CommandRefreshHooks,
+): Promise<void> {
+  const moduleName = treeName(value);
+  const uri = treeUri(value);
+  if (moduleName === undefined || uri === undefined) {
+    vscode.window.showWarningMessage("xlflow rename module received invalid module arguments.");
+    return;
+  }
+  if (treeModuleKind(value) === "document") {
+    vscode.window.showErrorMessage(
+      `Failed to rename module "${moduleName}": document modules cannot be renamed.`,
+    );
+    return;
+  }
+
+  const newName = await promptComponentName("xlflow: Rename Module", moduleName);
+  if (newName === undefined || newName.trim() === moduleName) {
+    return;
+  }
+
+  const workspaceFolder = await workspaceFolderForUri(uri);
+  const wasOpen = vscode.workspace.textDocuments.some(
+    (document) => document.uri.toString() === uri.toString(),
+  );
+  const label = `xlflow module rename ${moduleName} ${newName.trim()}`;
+  const result = await runXlflowJsonCommand<XlflowMutationEnvelope>(
+    ["--json", "module", "rename", moduleName, newName.trim()],
+    label,
+    channels.output,
+    { requireWorkspace: true, workspaceFolder },
+  );
+  if (result.exitCode !== 0) {
+    showMutationFailure("rename", moduleName, result);
+    return;
+  }
+
+  await Promise.all([hooks.refreshModules(), hooks.refreshTests()]);
+  if (wasOpen && workspaceFolder !== undefined) {
+    const renamedUri = renamedModuleUri(workspaceFolder, result.json, newName.trim());
+    if (renamedUri !== undefined) {
+      await vscode.window.showTextDocument(renamedUri);
+    }
+  }
+}
+
+async function deleteModule(
+  value: unknown,
+  channels: XlflowChannels,
+  hooks: CommandRefreshHooks,
+): Promise<void> {
+  const moduleName = treeName(value);
+  const uri = treeUri(value);
+  if (moduleName === undefined || uri === undefined) {
+    vscode.window.showWarningMessage("xlflow delete module received invalid module arguments.");
+    return;
+  }
+  if (treeModuleKind(value) === "document") {
+    vscode.window.showErrorMessage(
+      `Failed to delete module "${moduleName}": document modules cannot be removed.`,
+    );
+    return;
+  }
+
+  const confirmed = await vscode.window.showWarningMessage(
+    `Delete module "${moduleName}" from the xlflow project?\n\nThis removes the source file. The workbook will be updated on the next xlflow push.`,
+    { modal: true },
+    "Delete",
+  );
+  if (confirmed !== "Delete") {
+    return;
+  }
+
+  const workspaceFolder = await workspaceFolderForUri(uri);
+  const label = `xlflow module remove ${moduleName}`;
+  const result = await runXlflowJsonCommand<XlflowMutationEnvelope>(
+    ["--json", "module", "remove", moduleName],
+    label,
+    channels.output,
+    { requireWorkspace: true, workspaceFolder },
+  );
+  if (result.exitCode !== 0) {
+    showMutationFailure("delete", moduleName, result);
+    return;
+  }
+
+  await Promise.all([hooks.refreshModules(), hooks.refreshTests()]);
+}
+
 async function promptComponentName(
   title: string,
   placeHolder: string,
@@ -478,10 +607,10 @@ function validateComponentNameInput(value: string): string | undefined {
   return undefined;
 }
 
-async function runProcedureFromCodeLens(value: unknown, channels: XlflowChannels): Promise<void> {
+async function runProcedure(value: unknown, channels: XlflowChannels): Promise<void> {
   const args = normalizeRunProcedureArgs(value);
   if (args === undefined) {
-    vscode.window.showWarningMessage("xlflow CodeLens received invalid run arguments.");
+    vscode.window.showWarningMessage("xlflow received invalid run procedure arguments.");
     return;
   }
   const uri = vscode.Uri.parse(args.uri);
@@ -607,12 +736,85 @@ async function workspaceFolderForUri(uri: vscode.Uri): Promise<vscode.WorkspaceF
   );
 }
 
+function renamedModuleUri(
+  workspaceFolder: vscode.WorkspaceFolder,
+  envelope: XlflowMutationEnvelope | undefined,
+  newName: string,
+): vscode.Uri | undefined {
+  const renamed = envelope?.source?.renamed ?? [];
+  const preferred =
+    renamed.find((candidate) => basenameWithoutExtension(candidate) === newName) ?? renamed[0];
+  if (preferred === undefined) {
+    return undefined;
+  }
+  if (path.isAbsolute(preferred)) {
+    return vscode.Uri.file(preferred);
+  }
+  return vscode.Uri.joinPath(workspaceFolder.uri, ...preferred.replace(/\\/g, "/").split("/"));
+}
+
+function basenameWithoutExtension(filePath: string): string {
+  const base = filePath.replace(/\\/g, "/").split("/").pop() ?? filePath;
+  const dot = base.lastIndexOf(".");
+  return dot === -1 ? base : base.slice(0, dot);
+}
+
+function showMutationFailure(
+  operation: "rename" | "delete",
+  moduleName: string,
+  result: { exitCode: number; stderr: string; json?: XlflowMutationEnvelope },
+): void {
+  const message =
+    readNonEmpty(result.json?.error?.message) ??
+    readNonEmpty(result.stderr.split(/\r?\n/).find((line) => line.trim().length > 0)) ??
+    `xlflow exited with code ${result.exitCode}.`;
+  vscode.window.showErrorMessage(`Failed to ${operation} module "${moduleName}": ${message}`);
+}
+
+async function copyText(label: string, value: string | undefined): Promise<void> {
+  if (value === undefined) {
+    vscode.window.showWarningMessage(`xlflow could not determine the ${label.toLowerCase()}.`);
+    return;
+  }
+  await vscode.env.clipboard.writeText(value);
+  vscode.window.showInformationMessage(`${label} copied.`);
+}
+
+function relativePathForUri(uri: vscode.Uri): string {
+  const folder = vscode.workspace.getWorkspaceFolder(uri);
+  if (folder === undefined) {
+    return vscode.workspace.asRelativePath(uri, false).replace(/\\/g, "/");
+  }
+  return path.relative(folder.uri.fsPath, uri.fsPath).replace(/\\/g, "/");
+}
+
 function readNonEmpty(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
   const trimmed = value.trim();
   return trimmed.length === 0 ? undefined : trimmed;
+}
+
+function treeName(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  return readNonEmpty((value as Record<string, unknown>).name);
+}
+
+function treeQualifiedName(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  return readNonEmpty((value as Record<string, unknown>).qualifiedName);
+}
+
+function treeModuleKind(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  return readNonEmpty((value as Record<string, unknown>).moduleKind);
 }
 
 function treeUri(value: unknown): vscode.Uri | undefined {

--- a/editors/vscode/src/commands.ts
+++ b/editors/vscode/src/commands.ts
@@ -283,6 +283,24 @@ export function registerCommands(
     vscode.commands.registerCommand("xlflow.copyQualifiedName", async (value: unknown) => {
       await copyText("Qualified name", treeQualifiedName(value));
     }),
+    vscode.commands.registerCommand("xlflow.renameUserForm", async (value: unknown) => {
+      await renameUserForm(value, channels, hooks);
+    }),
+    vscode.commands.registerCommand("xlflow.deleteUserForm", async (value: unknown) => {
+      await deleteUserForm(value, channels, hooks);
+    }),
+    vscode.commands.registerCommand("xlflow.revealUserFormSource", async (value: unknown) => {
+      const uri = treeUri(value);
+      if (uri !== undefined) {
+        await vscode.commands.executeCommand("revealInExplorer", uri);
+      }
+    }),
+    vscode.commands.registerCommand("xlflow.copyUserFormName", async (value: unknown) => {
+      await copyText("UserForm name", treeName(value));
+    }),
+    vscode.commands.registerCommand("xlflow.copyUserFormRelativePath", async (value: unknown) => {
+      await copyText("Relative path", treeRelativePath(value) ?? relativePathFromTreeUri(value));
+    }),
     vscode.commands.registerCommand("xlflow.openProcedure", async (value: unknown) => {
       const uri = treeUri(value);
       if (uri === undefined) {
@@ -490,6 +508,88 @@ async function newUserForm(channels: XlflowChannels, hooks: CommandRefreshHooks)
   }
 }
 
+async function renameUserForm(
+  value: unknown,
+  channels: XlflowChannels,
+  hooks: CommandRefreshHooks,
+): Promise<void> {
+  const name = treeName(value);
+  const uri = treeUri(value);
+  if (name === undefined) {
+    vscode.window.showWarningMessage("xlflow rename UserForm received invalid UserForm arguments.");
+    return;
+  }
+  const newName = await promptComponentName("xlflow: Rename UserForm", name);
+  if (newName === undefined || newName.trim() === name) {
+    return;
+  }
+
+  const workspaceFolder =
+    uri === undefined
+      ? await resolveWorkspaceRoot({ prompt: true, fallbackToFirst: true })
+      : await workspaceFolderForUri(uri);
+  const wasOpen =
+    uri !== undefined &&
+    vscode.workspace.textDocuments.some((document) => document.uri.toString() === uri.toString());
+  const result = await runModuleMutation(
+    ["rename", name, newName.trim()],
+    `xlflow module rename ${name} ${newName.trim()}`,
+    channels.output,
+    workspaceFolder,
+  );
+  if (result.exitCode !== 0) {
+    showMutationFailure("rename", name, result, "UserForm");
+    return;
+  }
+
+  await Promise.all([hooks.refreshUserForms(), hooks.refreshModules(), hooks.refreshTests()]);
+  if (wasOpen && workspaceFolder !== undefined) {
+    const renamedUri = renamedModuleUri(workspaceFolder, result.json, newName.trim());
+    if (renamedUri !== undefined) {
+      await vscode.window.showTextDocument(renamedUri);
+    }
+  }
+}
+
+async function deleteUserForm(
+  value: unknown,
+  channels: XlflowChannels,
+  hooks: CommandRefreshHooks,
+): Promise<void> {
+  const name = treeName(value);
+  const uri = treeUri(value);
+  if (name === undefined) {
+    vscode.window.showWarningMessage("xlflow delete UserForm received invalid UserForm arguments.");
+    return;
+  }
+
+  const confirmed = await vscode.window.showWarningMessage(
+    `Delete UserForm "${name}" from the xlflow project?\n\nThis may remove the .frm, .frx, sidecar code, and designer spec artifacts. The workbook will be updated on the next xlflow push.`,
+    { modal: true },
+    "Delete",
+  );
+  if (confirmed !== "Delete") {
+    return;
+  }
+
+  const workspaceFolder =
+    uri === undefined
+      ? await resolveWorkspaceRoot({ prompt: true, fallbackToFirst: true })
+      : await workspaceFolderForUri(uri);
+  const result = await runModuleMutation(
+    ["remove", name],
+    `xlflow module remove ${name}`,
+    channels.output,
+    workspaceFolder,
+  );
+  if (result.exitCode !== 0) {
+    showMutationFailure("delete", name, result, "UserForm");
+    return;
+  }
+
+  await Promise.all([hooks.refreshUserForms(), hooks.refreshModules(), hooks.refreshTests()]);
+}
+
 async function renameModule(
   value: unknown,
   channels: XlflowChannels,
@@ -517,12 +617,11 @@ async function renameModule(
   const wasOpen = vscode.workspace.textDocuments.some(
     (document) => document.uri.toString() === uri.toString(),
   );
-  const label = `xlflow module rename ${moduleName} ${newName.trim()}`;
-  const result = await runXlflowJsonCommand<XlflowMutationEnvelope>(
-    ["--json", "module", "rename", moduleName, newName.trim()],
-    label,
+  const result = await runModuleMutation(
+    ["rename", moduleName, newName.trim()],
+    `xlflow module rename ${moduleName} ${newName.trim()}`,
     channels.output,
-    { requireWorkspace: true, workspaceFolder },
+    workspaceFolder,
   );
   if (result.exitCode !== 0) {
     showMutationFailure("rename", moduleName, result);
@@ -566,12 +665,11 @@ async function deleteModule(
   }
 
   const workspaceFolder = await workspaceFolderForUri(uri);
-  const label = `xlflow module remove ${moduleName}`;
-  const result = await runXlflowJsonCommand<XlflowMutationEnvelope>(
-    ["--json", "module", "remove", moduleName],
-    label,
+  const result = await runModuleMutation(
+    ["remove", moduleName],
+    `xlflow module remove ${moduleName}`,
     channels.output,
-    { requireWorkspace: true, workspaceFolder },
+    workspaceFolder,
   );
   if (result.exitCode !== 0) {
     showMutationFailure("delete", moduleName, result);
@@ -736,6 +834,20 @@ async function workspaceFolderForUri(uri: vscode.Uri): Promise<vscode.WorkspaceF
   );
 }
 
+async function runModuleMutation(
+  args: string[],
+  label: string,
+  outputChannel: vscode.OutputChannel,
+  workspaceFolder: vscode.WorkspaceFolder | undefined,
+): Promise<{ exitCode: number; stderr: string; json?: XlflowMutationEnvelope }> {
+  return runXlflowJsonCommand<XlflowMutationEnvelope>(
+    ["--json", "module", ...args],
+    label,
+    outputChannel,
+    { requireWorkspace: true, workspaceFolder },
+  );
+}
+
 function renamedModuleUri(
   workspaceFolder: vscode.WorkspaceFolder,
   envelope: XlflowMutationEnvelope | undefined,
@@ -763,12 +875,15 @@ function showMutationFailure(
   operation: "rename" | "delete",
   moduleName: string,
   result: { exitCode: number; stderr: string; json?: XlflowMutationEnvelope },
+  targetKind = "module",
 ): void {
   const message =
     readNonEmpty(result.json?.error?.message) ??
     readNonEmpty(result.stderr.split(/\r?\n/).find((line) => line.trim().length > 0)) ??
     `xlflow exited with code ${result.exitCode}.`;
-  vscode.window.showErrorMessage(`Failed to ${operation} module "${moduleName}": ${message}`);
+  vscode.window.showErrorMessage(
+    `Failed to ${operation} ${targetKind} "${moduleName}": ${message}`,
+  );
 }
 
 async function copyText(label: string, value: string | undefined): Promise<void> {
@@ -786,6 +901,11 @@ function relativePathForUri(uri: vscode.Uri): string {
     return vscode.workspace.asRelativePath(uri, false).replace(/\\/g, "/");
   }
   return path.relative(folder.uri.fsPath, uri.fsPath).replace(/\\/g, "/");
+}
+
+function relativePathFromTreeUri(value: unknown): string | undefined {
+  const uri = treeUri(value);
+  return uri === undefined ? undefined : relativePathForUri(uri);
 }
 
 function readNonEmpty(value: unknown): string | undefined {
@@ -808,6 +928,13 @@ function treeQualifiedName(value: unknown): string | undefined {
     return undefined;
   }
   return readNonEmpty((value as Record<string, unknown>).qualifiedName);
+}
+
+function treeRelativePath(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  return readNonEmpty((value as Record<string, unknown>).relativePath);
 }
 
 function treeModuleKind(value: unknown): string | undefined {

--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -83,6 +83,7 @@ interface UserFormNode {
   kind: "userForm";
   name: string;
   codeSource: UserFormCodeSource;
+  workspaceUri: vscode.Uri;
   primaryUri?: vscode.Uri;
   primaryRelativePath?: string;
   children: UserFormArtifactNode[];
@@ -448,6 +449,7 @@ class UserFormsTreeProvider implements vscode.TreeDataProvider<TreeNode> {
         kind: "userForm",
         name: form.name,
         codeSource: form.codeSource,
+        workspaceUri: state.workspaceFolder.uri,
         primaryUri: primary?.uri,
         primaryRelativePath: primary?.relativePath,
         children,

--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -6,7 +6,7 @@ import {
   XlflowProjectState,
   XlflowProjectStateService,
 } from "./projectState";
-import { SessionManager, SessionSnapshot, SessionState, XlflowSessionPayload } from "./session";
+import { SessionManager, SessionState, XlflowSessionPayload } from "./session";
 import { discoverTests, readNonEmpty, sourceUri, XlflowDiscoveredTest } from "./testDiscovery";
 import { runXlflowJsonCommand } from "./xlflow";
 

--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -82,6 +82,9 @@ export interface UserFormModel {
 interface UserFormNode {
   kind: "userForm";
   name: string;
+  codeSource: UserFormCodeSource;
+  primaryUri?: vscode.Uri;
+  primaryRelativePath?: string;
   children: UserFormArtifactNode[];
 }
 
@@ -89,6 +92,7 @@ interface UserFormArtifactNode {
   kind: "userFormArtifact";
   label: string;
   uri?: vscode.Uri;
+  relativePath?: string;
   missing: boolean;
   artifactKind: UserFormArtifactModel["kind"];
 }
@@ -424,11 +428,9 @@ class UserFormsTreeProvider implements vscode.TreeDataProvider<TreeNode> {
     }
 
     const forms = await discoverUserForms(state.workspaceFolder, state.configPath);
-    this.nodes = forms.map((form) => ({
-      kind: "userForm",
-      name: form.name,
-      children: form.artifacts.map((artifact) => ({
-        kind: "userFormArtifact",
+    this.nodes = forms.map((form) => {
+      const children: UserFormArtifactNode[] = form.artifacts.map((artifact) => ({
+        kind: "userFormArtifact" as const,
         label: artifact.label,
         uri:
           artifact.relativePath === undefined
@@ -437,10 +439,20 @@ class UserFormsTreeProvider implements vscode.TreeDataProvider<TreeNode> {
                 state.workspaceFolder.uri,
                 ...artifact.relativePath.replace(/\\/g, "/").split("/"),
               ),
+        relativePath: artifact.relativePath,
         missing: artifact.missing,
         artifactKind: artifact.kind,
-      })),
-    }));
+      }));
+      const primary = primaryUserFormArtifact(form.codeSource, children);
+      return {
+        kind: "userForm",
+        name: form.name,
+        codeSource: form.codeSource,
+        primaryUri: primary?.uri,
+        primaryRelativePath: primary?.relativePath,
+        children,
+      };
+    });
     this.emitter.fire(undefined);
   }
 
@@ -448,15 +460,15 @@ class UserFormsTreeProvider implements vscode.TreeDataProvider<TreeNode> {
     if (element.kind === "userForm") {
       const item = new vscode.TreeItem(element.name, vscode.TreeItemCollapsibleState.Collapsed);
       item.iconPath = new vscode.ThemeIcon("window");
-      item.contextValue = "xlflow.userForm";
+      item.contextValue = userFormContextValue(element.codeSource);
+      item.resourceUri = element.primaryUri;
+      item.tooltip = element.primaryUri?.fsPath;
       return item;
     }
     if (element.kind === "userFormArtifact") {
       const item = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.None);
       item.iconPath = new vscode.ThemeIcon(userFormArtifactIcon(element));
-      item.contextValue = element.missing
-        ? "xlflow.userFormMissingArtifact"
-        : "xlflow.userFormArtifact";
+      item.contextValue = userFormArtifactContextValue(element);
       item.description = element.missing ? "missing" : undefined;
       item.tooltip = element.uri?.fsPath;
       item.resourceUri = element.uri;
@@ -482,6 +494,29 @@ class UserFormsTreeProvider implements vscode.TreeDataProvider<TreeNode> {
     }
     return [];
   }
+}
+
+function primaryUserFormArtifact(
+  codeSource: UserFormCodeSource,
+  artifacts: UserFormArtifactNode[],
+): UserFormArtifactNode | undefined {
+  const preferredKind: UserFormArtifactModel["kind"] = codeSource === "frm" ? "frm" : "code";
+  return (
+    artifacts.find((artifact) => !artifact.missing && artifact.artifactKind === preferredKind) ??
+    artifacts.find((artifact) => !artifact.missing)
+  );
+}
+
+export function userFormContextValue(codeSource: UserFormCodeSource): string {
+  return `xlflow.userForm.${codeSource}`;
+}
+
+export function userFormArtifactContextValue(node: {
+  artifactKind: UserFormArtifactModel["kind"];
+  missing: boolean;
+}): string {
+  const prefix = node.missing ? "xlflow.userFormMissingArtifact" : "xlflow.userFormArtifact";
+  return `${prefix}.${node.artifactKind}`;
 }
 
 class TestsTreeProvider implements vscode.TreeDataProvider<TreeNode> {

--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -365,7 +365,7 @@ class ModulesTreeProvider implements vscode.TreeDataProvider<TreeNode> {
         const item = new vscode.TreeItem(element.name, vscode.TreeItemCollapsibleState.Collapsed);
         item.iconPath = new vscode.ThemeIcon(moduleIcon(element.moduleKind));
         item.resourceUri = element.uri;
-        item.contextValue = "xlflow.module";
+        item.contextValue = moduleContextValue(element.moduleKind);
         item.command = {
           command: "xlflow.openModule",
           title: "Open Module",
@@ -877,6 +877,9 @@ export function moduleGroups(
       continue;
     }
     const moduleKind = normalizeModuleKind(file.moduleKind);
+    if (moduleKind === "form") {
+      continue;
+    }
     const uri = sourceUri(folder, sourcePath) ?? vscode.Uri.joinPath(folder.uri, sourcePath);
     const module: ModuleNode = {
       kind: "module",
@@ -896,6 +899,17 @@ export function moduleGroups(
       return { kind: "moduleGroup" as const, label: moduleGroupLabel(kind), children: modules };
     })
     .filter((group) => group.children.length > 0);
+}
+
+export function moduleContextValue(kind: string): string {
+  switch (kind) {
+    case "class":
+      return "xlflow.module.class";
+    case "document":
+      return "xlflow.module.document";
+    default:
+      return "xlflow.module.standard";
+  }
 }
 
 function procedureNodes(

--- a/editors/vscode/test/suite/extension.test.ts
+++ b/editors/vscode/test/suite/extension.test.ts
@@ -8,6 +8,8 @@ import {
   readExcelPathFromToml,
   readFormsRootFromToml,
   readUserFormCodeSourceFromToml,
+  userFormArtifactContextValue,
+  userFormContextValue,
 } from "../../src/sidebar";
 
 export async function run(): Promise<void> {
@@ -55,6 +57,11 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
     "xlflow.copyRelativePath",
     "xlflow.copyProcedureName",
     "xlflow.copyQualifiedName",
+    "xlflow.renameUserForm",
+    "xlflow.deleteUserForm",
+    "xlflow.revealUserFormSource",
+    "xlflow.copyUserFormName",
+    "xlflow.copyUserFormRelativePath",
     "xlflow.test",
     "xlflow.lintWorkspace",
     "xlflow.formatDocument",
@@ -214,4 +221,14 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
   assert.strictEqual(moduleContextValue("standard"), "xlflow.module.standard");
   assert.strictEqual(moduleContextValue("class"), "xlflow.module.class");
   assert.strictEqual(moduleContextValue("document"), "xlflow.module.document");
+  assert.strictEqual(userFormContextValue("sidecar"), "xlflow.userForm.sidecar");
+  assert.strictEqual(userFormContextValue("frm"), "xlflow.userForm.frm");
+  assert.strictEqual(
+    userFormArtifactContextValue({ artifactKind: "code", missing: false }),
+    "xlflow.userFormArtifact.code",
+  );
+  assert.strictEqual(
+    userFormArtifactContextValue({ artifactKind: "spec", missing: true }),
+    "xlflow.userFormMissingArtifact.spec",
+  );
 }

--- a/editors/vscode/test/suite/extension.test.ts
+++ b/editors/vscode/test/suite/extension.test.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { sessionStateFromEnvelope, sessionStatusText } from "../../src/session";
 import {
   buildUserFormModels,
+  moduleContextValue,
   moduleGroups,
   readExcelPathFromToml,
   readFormsRootFromToml,
@@ -47,6 +48,13 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
     "xlflow.runMacro",
     "xlflow.runProcedure",
     "xlflow.runTestProcedure",
+    "xlflow.renameModule",
+    "xlflow.deleteModule",
+    "xlflow.revealSourceFile",
+    "xlflow.copyModuleName",
+    "xlflow.copyRelativePath",
+    "xlflow.copyProcedureName",
+    "xlflow.copyQualifiedName",
     "xlflow.test",
     "xlflow.lintWorkspace",
     "xlflow.formatDocument",
@@ -192,9 +200,18 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
         files: [
           { path: "src/forms/code/Form1.bas", moduleName: "Form1", moduleKind: "form" },
           { path: "src/modules/Main.bas", moduleName: "Main", moduleKind: "standard" },
+          { path: "src/classes/Invoice.cls", moduleName: "Invoice", moduleKind: "class" },
+          {
+            path: "src/workbook/ThisWorkbook.cls",
+            moduleName: "ThisWorkbook",
+            moduleKind: "document",
+          },
         ],
       },
     }).map((group) => group.label),
-    ["Standard Modules"],
+    ["Standard Modules", "Class Modules", "Document Modules"],
   );
+  assert.strictEqual(moduleContextValue("standard"), "xlflow.module.standard");
+  assert.strictEqual(moduleContextValue("class"), "xlflow.module.class");
+  assert.strictEqual(moduleContextValue("document"), "xlflow.module.document");
 }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs:dev": "vitepress dev vitepress",
     "docs:build": "vitepress build vitepress",
-    "docs:preview": "vitepress preview vitepress"
+    "docs:preview": "vitepress preview vitepress",
+    "lint": "oxlint editors/vscode"
   },
   "devDependencies": {
     "esbuild": "^0.28.1",
     "oxfmt": "^0.47.0",
+    "oxlint": "^1.71.0",
     "vite": "^6.4.2",
     "vitepress": "^1.6.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       oxfmt:
         specifier: ^0.47.0
         version: 0.47.0
+      oxlint:
+        specifier: ^1.71.0
+        version: 1.71.0
       vite:
         specifier: ^6.4.2
         version: 6.4.3(lightningcss@1.32.0)
@@ -586,6 +589,128 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxlint/binding-android-arm-eabi@1.71.0':
+    resolution: {integrity: sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.71.0':
+    resolution: {integrity: sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.71.0':
+    resolution: {integrity: sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.71.0':
+    resolution: {integrity: sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.71.0':
+    resolution: {integrity: sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.71.0':
+    resolution: {integrity: sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.71.0':
+    resolution: {integrity: sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.71.0':
+    resolution: {integrity: sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.71.0':
+    resolution: {integrity: sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.71.0':
+    resolution: {integrity: sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.71.0':
+    resolution: {integrity: sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.71.0':
+    resolution: {integrity: sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.71.0':
+    resolution: {integrity: sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.71.0':
+    resolution: {integrity: sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.71.0':
+    resolution: {integrity: sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.71.0':
+    resolution: {integrity: sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.71.0':
+    resolution: {integrity: sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.71.0':
+    resolution: {integrity: sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.71.0':
+    resolution: {integrity: sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-android-arm-eabi@4.62.0':
     resolution: {integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==}
     cpu: [arm]
@@ -1076,6 +1201,19 @@ packages:
     resolution: {integrity: sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  oxlint@1.71.0:
+    resolution: {integrity: sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -1608,6 +1746,63 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.47.0':
     optional: true
 
+  '@oxlint/binding-android-arm-eabi@1.71.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.71.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.71.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.71.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.71.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.71.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.71.0':
+    optional: true
+
   '@rollup/rollup-android-arm-eabi@4.62.0':
     optional: true
 
@@ -2113,6 +2308,28 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.47.0
       '@oxfmt/binding-win32-ia32-msvc': 0.47.0
       '@oxfmt/binding-win32-x64-msvc': 0.47.0
+
+  oxlint@1.71.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.71.0
+      '@oxlint/binding-android-arm64': 1.71.0
+      '@oxlint/binding-darwin-arm64': 1.71.0
+      '@oxlint/binding-darwin-x64': 1.71.0
+      '@oxlint/binding-freebsd-x64': 1.71.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.71.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.71.0
+      '@oxlint/binding-linux-arm64-gnu': 1.71.0
+      '@oxlint/binding-linux-arm64-musl': 1.71.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.71.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.71.0
+      '@oxlint/binding-linux-riscv64-musl': 1.71.0
+      '@oxlint/binding-linux-s390x-gnu': 1.71.0
+      '@oxlint/binding-linux-x64-gnu': 1.71.0
+      '@oxlint/binding-linux-x64-musl': 1.71.0
+      '@oxlint/binding-openharmony-arm64': 1.71.0
+      '@oxlint/binding-win32-arm64-msvc': 1.71.0
+      '@oxlint/binding-win32-ia32-msvc': 1.71.0
+      '@oxlint/binding-win32-x64-msvc': 1.71.0
 
   perfect-debounce@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- Add tree view context menu actions for xlflow modules in the VS Code extension
- Update sidebar and command wiring so module actions are exposed from the explorer
- Refresh extension docs, changelog, and workspace package metadata/lockfiles

## Testing
- Updated and exercised the VS Code extension test suite to cover the new sidebar/command behavior
- Verified the extension package configuration and lockfiles stay in sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the VS Code extension with more sidebar and command palette actions for modules and user forms, including rename, delete, reveal, and copy options.
  * Added support for running eligible procedures directly from the editor and improved sidebar behavior for module and form items.

* **Bug Fixes**
  * Improved handling of renamed items so open files can follow the updated location.
  * Refined visibility and grouping of module and user form entries in the sidebar.

* **Chores**
  * Added linting coverage for the VS Code extension and repository checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->