### PR TITLE
Add clickable save actions in the VS Code project sidebar

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added sidebar save actions so the Project view toolbar and `Save required` indicator can run `xlflow save` when a session workbook needs saving.
+
 ## 0.1.0
 
 - Added CodeLens commands for running no-argument VBA procedures and tests through `xlflow.runProcedure` and `xlflow.runTestProcedure`.

--- a/editors/vscode/l10n/bundle.l10n.ja.json
+++ b/editors/vscode/l10n/bundle.l10n.ja.json
@@ -58,6 +58,8 @@
   "Session Actions": "セッション操作",
   "Save required": "保存が必要",
   "Whether the managed session workbook has unsaved changes that should be saved.": "管理中のセッションブックに保存すべき未保存の変更があるかどうか。",
+  "Click to save the managed session workbook.": "クリックして管理中のセッションブックを保存します。",
+  "The managed session workbook does not require saving.": "管理中のセッションブックは保存不要です。",
   "Open Module": "モジュールを開く",
   "Open Procedure": "プロシージャを開く",
   "missing": "未作成",

--- a/editors/vscode/l10n/bundle.l10n.json
+++ b/editors/vscode/l10n/bundle.l10n.json
@@ -58,6 +58,8 @@
   "Session Actions": "Session Actions",
   "Save required": "Save required",
   "Whether the managed session workbook has unsaved changes that should be saved.": "Whether the managed session workbook has unsaved changes that should be saved.",
+  "Click to save the managed session workbook.": "Click to save the managed session workbook.",
+  "The managed session workbook does not require saving.": "The managed session workbook does not require saving.",
   "Open Module": "Open Module",
   "Open Procedure": "Open Procedure",
   "missing": "missing",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -297,7 +297,8 @@
       {
         "command": "xlflow.saveWorkbook",
         "title": "%command.saveWorkbook.title%",
-        "category": "%command.category%"
+        "category": "%command.category%",
+        "icon": "$(save)"
       },
       {
         "command": "xlflow.sessionStart",
@@ -484,14 +485,19 @@
           "group": "navigation@3"
         },
         {
+          "command": "xlflow.saveWorkbook",
+          "when": "view == xlflow.project && xlflow.saveRequired",
+          "group": "navigation@4"
+        },
+        {
           "command": "xlflow.sessionStart",
           "when": "view == xlflow.project && xlflow.sessionStartEnabled",
-          "group": "navigation@4"
+          "group": "navigation@5"
         },
         {
           "command": "xlflow.sessionStop",
           "when": "view == xlflow.project && xlflow.sessionStopEnabled",
-          "group": "navigation@5"
+          "group": "navigation@6"
         },
         {
           "command": "xlflow.newModule",

--- a/editors/vscode/src/commands.ts
+++ b/editors/vscode/src/commands.ts
@@ -185,18 +185,20 @@ export function registerCommands(
         requireWorkspace: true,
         uiLabel: vscode.l10n.t("xlflow run"),
       });
+      await refreshSessionProjectState(sessionManager, hooks);
     }),
     vscode.commands.registerCommand("xlflow.runProcedure", async (args: unknown) => {
-      await runProcedure(args, channels);
+      await runProcedure(args, channels, sessionManager, hooks);
     }),
     vscode.commands.registerCommand("xlflow.runTestProcedure", async (args: unknown) => {
-      await runTestProcedureFromCodeLens(args, channels);
+      await runTestProcedureFromCodeLens(args, channels, sessionManager, hooks);
     }),
     vscode.commands.registerCommand("xlflow.test", async () => {
       const code = await runXlflowCommand(["test"], "xlflow test", channels.output, {
         requireWorkspace: true,
         uiLabel: vscode.l10n.t("xlflow test"),
       });
+      await refreshSessionProjectState(sessionManager, hooks);
       if (code === 0) {
         await hooks.refreshTests();
       }
@@ -222,8 +224,7 @@ export function registerCommands(
         uiLabel: vscode.l10n.t("xlflow save"),
       });
       if (code === 0) {
-        await sessionManager.refreshStatus();
-        hooks.refreshProject();
+        await refreshSessionProjectState(sessionManager, hooks);
       }
     }),
     vscode.commands.registerCommand("xlflow.sessionStart", async () => {
@@ -803,7 +804,12 @@ function validateComponentNameInput(value: string): string | undefined {
   return undefined;
 }
 
-async function runProcedure(value: unknown, channels: XlflowChannels): Promise<void> {
+async function runProcedure(
+  value: unknown,
+  channels: XlflowChannels,
+  sessionManager: SessionManager,
+  hooks: CommandRefreshHooks,
+): Promise<void> {
   const args = normalizeRunProcedureArgs(value);
   if (args === undefined) {
     vscode.window.showWarningMessage(
@@ -822,11 +828,14 @@ async function runProcedure(value: unknown, channels: XlflowChannels): Promise<v
     uiLabel: vscode.l10n.t("xlflow run {target}", { target }),
     workspaceFolder,
   });
+  await refreshSessionProjectState(sessionManager, hooks);
 }
 
 async function runTestProcedureFromCodeLens(
   value: unknown,
   channels: XlflowChannels,
+  sessionManager: SessionManager,
+  hooks: CommandRefreshHooks,
 ): Promise<void> {
   const args = normalizeRunProcedureArgs(value);
   if (args === undefined) {
@@ -857,6 +866,15 @@ async function runTestProcedureFromCodeLens(
       workspaceFolder,
     },
   );
+  await refreshSessionProjectState(sessionManager, hooks);
+}
+
+async function refreshSessionProjectState(
+  sessionManager: SessionManager,
+  hooks: CommandRefreshHooks,
+): Promise<void> {
+  await sessionManager.refreshStatus();
+  await hooks.refreshProject();
 }
 
 function normalizeRunProcedureArgs(value: unknown): RunProcedureArgs | undefined {

--- a/editors/vscode/src/commands.ts
+++ b/editors/vscode/src/commands.ts
@@ -217,10 +217,14 @@ export function registerCommands(
       });
     }),
     vscode.commands.registerCommand("xlflow.saveWorkbook", async () => {
-      await runXlflowCommand(["save"], "xlflow save", channels.output, {
+      const code = await runXlflowCommand(["save"], "xlflow save", channels.output, {
         requireWorkspace: true,
         uiLabel: vscode.l10n.t("xlflow save"),
       });
+      if (code === 0) {
+        await sessionManager.refreshStatus();
+        hooks.refreshProject();
+      }
     }),
     vscode.commands.registerCommand("xlflow.sessionStart", async () => {
       await sessionManager.start();

--- a/editors/vscode/src/session.ts
+++ b/editors/vscode/src/session.ts
@@ -345,6 +345,11 @@ export class SessionManager implements vscode.Disposable {
       "xlflow.sessionStopEnabled",
       projectReady && this.snapshot.state === "active",
     );
+    void vscode.commands.executeCommand(
+      "setContext",
+      "xlflow.saveRequired",
+      projectReady && this.snapshot.session?.save_required === true,
+    );
   }
 }
 

--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -306,6 +306,7 @@ class ProjectTreeProvider implements vscode.TreeDataProvider<ProjectNode> {
     const configuredWorkbookPath = await configuredWorkbook(state);
     const workbookPath = workbookPathFromSession(snapshot.session) ?? configuredWorkbookPath;
     const workbookLabel = workbookDisplayName(snapshot.session) ?? configuredWorkbookPath;
+    const saveRequired = snapshot.session?.save_required === true;
     const nodes: ProjectNode[] = [
       {
         kind: "project",
@@ -352,18 +353,25 @@ class ProjectTreeProvider implements vscode.TreeDataProvider<ProjectNode> {
         icon: sessionIcon(snapshot.state),
         command: { command: "xlflow.sessionActions", title: vscode.l10n.t("Session Actions") },
       },
-      {
-        kind: "project",
-        label: vscode.l10n.t("Save required"),
-        description: String(snapshot.session?.save_required === true),
-        tooltip: vscode.l10n.t(
-          "Whether the managed session workbook has unsaved changes that should be saved.",
-        ),
-        icon: new vscode.ThemeIcon(snapshot.session?.save_required === true ? "warning" : "check"),
-      },
+      saveRequiredProjectNode(saveRequired),
     ];
     return nodes;
   }
+}
+
+export function saveRequiredProjectNode(saveRequired: boolean): ProjectNode {
+  return {
+    kind: "project",
+    label: vscode.l10n.t("Save required"),
+    description: String(saveRequired),
+    tooltip: saveRequired
+      ? vscode.l10n.t("Click to save the managed session workbook.")
+      : vscode.l10n.t("The managed session workbook does not require saving."),
+    icon: new vscode.ThemeIcon(saveRequired ? "warning" : "check"),
+    command: saveRequired
+      ? { command: "xlflow.saveWorkbook", title: vscode.l10n.t("xlflow save") }
+      : undefined,
+  };
 }
 
 class ModulesTreeProvider implements vscode.TreeDataProvider<TreeNode> {

--- a/editors/vscode/test/suite/extension.test.ts
+++ b/editors/vscode/test/suite/extension.test.ts
@@ -16,6 +16,7 @@ import {
   readExcelPathFromToml,
   readFormsRootFromToml,
   readUserFormCodeSourceFromToml,
+  saveRequiredProjectNode,
   userFormArtifactContextValue,
   userFormContextValue,
 } from "../../src/sidebar";
@@ -149,6 +150,8 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
     "inactive",
   );
   assert.strictEqual(sessionStateFromEnvelope({ status: "failed" }), "error");
+  assert.strictEqual(saveRequiredProjectNode(true).command?.command, "xlflow.saveWorkbook");
+  assert.strictEqual(saveRequiredProjectNode(false).command, undefined);
   assert.strictEqual(
     readExcelPathFromToml('[project]\nname = "sample"\n[excel]\npath = "build/Book.xlsm"\n'),
     "build/Book.xlsm",
@@ -320,6 +323,13 @@ function assertLocalizationResources(extensionPath: string): void {
   assert.strictEqual(
     menuWhen(manifest, "view/title", "xlflow.sessionStop"),
     "view == xlflow.project && xlflow.sessionStopEnabled",
+  );
+  assert.ok(
+    hasMenuItem(manifest, "view/title", "xlflow.saveWorkbook", {
+      when: "view == xlflow.project && xlflow.saveRequired",
+      group: "navigation@4",
+    }),
+    "project view title menu should contribute xlflow.saveWorkbook only when save is required",
   );
   assert.ok(
     hasMenuItem(manifest, "view/item/context", "xlflow.formatDocument", {

--- a/internal/excel/bridge_windows_test.go
+++ b/internal/excel/bridge_windows_test.go
@@ -52,9 +52,9 @@ func TestUIStreamSessionCollectsNamedPipeEvents(t *testing.T) {
 		_ = session.Close()
 		t.Fatal(err)
 	}
-	_ = conn.Close()
 	events := waitForUIStreamEvents(session, 1, uiStreamTestEventTimeout)
 	if len(events) != 1 {
+		_ = conn.Close()
 		closeErr := session.Close()
 		events = session.Events()
 		if len(events) == 1 && closeErr == nil {
@@ -62,6 +62,9 @@ func TestUIStreamSessionCollectsNamedPipeEvents(t *testing.T) {
 		} else {
 			t.Fatalf("events = %#v after close error %v, want 1 event", events, closeErr)
 		}
+	} else if err := conn.Close(); err != nil {
+		_ = session.Close()
+		t.Fatal(err)
 	} else if err := session.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/excel/debug_stream_windows_test.go
+++ b/internal/excel/debug_stream_windows_test.go
@@ -37,10 +37,10 @@ func TestDebugStreamSessionCollectsNamedPipeEvents(t *testing.T) {
 		_ = session.Close()
 		t.Fatal(err)
 	}
-	_ = conn.Close()
 	result := waitForDebugStreamResult(session, 1, uiStreamTestEventTimeout)
 	resultMap, ok := result.(map[string]any)
 	if !ok {
+		_ = conn.Close()
 		closeErr := session.Close()
 		result = session.Result()
 		resultMap, ok = result.(map[string]any)
@@ -48,6 +48,9 @@ func TestDebugStreamSessionCollectsNamedPipeEvents(t *testing.T) {
 			t.Fatalf("result = %#v after close error %v, want map", result, closeErr)
 		}
 		t.Log("debug stream event was collected only after session close")
+	} else if err := conn.Close(); err != nil {
+		_ = session.Close()
+		t.Fatal(err)
 	} else if err := session.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -6,6 +6,7 @@
 - Temporary import/export workspaces must be removed in `finally` after the owning command finishes. Do not leave generated source copies under `.xlflow/tmp` after success or failure.
 - Excel COM-backed Go tests can take several minutes, especially userform/VBIDE round-trip tests. Do not use two-minute timeouts for full `go test ./...` or `go test ./scripts`; use at least 8 minutes for full runs and 5 minutes for `scripts` package runs before treating slowness as a hang.
 - Avoid tight wall-clock sleeps in concurrency/ticker tests. Prefer polling with a generous deadline or injecting the clock/ticker so Windows CI scheduler delays do not make tests flaky.
+- Windows named-pipe stream tests must keep the client connection open until the server observes the expected event. Closing immediately after `Write` can race on hosted runners and make the server see only pipe closure, even when the write succeeded locally.
 - Validate cheap CLI/script action enums before opening Excel COM or workbook files. Unsupported actions should return argument errors without starting Excel, so invalid input cannot be masked by workbook-open failures or localized COM messages.
 - After refactoring shared CLI helpers, run lint or search for now-unused wrappers before finalizing; tests can pass while `unused` still fails CI lint.
 - Avoid depending on optional PowerShell cmdlets for core Excel bridge behavior. Prefer stable .NET APIs for file hashing and add regression tests that shadow missing cmdlets when environment differences can break agent workflows.


### PR DESCRIPTION
## Summary
- Add a save command to the Project view toolbar and the `Save required` tree item when a session workbook needs saving
- Refresh session status and the project view after a successful save
- Add localization strings and tests for the save-required node behavior

## Testing
- Added unit tests for `saveRequiredProjectNode`
- Added manifest and localization assertions for the new save action