### PR TITLE
Fix VB029 false positives in conditional compilation blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed `VB029` false positives for module-level declarations inside `#If ... #Else ... #End If` conditional compilation blocks.
+
 ## v0.16.0
 
 - Removed the legacy PowerShell Excel bridge for v0.16.0. The only supported bridge modes are now `auto` and `dotnet`; `--bridge powershell`, `XLFLOW_EXCEL_BRIDGE=powershell`, and `[excel].bridge = "powershell"` now fail with bridge-mode/configuration errors instead of emitting a deprecation warning.

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -1258,6 +1258,59 @@ End Function
 	assertIssue(t, PushBlockingIssues(issues), "VB029", 10)
 }
 
+func TestLinterAllowsModuleVariablesDeclaredInsideConditionalCompilationBlocks(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
+Option Explicit
+
+Private Const TimerIntervalMs As Long = 180
+
+#If VBA7 Then
+Private Declare PtrSafe Function SetTimer Lib "user32" (ByVal hwnd As LongPtr, ByVal nIDEvent As LongPtr, ByVal uElapse As Long, ByVal lpTimerFunc As LongPtr) As LongPtr
+Private Declare PtrSafe Function KillTimer Lib "user32" (ByVal hwnd As LongPtr, ByVal uIDEvent As LongPtr) As Long
+Private mTimerId As LongPtr
+#Else
+Private Declare Function SetTimer Lib "user32" (ByVal hwnd As Long, ByVal nIDEvent As Long, ByVal uElapse As Long, ByVal lpTimerFunc As Long) As Long
+Private Declare Function KillTimer Lib "user32" (ByVal hwnd As Long, ByVal uIDEvent As Long) As Long
+Private mTimerId As Long
+#End If
+
+Public Sub StartLoop()
+    If mTimerId <> 0 Then
+        Exit Sub
+    End If
+
+    #If VBA7 Then
+    mTimerId = SetTimer(0, 0, TimerIntervalMs, AddressOf MazeChaseTimerProc)
+    #Else
+    mTimerId = SetTimer(0, 0, TimerIntervalMs, AddressOf MazeChaseTimerProc)
+    #End If
+End Sub
+
+Public Sub StopLoop()
+    If mTimerId = 0 Then
+        Exit Sub
+    End If
+
+    KillTimer 0, mTimerId
+    mTimerId = 0
+    stillMissing = 1
+End Sub
+`)
+
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb029 := issuesByCode(issues, "VB029")
+	if len(vb029) != 1 {
+		t.Fatalf("expected only the truly undeclared assignment to trigger VB029, got %+v", vb029)
+	}
+	if vb029[0].Symbol != "stillMissing" {
+		t.Fatalf("mTimerId declared inside conditional compilation should not trigger VB029: %+v", vb029)
+	}
+}
+
 func TestLinterUndeclaredAssignmentsRequireOptionExplicit(t *testing.T) {
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Public Sub Run()

--- a/internal/vba/symbols/symbols.go
+++ b/internal/vba/symbols/symbols.go
@@ -470,10 +470,22 @@ func (e *extractor) visit(node *tree_sitter.Node, parentProc string) {
 		if child == nil {
 			continue
 		}
-		if child.Kind() == "block" || node.Kind() == "source_file" || node.Kind() == "block" {
+		if shouldVisitSymbolChild(node.Kind(), child.Kind()) {
 			e.visit(child, parentProc)
 		}
 	}
+}
+
+func shouldVisitSymbolChild(parentKind, childKind string) bool {
+	return childKind == "block" ||
+		parentKind == "source_file" ||
+		parentKind == "block" ||
+		isPreprocessorNode(parentKind) ||
+		isPreprocessorNode(childKind)
+}
+
+func isPreprocessorNode(kind string) bool {
+	return strings.HasPrefix(kind, "preprocessor_")
 }
 
 func (e *extractor) procedureSymbol(node *tree_sitter.Node) Symbol {

--- a/internal/vba/symbols/symbols_test.go
+++ b/internal/vba/symbols/symbols_test.go
@@ -109,6 +109,39 @@ End Sub
 	assertSymbol(t, privateFile.Symbols, "LocalLimit", "const")
 }
 
+func TestInspectExtractsSymbolsInsideConditionalCompilationBlocks(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	moduleDir := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `Attribute VB_Name = "Main"
+Option Explicit
+#If VBA7 Then
+Private Declare PtrSafe Function SetTimer Lib "user32" () As LongPtr
+Private mTimerId As LongPtr
+#Else
+Private Declare Function SetTimer Lib "user32" () As Long
+Private mTimerId As Long
+#End If
+
+Public Sub Run()
+End Sub
+`
+	if err := os.WriteFile(filepath.Join(moduleDir, "Main.bas"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Inspect(Options{RootDir: dir, Config: cfg, IncludePrivate: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := result.Files[0]
+	assertSymbol(t, file.Symbols, "SetTimer", "declare_function")
+	assertSymbol(t, file.Symbols, "mTimerId", "module_variable")
+}
+
 func TestInspectExtractsClassFieldsPropertiesAndImplements(t *testing.T) {
 	dir := t.TempDir()
 	cfg := config.Default()


### PR DESCRIPTION
## Summary
- Prevent `VB029` from flagging module-level declarations inside `#If ... #Else ... #End If` blocks.
- Extend symbol extraction so preprocessor-wrapped declarations are still discovered.
- Add regression coverage for both linting and symbol inspection.

## Testing
- Added unit tests covering conditional-compilation module variables and symbol extraction.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positives for undeclared identifiers in module-level code inside conditional compilation blocks.
  * Improved symbol detection so declarations within conditional branches are recognized correctly.

* **Tests**
  * Added coverage for conditional compilation scenarios to verify symbols and linter results are reported as expected.

* **Documentation**
  * Updated the changelog with the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->