### PR TITLE
Fix VB029 false positives in Excel member chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.16.1
+
 - Fixed `VB029` false positives for module-level declarations inside `#If ... #Else ... #End If` conditional compilation blocks.
 - Fixed `VB029` false positives for Excel member chains such as `Cells(ws.Rows.Count, "A").End(xlUp).Row`, where string or numeric arguments were mistaken for undeclared receiver identifiers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to xlflow will be documented in this file.
 ## Unreleased
 
 - Fixed `VB029` false positives for module-level declarations inside `#If ... #Else ... #End If` conditional compilation blocks.
+- Fixed `VB029` false positives for Excel member chains such as `Cells(ws.Rows.Count, "A").End(xlUp).Row`, where string or numeric arguments were mistaken for undeclared receiver identifiers.
 
 ## v0.16.0
 

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -1147,11 +1147,41 @@ func callTargetBeforeOpen(prefix string) string {
 	if strings.HasPrefix(strings.ToLower(target), "call ") {
 		target = strings.TrimSpace(target[len("call "):])
 	}
-	fields := strings.Fields(target)
-	if len(fields) > 1 {
-		target = fields[len(fields)-1]
-	}
+	target = lastTopLevelSpaceSeparatedField(target)
 	return strings.TrimSpace(target)
+}
+
+func lastTopLevelSpaceSeparatedField(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	inString := false
+	depth := 0
+	start := 0
+	for i := 0; i < len(text); i++ {
+		switch text[i] {
+		case '"':
+			if inString && i+1 < len(text) && text[i+1] == '"' {
+				i++
+				continue
+			}
+			inString = !inString
+		case '(':
+			if !inString {
+				depth++
+			}
+		case ')':
+			if !inString && depth > 0 {
+				depth--
+			}
+		case ' ', '\t':
+			if !inString && depth == 0 {
+				start = i + 1
+			}
+		}
+	}
+	return strings.TrimSpace(text[start:])
 }
 
 func parseArguments(text string) []argument {
@@ -2121,7 +2151,7 @@ func bestSetAssignmentExpression(source, word string, offset int) (string, int, 
 
 func (a Analyzer) collectionDefaultType(name string) (string, bool) {
 	typ, ok := a.DB.ResolveType(name)
-	if !ok || typ.ElementType == "" {
+	if !ok || !strings.EqualFold(typ.Kind, "collection") || typ.ElementType == "" {
 		return "", false
 	}
 	return typ.ElementType, true

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -1156,6 +1156,7 @@ func lastTopLevelSpaceSeparatedField(text string) string {
 	if text == "" {
 		return ""
 	}
+	targetDepth := unmatchedParenDepth(text)
 	inString := false
 	depth := 0
 	start := 0
@@ -1175,13 +1176,41 @@ func lastTopLevelSpaceSeparatedField(text string) string {
 			if !inString && depth > 0 {
 				depth--
 			}
-		case ' ', '\t':
-			if !inString && depth == 0 {
+		case ',', ' ', '\t':
+			if !inString && callTargetBoundaryDepth(depth, targetDepth) {
 				start = i + 1
 			}
 		}
 	}
 	return strings.TrimSpace(text[start:])
+}
+
+func unmatchedParenDepth(text string) int {
+	inString := false
+	depth := 0
+	for i := 0; i < len(text); i++ {
+		switch text[i] {
+		case '"':
+			if inString && i+1 < len(text) && text[i+1] == '"' {
+				i++
+				continue
+			}
+			inString = !inString
+		case '(':
+			if !inString {
+				depth++
+			}
+		case ')':
+			if !inString && depth > 0 {
+				depth--
+			}
+		}
+	}
+	return depth
+}
+
+func callTargetBoundaryDepth(depth, targetDepth int) bool {
+	return depth == 0 || (targetDepth > 0 && depth == targetDepth)
 }
 
 func parseArguments(text string) []argument {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -516,6 +516,30 @@ End Sub
 	}
 }
 
+func TestDiagnosticsDoNotReportExcelRangeCallChainArgumentsAsUndeclared(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Sub TestLastRow()
+    Dim ws As Worksheet
+    Dim lastRowA As Long
+
+    lastRowA = ws.Cells(ws.Rows.Count, "A").End(xlUp).Row
+    lastRowA = Cells(ws.Rows.Count, 1).End(xlUp).Row
+    Debug.Print ws.Range("A1").Value
+    Debug.Print ws.Range("A1:B10").Rows.Count
+    Debug.Print ThisWorkbook.Worksheets("Sheet1").Cells(1, "A").Value
+End Sub
+`,
+	}
+
+	diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VB029")
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no undeclared diagnostics for Excel member chains, got %+v", diagnostics)
+	}
+}
+
 func TestE2ESmokeNamespaceBuiltinAndWithSignatureCompletions(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	source := `Option Explicit
@@ -786,6 +810,9 @@ func TestResolveExpressionTypeHandlesExcelCollectionsAndCreateObject(t *testing.
 	}
 	if got, ok := analyzer.ResolveExpressionType(`Range("A1").Font`); !ok || got != "Excel.Font" {
 		t.Fatalf("Range(...).Font = %q, %v", got, ok)
+	}
+	if got, ok := analyzer.ResolveExpressionType(`Cells(1, "A").End(xlUp)`); !ok || got != "Excel.Range" {
+		t.Fatalf("Cells(...).End(...) = %q, %v", got, ok)
 	}
 	if got, ok := analyzer.ResolveExpressionType(`Application.WorksheetFunction`); !ok || got != "Excel.WorksheetFunction" {
 		t.Fatalf("Application.WorksheetFunction = %q, %v", got, ok)

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -234,6 +234,28 @@ End Sub
 	}
 }
 
+func TestSignatureHelpResolvesFormattedNestedCallTarget(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	source := `Option Explicit
+Sub Test()
+    Debug.Print IIf(True, MsgBox(
+End Sub
+`
+	doc := Document{Path: filepath.Join(t.TempDir(), "Main.bas"), Source: source}
+	line := `    Debug.Print IIf(True, MsgBox(`
+
+	help, err := analyzer.SignatureHelp(doc, Position{Line: 2, Character: utf16Len(line)}, []Document{doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if help == nil || len(help.Signatures) != 1 {
+		t.Fatalf("signature help = %+v, want one MsgBox signature", help)
+	}
+	if got := help.Signatures[0].Label; !strings.HasPrefix(got, "VBA.Global.MsgBox(") {
+		t.Fatalf("signature label = %q, want MsgBox signature", got)
+	}
+}
+
 func TestDiagnosticsTreatErrAsBuiltinGlobal(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	doc := Document{


### PR DESCRIPTION
## Summary
- Improve call-target parsing so space-separated arguments inside Excel member chains are not misread as undeclared identifiers.
- Restrict collection default type resolution to actual collection types before inferring element types.
- Add regression coverage for `Cells(...).End(xlUp)` and related Excel range chains.

## Testing
- Added unit tests covering VB029 diagnostics and expression type resolution for Excel member chains.
- Not run (not requested)