### PR TITLE
Enable VB020 by default and add inline suppression quick fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to xlflow will be documented in this file.
 - Improved human-readable CLI output with clearer sections, status markers, warnings/hints, and table-style summaries while preserving `--json` contracts.
 - Added `xlflow run --push` to import edited VBA source into the configured workbook before running a macro.
 - Improved `xlflow run` macro-failure diagnostics to suggest `xlflow push` / `xlflow run --push` when source files are newer than the saved workbook.
+- Enabled `VB020` unused local variable warnings by default; projects can opt out with `[lint].disabled_rules = ["VB020"]`.
+- Updated generated `xlflow.toml` files to show how to opt out of `VB020` and how to opt in to heavier project-wide rules such as `VB021` unused private procedures.
+- Improved `VB020` unused local variable detection so write-only assignments no longer count as variable references.
+- Fixed VBA LSP diagnostics so `VB020` unused local variable warnings appear in editor diagnostics for the current buffer.
 - Fixed `.NET` `xlflow run --interactive` so native VBA UI such as `MsgBox` is left for the user to dismiss instead of being misreported as `macro_failed`.
 - Fixed `.NET` Excel cleanup so direct `run`/`test` executions and `session stop` do not leave owned Excel processes behind after successful commands.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.18.0
+
 - Improved human-readable CLI output with clearer sections, status markers, warnings/hints, and table-style summaries while preserving `--json` contracts.
 - Added `xlflow run --push` to import edited VBA source into the configured workbook before running a macro.
 - Improved `xlflow run` macro-failure diagnostics to suggest `xlflow push` / `xlflow run --push` when source files are newer than the saved workbook.
@@ -11,6 +13,7 @@ All notable changes to xlflow will be documented in this file.
 - Updated generated `xlflow.toml` files to show how to opt out of `VB020` and how to opt in to heavier project-wide rules such as `VB021` unused private procedures.
 - Improved `VB020` unused local variable detection so write-only assignments no longer count as variable references.
 - Fixed VBA LSP diagnostics so `VB020` unused local variable warnings appear in editor diagnostics for the current buffer.
+- Added VS Code Quick Fix actions for xlflow diagnostics to insert line-level suppression comments.
 - Fixed `.NET` `xlflow run --interactive` so native VBA UI such as `MsgBox` is left for the user to dismiss instead of being misreported as `macro_failed`.
 - Fixed `.NET` Excel cleanup so direct `run`/`test` executions and `session stop` do not leave owned Excel processes behind after successful commands.
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -129,7 +129,7 @@ For GitHub Copilot, use `agents` because Copilot reads repository instructions f
 
 `update check` queries the latest GitHub Release and compares it with the current xlflow build version. The command does not require Excel COM. Successful JSON uses `command="update check"` and includes top-level `update.current_version`, `update.latest_version` when a newer release is available, `update.update_available`, and optional `update.release_url`. Versions that cannot be parsed as semantic versions, such as `dev`, are treated as not updateable and return `update_available=false`. Network, API, or malformed release responses fail with `error.code="update_check_failed"` and exit code `3`.
 
-`lsp --stdio` starts the reusable VBA language server over Language Server Protocol JSON-RPC using standard input and standard output. While the server is running, stdout is reserved exclusively for framed LSP messages; normal logging goes to stderr by default or to `--log-file <path>` when supplied. The initial MVP supports `initialize`, `initialized`, `shutdown`, `exit`, full-document `textDocument/didOpen`, `textDocument/didChange`, `textDocument/didClose`, diagnostic publication, `textDocument/documentSymbol`, `workspace/symbol`, `textDocument/definition`, `textDocument/references`, `textDocument/prepareRename`, `textDocument/rename`, `textDocument/hover`, `textDocument/completion`, and `textDocument/codeLens`. Open editor buffers are authoritative over filesystem content until `didClose`. Diagnostics use `source="xlflow"` and xlflow rule IDs such as `VB001`, `VB005`, and `VB014`. LSP diagnostics reuse the file-local lint rules used by `xlflow lint` against the current in-memory buffer; project-wide and filesystem-only lint checks remain CLI-only.
+`lsp --stdio` starts the reusable VBA language server over Language Server Protocol JSON-RPC using standard input and standard output. While the server is running, stdout is reserved exclusively for framed LSP messages; normal logging goes to stderr by default or to `--log-file <path>` when supplied. The initial MVP supports `initialize`, `initialized`, `shutdown`, `exit`, full-document `textDocument/didOpen`, `textDocument/didChange`, `textDocument/didClose`, diagnostic publication, `textDocument/documentSymbol`, `workspace/symbol`, `textDocument/definition`, `textDocument/references`, `textDocument/prepareRename`, `textDocument/rename`, `textDocument/hover`, `textDocument/completion`, and `textDocument/codeLens`. Open editor buffers are authoritative over filesystem content until `didClose`. Diagnostics use `source="xlflow"` and xlflow rule IDs such as `VB001`, `VB005`, `VB014`, and `VB020`. LSP diagnostics reuse the file-local lint rules used by `xlflow lint` against the current in-memory buffer; project-wide and filesystem-only lint checks such as unused private procedure detection remain CLI-only.
 
 LSP rename is intentionally conservative and identity-based. `textDocument/prepareRename` returns a range only for high-confidence project/source symbols: local variables, parameters, procedure-local constants, private or implicit-private module variables/constants, same-module private procedures, and same-procedure labels referenced by `GoTo`, `GoSub`, `Resume`, or `On Error GoTo`. `textDocument/rename` returns edits only for resolved references to that same declaration and never edits strings or comments. Rename is rejected for host, Office, TypeLib, external library, public project-wide API, module/class file, `Attribute VB_Name`, UserForm control, event-handler, property group, ambiguous, or unresolved targets.
 
@@ -281,6 +281,10 @@ code_source = "sidecar"
 
 [lint]
 disabled_rules = []
+# VB020 unused-local-variable warnings are enabled by default.
+# Add "VB020" to disabled_rules if a project intentionally keeps scratch locals.
+# Other project-wide lint rules remain disabled by default.
+# detect_unused_private_procedures = true # VB021
 
 [analyze]
 disabled_rules = []
@@ -510,7 +514,7 @@ Unknown inline suppression IDs are reported in command `warnings` as `unknown_in
 
 Configurable lint rule IDs map to legacy keys as follows: `VB001` = `require_option_explicit`, `VB002` = `forbid_select`, `VB003` = `forbid_activate`, `VB004` = `forbid_on_error_resume_next`, `VB005` = `detect_implicit_variant`, `VB006` = `forbid_public_module_fields`, `VB007` = `forbid_interactive_input`, `VB018` = `detect_scope_shadowing`, `VB019` = `detect_multiple_declarator_clarity`, `VB020` = `detect_unused_local_variables`, `VB021` = `detect_unused_private_procedures`, `VB022` = `detect_confusing_call_syntax`, `VB023` = `detect_for_each_control_type`, `VB026` = `detect_dangerous_resume`, and `VB027` = `detect_nested_with_ambiguity`.
 
-Higher-signal lint rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide lint rules `VB018`, `VB020`, `VB021`, and `VB027` are disabled by default and can still be enabled with their legacy `[lint]` booleans during the compatibility window.
+Higher-signal lint rules `VB019`, `VB020`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide lint rules `VB018`, `VB021`, and `VB027` are disabled by default and can still be enabled with their legacy `[lint]` booleans during the compatibility window.
 
 ## Analysis Rules
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## v0.3.0
+
+- Added Quick Fix actions for xlflow diagnostics to insert `xlflow:disable-next-line` or `xlflow:disable-line` suppression comments.
 - Offer a Push & Run choice before VS Code macro/procedure runs when source files are newer than the workbook.
 - Run macros from VS Code with `xlflow run --interactive` so user-triggered macro execution uses interactive mode explicitly.
 - Run user-triggered macro and procedure commands in the VS Code terminal instead of the Output panel.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xlflow-vscode",
   "displayName": "%extension.displayName%",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "%extension.description%",
   "categories": [
     "Formatters",

--- a/editors/vscode/src/codeActions.ts
+++ b/editors/vscode/src/codeActions.ts
@@ -38,12 +38,22 @@ class XlflowLineSuppressionCodeActionProvider implements vscode.CodeActionProvid
     const seen = new Set<string>();
     for (const diagnostic of context.diagnostics) {
       const code = diagnosticRuleCode(diagnostic);
-      if (code === undefined || seen.has(code)) {
+      if (code === undefined) {
         continue;
       }
-      seen.add(code);
-      actions.push(disableNextLineAction(document, diagnostic, code));
-      actions.push(disableLineAction(document, diagnostic, code));
+      const key = diagnosticActionKey(diagnostic, code);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      const nextLineAction = disableNextLineAction(document, diagnostic, code);
+      if (nextLineAction !== undefined) {
+        actions.push(nextLineAction);
+      }
+      const lineAction = disableLineAction(document, diagnostic, code);
+      if (lineAction !== undefined) {
+        actions.push(lineAction);
+      }
     }
     return actions;
   }
@@ -70,11 +80,23 @@ export function diagnosticRuleCode(diagnostic: vscode.Diagnostic): string | unde
   return normalized;
 }
 
+export function diagnosticActionKey(diagnostic: vscode.Diagnostic, code: string): string {
+  const range = diagnostic.range;
+  return [
+    code,
+    range.start.line,
+    range.start.character,
+    range.end.line,
+    range.end.character,
+    diagnostic.message,
+  ].join(":");
+}
+
 function disableNextLineAction(
   document: vscode.TextDocument,
   diagnostic: vscode.Diagnostic,
   code: string,
-): vscode.CodeAction {
+): vscode.CodeAction | undefined {
   const line = diagnostic.range.start.line;
   const action = new vscode.CodeAction(
     vscode.l10n.t("Suppress {0} on the next line", code),
@@ -85,6 +107,9 @@ function disableNextLineAction(
   action.edit = new vscode.WorkspaceEdit();
   const previous = existingDirectiveLine(document, line, "xlflow:disable-next-line");
   if (previous !== undefined) {
+    if (directiveLineHasCode(document.lineAt(previous).text, "xlflow:disable-next-line", code)) {
+      return undefined;
+    }
     action.edit.insert(
       document.uri,
       new vscode.Position(previous, document.lineAt(previous).text.length),
@@ -104,7 +129,7 @@ function disableLineAction(
   document: vscode.TextDocument,
   diagnostic: vscode.Diagnostic,
   code: string,
-): vscode.CodeAction {
+): vscode.CodeAction | undefined {
   const line = diagnostic.range.start.line;
   const action = new vscode.CodeAction(
     vscode.l10n.t("Suppress {0} on this line", code),
@@ -113,11 +138,11 @@ function disableLineAction(
   action.diagnostics = [diagnostic];
   action.edit = new vscode.WorkspaceEdit();
   const text = document.lineAt(line).text;
-  action.edit.insert(
-    document.uri,
-    new vscode.Position(line, text.length),
-    disableLineSuffix(text, code),
-  );
+  const suffix = disableLineSuffix(text, code);
+  if (suffix === "") {
+    return undefined;
+  }
+  action.edit.insert(document.uri, new vscode.Position(line, text.length), suffix);
   return action;
 }
 
@@ -148,9 +173,26 @@ export function disableNextLineComment(
 }
 
 export function disableLineSuffix(lineText: string, code: string): string {
-  if (/'\s*xlflow:disable-line\b/i.test(lineText)) {
+  const existing = /'\s*xlflow:disable-line\b(.*)$/i.exec(lineText);
+  if (existing !== null) {
+    if (directiveCodesInclude(existing[1], code)) {
+      return "";
+    }
     return ` ${code}`;
   }
   const spacer = lineText.trimEnd().length === 0 ? "" : " ";
   return `${spacer}' xlflow:disable-line ${code}`;
+}
+
+function directiveLineHasCode(lineText: string, directive: string, code: string): boolean {
+  const escaped = directive.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`'\\s*${escaped}\\b(.*)$`, "i").exec(lineText);
+  return match !== null && directiveCodesInclude(match[1], code);
+}
+
+function directiveCodesInclude(text: string, code: string): boolean {
+  return text
+    .trim()
+    .split(/\s+/)
+    .some((candidate) => candidate.toUpperCase() === code.toUpperCase());
 }

--- a/editors/vscode/src/codeActions.ts
+++ b/editors/vscode/src/codeActions.ts
@@ -1,0 +1,156 @@
+import * as vscode from "vscode";
+
+const unsupportedInlineSuppressionRules = new Set([
+  "VB008",
+  "VB009",
+  "VB010",
+  "VB011",
+  "VB012",
+  "VB013",
+  "VB014",
+  "VB028",
+  "VB029",
+  "VB031",
+  "VB032",
+  "VBA104",
+  "VBA105",
+  "VBA106",
+  "VBA211",
+]);
+
+export function registerLineSuppressionCodeActions(): vscode.Disposable {
+  return vscode.languages.registerCodeActionsProvider(
+    { language: "vba", scheme: "file" },
+    new XlflowLineSuppressionCodeActionProvider(),
+    {
+      providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],
+    },
+  );
+}
+
+class XlflowLineSuppressionCodeActionProvider implements vscode.CodeActionProvider {
+  public provideCodeActions(
+    document: vscode.TextDocument,
+    _range: vscode.Range,
+    context: vscode.CodeActionContext,
+  ): vscode.CodeAction[] {
+    const actions: vscode.CodeAction[] = [];
+    const seen = new Set<string>();
+    for (const diagnostic of context.diagnostics) {
+      const code = diagnosticRuleCode(diagnostic);
+      if (code === undefined || seen.has(code)) {
+        continue;
+      }
+      seen.add(code);
+      actions.push(disableNextLineAction(document, diagnostic, code));
+      actions.push(disableLineAction(document, diagnostic, code));
+    }
+    return actions;
+  }
+}
+
+export function diagnosticRuleCode(diagnostic: vscode.Diagnostic): string | undefined {
+  if (diagnostic.source !== "xlflow") {
+    return undefined;
+  }
+  const raw = diagnostic.code;
+  const code =
+    typeof raw === "string" || typeof raw === "number"
+      ? String(raw)
+      : raw === undefined
+        ? ""
+        : String(raw.value);
+  const normalized = code.trim().toUpperCase();
+  if (!/^(?:VB|VBA)\d{3}$/.test(normalized)) {
+    return undefined;
+  }
+  if (unsupportedInlineSuppressionRules.has(normalized)) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function disableNextLineAction(
+  document: vscode.TextDocument,
+  diagnostic: vscode.Diagnostic,
+  code: string,
+): vscode.CodeAction {
+  const line = diagnostic.range.start.line;
+  const action = new vscode.CodeAction(
+    vscode.l10n.t("Suppress {0} on the next line", code),
+    vscode.CodeActionKind.QuickFix,
+  );
+  action.diagnostics = [diagnostic];
+  action.isPreferred = true;
+  action.edit = new vscode.WorkspaceEdit();
+  const previous = existingDirectiveLine(document, line, "xlflow:disable-next-line");
+  if (previous !== undefined) {
+    action.edit.insert(
+      document.uri,
+      new vscode.Position(previous, document.lineAt(previous).text.length),
+      ` ${code}`,
+    );
+    return action;
+  }
+  action.edit.insert(
+    document.uri,
+    new vscode.Position(line, 0),
+    disableNextLineComment(document.lineAt(line).text, code, document.eol),
+  );
+  return action;
+}
+
+function disableLineAction(
+  document: vscode.TextDocument,
+  diagnostic: vscode.Diagnostic,
+  code: string,
+): vscode.CodeAction {
+  const line = diagnostic.range.start.line;
+  const action = new vscode.CodeAction(
+    vscode.l10n.t("Suppress {0} on this line", code),
+    vscode.CodeActionKind.QuickFix,
+  );
+  action.diagnostics = [diagnostic];
+  action.edit = new vscode.WorkspaceEdit();
+  const text = document.lineAt(line).text;
+  action.edit.insert(
+    document.uri,
+    new vscode.Position(line, text.length),
+    disableLineSuffix(text, code),
+  );
+  return action;
+}
+
+function existingDirectiveLine(
+  document: vscode.TextDocument,
+  targetLine: number,
+  directive: "xlflow:disable-next-line",
+): number | undefined {
+  const previousLine = targetLine - 1;
+  if (previousLine < 0) {
+    return undefined;
+  }
+  const text = document.lineAt(previousLine).text;
+  if (new RegExp(`'\\s*${directive}\\b`, "i").test(text)) {
+    return previousLine;
+  }
+  return undefined;
+}
+
+export function disableNextLineComment(
+  targetLineText: string,
+  code: string,
+  eol: vscode.EndOfLine,
+): string {
+  const indent = targetLineText.match(/^\s*/)?.[0] ?? "";
+  const newline = eol === vscode.EndOfLine.CRLF ? "\r\n" : "\n";
+  return `${indent}' xlflow:disable-next-line ${code}${newline}`;
+}
+
+export function disableLineSuffix(lineText: string, code: string): string {
+  if (/'\s*xlflow:disable-line\b/i.test(lineText)) {
+    return ` ${code}`;
+  }
+  const spacer = lineText.trimEnd().length === 0 ? "" : " ";
+  return `${spacer}' xlflow:disable-line ${code}`;
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { registerLineSuppressionCodeActions } from "./codeActions";
 import { showProjectCliUnavailableNotice, XlflowCliAvailabilityService } from "./cliAvailability";
 import { XlflowLanguageClientManager } from "./client";
 import { registerCommands } from "./commands";
@@ -45,6 +46,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     projectState,
     updateService,
     sidebar,
+    registerLineSuppressionCodeActions(),
   );
   let lastSelectedWorkspaceKey = selectedWorkspaceKey();
 

--- a/editors/vscode/test/suite/extension.test.ts
+++ b/editors/vscode/test/suite/extension.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeAvailabilitySuccess,
 } from "../../src/cliAvailability";
 import {
+  diagnosticActionKey,
   diagnosticRuleCode,
   disableLineSuffix,
   disableNextLineComment,
@@ -139,6 +140,10 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
     " VB021",
   );
   assert.strictEqual(
+    disableLineSuffix("    Dim staleValue As Long ' xlflow:disable-line VB020", "VB020"),
+    "",
+  );
+  assert.strictEqual(
     disableNextLineComment("    Dim staleValue As Long", "VB020", vscode.EndOfLine.LF),
     "    ' xlflow:disable-next-line VB020\n",
   );
@@ -150,6 +155,17 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
   suppressibleDiagnostic.source = "xlflow";
   suppressibleDiagnostic.code = "VB020";
   assert.strictEqual(diagnosticRuleCode(suppressibleDiagnostic), "VB020");
+  const secondSuppressibleDiagnostic = new vscode.Diagnostic(
+    new vscode.Range(1, 0, 1, 1),
+    "unused local",
+    vscode.DiagnosticSeverity.Warning,
+  );
+  secondSuppressibleDiagnostic.source = "xlflow";
+  secondSuppressibleDiagnostic.code = "VB020";
+  assert.notStrictEqual(
+    diagnosticActionKey(suppressibleDiagnostic, "VB020"),
+    diagnosticActionKey(secondSuppressibleDiagnostic, "VB020"),
+  );
   suppressibleDiagnostic.code = "VB029";
   assert.strictEqual(diagnosticRuleCode(suppressibleDiagnostic), undefined);
   assert.deepStrictEqual(

--- a/editors/vscode/test/suite/extension.test.ts
+++ b/editors/vscode/test/suite/extension.test.ts
@@ -8,6 +8,11 @@ import {
   normalizeAvailabilityFailure,
   normalizeAvailabilitySuccess,
 } from "../../src/cliAvailability";
+import {
+  diagnosticRuleCode,
+  disableLineSuffix,
+  disableNextLineComment,
+} from "../../src/codeActions";
 import { lspCodeLensOptions, lspServerArgs } from "../../src/client";
 import { sessionStateFromEnvelope, sessionStatusText } from "../../src/session";
 import {
@@ -125,6 +130,28 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
     buildTerminalCommandLine("C:\\Program Files\\xlflow\\xlflow.exe", ["run", "Main.Hello World"]),
     '"C:\\Program Files\\xlflow\\xlflow.exe" run "Main.Hello World"',
   );
+  assert.strictEqual(
+    disableLineSuffix("    Dim staleValue As Long", "VB020"),
+    " ' xlflow:disable-line VB020",
+  );
+  assert.strictEqual(
+    disableLineSuffix("    Dim staleValue As Long ' xlflow:disable-line VB020", "VB021"),
+    " VB021",
+  );
+  assert.strictEqual(
+    disableNextLineComment("    Dim staleValue As Long", "VB020", vscode.EndOfLine.LF),
+    "    ' xlflow:disable-next-line VB020\n",
+  );
+  const suppressibleDiagnostic = new vscode.Diagnostic(
+    new vscode.Range(0, 0, 0, 1),
+    "unused local",
+    vscode.DiagnosticSeverity.Warning,
+  );
+  suppressibleDiagnostic.source = "xlflow";
+  suppressibleDiagnostic.code = "VB020";
+  assert.strictEqual(diagnosticRuleCode(suppressibleDiagnostic), "VB020");
+  suppressibleDiagnostic.code = "VB029";
+  assert.strictEqual(diagnosticRuleCode(suppressibleDiagnostic), undefined);
   assert.deepStrictEqual(
     await lspServerArgs({ lspLogFile: ".xlflow/lsp.log", lspLogFileConfigured: false }, undefined),
     ["lsp", "--stdio"],

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -549,6 +549,11 @@ func renderLintConfig(cfg LintConfig) string {
 		}
 		b.WriteString("]\n")
 	}
+	optIn := legacyOptInLintRulesForWrite(cfg)
+	optInSet := map[string]bool{}
+	for _, rule := range optIn {
+		optInSet[rule.Key] = true
+	}
 	b.WriteString("\n")
 	b.WriteString("# VB020 unused-local-variable warnings are enabled by default.\n")
 	b.WriteString("# Add \"VB020\" to disabled_rules if a project intentionally keeps scratch locals.\n")
@@ -556,10 +561,18 @@ func renderLintConfig(cfg LintConfig) string {
 	b.WriteString("# Optional project-wide lint rules. They are disabled by default because\n")
 	b.WriteString("# they can be noisy in projects with callback-heavy or workbook-driven VBA.\n")
 	b.WriteString("# Uncomment individual rules to enable them.\n")
-	b.WriteString("# detect_scope_shadowing = true          # VB018\n")
-	b.WriteString("# detect_unused_private_procedures = true # VB021\n")
-	b.WriteString("# detect_nested_with_ambiguity = true    # VB027\n")
-	optIn := legacyOptInLintRulesForWrite(cfg)
+	for _, hint := range []struct {
+		Key  string
+		Line string
+	}{
+		{"detect_scope_shadowing", "# detect_scope_shadowing = true          # VB018\n"},
+		{"detect_unused_private_procedures", "# detect_unused_private_procedures = true # VB021\n"},
+		{"detect_nested_with_ambiguity", "# detect_nested_with_ambiguity = true    # VB027\n"},
+	} {
+		if !optInSet[hint.Key] {
+			b.WriteString(hint.Line)
+		}
+	}
 	if len(optIn) > 0 {
 		b.WriteString("\n")
 		b.WriteString("# Enabled optional lint settings.\n")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,7 +124,7 @@ var configurableLintRules = []lintRuleConfig{
 	{ID: "VB007", Key: "forbid_interactive_input", Default: true, Get: func(c LintConfig) bool { return c.ForbidInteractiveInput }, Set: func(c *LintConfig, v bool) { c.ForbidInteractiveInput = v }},
 	{ID: "VB018", Key: "detect_scope_shadowing", Default: false, Get: func(c LintConfig) bool { return c.DetectScopeShadowing }, Set: func(c *LintConfig, v bool) { c.DetectScopeShadowing = v }},
 	{ID: "VB019", Key: "detect_multiple_declarator_clarity", Default: true, Get: func(c LintConfig) bool { return c.DetectMultipleDeclaratorClarity }, Set: func(c *LintConfig, v bool) { c.DetectMultipleDeclaratorClarity = v }},
-	{ID: "VB020", Key: "detect_unused_local_variables", Default: false, Get: func(c LintConfig) bool { return c.DetectUnusedLocalVariables }, Set: func(c *LintConfig, v bool) { c.DetectUnusedLocalVariables = v }},
+	{ID: "VB020", Key: "detect_unused_local_variables", Default: true, Get: func(c LintConfig) bool { return c.DetectUnusedLocalVariables }, Set: func(c *LintConfig, v bool) { c.DetectUnusedLocalVariables = v }},
 	{ID: "VB021", Key: "detect_unused_private_procedures", Default: false, Get: func(c LintConfig) bool { return c.DetectUnusedPrivateProcedures }, Set: func(c *LintConfig, v bool) { c.DetectUnusedPrivateProcedures = v }},
 	{ID: "VB022", Key: "detect_confusing_call_syntax", Default: true, Get: func(c LintConfig) bool { return c.DetectConfusingCallSyntax }, Set: func(c *LintConfig, v bool) { c.DetectConfusingCallSyntax = v }},
 	{ID: "VB023", Key: "detect_for_each_control_type", Default: true, Get: func(c LintConfig) bool { return c.DetectForEachControlType }, Set: func(c *LintConfig, v bool) { c.DetectForEachControlType = v }},
@@ -250,6 +250,7 @@ func Default() Config {
 			ForbidPublicModuleFields:        true,
 			ForbidInteractiveInput:          true,
 			DetectMultipleDeclaratorClarity: true,
+			DetectUnusedLocalVariables:      true,
 			DetectConfusingCallSyntax:       true,
 			DetectForEachControlType:        true,
 			DetectDangerousResume:           true,
@@ -548,10 +549,20 @@ func renderLintConfig(cfg LintConfig) string {
 		}
 		b.WriteString("]\n")
 	}
+	b.WriteString("\n")
+	b.WriteString("# VB020 unused-local-variable warnings are enabled by default.\n")
+	b.WriteString("# Add \"VB020\" to disabled_rules if a project intentionally keeps scratch locals.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Optional project-wide lint rules. They are disabled by default because\n")
+	b.WriteString("# they can be noisy in projects with callback-heavy or workbook-driven VBA.\n")
+	b.WriteString("# Uncomment individual rules to enable them.\n")
+	b.WriteString("# detect_scope_shadowing = true          # VB018\n")
+	b.WriteString("# detect_unused_private_procedures = true # VB021\n")
+	b.WriteString("# detect_nested_with_ambiguity = true    # VB027\n")
 	optIn := legacyOptInLintRulesForWrite(cfg)
 	if len(optIn) > 0 {
 		b.WriteString("\n")
-		b.WriteString("# Legacy opt-in lint settings. Prefer disabled_rules for disabling recommended rules.\n")
+		b.WriteString("# Enabled optional lint settings.\n")
 		for _, rule := range optIn {
 			b.WriteString(rule.Key)
 			b.WriteString(" = true\n")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,11 +52,12 @@ path = "build/Sales.xlsm"
 		t.Fatalf("interactive input lint default was not applied")
 	}
 	if !cfg.Lint.DetectMultipleDeclaratorClarity ||
+		!cfg.Lint.DetectUnusedLocalVariables ||
 		!cfg.Lint.DetectConfusingCallSyntax || !cfg.Lint.DetectForEachControlType ||
 		!cfg.Lint.DetectDangerousResume {
 		t.Fatalf("expected high-signal AST lint defaults to be enabled: %+v", cfg.Lint)
 	}
-	if cfg.Lint.DetectScopeShadowing || cfg.Lint.DetectUnusedLocalVariables ||
+	if cfg.Lint.DetectScopeShadowing ||
 		cfg.Lint.DetectUnusedPrivateProcedures ||
 		cfg.Lint.DetectNestedWithAmbiguity {
 		t.Fatalf("expected false-positive-prone AST lint defaults to be opt-in: %+v", cfg.Lint)
@@ -592,6 +593,15 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 		!strings.Contains(text, "operator_spacing = true") ||
 		!strings.Contains(text, "declaration_spacing = true") {
 		t.Fatalf("generated config should include fmt spacing settings:\n%s", text)
+	}
+	for _, want := range []string{
+		"# VB020 unused-local-variable warnings are enabled by default.",
+		"# Add \"VB020\" to disabled_rules if a project intentionally keeps scratch locals.",
+		"# detect_unused_private_procedures = true # VB021",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generated config missing %q:\n%s", want, text)
+		}
 	}
 
 	loaded, err := Load(dir)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -637,6 +637,28 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	}
 }
 
+func TestWriteOmitsOptionalLintHintsForEnabledOptIns(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Default()
+	cfg.Lint.DetectUnusedPrivateProcedures = true
+
+	p := filepath.Join(dir, FileName)
+	if err := Write(p, cfg); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	body, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if strings.Contains(text, "# detect_unused_private_procedures = true # VB021") {
+		t.Fatalf("generated config should not include opt-in hint for enabled VB021:\n%s", text)
+	}
+	if !strings.Contains(text, "detect_unused_private_procedures = true") {
+		t.Fatalf("generated config should include enabled VB021 setting:\n%s", text)
+	}
+}
+
 func hasConfigWarning(warnings []map[string]any, code string, rule string) bool {
 	for _, warning := range warnings {
 		if warning["code"] == code && warning["rule"] == rule {

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -202,6 +202,7 @@ func (l Linter) lintSource(path string, source []byte, includeFilesystemRules bo
 	}
 	issues = append(issues, l.flowIssues(path, string(source), parsed.Root)...)
 	issues = append(issues, l.undeclaredVariableIssues(path, string(source), parsed.Root)...)
+	issues = append(issues, l.unusedLocalVariableIssues(path, string(source))...)
 
 	if includeFilesystemRules && l.Config.Lint.ForbidInteractiveInput {
 		boundaries, err := gui.Analyzer{RootDir: l.RootDir, Config: l.Config}.AnalyzeFile(path)
@@ -1179,7 +1180,7 @@ afterVisibility:
 
 func (l Linter) projectIssues() ([]Issue, error) {
 	cfg := l.Config.Lint
-	if !cfg.DetectScopeShadowing && !cfg.DetectUnusedLocalVariables && !cfg.DetectUnusedPrivateProcedures {
+	if !cfg.DetectScopeShadowing && !cfg.DetectUnusedPrivateProcedures {
 		return nil, nil
 	}
 	result, err := symbols.Inspect(symbols.Options{
@@ -1192,7 +1193,7 @@ func (l Linter) projectIssues() ([]Issue, error) {
 		return nil, err
 	}
 	var issues []Issue
-	if cfg.DetectScopeShadowing || cfg.DetectUnusedLocalVariables {
+	if cfg.DetectScopeShadowing {
 		issues = append(issues, l.symbolScopeIssues(result)...)
 	}
 	if cfg.DetectUnusedPrivateProcedures {
@@ -1210,7 +1211,6 @@ func (l Linter) symbolScopeIssues(result *symbols.Result) []Issue {
 		return nil
 	}
 	var issues []Issue
-	sourceCache := map[string]string{}
 	for _, file := range result.Files {
 		moduleNames := map[string]symbols.Symbol{}
 		procedureNames := map[string]symbols.Symbol{}
@@ -1255,26 +1255,41 @@ func (l Linter) symbolScopeIssues(result *symbols.Result) []Issue {
 					sameScope[scopeKey][key] = sym
 				}
 			}
-			if l.Config.Lint.DetectUnusedLocalVariables && !isIgnoredLocalName(sym.Name) {
-				source, ok := sourceCache[sym.File]
-				if !ok {
-					body, err := os.ReadFile(filepath.Join(l.RootDir, filepath.FromSlash(sym.File)))
-					if err != nil {
-						continue
-					}
-					source = string(body)
-					sourceCache[sym.File] = source
-				}
-				if !localNameReferenced(source, sym, procedureEndLineForSymbol(file.Symbols, sym)) {
-					issue := l.issueForSymbol(sym, "VB020", "warning", "Procedure-local variable is declared but never referenced.")
-					issue.Symbol = sym.Name
-					issues = append(issues, issue)
-				}
-			}
 		}
 		if l.Config.Lint.DetectScopeShadowing {
 			issues = append(issues, l.parameterShadowingIssues(file, moduleNames, procedureNames)...)
 		}
+	}
+	return issues
+}
+
+func (l Linter) unusedLocalVariableIssues(path, source string) []Issue {
+	if !l.Config.Lint.DetectUnusedLocalVariables {
+		return nil
+	}
+	file, err := symbols.InspectSource(symbols.SourceOptions{
+		RootDir:        l.RootDir,
+		Path:           path,
+		IncludePrivate: true,
+		IncludeLabels:  false,
+	}, []byte(source))
+	if err != nil {
+		return nil
+	}
+	var issues []Issue
+	for _, sym := range file.Symbols {
+		if sym.Kind != "local_variable" && (sym.Kind != "const" || sym.Parent == "") {
+			continue
+		}
+		if isIgnoredLocalName(sym.Name) {
+			continue
+		}
+		if localNameReferenced(source, sym, procedureEndLineForSymbol(file.Symbols, sym)) {
+			continue
+		}
+		issue := l.issueForSymbol(sym, "VB020", "warning", "Procedure-local variable is declared but never referenced.")
+		issue.Symbol = sym.Name
+		issues = append(issues, issue)
 	}
 	return issues
 }
@@ -1432,37 +1447,66 @@ func procedureEndLineForSymbol(all []symbols.Symbol, sym symbols.Symbol) int {
 func localNameReferenced(source string, sym symbols.Symbol, endLine int) bool {
 	lines := normalizedSourceLines(source)
 	needle := sym.Name
-	count := 0
 	for i := sym.StartLine - 1; i < len(lines); i++ {
 		lineNo := i + 1
 		if sym.Parent != "" && endLine > 0 && lineNo > endLine {
 			break
 		}
 		line := normalizedCodeLine(lines[i])
-		if lineNo == sym.StartLine {
-			line = stripDeclarationPrefix(line)
-		}
-		if hasWord(line, needle) {
-			count++
-		}
-		if count > 0 {
-			return true
+		for _, statement := range splitStatements(line) {
+			if lineNo == sym.StartLine && isLocalDeclarationStatement(statement) {
+				continue
+			}
+			if hasLocalReadUse(statement, needle) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func stripDeclarationPrefix(line string) string {
-	lower := strings.ToLower(line)
-	for _, prefix := range []string{"dim ", "static ", "private ", "public "} {
-		if strings.HasPrefix(lower, prefix) {
-			if idx := strings.Index(line, ","); idx >= 0 {
-				return line[idx+1:]
-			}
-			return ""
-		}
+func isLocalDeclarationStatement(statement string) bool {
+	fields := lowerFields(statement)
+	if len(fields) == 0 {
+		return false
 	}
-	return line
+	switch fields[0] {
+	case "dim", "static", "const":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasLocalReadUse(code, symbol string) bool {
+	lowerCode := strings.ToLower(code)
+	lowerSymbol := strings.ToLower(symbol)
+	for offset := 0; ; {
+		index := strings.Index(lowerCode[offset:], lowerSymbol)
+		if index < 0 {
+			return false
+		}
+		index += offset
+		end := index + len(symbol)
+		if isIdentifierBoundary(code, index-1) &&
+			isIdentifierBoundary(code, end) &&
+			!isQualifiedIdentifier(code, index) &&
+			!isLocalAssignmentTargetOccurrence(code, index, end) {
+			return true
+		}
+		offset = end
+	}
+}
+
+func isLocalAssignmentTargetOccurrence(code string, index, end int) bool {
+	if !isAssignmentTarget(code, end) {
+		return false
+	}
+	prefix := strings.TrimSpace(code[:index])
+	if prefix == "" {
+		return true
+	}
+	return strings.EqualFold(prefix, "Set") || strings.EqualFold(prefix, "Let")
 }
 
 func isKnownCallbackProcedure(name string) bool {

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -1510,7 +1510,16 @@ func isLocalAssignmentTargetOccurrence(code string, index, end int) bool {
 	if prefix == "" {
 		return true
 	}
-	return strings.EqualFold(prefix, "Set") || strings.EqualFold(prefix, "Let")
+	fields := strings.Fields(prefix)
+	if len(fields) == 0 {
+		return true
+	}
+	switch strings.ToLower(fields[len(fields)-1]) {
+	case "set", "let", "then", "else":
+		return true
+	default:
+		return false
+	}
 }
 
 func isKnownCallbackProcedure(name string) bool {

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -222,6 +222,10 @@ func (l Linter) lintSource(path string, source []byte, includeFilesystemRules bo
 			})
 		}
 	}
+	if !includeFilesystemRules {
+		directives, _ := suppression.DirectivesForSource(l.RootDir, path, string(source))
+		issues, _ = applyInlineSuppressions(issues, directives)
+	}
 	return issues, nil
 }
 

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -1296,6 +1296,25 @@ func TestLinterLintSourceUsesUnsavedContent(t *testing.T) {
 	assertIssue(t, issues, "VB020", 3)
 }
 
+func TestLinterLintSourceAppliesInlineSuppressions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "src", "modules", "Main.bas")
+	source := []byte(`Option Explicit
+Public Sub Run()
+    Dim x As Integer ' xlflow:disable-line VB020
+    x = 2
+End Sub
+`)
+
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.LintSource(path, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := issuesByCode(issues, "VB020"); len(got) != 0 {
+		t.Fatalf("VB020 should be suppressed for in-memory lint source, got %+v", got)
+	}
+}
+
 func TestLinterReportsUndeclaredAssignmentsWithOptionExplicit(t *testing.T) {
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -1194,6 +1194,31 @@ End Sub
 	}
 }
 
+func TestLinterUnusedLocalVariableIgnoresWriteOnlyAssignments(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim writtenOnly As Long
+  Dim assignedObject As Object
+  Dim updated As Long
+  writtenOnly = 1
+  Set assignedObject = Nothing
+  updated = updated + 1
+End Sub
+`)
+	cfg := config.Default()
+	cfg.Lint.DetectUnusedLocalVariables = true
+
+	issues, err := Linter{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb020 := issuesByCode(issues, "VB020")
+	if len(vb020) != 2 || vb020[0].Symbol != "writtenOnly" || vb020[1].Symbol != "assignedObject" {
+		t.Fatalf("expected only write-only assignments to trigger VB020, got %+v", vb020)
+	}
+}
+
 func TestLinterDetectsNestedWithAmbiguityWhenEnabled(t *testing.T) {
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
@@ -1268,6 +1293,7 @@ func TestLinterLintSourceUsesUnsavedContent(t *testing.T) {
 	assertIssue(t, issues, "VB001", 1)
 	assertIssue(t, issues, "VB002", 2)
 	assertIssue(t, issues, "VB005", 3)
+	assertIssue(t, issues, "VB020", 3)
 }
 
 func TestLinterReportsUndeclaredAssignmentsWithOptionExplicit(t *testing.T) {

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -1219,6 +1219,29 @@ End Sub
 	}
 }
 
+func TestLinterUnusedLocalVariableTreatsOneLineConditionalAssignmentsAsWrites(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim scalarValue As Long
+  Dim objectValue As Object
+  If True Then scalarValue = 1
+  If True Then Set objectValue = Nothing
+End Sub
+`)
+	cfg := config.Default()
+	cfg.Lint.DetectUnusedLocalVariables = true
+
+	issues, err := Linter{RootDir: dir, Config: cfg}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb020 := issuesByCode(issues, "VB020")
+	if len(vb020) != 2 || vb020[0].Symbol != "scalarValue" || vb020[1].Symbol != "objectValue" {
+		t.Fatalf("expected one-line conditional write-only assignments to trigger VB020, got %+v", vb020)
+	}
+}
+
 func TestLinterDetectsNestedWithAmbiguityWhenEnabled(t *testing.T) {
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/suppression/suppression.go
+++ b/internal/suppression/suppression.go
@@ -44,6 +44,17 @@ func DirectivesForFiles(root string, paths []string) ([]Directive, []map[string]
 	return directives, warnings, nil
 }
 
+func DirectivesForSource(root, path, source string) ([]Directive, []map[string]any) {
+	file, err := filepath.Rel(root, path)
+	if err != nil {
+		file = path
+	}
+	if !filepath.IsAbs(path) {
+		file = path
+	}
+	return directivesForSource(filepath.ToSlash(file), source)
+}
+
 func Apply(diagnostics []Diagnostic, directives []Directive, family Family) ([]bool, []map[string]any) {
 	suppressed := make([]bool, len(diagnostics))
 	used := make([]bool, len(directives))
@@ -92,7 +103,12 @@ func directivesForFile(root, path string) ([]Directive, []map[string]any, error)
 		file = path
 	}
 	file = filepath.ToSlash(file)
-	lines := normalizedSourceLines(string(body))
+	directives, warnings := directivesForSource(file, string(body))
+	return directives, warnings, nil
+}
+
+func directivesForSource(file, source string) ([]Directive, []map[string]any) {
+	lines := normalizedSourceLines(source)
 	var directives []Directive
 	var warnings []map[string]any
 	for i, line := range lines {
@@ -143,7 +159,7 @@ func directivesForFile(root, path string) ([]Directive, []map[string]any, error)
 			})
 		}
 	}
-	return directives, warnings, nil
+	return directives, warnings
 }
 
 func parseDirective(comment string) (string, []string, bool) {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -859,6 +859,24 @@ End Sub
 	}
 }
 
+func TestDiagnosticsApplyInlineSuppressionsForUnsavedContent(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Public Sub Run()
+    Dim x As Integer ' xlflow:disable-line VB020
+    x = 2
+End Sub
+`,
+	}
+
+	diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VB020")
+	if len(diagnostics) != 0 {
+		t.Fatalf("VB020 should be suppressed for unsaved LSP diagnostics, got %+v", diagnostics)
+	}
+}
+
 func TestDiagnosticsDoNotReportExcelRangeCallChainArgumentsAsUndeclared(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	doc := Document{

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -73,6 +73,7 @@ End Sub
 Public Sub Run()
     Dim missingValue As Long
     missingValue = 1
+    Debug.Print missingValue
 End Sub
 `
 	doc.Source = `Attribute VB_Name = "Main"
@@ -836,6 +837,25 @@ End Sub
 	diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VB029")
 	if !hasDiagnosticMessage(diagnostics, `Undeclared identifier "dict"`) {
 		t.Fatalf("missing out-of-scope dict diagnostic: %+v", diagnostics)
+	}
+}
+
+func TestDiagnosticsIncludeUnusedLocalVariables(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Public Sub Run()
+    Dim staleValue As Long
+    Dim usedValue As Long
+    usedValue = usedValue + 1
+End Sub
+`,
+	}
+
+	diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VB020")
+	if len(diagnostics) != 1 || !strings.Contains(diagnostics[0].Message, "Procedure-local variable") {
+		t.Fatalf("expected one VB020 diagnostic for staleValue, got %+v", diagnostics)
 	}
 }
 

--- a/vitepress/commands/lint.md
+++ b/vitepress/commands/lint.md
@@ -85,7 +85,7 @@ Multiple IDs may be listed with spaces. Unknown IDs, unsupported preflight-block
 
 Safety diagnostics `VB008` through `VB014`, `VB028`, `VB029`, `VB031`, and `VB032` are always enabled and cannot be suppressed inline because they prevent VBE compile dialogs before `push` or `run` opens Excel.
 
-Rules `VB019`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide rules stay conservative opt-ins through legacy `[lint]` settings. Use [`analyze`](./analyze) for semantic runtime-risk checks such as unqualified Excel access, error-handler fallthrough, Application state leaks, and `Range.Find` `Nothing` guards.
+Rules `VB019`, `VB020`, `VB022`, `VB023`, and `VB026` are enabled by default. Disable `VB020` with `disabled_rules = ["VB020"]` when a project intentionally keeps scratch locals. Heavier project-wide rules such as `detect_unused_private_procedures = true` (`VB021`) stay conservative opt-ins; new `xlflow.toml` files include commented examples. Use [`analyze`](./analyze) for semantic runtime-risk checks such as unqualified Excel access, error-handler fallthrough, Application state leaks, and `Range.Find` `Nothing` guards.
 
 ## JSON Output Example
 

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -62,6 +62,14 @@ code_source = "sidecar"
 # Disable specific lint rules by diagnostic ID.
 disabled_rules = []
 
+# VB020 unused-local-variable warnings are enabled by default.
+# Add "VB020" to disabled_rules if a project intentionally keeps scratch locals.
+#
+# Optional project-wide lint rules. Uncomment individual rules to enable them.
+# detect_scope_shadowing = true          # VB018
+# detect_unused_private_procedures = true # VB021
+# detect_nested_with_ambiguity = true    # VB027
+
 # Runtime-risk analysis rules.
 [analyze]
 # Disable specific analyzer rules by diagnostic ID.
@@ -120,6 +128,8 @@ When `[vba].folders = true`, files may be nested under these roots according to 
 | `disabled_rules` | string[] | no       | `[]`    | Disable configurable lint rules by diagnostic ID. |
 
 Legacy per-rule booleans such as `forbid_select = false` remain accepted for compatibility, but xlflow emits a deprecation warning. Prefer `disabled_rules = ["VB002"]`.
+
+`VB020` unused-local-variable warnings are enabled by default and can be disabled with `disabled_rules = ["VB020"]`. Other project-wide lint rules such as `detect_unused_private_procedures = true` (`VB021`) remain disabled by default. New `xlflow.toml` files include commented examples so projects can opt in deliberately.
 
 Configurable lint rule IDs:
 


### PR DESCRIPTION
## Summary
- Enabled `VB020` unused local variable warnings by default and updated generated config/docs to reflect the new default.
- Improved VB020 detection so write-only assignments do not count as reads, and moved unused-local detection into file-local linting so it also applies to LSP diagnostics.
- Added VS Code Quick Fix actions to insert `xlflow:disable-next-line` and `xlflow:disable-line` suppression comments.

## Testing
- Added coverage for VB020 write-only assignment handling, in-memory lint suppression, and VS Code suppression comment helpers.
- Updated config and documentation tests to verify the generated defaults and comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick fixes in VS Code to suppress individual diagnostics inline.
  * Enabled the unused-local-variable warning by default and improved lint/diagnostic handling.
  * Improved CLI output and added support for pushing edited workbook VBA back into Excel.

* **Bug Fixes**
  * Made macro failure messages clearer and improved cleanup after successful runs.
  * Fixed interactive Excel behavior so native dialogs remain usable.

* **Documentation**
  * Updated lint and config docs with new default rules and suppression examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->