### PR TITLE
Fix VB009 false positives for valid VBA escaped quote strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to xlflow will be documented in this file.
 
 - Added `xlflow session attach` to adopt an already-open configured workbook as an external xlflow session, and deprecated legacy `xlflow attach --active` validation-only usage.
 - Added VS Code extension actions to connect to an already-open workbook from the session menu and open the configured workbook in Excel from the Project view.
+- Fixed `VB009` false positives for valid VBA strings such as the official VBA-JSON `JsonConverter.bas` escaped quote output (`json_Char = "\"""`).
 
 ## v0.19.0
 

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -1629,19 +1629,28 @@ func containsTypographicQuote(line string) bool {
 }
 
 func containsLikelyCStyleQuoteEscape(line string) bool {
-	for i := 0; i < len(line)-2; i++ {
-		if line[i] != '\\' || line[i+1] != '"' {
+	inString := false
+	sawBackslashEscapedQuote := false
+	for i := 0; i < len(line); i++ {
+		if line[i] != '"' {
 			continue
 		}
-		quoteCount := 0
-		for j := i + 1; j < len(line) && line[j] == '"'; j++ {
-			quoteCount++
+		if !inString {
+			inString = true
+			sawBackslashEscapedQuote = false
+			continue
 		}
-		if quoteCount >= 2 {
-			return true
+		if i+1 < len(line) && line[i+1] == '"' {
+			if i > 0 && line[i-1] == '\\' {
+				sawBackslashEscapedQuote = true
+			}
+			i++
+			continue
 		}
+		inString = false
+		sawBackslashEscapedQuote = false
 	}
-	return false
+	return inString && sawBackslashEscapedQuote
 }
 
 func repeatedQuestionShorthandColumns(line string) []int {

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -1630,27 +1630,28 @@ func containsTypographicQuote(line string) bool {
 
 func containsLikelyCStyleQuoteEscape(line string) bool {
 	inString := false
-	sawBackslashEscapedQuote := false
-	for i := 0; i < len(line); i++ {
+	for i := 0; i < len(line); {
 		if line[i] != '"' {
-			continue
-		}
-		if !inString {
-			inString = true
-			sawBackslashEscapedQuote = false
-			continue
-		}
-		if i+1 < len(line) && line[i+1] == '"' {
-			if i > 0 && line[i-1] == '\\' {
-				sawBackslashEscapedQuote = true
-			}
 			i++
 			continue
 		}
-		inString = false
-		sawBackslashEscapedQuote = false
+		runStart := i
+		for i < len(line) && line[i] == '"' {
+			i++
+		}
+		runLength := i - runStart
+		if !inString {
+			inString = (runLength-1)%2 == 0
+			continue
+		}
+		if runStart > 0 && line[runStart-1] == '\\' && runLength >= 2 && runLength%2 == 0 {
+			return true
+		}
+		if runLength%2 == 1 {
+			inString = false
+		}
 	}
-	return inString && sawBackslashEscapedQuote
+	return false
 }
 
 func repeatedQuestionShorthandColumns(line string) []int {

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -770,6 +770,31 @@ func TestLinterFindsLikelyCStyleQuoteEscapesThatTriggerVBECompileDialogs(t *test
 	}
 }
 
+func TestLinterAllowsVBAJSONEscapedQuoteStrings(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "JsonConverter.bas", `Attribute VB_Name = "JsonConverter"
+Option Explicit
+Private Function JsonEscape(ByVal json_Char As String) As String
+  Select Case AscW(json_Char)
+  Case 34
+    json_Char = "\"""
+  Case 92
+    json_Char = "\\"
+  End Select
+  JsonEscape = json_Char
+End Function
+`)
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range issues {
+		if issue.Code == "VB009" {
+			t.Fatalf("valid VBA-JSON escaped quote strings should not trigger VB009: %+v", issues)
+		}
+	}
+}
+
 func TestLinterAllowsValidProcedureBoundaries(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -770,6 +770,22 @@ func TestLinterFindsLikelyCStyleQuoteEscapesThatTriggerVBECompileDialogs(t *test
 	}
 }
 
+func TestLinterKeepsEarlierCStyleQuoteEscapeWhenLaterQuoteExists(t *testing.T) {
+	dir := t.TempDir()
+	writeLintModule(t, dir, "Main.bas", "Option Explicit\nPublic Sub Run()\n  s = \"\\\"\": Debug.Print \"x\"\nEnd Sub\n")
+	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocking := issuesByCode(PushBlockingIssues(issues), "VB009")
+	if len(blocking) != 1 {
+		t.Fatalf("expected one push-blocking C-style escape issue, got %+v", blocking)
+	}
+	if blocking[0].Line != 3 {
+		t.Fatalf("unexpected C-style escape issue: %+v", blocking[0])
+	}
+}
+
 func TestLinterAllowsVBAJSONEscapedQuoteStrings(t *testing.T) {
 	dir := t.TempDir()
 	writeLintModule(t, dir, "JsonConverter.bas", `Attribute VB_Name = "JsonConverter"


### PR DESCRIPTION
## Summary
- Fixed `VB009` so valid VBA string literals with escaped quotes are no longer flagged as C-style quote escapes.
- Preserved detection for the actual problematic pattern that can trigger VBE compile dialogs.
- Added a regression test covering the official VBA-JSON `JsonConverter.bas` escaped quote case.
- Documented the fix in `CHANGELOG.md`.

## Testing
- Added a unit test to verify `VB009` does not fire for the VBA-JSON escaped quote string.
- Not run (not requested).