### PR TITLE
Fix VBA LSP diagnostics to resolve `Me` in document modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to xlflow will be documented in this file.
 - Added `xlflow session attach` to adopt an already-open configured workbook as an external xlflow session, and deprecated legacy `xlflow attach --active` validation-only usage.
 - Added VS Code extension actions to connect to an already-open workbook from the session menu and open the configured workbook in Excel from the Project view.
 - Fixed `VB009` false positives for valid VBA strings such as the official VBA-JSON `JsonConverter.bas` escaped quote output (`json_Char = "\"""`).
+- Fixed VBA LSP diagnostics so `Me` is recognized as the current instance in UserForm, workbook, sheet, class, and non-xlflow fallback modules, preventing false `VB029` undeclared warnings for sheet code such as `Me.Rows(...)`.
 
 ## v0.19.0
 

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -3036,13 +3036,22 @@ func (a Analyzer) currentInstanceType(doc Document) (currentInstanceInfo, bool) 
 		if strings.EqualFold(name, "ThisWorkbook") {
 			return currentInstanceInfo{Type: "Excel.Workbook", Source: "workbook document instance", Confidence: "high"}, true
 		}
-		return currentInstanceInfo{Type: "Excel.Worksheet", Source: "worksheet document instance", Confidence: "high"}, true
+		if looksLikeWorksheetModuleName(name) {
+			return currentInstanceInfo{Type: "Excel.Worksheet", Source: "worksheet document instance", Confidence: "high"}, true
+		}
+		if looksLikeChartModuleName(name) {
+			return currentInstanceInfo{Type: "Excel.Chart", Source: "chart document instance", Confidence: "high"}, true
+		}
+		return currentInstanceInfo{Type: "Object", Source: "document instance", Confidence: "low"}, true
 	}
 	if strings.EqualFold(name, "ThisWorkbook") {
 		return currentInstanceInfo{Type: "Excel.Workbook", Source: "inferred workbook document instance", Confidence: "medium"}, true
 	}
 	if looksLikeWorksheetModuleName(name) {
 		return currentInstanceInfo{Type: "Excel.Worksheet", Source: "inferred worksheet document instance", Confidence: "medium"}, true
+	}
+	if looksLikeChartModuleName(name) {
+		return currentInstanceInfo{Type: "Excel.Chart", Source: "inferred chart document instance", Confidence: "medium"}, true
 	}
 	if strings.EqualFold(doc.ModuleKind, "class") || strings.EqualFold(filepath.Ext(doc.Path), ".cls") {
 		return currentInstanceInfo{Type: "Object", Source: "class instance", Confidence: "low"}, true
@@ -3100,9 +3109,14 @@ func moduleNameForCurrentInstance(doc Document) string {
 
 var attrNameRe = regexp.MustCompile(`(?i)^\s*Attribute\s+VB_Name\s*=\s*"([^"]+)"`)
 var worksheetModuleNameRe = regexp.MustCompile(`(?i)^sheet\d+$`)
+var chartModuleNameRe = regexp.MustCompile(`(?i)^chart\d+$`)
 
 func looksLikeWorksheetModuleName(name string) bool {
 	return worksheetModuleNameRe.MatchString(strings.TrimSpace(name))
+}
+
+func looksLikeChartModuleName(name string) bool {
+	return chartModuleNameRe.MatchString(strings.TrimSpace(name))
 }
 
 func (a Analyzer) formName(doc Document) string {

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -887,7 +887,7 @@ func (a Analyzer) unresolvedMemberReceiverDiagnostics(doc Document) []Diagnostic
 				continue
 			}
 			base := memberReceiverBase(receiver)
-			if base == "" || a.knownModuleOrNamespaceReceiver(doc, base) {
+			if base == "" || strings.EqualFold(base, "Me") || a.knownModuleOrNamespaceReceiver(doc, base) {
 				continue
 			}
 			key := fmt.Sprintf("%d:%s", lineNo, strings.ToLower(base))
@@ -980,8 +980,12 @@ func (a Analyzer) typeDiagnosticBaseType(doc Document, raw string, offset int) (
 	}
 	var current string
 	switch {
-	case strings.EqualFold(base, "Me") && a.isFormDocument(doc):
-		current = "MSForms.UserForm"
+	case strings.EqualFold(base, "Me"):
+		instance, ok := a.currentInstanceType(doc)
+		if !ok || currentInstanceLowConfidence(instance) {
+			return "", false
+		}
+		current = instance.Type
 	case a.DB != nil:
 		if typ, ok := a.DB.ResolveGlobal(base); ok {
 			current = typ.Name
@@ -2534,8 +2538,10 @@ func (a Analyzer) inferWordTypeAt(doc Document, word string, offset int) (string
 }
 
 func (a Analyzer) inferWordTypeInfoAt(doc Document, word string, offset int) (inferredType, bool) {
-	if strings.EqualFold(word, "Me") && a.isFormDocument(doc) {
-		return inferredType{Type: "MSForms.UserForm", Source: "UserForm instance"}, true
+	if strings.EqualFold(word, "Me") {
+		if instance, ok := a.currentInstanceType(doc); ok {
+			return inferredType{Type: instance.Type, Source: instance.Source}, true
+		}
 	}
 	if control, ok := a.resolveFormControl(doc, word); ok {
 		return inferredType{Type: control.Type, Source: "UserForm control"}, true
@@ -2734,9 +2740,14 @@ func (a Analyzer) resolveExpressionTypeAt(doc Document, expr string, useDocument
 		base = strings.TrimSpace(base[:idx])
 	}
 	var current string
-	formMode := useDocument && strings.EqualFold(base, "Me") && a.isFormDocument(doc)
-	if formMode {
-		current = "MSForms.UserForm"
+	formMode := false
+	if useDocument && strings.EqualFold(base, "Me") {
+		instance, ok := a.currentInstanceType(doc)
+		if !ok {
+			return "", false
+		}
+		current = instance.Type
+		formMode = strings.EqualFold(current, "MSForms.UserForm")
 	} else if typ, ok := a.DB.ResolveGlobal(base); ok {
 		current = typ.Name
 	} else if typ, ok := a.DB.ResolveType(base); ok {
@@ -3008,6 +3019,90 @@ func (a Analyzer) resolveFormControl(doc Document, name string) (userforms.Contr
 
 func (a Analyzer) isFormDocument(doc Document) bool {
 	return strings.EqualFold(doc.ModuleKind, "form") || strings.EqualFold(filepath.Ext(doc.Path), ".frm") || a.formSource(doc) != ""
+}
+
+type currentInstanceInfo struct {
+	Type       string
+	Source     string
+	Confidence string
+}
+
+func (a Analyzer) currentInstanceType(doc Document) (currentInstanceInfo, bool) {
+	if a.isFormDocument(doc) {
+		return currentInstanceInfo{Type: "MSForms.UserForm", Source: "UserForm instance", Confidence: "high"}, true
+	}
+	name := moduleNameForCurrentInstance(doc)
+	if a.isWorkbookDocument(doc) {
+		if strings.EqualFold(name, "ThisWorkbook") {
+			return currentInstanceInfo{Type: "Excel.Workbook", Source: "workbook document instance", Confidence: "high"}, true
+		}
+		return currentInstanceInfo{Type: "Excel.Worksheet", Source: "worksheet document instance", Confidence: "high"}, true
+	}
+	if strings.EqualFold(name, "ThisWorkbook") {
+		return currentInstanceInfo{Type: "Excel.Workbook", Source: "inferred workbook document instance", Confidence: "medium"}, true
+	}
+	if looksLikeWorksheetModuleName(name) {
+		return currentInstanceInfo{Type: "Excel.Worksheet", Source: "inferred worksheet document instance", Confidence: "medium"}, true
+	}
+	if strings.EqualFold(doc.ModuleKind, "class") || strings.EqualFold(filepath.Ext(doc.Path), ".cls") {
+		return currentInstanceInfo{Type: "Object", Source: "class instance", Confidence: "low"}, true
+	}
+	return currentInstanceInfo{Type: "Object", Source: "current instance", Confidence: "low"}, true
+}
+
+func currentInstanceLowConfidence(instance currentInstanceInfo) bool {
+	return strings.EqualFold(instance.Confidence, "low") || lowConfidenceDiagnosticType(instance.Type)
+}
+
+func (a Analyzer) isWorkbookDocument(doc Document) bool {
+	if strings.EqualFold(doc.ModuleKind, "document") {
+		return true
+	}
+	if strings.TrimSpace(a.RootDir) == "" || strings.TrimSpace(a.Config.Src.Workbook) == "" || strings.TrimSpace(doc.Path) == "" {
+		return false
+	}
+	root := filepath.Join(a.RootDir, filepath.FromSlash(a.Config.Src.Workbook))
+	return pathInsideRoot(doc.Path, root)
+}
+
+func pathInsideRoot(path, root string) bool {
+	cleanPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		cleanPath = filepath.Clean(path)
+	}
+	cleanRoot, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		cleanRoot = filepath.Clean(root)
+	}
+	if runtime.GOOS == "windows" {
+		cleanPath = strings.ToLower(cleanPath)
+		cleanRoot = strings.ToLower(cleanRoot)
+	}
+	if cleanPath == cleanRoot {
+		return true
+	}
+	rel, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func moduleNameForCurrentInstance(doc Document) string {
+	for _, line := range strings.Split(doc.Source, "\n") {
+		match := attrNameRe.FindStringSubmatch(line)
+		if match != nil && strings.TrimSpace(match[1]) != "" {
+			return strings.TrimSpace(match[1])
+		}
+	}
+	return moduleNameForDocument(doc)
+}
+
+var attrNameRe = regexp.MustCompile(`(?i)^\s*Attribute\s+VB_Name\s*=\s*"([^"]+)"`)
+var worksheetModuleNameRe = regexp.MustCompile(`(?i)^sheet\d+$`)
+
+func looksLikeWorksheetModuleName(name string) bool {
+	return worksheetModuleNameRe.MatchString(strings.TrimSpace(name))
 }
 
 func (a Analyzer) formName(doc Document) string {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -840,6 +840,70 @@ End Sub
 	}
 }
 
+func TestDiagnosticsResolveMeInWorkbookDocumentModules(t *testing.T) {
+	root := t.TempDir()
+	analyzer := newTestAnalyzer(t)
+	analyzer.RootDir = root
+	analyzer.Config = config.Default()
+
+	sheetDoc := Document{
+		Path:       filepath.Join(root, "src", "workbook", "Sheet1.bas"),
+		ModuleKind: "standard",
+		Source: `Attribute VB_Name = "Sheet1"
+Option Explicit
+Private Sub HideTemplate()
+    Dim TemplateRow As Long
+    TemplateRow = 3
+    Me.Rows(TemplateRow).Hidden = True
+End Sub
+`,
+	}
+	if got, ok := analyzer.resolveDocumentExpressionTypeAt(sheetDoc, "Me.Rows(TemplateRow)", len(sheetDoc.Source)); !ok || got != "Excel.Range" {
+		t.Fatalf("Me.Rows(...) type = %q, %v; want Excel.Range", got, ok)
+	}
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(sheetDoc), "VB029"); len(diagnostics) != 0 {
+		t.Fatalf("worksheet Me should not produce undeclared diagnostics: %+v", diagnostics)
+	}
+
+	workbookDoc := Document{
+		Path:       filepath.Join(root, "src", "workbook", "ThisWorkbook.cls"),
+		ModuleKind: "standard",
+		Source: `VERSION 1.0 CLASS
+Attribute VB_Name = "ThisWorkbook"
+Option Explicit
+Private Sub Workbook_Open()
+    Me.Worksheets(1).Range("A1").Value = 1
+End Sub
+`,
+	}
+	if got, ok := analyzer.resolveDocumentExpressionTypeAt(workbookDoc, "Me.Worksheets(1)", len(workbookDoc.Source)); !ok || got != "Excel.Worksheet" {
+		t.Fatalf("Me.Worksheets(...) type = %q, %v; want Excel.Worksheet", got, ok)
+	}
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(workbookDoc), "VB029"); len(diagnostics) != 0 {
+		t.Fatalf("workbook Me should not produce undeclared diagnostics: %+v", diagnostics)
+	}
+}
+
+func TestDiagnosticsTreatUnknownProjectMeAsCurrentInstanceFallback(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "PlainModule.bas"),
+		Source: `Option Explicit
+Private Sub Run()
+    Me.Anything
+End Sub
+`,
+	}
+
+	diagnostics := analyzer.Diagnostics(doc)
+	if got := diagnosticsByCode(diagnostics, "VB029"); len(got) != 0 {
+		t.Fatalf("fallback Me should not produce undeclared diagnostics: %+v", got)
+	}
+	if got := diagnosticsByCode(diagnostics, "VB033"); len(got) != 0 {
+		t.Fatalf("fallback Me should not produce unknown-member diagnostics: %+v", got)
+	}
+}
+
 func TestDiagnosticsIncludeUnusedLocalVariables(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	doc := Document{

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -882,6 +882,45 @@ End Sub
 	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(workbookDoc), "VB029"); len(diagnostics) != 0 {
 		t.Fatalf("workbook Me should not produce undeclared diagnostics: %+v", diagnostics)
 	}
+
+	chartDoc := Document{
+		Path:       filepath.Join(root, "src", "workbook", "Chart1.cls"),
+		ModuleKind: "standard",
+		Source: `VERSION 1.0 CLASS
+Attribute VB_Name = "Chart1"
+Option Explicit
+Private Sub Chart_Activate()
+    Me.ChartArea.Select
+End Sub
+`,
+	}
+	if got, ok := analyzer.resolveDocumentExpressionTypeAt(chartDoc, "Me.ChartArea", len(chartDoc.Source)); !ok || got != "Excel.ChartArea" {
+		t.Fatalf("Me.ChartArea type = %q, %v; want Excel.ChartArea", got, ok)
+	}
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(chartDoc), "VB029"); len(diagnostics) != 0 {
+		t.Fatalf("chart Me should not produce undeclared diagnostics: %+v", diagnostics)
+	}
+
+	unknownHostDoc := Document{
+		Path:       filepath.Join(root, "src", "workbook", "Report.cls"),
+		ModuleKind: "standard",
+		Source: `VERSION 1.0 CLASS
+Attribute VB_Name = "Report"
+Option Explicit
+Private Sub Activate()
+    Me.ChartArea.Select
+End Sub
+`,
+	}
+	if got, ok := analyzer.resolveDocumentExpressionTypeAt(unknownHostDoc, "Me.ChartArea", len(unknownHostDoc.Source)); ok {
+		t.Fatalf("unknown document host should not resolve Me.ChartArea, got %q", got)
+	}
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(unknownHostDoc), "VB029"); len(diagnostics) != 0 {
+		t.Fatalf("unknown document host Me should not produce undeclared diagnostics: %+v", diagnostics)
+	}
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(unknownHostDoc), "VB033"); len(diagnostics) != 0 {
+		t.Fatalf("unknown document host Me should not produce unknown-member diagnostics: %+v", diagnostics)
+	}
 }
 
 func TestDiagnosticsTreatUnknownProjectMeAsCurrentInstanceFallback(t *testing.T) {


### PR DESCRIPTION
**Summary**
- Treat `Me` as the current instance across UserForm, workbook, sheet, class, and fallback modules.
- Prevent false `VB029` undeclared-member warnings for sheet and workbook code paths such as `Me.Rows(...)`.
- Add regression coverage for document-module `Me` resolution and the unknown-project fallback case.
- Update the changelog to document the diagnostics fix.

**Testing**
- Added unit tests covering workbook document modules, sheet modules, and fallback `Me` handling.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VBA diagnostics so `Me` is correctly recognized in workbook, worksheet, class, and form contexts.
  * Reduced false undeclared-member warnings for code like `Me.Rows(...)` and `Me.Worksheets(...)`.
  * Added safer fallback handling so `Me` no longer triggers incorrect member errors in unsupported module contexts.

* **Chores**
  * Updated the changelog with the latest diagnostic fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->