### PR TITLE
Capture top-level UserForm dimensions from VBComponent properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed non-executing UserForm Designer snapshots to capture top-level form width and height from VBComponent properties when available.
+
 ## v0.22.0
 
 - Added configurable automatic backup retention through `[backup.retention]`, disabled by default, with workbook-scoped pruning after successful backup-producing `push` and `rollback` operations.

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormInspectionService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormInspectionService.cs
@@ -382,8 +382,8 @@ public sealed class ExcelFormInspectionService : IInspectFormService
                 ["name"] = formName,
                 ["basis"] = "designer",
                 ["caption"] = ExcelBridgeSupport.GetString(designer, "Caption") ?? "",
-                ["width"] = TryGetDouble(designer, "Width"),
-                ["height"] = TryGetDouble(designer, "Height"),
+                ["width"] = TryGetDesignerFormDimension(component, designer, "Width"),
+                ["height"] = TryGetDesignerFormDimension(component, designer, "Height"),
                 ["coordinate_system"] = "parent-relative",
                 ["controls"] = rootControls,
             };
@@ -817,6 +817,44 @@ public sealed class ExcelFormInspectionService : IInspectFormService
         catch
         {
             return null;
+        }
+    }
+
+    internal static double? TryGetDesignerFormDimension(object component, object designer, string memberName)
+    {
+        return TryGetComponentPropertyDouble(component, memberName)
+            ?? TryGetDouble(designer, memberName);
+    }
+
+    private static double? TryGetComponentPropertyDouble(object component, string propertyName)
+    {
+        object? properties = null;
+        object? property = null;
+        try
+        {
+            properties = ExcelBridgeSupport.Get(component, "Properties");
+            if (properties is null)
+            {
+                return null;
+            }
+
+            property = ExcelBridgeSupport.Get(properties, "Item", propertyName);
+            if (property is null)
+            {
+                return null;
+            }
+
+            var value = ExcelBridgeSupport.Get(property, "Value");
+            return value is null ? null : Convert.ToDouble(value, CultureInfo.InvariantCulture);
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(property);
+            ExcelBridgeSupport.ReleaseComObject(properties);
         }
     }
 

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/InspectFormCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/InspectFormCommandTests.cs
@@ -53,6 +53,28 @@ public sealed class InspectFormCommandTests
     }
 
     [Fact]
+    public void TryGetDesignerFormDimension_PrefersComponentProperty()
+    {
+        var actual = ExcelFormInspectionService.TryGetDesignerFormDimension(
+            new DesignerComponentWithProperties(),
+            new DesignerFormWithDimensions(width: 0, height: 0),
+            "Width");
+
+        Assert.Equal(300.0, actual);
+    }
+
+    [Fact]
+    public void TryGetDesignerFormDimension_FallsBackToDesignerMember()
+    {
+        var actual = ExcelFormInspectionService.TryGetDesignerFormDimension(
+            new DesignerComponentWithoutProperties(),
+            new DesignerFormWithDimensions(width: 280.5, height: 240.25),
+            "Height");
+
+        Assert.Equal(240.25, actual);
+    }
+
+    [Fact]
     public void HandleParsesPayloadAndReturnsExpectedExtensions()
     {
         var service = new FakeInspectFormService((request, args) =>
@@ -192,6 +214,40 @@ public sealed class InspectFormCommandTests
     private sealed class DesignerControlWithBrokenChildren
     {
         public BrokenControls Controls => new();
+    }
+
+    private sealed class DesignerFormWithDimensions(double width, double height)
+    {
+        public double Width { get; } = width;
+
+        public double Height { get; } = height;
+    }
+
+    private sealed class DesignerComponentWithProperties
+    {
+        public DesignerProperties Properties { get; } = new();
+    }
+
+    private sealed class DesignerComponentWithoutProperties
+    {
+    }
+
+    private sealed class DesignerProperties
+    {
+        public DesignerProperty Item(string name)
+        {
+            return name switch
+            {
+                "Width" => new DesignerProperty(300.0),
+                "Height" => new DesignerProperty(262.2),
+                _ => throw new ArgumentException("unknown designer property", nameof(name)),
+            };
+        }
+    }
+
+    private sealed class DesignerProperty(double value)
+    {
+        public double Value { get; } = value;
     }
 
     private sealed class BrokenControls


### PR DESCRIPTION
## Summary
- Updated non-executing UserForm designer snapshot inspection to read top-level `Width` and `Height` from `VBComponent.Properties` when available.
- Kept the existing designer-member fallback so snapshot generation remains resilient when component properties are unavailable.
- Added regression coverage for preferring component properties and falling back to designer members.
- Recorded the behavior change in `CHANGELOG.md`.

## Testing
- Added unit tests covering both the preferred property path and the fallback path.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UserForm Designer snapshots that previously failed to execute correctly.
  * Improved snapshot accuracy by capturing the form’s width and height from component properties when available.
  * Added fallback handling to use designer dimensions when component properties cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->