### PR TITLE
Fix UserForm build to apply sidecar width and height correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.23.0
+
 - Added `xlflow form migrate sidecar` for converting imported UserForms from `frm` code-source mode to sidecar code plus Designer specs, and added `xlflow init --userform-code-source sidecar` for opting imported workbooks into the modern UserForm layout.
 - Fixed non-executing UserForm Designer snapshots to capture top-level form width and height from VBComponent properties when available.
+- Fixed `.NET` UserForm Designer builds so top-level form width and height from sidecar specs are applied through VBComponent properties instead of staying at Excel's default size.
 
 ## v0.22.0
 

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormWriteService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormWriteService.cs
@@ -651,7 +651,7 @@ public sealed class ExcelFormWriteService : IFormWriteService
                 return false;
             }
             var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(properties, "Count"));
-            for (var index = 0; index < count; index++)
+            for (var index = 1; index <= count; index++)
             {
                 object? property = null;
                 try

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormWriteCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormWriteCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Xlflow.ExcelBridge.Commands;
 using Xlflow.ExcelBridge.Contract;
@@ -104,6 +105,19 @@ public sealed class FormWriteCommandTests
         Assert.Equal("form_build_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
     }
 
+    [Fact]
+    public void SetVBComponentPropertyUsesOneBasedVBIDEPropertyIndexes()
+    {
+        var component = new FakeVBComponent();
+        var method = typeof(ExcelFormWriteService).GetMethod("SetVBComponentProperty", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var result = method.Invoke(null, [component, "Width", 333.0]);
+
+        Assert.Equal(true, result);
+        Assert.Equal(333.0, component.Properties.Width.Value);
+    }
+
     private sealed class FakeFormWriteService(Func<BridgeRequest, FormWriteCommandArguments, BridgeResponse> handler) : IFormWriteService
     {
         public BridgeResponse Execute(BridgeRequest request, FormWriteCommandArguments args, CancellationToken cancellationToken)
@@ -111,5 +125,33 @@ public sealed class FormWriteCommandTests
             cancellationToken.ThrowIfCancellationRequested();
             return handler(request, args);
         }
+    }
+
+    private sealed class FakeVBComponent
+    {
+        public FakeVBIDEProperties Properties { get; } = new();
+    }
+
+    private sealed class FakeVBIDEProperties
+    {
+        public FakeVBIDEProperty Width { get; } = new("Width", 240.0);
+
+        public FakeVBIDEProperty Height { get; } = new("Height", 180.0);
+
+        public int Count => 2;
+
+        public FakeVBIDEProperty Item(int index) => index switch
+        {
+            1 => Width,
+            2 => Height,
+            _ => throw new ArgumentOutOfRangeException(nameof(index), "VBIDE Properties is one-based."),
+        };
+    }
+
+    private sealed class FakeVBIDEProperty(string name, double value)
+    {
+        public string Name { get; } = name;
+
+        public double Value { get; set; } = value;
     }
 }


### PR DESCRIPTION
## Summary
- Fix `.NET` UserForm Designer builds so top-level `Width` and `Height` from sidecar specs are written to `VBComponent` properties instead of being skipped.
- Correct the property iteration to use VBIDE's one-based indexing.
- Add a regression test covering one-based property access.
- Document the fix in `CHANGELOG.md`.

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for migrating forms through a sidecar workflow.
  * Added an initialization option to import workbooks into the modern UserForm layout.

* **Bug Fixes**
  * Improved UserForm Designer sizing by preserving top-level form dimensions.
  * .NET-built UserForms now apply the correct dimensions instead of using Excel’s default size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->