### PR TITLE
Persist UserForm captions through VBComponent properties and capture runtime captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to xlflow will be documented in this file.
 ## Unreleased
 
 - Added strict reusable UserForm spec validation based on the canonical contract, including unknown-field, type, fixed-value, control-property, parent-reference, and type/ProgID mismatch diagnostics before `form build` opens Excel.
+- Fixed `form build` so a UserForm caption is persisted through the VBComponent property path and remains consistent with runtime forms; `form export-image` now captures the actual runtime caption instead of substituting the Designer value.
 
 ## v0.23.0
 

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormExportImageService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormExportImageService.cs
@@ -70,11 +70,10 @@ public sealed class ExcelFormExportImageService : IFormExportImageService
             helperModuleName = ExcelBridgeSupport.GetString(helperComponent, "Name") ?? "";
 
             var processId = ExcelBridgeSupport.GetExcelProcessId(runtimeExcel);
-            var sourceCaption = GetDesignerCaption(workbook, args.FormName);
             var token = $"xlflow-capture-{Guid.NewGuid():N}";
 
             phase = "schedule_form_capture";
-            InvokePrepareCapture(runtimeExcel, runtimeWorkbook, helperModuleName, args.FormName, token, args.Initializer, sourceCaption);
+            InvokePrepareCapture(runtimeExcel, runtimeWorkbook, helperModuleName, args.FormName, token, args.Initializer);
 
             phase = "find_form_window";
             var capture = WaitForCaptureWindow(runtimeExcel, runtimeWorkbook, helperModuleName, processId, token, cancellationToken);
@@ -322,29 +321,6 @@ public sealed class ExcelFormExportImageService : IFormExportImageService
         return (direct.Excel, direct.Workbook, tempPath);
     }
 
-    private static string GetDesignerCaption(object workbook, string formName)
-    {
-        object? component = null;
-        object? designer = null;
-        try
-        {
-            var vbProject = ExcelBridgeSupport.TryGetWorkbookVbProject(workbook);
-            var components = ExcelBridgeSupport.Get(vbProject!, "VBComponents");
-            component = ExcelBridgeSupport.Get(components!, "Item", formName);
-            designer = ExcelBridgeSupport.Get(component!, "Designer");
-            return ExcelBridgeSupport.GetString(designer!, "Caption") ?? "";
-        }
-        catch
-        {
-            return "";
-        }
-        finally
-        {
-            ExcelBridgeSupport.ReleaseComObject(designer);
-            ExcelBridgeSupport.ReleaseComObject(component);
-        }
-    }
-
     private static object InstallHelper(object runtimeVbProject)
     {
         object? components = null;
@@ -369,12 +345,12 @@ public sealed class ExcelFormExportImageService : IFormExportImageService
         }
     }
 
-    private static void InvokePrepareCapture(object runtimeExcel, object runtimeWorkbook, string helperModuleName, string formName, string token, string initializer, string expectedCaption)
+    private static void InvokePrepareCapture(object runtimeExcel, object runtimeWorkbook, string helperModuleName, string formName, string token, string initializer)
     {
         var workbookName = (ExcelBridgeSupport.TryGetWorkbookName(runtimeWorkbook) ?? "").Replace("'", "''", StringComparison.Ordinal);
         var moduleName = string.IsNullOrWhiteSpace(helperModuleName) ? "XlflowCap" : helperModuleName;
         var macroName = $"'{workbookName}'!{moduleName}.XlflowPrepareFormImageCapture";
-        ExcelBridgeSupport.RunExcelMacro(runtimeExcel, macroName, formName, token, initializer, expectedCaption);
+        ExcelBridgeSupport.RunExcelMacro(runtimeExcel, macroName, formName, token, initializer);
     }
 
     private static WindowInfo WaitForCaptureWindow(object runtimeExcel, object runtimeWorkbook, string helperModuleName, int processId, string token, CancellationToken cancellationToken)
@@ -638,7 +614,6 @@ Private xlflowLastErrorMessage As String
 Private xlflowCaptureReady As Boolean
 Private xlflowCaptureWindowCaption As String
 Private xlflowCaptureWindowHandle As String
-Private xlflowExpectedCaption As String
 
 Private Function XlflowFindFormWindowHandle(ByVal caption As String) As String
 #If VBA7 Then
@@ -654,11 +629,10 @@ Private Function XlflowFindFormWindowHandle(ByVal caption As String) As String
   XlflowFindFormWindowHandle = CStr(hwnd)
 End Function
 
-Public Sub XlflowPrepareFormImageCapture(ByVal formName As String, ByVal token As String, Optional ByVal initializer As String = "", Optional ByVal expectedCaption As String = "")
+Public Sub XlflowPrepareFormImageCapture(ByVal formName As String, ByVal token As String, Optional ByVal initializer As String = "")
   xlflowCaptureFormName = formName
   xlflowCaptureToken = token
   xlflowCaptureInitializer = Trim$(initializer)
-  xlflowExpectedCaption = Trim$(expectedCaption)
   xlflowLastErrorSource = ""
   xlflowLastErrorMessage = ""
   xlflowCaptureReady = False
@@ -686,17 +660,6 @@ Public Sub XlflowExecuteFormImageCapture()
   On Error Resume Next
   caption = CStr(xlflowCapturedForm.Caption)
   On Error GoTo ErrHandler
-  If Len(xlflowExpectedCaption) > 0 Then
-    If Len(caption) = 0 _
-      Or StrComp(caption, xlflowCaptureFormName, vbTextCompare) = 0 _
-      Or LCase$(Left$(caption, 8)) = "userform" Then
-      caption = xlflowExpectedCaption
-    End If
-  End If
-  If Len(caption) = 0 Then
-    caption = xlflowCaptureFormName
-  End If
-
   PrimeFocusableControl xlflowCapturedForm
   xlflowCapturedForm.Caption = caption & " [xlflow-capture-" & xlflowCaptureToken & "]"
   xlflowCapturedForm.Show vbModeless
@@ -812,7 +775,6 @@ Public Sub XlflowCleanupFormImageCapture()
   xlflowCaptureReady = False
   xlflowCaptureWindowCaption = ""
   xlflowCaptureWindowHandle = "0"
-  xlflowExpectedCaption = ""
   xlflowLastErrorSource = ""
   xlflowLastErrorMessage = ""
   On Error GoTo 0

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormWriteService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormWriteService.cs
@@ -503,9 +503,10 @@ public sealed class ExcelFormWriteService : IFormWriteService
     private static void SetDesignerFormProperties(object designer, object component, FormWriteFormSpec form)
     {
         var caption = form.Build?.Caption ?? form.Caption ?? form.Observed?.Caption;
-        if (!string.IsNullOrWhiteSpace(caption))
+        if (caption is not null)
         {
-            TrySetProperty(designer, "Caption", caption);
+            SetRequiredVBComponentProperty(component, "Caption", caption);
+            SetRequiredProperty(designer, "Caption", caption);
         }
         var width = form.Build?.Width ?? form.Width ?? form.Observed?.Width;
         if (width is not null)
@@ -679,6 +680,81 @@ public sealed class ExcelFormWriteService : IFormWriteService
             ExcelBridgeSupport.ReleaseComObject(properties);
         }
         return false;
+    }
+
+    private static void SetRequiredVBComponentProperty(object component, string propertyName, string expectedValue)
+    {
+        object? properties = null;
+        try
+        {
+            properties = ExcelBridgeSupport.Get(component, "Properties");
+            if (properties is null)
+            {
+                throw new InvalidOperationException($"designer_write_failed: failed to access VBComponent.Properties for UserForm {propertyName}.");
+            }
+
+            var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(properties, "Count"));
+            for (var index = 1; index <= count; index++)
+            {
+                object? property = null;
+                try
+                {
+                    property = ExcelBridgeSupport.Get(properties, "Item", index);
+                    var name = ExcelBridgeSupport.GetString(property!, "Name") ?? "";
+                    if (!string.Equals(name, propertyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    ExcelBridgeSupport.Set(property!, "Value", expectedValue);
+                    var actualValue = ExcelBridgeSupport.GetString(property!, "Value");
+                    if (!string.Equals(actualValue, expectedValue, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException($"designer_write_failed: UserForm {propertyName} did not persist through VBComponent.Properties.");
+                    }
+                    return;
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(property);
+                }
+            }
+
+            throw new InvalidOperationException($"designer_write_failed: VBComponent.Properties does not expose UserForm {propertyName}.");
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"designer_write_failed: failed to set UserForm {propertyName} through VBComponent.Properties. {ex.Message}", ex);
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(properties);
+        }
+    }
+
+    private static void SetRequiredProperty(object target, string propertyName, string expectedValue)
+    {
+        try
+        {
+            ExcelBridgeSupport.Set(target, propertyName, expectedValue);
+            var actualValue = ExcelBridgeSupport.GetString(target, propertyName);
+            if (!string.Equals(actualValue, expectedValue, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"designer_write_failed: UserForm Designer {propertyName} did not persist.");
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"designer_write_failed: failed to set UserForm Designer {propertyName}. {ex.Message}", ex);
+        }
     }
 
     private static object? GetComponentByName(object vbProject, string name)

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormExportImageCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormExportImageCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Xlflow.ExcelBridge.Commands;
 using Xlflow.ExcelBridge.Contract;
@@ -81,6 +82,20 @@ public sealed class FormExportImageCommandTests
 
         Assert.Equal("failed", json.RootElement.GetProperty("status").GetString());
         Assert.Equal("form_export_image_args_invalid", json.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public void CaptureHelperKeepsTheRuntimeCaptionInsteadOfMaskingItWithDesignerState()
+    {
+        var method = typeof(ExcelFormExportImageService).GetMethod("BuildHelperCode", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var helperCode = (string)method.Invoke(null, null)!;
+
+        Assert.Contains("caption = CStr(xlflowCapturedForm.Caption)", helperCode, StringComparison.Ordinal);
+        Assert.Contains("xlflowCapturedForm.Caption = caption & \" [xlflow-capture-\"", helperCode, StringComparison.Ordinal);
+        Assert.DoesNotContain("xlflowExpectedCaption", helperCode, StringComparison.Ordinal);
+        Assert.DoesNotContain("expectedCaption", helperCode, StringComparison.Ordinal);
     }
 
     private sealed class FakeFormExportImageService(Func<BridgeRequest, FormExportImageCommandArguments, BridgeResponse> handler) : IFormExportImageService

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormWriteCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/FormWriteCommandTests.cs
@@ -118,6 +118,31 @@ public sealed class FormWriteCommandTests
         Assert.Equal(333.0, component.Properties.Width.Value);
     }
 
+    [Fact]
+    public void SetRequiredVBComponentPropertyPersistsCaptionAndVerifiesReadback()
+    {
+        var component = new FakeVBComponent();
+        var method = typeof(ExcelFormWriteService).GetMethod("SetRequiredVBComponentProperty", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        _ = method.Invoke(null, [component, "Caption", "労務管理 実行"]);
+
+        Assert.Equal("労務管理 実行", component.Properties.Caption.Value);
+    }
+
+    [Fact]
+    public void SetRequiredVBComponentPropertyFailsWhenCaptionReadbackDoesNotMatch()
+    {
+        var component = new FakeVBComponent(ignoreCaptionWrites: true);
+        var method = typeof(ExcelFormWriteService).GetMethod("SetRequiredVBComponentProperty", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, [component, "Caption", "労務管理 実行"]));
+
+        var inner = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Contains("Caption did not persist", inner.Message, StringComparison.Ordinal);
+    }
+
     private sealed class FakeFormWriteService(Func<BridgeRequest, FormWriteCommandArguments, BridgeResponse> handler) : IFormWriteService
     {
         public BridgeResponse Execute(BridgeRequest request, FormWriteCommandArguments args, CancellationToken cancellationToken)
@@ -129,29 +154,54 @@ public sealed class FormWriteCommandTests
 
     private sealed class FakeVBComponent
     {
-        public FakeVBIDEProperties Properties { get; } = new();
+        public FakeVBComponent(bool ignoreCaptionWrites = false)
+        {
+            Properties = new FakeVBIDEProperties(ignoreCaptionWrites);
+        }
+
+        public FakeVBIDEProperties Properties { get; }
     }
 
     private sealed class FakeVBIDEProperties
     {
+        public FakeVBIDEProperties(bool ignoreCaptionWrites)
+        {
+            Caption = new FakeVBIDEProperty("Caption", "UserForm1", ignoreCaptionWrites);
+        }
+
         public FakeVBIDEProperty Width { get; } = new("Width", 240.0);
 
         public FakeVBIDEProperty Height { get; } = new("Height", 180.0);
 
-        public int Count => 2;
+        public FakeVBIDEProperty Caption { get; }
+
+        public int Count => 3;
 
         public FakeVBIDEProperty Item(int index) => index switch
         {
             1 => Width,
             2 => Height,
+            3 => Caption,
             _ => throw new ArgumentOutOfRangeException(nameof(index), "VBIDE Properties is one-based."),
         };
     }
 
-    private sealed class FakeVBIDEProperty(string name, double value)
+    private sealed class FakeVBIDEProperty(string name, object value, bool ignoreWrites = false)
     {
+        private object _value = value;
+
         public string Name { get; } = name;
 
-        public double Value { get; set; } = value;
+        public object Value
+        {
+            get => _value;
+            set
+            {
+                if (!ignoreWrites)
+                {
+                    _value = value;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Persist `UserForm.Caption` through `VBComponent.Properties` as well as the designer surface so the saved form keeps the intended caption.
- Strengthen write verification by reading back the persisted value and failing fast if the property does not stick.
- Simplify `form export-image` capture flow so it uses the live runtime caption instead of masking it with designer state.
- Add regression coverage for both the VBComponent property persistence path and the export-image helper behavior.

## Testing
- Added unit tests covering caption round-trip persistence and failure on mismatched readback.
- Added a helper-level regression test to confirm export-image no longer substitutes the designer caption.
- Not run (not requested).