### PR TITLE
Improve VBA semantic token coverage for parameter and project symbol references

### DIFF
--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -3379,6 +3379,46 @@ End Sub
 	}
 }
 
+func TestSemanticTokensCoverParameterUsesAndProjectTypeReferences(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	source := `Option Explicit
+Public Type Customer
+    Name As String
+End Type
+
+Public Sub PrintCustomer(ByVal record As Customer)
+    Debug.Print record.Name
+    Call Format(customer:=record)
+End Sub
+
+Public Sub Other()
+    Dim customer As String
+    Debug.Print customer
+End Sub
+`
+	doc := Document{
+		Path:       filepath.Join(t.TempDir(), "Main.bas"),
+		ModuleKind: "standard",
+		Source:     source,
+	}
+	tokens, err := analyzer.SemanticTokens(doc, []Document{doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasSemanticTokenAt(tokens, SemanticTokenParameter, "record", source, lineIndex(source, "Debug.Print record.Name")) {
+		t.Fatalf("parameter use should receive a parameter token: %+v", tokens)
+	}
+	if !hasSemanticTokenAt(tokens, SemanticTokenType, "Customer", source, lineIndex(source, "PrintCustomer(ByVal")) {
+		t.Fatalf("project type reference should receive a type token: %+v", tokens)
+	}
+	if hasSemanticTokenAt(tokens, SemanticTokenParameter, "customer", source, lineIndex(source, "Call Format(customer:=record)")) {
+		t.Fatalf("named argument must not receive a parameter token: %+v", tokens)
+	}
+	if hasSemanticTokenAt(tokens, SemanticTokenParameter, "customer", source, lineIndex(source, "Public Sub Other()")+2) {
+		t.Fatalf("local variable in another procedure must not receive a parameter token: %+v", tokens)
+	}
+}
+
 func TestSemanticTokensCoverUserFormControlsAndMalformedSource(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	source := `VERSION 5.00
@@ -3514,6 +3554,15 @@ func hasSemanticToken(tokens []SemanticToken, tokenType, text, source string) bo
 func hasSemanticTokenAtLine(tokens []SemanticToken, tokenType string, line int) bool {
 	for _, token := range tokens {
 		if token.Type == tokenType && token.Range.Start.Line == line {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSemanticTokenAt(tokens []SemanticToken, tokenType, text, source string, line int) bool {
+	for _, token := range tokens {
+		if token.Type == tokenType && token.Range.Start.Line == line && rangeText(source, token.Range) == text {
 			return true
 		}
 	}

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -3389,12 +3389,23 @@ End Type
 Public Sub PrintCustomer(ByVal record As Customer)
     Debug.Print record.Name
     Call Format(customer:=record)
+    LogCustomer record
+    Debug.Print CalculateScore(record)
 End Sub
 
 Public Sub Other()
     Dim customer As String
+    Dim LogCustomer As String
     Debug.Print customer
+    LogCustomer = "local"
 End Sub
+
+Public Sub LogCustomer(ByVal record As Customer)
+End Sub
+
+Private Function CalculateScore(ByVal record As Customer) As Long
+    CalculateScore = Len(record.Name)
+End Function
 `
 	doc := Document{
 		Path:       filepath.Join(t.TempDir(), "Main.bas"),
@@ -3416,6 +3427,15 @@ End Sub
 	}
 	if hasSemanticTokenAt(tokens, SemanticTokenParameter, "customer", source, lineIndex(source, "Public Sub Other()")+2) {
 		t.Fatalf("local variable in another procedure must not receive a parameter token: %+v", tokens)
+	}
+	if !hasSemanticTokenAt(tokens, SemanticTokenFunction, "LogCustomer", source, lineIndex(source, "    LogCustomer record")) {
+		t.Fatalf("bare Sub call should receive a function token: %+v", tokens)
+	}
+	if !hasSemanticTokenAt(tokens, SemanticTokenFunction, "CalculateScore", source, lineIndex(source, "Debug.Print CalculateScore")) {
+		t.Fatalf("Function call in an expression should receive a function token: %+v", tokens)
+	}
+	if hasSemanticTokenAt(tokens, SemanticTokenFunction, "LogCustomer", source, lineIndex(source, "    LogCustomer = \"local\"")) {
+		t.Fatalf("local variable must not receive a function token: %+v", tokens)
 	}
 }
 

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -3396,6 +3396,7 @@ End Sub
 Public Sub Other()
     Dim customer As String
     Dim LogCustomer As String
+    Dim service As New CustomerService
     Debug.Print customer
     LogCustomer = "local"
 End Sub
@@ -3412,7 +3413,12 @@ End Function
 		ModuleKind: "standard",
 		Source:     source,
 	}
-	tokens, err := analyzer.SemanticTokens(doc, []Document{doc})
+	classDoc := Document{
+		Path:       filepath.Join(filepath.Dir(doc.Path), "CustomerService.cls"),
+		ModuleKind: "class",
+		Source:     "VERSION 1.0 CLASS\nAttribute VB_Name = \"CustomerService\"\n",
+	}
+	tokens, err := analyzer.SemanticTokens(doc, []Document{doc, classDoc})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3421,6 +3427,9 @@ End Function
 	}
 	if !hasSemanticTokenAt(tokens, SemanticTokenType, "Customer", source, lineIndex(source, "PrintCustomer(ByVal")) {
 		t.Fatalf("project type reference should receive a type token: %+v", tokens)
+	}
+	if !hasSemanticTokenAt(tokens, SemanticTokenClass, "CustomerService", source, lineIndex(source, "Dim service As New CustomerService")) {
+		t.Fatalf("As New class reference should receive a class token: %+v", tokens)
 	}
 	if hasSemanticTokenAt(tokens, SemanticTokenParameter, "customer", source, lineIndex(source, "Call Format(customer:=record)")) {
 		t.Fatalf("named argument must not receive a parameter token: %+v", tokens)
@@ -3436,6 +3445,9 @@ End Function
 	}
 	if hasSemanticTokenAt(tokens, SemanticTokenFunction, "LogCustomer", source, lineIndex(source, "    LogCustomer = \"local\"")) {
 		t.Fatalf("local variable must not receive a function token: %+v", tokens)
+	}
+	if hasSemanticTokenAt(tokens, SemanticTokenFunction, "CalculateScore", source, lineIndex(source, "CalculateScore = Len(record.Name)")) {
+		t.Fatalf("Function result assignment must not receive a function token: %+v", tokens)
 	}
 }
 

--- a/internal/vba/intel/semantic.go
+++ b/internal/vba/intel/semantic.go
@@ -105,15 +105,97 @@ var operatorRunes = map[rune]bool{
 var memberExprRe = regexp.MustCompile(`(?i)([A-Za-z_][A-Za-z0-9_]*(?:\s*\([^()\r\n]*\))?(?:\.[A-Za-z_][A-Za-z0-9_]*(?:\s*\([^()\r\n]*\))?)*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)`)
 var procedureDeclRe = regexp.MustCompile(`(?i)\b(?:Public|Private|Friend|Static)?\s*(Sub|Function)\s+([A-Za-z_][A-Za-z0-9_]*)`)
 var propertyDeclRe = regexp.MustCompile(`(?i)\b(?:Public|Private|Friend|Static)?\s*(Property)\s+(?:Get|Let|Set)\s+([A-Za-z_][A-Za-z0-9_]*)`)
+var projectTypeReferenceRe = regexp.MustCompile(`(?i)\b(?:As|New|Implements)\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*([A-Za-z_][A-Za-z0-9_]*)`)
 
 func (a Analyzer) SemanticTokens(doc Document, open []Document) ([]SemanticToken, error) {
 	builder := semanticBuilder{analyzer: a, doc: doc}
 	builder.addLexicalTokens()
 	builder.addSymbolTokens(open)
+	builder.addParameterReferenceTokens()
+	builder.addProjectTypeReferenceTokens(open)
 	builder.addKnownIdentifierTokens(open)
 	builder.addMemberTokens()
 	builder.addUserFormControlTokens()
 	return normalizeSemanticTokens(builder.tokens), nil
+}
+
+// addParameterReferenceTokens applies the parameter classification to uses in
+// the declaring procedure as well as to the declaration itself. TextMate can
+// recognize only the declaration; these tokens keep the two appearances
+// visually consistent without confusing members or named arguments.
+func (b *semanticBuilder) addParameterReferenceTokens() {
+	syms, err := b.analyzer.DocumentSymbols(b.doc)
+	if err != nil {
+		return
+	}
+	for _, sym := range syms {
+		if !strings.EqualFold(sym.Kind, "parameter") || sym.Name == "" {
+			continue
+		}
+		scope, ok := currentProcedureRangeForDocument(b.doc, sym.Selection.Start)
+		if !ok {
+			continue
+		}
+		for _, rng := range codeIdentifierRanges(b.doc.Source, sym.Name) {
+			if rangeContains(scope, rng) && b.isParameterReference(rng) {
+				b.add(rng, SemanticTokenParameter)
+			}
+		}
+	}
+}
+
+func (b *semanticBuilder) isParameterReference(rng Range) bool {
+	line := lineAt(b.doc.Source, rng.Start.Line)
+	start := byteIndexForUTF16(line, rng.Start.Character)
+	end := byteIndexForUTF16(line, rng.End.Character)
+	if start > 0 && line[start-1] == '.' {
+		return false
+	}
+	return !strings.HasPrefix(strings.TrimSpace(line[end:]), ":=")
+}
+
+// addProjectTypeReferenceTokens highlights type positions such as "As Customer"
+// and "New Invoice" for types declared in the current workspace. Restricting
+// this to explicit type contexts avoids mistaking an ordinary variable that
+// happens to share a name with a type for a type reference.
+func (b *semanticBuilder) addProjectTypeReferenceTokens(open []Document) {
+	syms, err := b.analyzer.WorkspaceSymbols(open, "")
+	if err != nil {
+		return
+	}
+	types := make(map[string]string)
+	for _, sym := range syms {
+		tokenType := semanticTypeForProjectTypeSymbol(sym)
+		if tokenType == "" || !b.analyzer.visibleCompletionSymbol(b.doc, "", sym) {
+			continue
+		}
+		types[strings.ToLower(sym.Name)] = tokenType
+	}
+	for lineNo, line := range normalizedLines(b.doc.Source) {
+		limit := codeLimit(line)
+		for _, match := range projectTypeReferenceRe.FindAllStringSubmatchIndex(line[:limit], -1) {
+			if len(match) < 4 || match[2] < 0 || match[3] < 0 {
+				continue
+			}
+			name := strings.ToLower(line[match[2]:match[3]])
+			if tokenType, ok := types[name]; ok {
+				b.add(byteRange(lineNo, line, match[2], match[3]), tokenType)
+			}
+		}
+	}
+}
+
+func semanticTypeForProjectTypeSymbol(sym Symbol) string {
+	switch strings.ToLower(sym.Kind) {
+	case "type":
+		return SemanticTokenType
+	case "enum":
+		return SemanticTokenEnum
+	case "class":
+		return SemanticTokenClass
+	default:
+		return ""
+	}
 }
 
 func (b *semanticBuilder) addLexicalTokens() {

--- a/internal/vba/intel/semantic.go
+++ b/internal/vba/intel/semantic.go
@@ -113,6 +113,7 @@ func (a Analyzer) SemanticTokens(doc Document, open []Document) ([]SemanticToken
 	builder.addSymbolTokens(open)
 	builder.addParameterReferenceTokens()
 	builder.addProjectTypeReferenceTokens(open)
+	builder.addProjectProcedureReferenceTokens(open)
 	builder.addKnownIdentifierTokens(open)
 	builder.addMemberTokens()
 	builder.addUserFormControlTokens()
@@ -196,6 +197,83 @@ func semanticTypeForProjectTypeSymbol(sym Symbol) string {
 	default:
 		return ""
 	}
+}
+
+// addProjectProcedureReferenceTokens classifies calls to workspace Sub and
+// Function declarations. Declarations are already covered by addSymbolTokens;
+// this supplies the same function color for bare Sub calls and Functions used
+// in expressions.
+func (b *semanticBuilder) addProjectProcedureReferenceTokens(open []Document) {
+	syms, err := b.analyzer.WorkspaceSymbols(open, "")
+	if err != nil {
+		return
+	}
+	procedures := make(map[string]bool)
+	for _, sym := range syms {
+		if !isProjectProcedureSymbol(sym) || !b.analyzer.visibleCompletionSymbol(b.doc, "", sym) {
+			continue
+		}
+		procedures[strings.ToLower(sym.Name)] = true
+	}
+	if len(procedures) == 0 {
+		return
+	}
+
+	docSyms, err := b.analyzer.DocumentSymbols(b.doc)
+	if err != nil {
+		return
+	}
+	declarations := make(map[string]bool)
+	locals := make(map[string]bool)
+	for _, sym := range docSyms {
+		if isProjectProcedureSymbol(sym) {
+			declarations[semanticRangeKey(b.symbolNameRange(sym))] = true
+		}
+		if isLocalSymbol(sym) {
+			locals[procedureLocalKey(sym.Parent, sym.Name)] = true
+		}
+	}
+	for lineNo, line := range normalizedLines(b.doc.Source) {
+		for _, span := range codeIdentifierSpans(line) {
+			name := line[span.start:span.end]
+			if !procedures[strings.ToLower(name)] {
+				continue
+			}
+			rng := byteRange(lineNo, line, span.start, span.end)
+			if declarations[semanticRangeKey(rng)] || !b.isProjectProcedureReference(rng) {
+				continue
+			}
+			procedure := currentProcedureNameForDocument(b.doc, rng.Start)
+			if locals[procedureLocalKey(procedure, name)] {
+				continue
+			}
+			b.add(rng, SemanticTokenFunction)
+		}
+	}
+}
+
+func isProjectProcedureSymbol(sym Symbol) bool {
+	switch strings.ToLower(sym.Kind) {
+	case "sub", "function", "declare_sub", "declare_function":
+		return true
+	default:
+		return false
+	}
+}
+
+func procedureLocalKey(procedure, name string) string {
+	return strings.ToLower(procedure) + "\x00" + strings.ToLower(name)
+}
+
+func (b *semanticBuilder) isProjectProcedureReference(rng Range) bool {
+	line := lineAt(b.doc.Source, rng.Start.Line)
+	start := byteIndexForUTF16(line, rng.Start.Character)
+	end := byteIndexForUTF16(line, rng.End.Character)
+	before := strings.TrimSpace(line[:start])
+	if strings.HasSuffix(before, ".") {
+		return false
+	}
+	return !strings.HasPrefix(strings.TrimSpace(line[end:]), ":=")
 }
 
 func (b *semanticBuilder) addLexicalTokens() {

--- a/internal/vba/intel/semantic.go
+++ b/internal/vba/intel/semantic.go
@@ -105,7 +105,7 @@ var operatorRunes = map[rune]bool{
 var memberExprRe = regexp.MustCompile(`(?i)([A-Za-z_][A-Za-z0-9_]*(?:\s*\([^()\r\n]*\))?(?:\.[A-Za-z_][A-Za-z0-9_]*(?:\s*\([^()\r\n]*\))?)*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)`)
 var procedureDeclRe = regexp.MustCompile(`(?i)\b(?:Public|Private|Friend|Static)?\s*(Sub|Function)\s+([A-Za-z_][A-Za-z0-9_]*)`)
 var propertyDeclRe = regexp.MustCompile(`(?i)\b(?:Public|Private|Friend|Static)?\s*(Property)\s+(?:Get|Let|Set)\s+([A-Za-z_][A-Za-z0-9_]*)`)
-var projectTypeReferenceRe = regexp.MustCompile(`(?i)\b(?:As|New|Implements)\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*([A-Za-z_][A-Za-z0-9_]*)`)
+var projectTypeReferenceRe = regexp.MustCompile(`(?i)\b(?:As\s+(?:New\s+)?|New\s+|Implements\s+)(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*([A-Za-z_][A-Za-z0-9_]*)`)
 
 func (a Analyzer) SemanticTokens(doc Document, open []Document) ([]SemanticToken, error) {
 	builder := semanticBuilder{analyzer: a, doc: doc}
@@ -194,9 +194,12 @@ func semanticTypeForProjectTypeSymbol(sym Symbol) string {
 		return SemanticTokenEnum
 	case "class":
 		return SemanticTokenClass
-	default:
-		return ""
+	case "module":
+		if strings.EqualFold(sym.ModuleKind, "class") {
+			return SemanticTokenClass
+		}
 	}
+	return ""
 }
 
 // addProjectProcedureReferenceTokens classifies calls to workspace Sub and
@@ -225,9 +228,13 @@ func (b *semanticBuilder) addProjectProcedureReferenceTokens(open []Document) {
 	}
 	declarations := make(map[string]bool)
 	locals := make(map[string]bool)
+	functions := make(map[string]bool)
 	for _, sym := range docSyms {
 		if isProjectProcedureSymbol(sym) {
 			declarations[semanticRangeKey(b.symbolNameRange(sym))] = true
+		}
+		if strings.EqualFold(sym.Kind, "function") {
+			functions[strings.ToLower(sym.Name)] = true
 		}
 		if isLocalSymbol(sym) {
 			locals[procedureLocalKey(sym.Parent, sym.Name)] = true
@@ -244,6 +251,9 @@ func (b *semanticBuilder) addProjectProcedureReferenceTokens(open []Document) {
 				continue
 			}
 			procedure := currentProcedureNameForDocument(b.doc, rng.Start)
+			if strings.EqualFold(procedure, name) && functions[strings.ToLower(procedure)] && b.isAssignment(rng) {
+				continue
+			}
 			if locals[procedureLocalKey(procedure, name)] {
 				continue
 			}
@@ -274,6 +284,12 @@ func (b *semanticBuilder) isProjectProcedureReference(rng Range) bool {
 		return false
 	}
 	return !strings.HasPrefix(strings.TrimSpace(line[end:]), ":=")
+}
+
+func (b *semanticBuilder) isAssignment(rng Range) bool {
+	line := lineAt(b.doc.Source, rng.Start.Line)
+	end := byteIndexForUTF16(line, rng.End.Character)
+	return strings.HasPrefix(strings.TrimSpace(line[end:]), "=")
 }
 
 func (b *semanticBuilder) addLexicalTokens() {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -69,3 +69,4 @@
 - Excel/VBE runtime error dialogs can remain hidden until Excel receives focus. A watcher must not require `IsWindowVisible` for owned `#32770` dialog candidates; capture visibility as diagnostics instead.
 - Clicking `Debug` on a runtime error dialog can leave VBE in break mode and make later COM attachment fail. Until selection capture and reset are proven reliable, prefer `End` for unattended suppression.
 - When rewriting test results from `inconclusive` to `failed`, update both counters. Per-item status and top-level command status must not diverge after lifecycle hook failures.
+- Semantic highlighting for VBA must model language-specific implicit identifiers and extractor shapes: a Function name on an assignment is its return variable, `As New` must color the type rather than `New`, and class modules may be represented as `module` symbols with `ModuleKind == "class"`.


### PR DESCRIPTION
**Summary**
- Add semantic token coverage for parameter uses inside their declaring procedure.
- Highlight workspace type references in explicit `As` / `New` / `Implements` contexts.
- Classify calls to workspace `Sub` / `Function` declarations so bare calls and expression calls share function coloring.
- Extend tests to cover named arguments, local shadowing, type references, and procedure call edge cases.

**Testing**
- Added/updated unit tests for semantic token classification in `internal/vba/intel/intel_test.go`.
- Not run (not requested).