### PR TITLE
Add optional workbook coordination waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to xlflow will be documented in this file.
   `LockFileEx` ownership, immediate structured `workbook_busy` diagnostics, and
   guarded atomic owner metadata for conflicting CLI processes and
   WSL-delegated commands.
+- Added opt-in `--wait` and `--wait-timeout` workbook coordination with a finite
+  30-second default, Ctrl+C cancellation, and structured timeout/cancel errors.
 - Changed new-project scaffolds and `module install` to place bundled `Xlflow*.bas` helpers under `src/modules/Xlflow/`; existing root-level helper files are not moved, and `module install` now refuses those legacy collisions rather than creating duplicate VBA components.
 - Fixed .NET `push` to stop before importing when Excel cannot remove an existing VBA component and to reject Excel-renamed imports, preventing duplicate modules with a `1` suffix; every removal/import failure poisons a partial session replacement, managed sessions discard the unsafe unsaved state on stop, and external sessions receive owner-correct recovery guidance.
 - Fixed .NET bridge workbook persistence so transient `__XLFLOW_MODE__`, related runtime/UI/debug defined names, and generated helper modules are removed before save, including after a timed-out session run or a macro that saves and then edits again, preventing manually opened workbooks from remaining in headless mode or retaining temporary harness code.

--- a/docs/adr/ADR-0019-opt-in-workbook-wait-policy.md
+++ b/docs/adr/ADR-0019-opt-in-workbook-wait-policy.md
@@ -1,0 +1,77 @@
+# ADR-0019: Opt-in Workbook Coordination Waiting
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0018 makes immediate `workbook_busy` failure the safe default and provides
+context-aware polling in the Windows workbook lock. Automation and AI-agent
+workflows also need a bounded way to wait for short operations without retrying
+the workbook command itself or treating an unbounded queue as a hung process.
+
+Waiting affects every non-parallel-safe workbook command, its public CLI flags,
+structured diagnostics, cancellation behavior, multi-workbook acquisition, and
+WSL delegation. The timeout therefore needs one cross-command contract rather
+than command-specific retry loops.
+
+## Decision
+
+xlflow exposes global `--wait` and `--wait-timeout <duration>` options. Waiting
+is opt-in; without `--wait`, contention continues to fail immediately with
+`workbook_busy`. `--wait` uses a finite 30-second timeout unless the caller
+overrides it with a positive `--wait-timeout` value.
+
+The timeout is one budget for acquiring every required workbook lock in stable
+lock-ID order. It starts immediately before lock acquisition and ends once all
+leases are held. It does not limit validation, the command body, Excel or VBA
+execution, saves, or cleanup. A failure releases any earlier leases in reverse
+order, and the workbook command body is never retried.
+
+Waiting is allowed only when the authoritative command policy uses workbook
+scope, is non-parallel-safe, and is retryable when busy. Unsupported commands
+and invalid option combinations fail before Excel or the bridge starts.
+
+The CLI initially attempts non-blocking acquisition. Only real contention
+enters the polling wait and emits one human-readable waiting message. JSON mode
+emits no progress text. Timeout and cancellation return stable
+`workbook_busy_timeout` and `workbook_busy_cancelled` diagnostics with
+operational exit code 3. Ctrl+C is intercepted only during lock acquisition;
+normal signal behavior resumes after the leases are acquired.
+
+WSL continues to delegate the complete invocation to Windows under ADR-0011,
+including both wait options. The delegated Windows process owns the timeout and
+lock lifecycle.
+
+## Consequences
+
+- Positive: automation can wait for short contention without duplicating retry
+  policy or re-running a partially started command.
+- Positive: every wait is finite by default and cancellation-aware.
+- Positive: JSON output remains a single machine-readable envelope.
+- Negative: polling does not guarantee FIFO fairness and a waiter may lose a
+  handoff to another process.
+- Negative: one slow earlier target consumes budget available to later targets
+  in a multi-workbook operation.
+- Negative: callers must distinguish immediate busy, wait timeout, and wait
+  cancellation codes.
+
+## Alternatives Considered
+
+1. **Wait indefinitely when only `--wait` is provided** - Rejected because an
+   executing macro can run without a bound and make automation appear hung.
+2. **Require `--wait-timeout` with every `--wait`** - Rejected because a safe
+   finite default gives interactive and agent callers a simpler common path.
+3. **Retry the complete command after `workbook_busy`** - Rejected because only
+   pre-execution lock acquisition is known to be safe to retry.
+4. **Maintain a persistent FIFO queue** - Rejected because it requires a daemon
+   and recovery protocol outside the initial coordination model.
+
+## Related
+
+- `docs/adr/ADR-0016-workbook-operation-coordination.md`
+- `docs/adr/ADR-0018-windows-workbook-lock-and-owner-metadata.md`
+- `docs/specs/workbook-coordination.md`
+- `docs/specs/cli-contract.md`
+- xlflow issues #311 and #322

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -383,6 +383,21 @@ result. Owner metadata is diagnostic rather than authoritative, and clients must
 not infer that a workbook is free from missing owner details. Human output names
 the busy workbook and indicates whether retrying is appropriate.
 
+All commands accept global `--wait` and `--wait-timeout <duration>` options, but
+the options are valid only for non-parallel-safe workbook commands whose central
+policy is retryable. Immediate failure remains the default. `--wait` uses a
+30-second timeout unless a positive override is supplied. A changed
+`--wait-timeout` without `--wait` returns `coordination_wait_args_invalid`;
+unsupported commands return `coordination_wait_unsupported`, both with exit code
+2 before workbook or bridge work starts.
+
+Waiting covers only acquisition of all required workbook locks, not the command
+body. Timeout returns `workbook_busy_timeout`; Ctrl+C or context cancellation
+returns `workbook_busy_cancelled`. Both use phase `coordination.acquire`, include
+`wait_timeout` in error details, and return exit code 3. JSON output contains no
+wait progress text; human output prints one concise line after contention is
+actually observed.
+
 Command-specific fields are added at the top level:
 
 - `diagnostics` for `doctor` (includes `excel.com_activation` which indicates successful `Excel.Application` creation on the STA thread, plus `.NET` bridge `excel.systemprofile_desktop` readiness with per-path `status` values of `exists`, `missing`, `access_denied`, or `unknown`; `doctor --workbook` additionally opens the configured workbook and reports `workbook_openable`; WSL adds `host`, `windows`, and `path_translation`)
@@ -535,7 +550,7 @@ When no Excel processes are running, `process` is an empty array and the command
 - `0`: success
 - `1`: user-code or validation failure, including lint findings, analysis findings, GUI boundary preflight failures, macro failure, macro timeout, VBE compile failure, missing macro target, removed-helper findings, missing UI sheets or buttons, VBA test failure, no tests found, missing or ambiguous filter targets, active workbook mismatches, duplicate test names within one module, invalid exported ranges, existing output files, unsupported export-image formats, unsupported form export-image formats, missing UserForms, `form_already_exists`, `unsupported_form_control`, `designer_write_failed`, capture window lookup failures, image capture failures, `edit` session requirements, invalid workbook edit selectors, invalid edit colors, `invalid_sheet_name`, `sheet_exists`, `fmt_check_failed` (unformatted files in `--check` mode), and workbook event-handler failures returned by the bridge
 - `2`: CLI argument or configuration error, including invalid `push`, `run`, `session`, `save`, `runner`, `export-image`, `form new`, `form build`, `form export-image`, `module new`, `edit`, and `process` option combinations, invalid `fmt` mode combinations, plus `process_args_invalid` and `process_not_found` errors from the bridge
-- `3`: environment or operational failure, including workbook lock contention (`workbook_busy`), Excel, COM, VBIDE, PowerShell, script execution failures, WSL delegation failures, and process enumeration/termination errors (`process_enumeration_failed`, `process_termination_failed`, `process_cleanup_failed`)
+- `3`: environment or operational failure, including workbook lock contention (`workbook_busy`, `workbook_busy_timeout`, `workbook_busy_cancelled`), Excel, COM, VBIDE, PowerShell, script execution failures, WSL delegation failures, and process enumeration/termination errors (`process_enumeration_failed`, `process_termination_failed`, `process_cleanup_failed`)
 
 `diff` intentionally returns `0` when differences are found. Consumers should inspect `diff.summary.total_diffs` to distinguish changed and unchanged inputs.
 

--- a/docs/specs/workbook-coordination.md
+++ b/docs/specs/workbook-coordination.md
@@ -25,8 +25,8 @@ The policy vocabulary is:
 | `retryable_when_busy` | boolean                                 | Whether a future caller may opt into retrying after resource contention.       |
 | `default_wait_policy` | `fail`, `wait`                          | Whether acquisition should fail immediately or wait by default.                |
 
-All initial policies use `default_wait_policy: fail`. Waiting remains explicit in
-future work. A resource operation is retryable only when it is non-parallel-safe
+All policies use `default_wait_policy: fail`. Callers may opt into bounded
+waiting through the public CLI contract below. A resource operation is retryable only when it is non-parallel-safe
 and retrying after contention is meaningful. `parallel_safe: true` means that the
 operation does not need exclusive acquisition at its declared scope; it does not
 introduce a shared read-lock mode.
@@ -189,8 +189,8 @@ before acquisition.
 
 Immediate acquisition is the default. If the authoritative byte range is
 already locked, acquisition returns a typed busy result without entering the
-command body. The internal API may poll with a context for cancellation-aware
-blocking acquisition, but no public `--wait` or timeout flag is defined here.
+command body. The internal API also polls with a context for the explicit,
+cancellation-aware wait contract below.
 
 ### Windows Primitive and Storage
 
@@ -306,11 +306,33 @@ information never changes the `workbook_busy` result. Human output identifies
 the workbook and operation as busy and indicates whether retrying is appropriate.
 The CLI maps contention to environment/operational exit code `3`.
 
+## Opt-in Waiting Contract
+
+`--wait` opts a retryable, non-parallel-safe workbook command into lock waiting.
+`--wait-timeout <duration>` overrides the finite 30-second default and is valid
+only with `--wait`; zero and negative durations are invalid. Source-only,
+parallel-safe, `excel_instance`, and non-retryable commands reject waiting from
+their central policy before command execution.
+
+The CLI uses one timeout for the complete sorted multi-workbook acquisition.
+It releases partial acquisitions in reverse order on timeout, cancellation, or
+error. The timeout ends when every required lease is acquired and never applies
+to the command body. Acquisition first attempts the lock without waiting; only
+actual contention enters polling. Human output prints one waiting line, while
+JSON output remains a single envelope with no progress text.
+
+Timeout returns `workbook_busy_timeout`; Ctrl+C or parent-context cancellation
+returns `workbook_busy_cancelled`. Both use phase `coordination.acquire`, include
+the attempted workbook, operation, resource scope, retryability, and configured
+wait timeout, and map to operational exit code `3`. The underlying workbook
+operation is never retried. Polling is cancellation-aware but does not guarantee
+FIFO ordering.
+
 ## Out of Scope for This Version
 
 This contract does not add:
 
-- public `--wait`, timeout, cancellation, or FIFO queue behavior;
+- FIFO queue behavior;
 - coordination fields in `session status`;
 - an `excel_instance` lock primitive;
 - a public policy/capabilities endpoint or serialized bridge schema; or

--- a/internal/cli/coordination.go
+++ b/internal/cli/coordination.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -16,6 +18,46 @@ import (
 	"github.com/harumiWeb/xlflow/internal/output"
 	"github.com/harumiWeb/xlflow/internal/workbookformat"
 )
+
+const (
+	coordinationWaitArgsInvalidCode = "coordination_wait_args_invalid"
+	coordinationWaitUnsupportedCode = "coordination_wait_unsupported"
+)
+
+func (a *app) validateCoordinationWaitOptions(cmd *cobra.Command) error {
+	timeoutChanged := false
+	if cmd != nil {
+		if flag := cmd.Flags().Lookup("wait-timeout"); flag != nil {
+			timeoutChanged = flag.Changed
+		}
+	}
+	commandName := coordinationCommandName(cmd)
+	if a.waitTimeout <= 0 {
+		return a.writeFailure(commandName, output.ExitConfig, coordinationWaitArgsInvalidCode, fmt.Errorf("--wait-timeout must be greater than zero"))
+	}
+	if timeoutChanged && !a.wait {
+		return a.writeFailure(commandName, output.ExitConfig, coordinationWaitArgsInvalidCode, fmt.Errorf("--wait-timeout requires --wait"))
+	}
+	if !a.wait {
+		return nil
+	}
+	descriptor, err := coordination.LookupCLI(cmd.CommandPath())
+	if err != nil {
+		return a.writeFailure(commandName, output.ExitEnvironment, coordination.MissingPolicyCode, err)
+	}
+	policy := descriptor.Policy
+	if policy.ResourceScope != coordination.ResourceWorkbook || policy.ParallelSafe || !policy.RetryableWhenBusy {
+		return a.writeFailure(commandName, output.ExitConfig, coordinationWaitUnsupportedCode, fmt.Errorf("--wait is not supported for %s", commandName))
+	}
+	return nil
+}
+
+func coordinationCommandName(cmd *cobra.Command) string {
+	if cmd == nil {
+		return "xlflow"
+	}
+	return strings.TrimSpace(strings.TrimPrefix(cmd.CommandPath(), "xlflow"))
+}
 
 func (a *app) wrapCoordinatedLeaves(root *cobra.Command) {
 	var walk func(*cobra.Command)
@@ -153,7 +195,6 @@ func (a *app) acquireWorkbookCoordination(ctx context.Context, commandID coordin
 	if ctx == nil {
 		ctx = context.Background()
 	}
-
 	identities := make(map[string]coordination.WorkbookIdentity, len(workbookPaths))
 	for _, workbookPath := range workbookPaths {
 		if strings.TrimSpace(workbookPath) == "" {
@@ -182,22 +223,53 @@ func (a *app) acquireWorkbookCoordination(ctx context.Context, commandID coordin
 		}
 	}
 
+	acquireCtx := ctx
+	stopSignal := func() {}
+	cancelTimeout := func() {}
+	if a.wait {
+		acquireCtx, stopSignal = signal.NotifyContext(ctx, os.Interrupt)
+		acquireCtx, cancelTimeout = context.WithTimeout(acquireCtx, a.waitTimeout)
+	}
+	defer stopSignal()
+	defer cancelTimeout()
+
 	leases := make([]*coordination.Lease, 0, len(lockIDs))
+	waitingAnnounced := false
 	release := func() {
 		for i := len(leases) - 1; i >= 0; i-- {
 			_ = leases[i].Release()
 		}
 	}
 	for _, lockID := range lockIDs {
-		lease, acquireErr := manager.Acquire(ctx, coordination.AcquireRequest{
-			Identity:      identities[lockID],
+		identity := identities[lockID]
+		request := coordination.AcquireRequest{
+			Identity:      identity,
 			Command:       descriptor.ID,
 			OperationKind: policy.OperationKind,
 			ResourceScope: policy.ResourceScope,
-		})
+		}
+		lease, acquireErr := manager.Acquire(acquireCtx, request)
+		var busy *coordination.BusyError
+		if a.wait && errors.As(acquireErr, &busy) {
+			if !waitingAnnounced && !a.json {
+				_, _ = fmt.Fprintf(a.stderrWriter(), "Waiting up to %s for the workbook to become available: %s\n", a.waitTimeout, busy.Identity.CanonicalPath)
+				waitingAnnounced = true
+			}
+			request.Wait = true
+			lease, acquireErr = manager.Acquire(acquireCtx, request)
+		}
+		if acquireErr == nil && a.wait && acquireCtx.Err() != nil {
+			_ = lease.Release()
+			acquireErr = acquireCtx.Err()
+		}
 		if acquireErr != nil {
 			release()
-			var busy *coordination.BusyError
+			if a.wait && errors.Is(acquireErr, context.DeadlineExceeded) {
+				return nil, a.writeWorkbookWaitFailure(descriptor, identity, coordination.WorkbookBusyTimeoutCode, fmt.Sprintf("The workbook did not become available within %s.", a.waitTimeout), acquireErr)
+			}
+			if a.wait && errors.Is(acquireErr, context.Canceled) {
+				return nil, a.writeWorkbookWaitFailure(descriptor, identity, coordination.WorkbookBusyCancelledCode, "Waiting for the workbook was cancelled.", acquireErr)
+			}
 			if errors.As(acquireErr, &busy) {
 				return nil, a.writeWorkbookBusyFailure(descriptor, busy)
 			}
@@ -206,6 +278,32 @@ func (a *app) acquireWorkbookCoordination(ctx context.Context, commandID coordin
 		leases = append(leases, lease)
 	}
 	return release, nil
+}
+
+func (a *app) writeWorkbookWaitFailure(descriptor coordination.Descriptor, identity coordination.WorkbookIdentity, code, message string, cause error) error {
+	details := map[string]any{
+		"workbook":       identity.CanonicalPath,
+		"operation":      descriptor.ID,
+		"resource_scope": descriptor.Policy.ResourceScope,
+		"retryable":      descriptor.Policy.RetryableWhenBusy,
+		"wait_timeout":   a.waitTimeout.String(),
+	}
+	commandName := string(descriptor.ID)
+	if len(descriptor.CLI) > 0 && strings.TrimSpace(descriptor.CLI[0].Path) != "" {
+		commandName = descriptor.CLI[0].Path
+	}
+	env := output.Failure(commandName, output.Error{
+		Code:    code,
+		Message: message,
+		Source:  "xlflow",
+		Phase:   "coordination.acquire",
+		Details: details,
+	})
+	a.addConfigWarnings(&env)
+	if err := output.WriteWithOptions(a.stdoutWriter(), env, a.outputOptions()); err != nil {
+		return output.WithExitCode(output.ExitEnvironment, err)
+	}
+	return output.WithExitCode(output.ExitEnvironment, cause)
 }
 
 func (a *app) writeWorkbookBusyFailure(descriptor coordination.Descriptor, busy *coordination.BusyError) error {

--- a/internal/cli/coordination.go
+++ b/internal/cli/coordination.go
@@ -38,7 +38,7 @@ func (a *app) validateCoordinationWaitOptions(cmd *cobra.Command) error {
 	if timeoutChanged && !a.wait {
 		return a.writeFailure(commandName, output.ExitConfig, coordinationWaitArgsInvalidCode, fmt.Errorf("--wait-timeout requires --wait"))
 	}
-	if !a.wait {
+	if !a.wait || isGeneratedCobraCommand(cmd) {
 		return nil
 	}
 	descriptor, err := coordination.LookupCLI(cmd.CommandPath())

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -342,9 +342,9 @@ func TestWorkbookCoordinationTimeoutDoesNotCoverHandlerRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	a := &app{cwd: rootDir, wait: true, waitTimeout: 20 * time.Millisecond, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
+	a := &app{cwd: rootDir, wait: true, waitTimeout: 500 * time.Millisecond, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
 	err = a.withWorkbookCoordination(context.Background(), "push", []string{filepath.Join(rootDir, "book.xlsm")}, func() error {
-		time.Sleep(60 * time.Millisecond)
+		time.Sleep(600 * time.Millisecond)
 		return nil
 	})
 	if err != nil {

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/coordination"
@@ -76,6 +78,313 @@ func TestWorkbookContentionStopsCLILeafWithStructuredBusyFailure(t *testing.T) {
 	owner, ok := details["owner"].(map[string]any)
 	if !ok || owner["command"] != "run" {
 		t.Fatalf("owner details = %#v", details["owner"])
+	}
+}
+
+func TestCoordinationWaitOptionsValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantCode string
+	}{
+		{name: "timeout requires wait", args: []string{"--json", "--wait-timeout", "1s", "push"}, wantCode: coordinationWaitArgsInvalidCode},
+		{name: "timeout must be positive", args: []string{"--json", "--wait", "--wait-timeout", "0s", "push"}, wantCode: coordinationWaitArgsInvalidCode},
+		{name: "timeout cannot be negative", args: []string{"--json", "--wait", "--wait-timeout", "-1s", "push"}, wantCode: coordinationWaitArgsInvalidCode},
+		{name: "source command cannot wait", args: []string{"--json", "--wait", "lint"}, wantCode: coordinationWaitUnsupportedCode},
+		{name: "parallel observer cannot wait", args: []string{"--json", "--wait", "session", "status"}, wantCode: coordinationWaitUnsupportedCode},
+		{name: "excel instance command cannot wait", args: []string{"--json", "--wait", "doctor"}, wantCode: coordinationWaitUnsupportedCode},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			a := &app{cwd: t.TempDir(), rawArgs: tt.args, stdout: &stdout, stderr: &bytes.Buffer{}}
+			root := a.rootCommand()
+			root.SetArgs(tt.args)
+			err := root.Execute()
+			if output.ExitCode(err) != output.ExitConfig {
+				t.Fatalf("exit code = %d, want %d (err=%v)", output.ExitCode(err), output.ExitConfig, err)
+			}
+			var env output.Envelope
+			if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+				t.Fatalf("decode JSON: %v\n%s", decodeErr, stdout.String())
+			}
+			if env.Error == nil || env.Error.Code != tt.wantCode {
+				t.Fatalf("error = %#v, want %s", env.Error, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestCoordinationWaitDefaultIsThirtySeconds(t *testing.T) {
+	a := &app{}
+	root := a.rootCommand()
+	if a.waitTimeout != 30*time.Second {
+		t.Fatalf("wait timeout = %s, want 30s", a.waitTimeout)
+	}
+	if got := root.PersistentFlags().Lookup("wait-timeout").DefValue; got != "30s" {
+		t.Fatalf("wait-timeout default = %q, want 30s", got)
+	}
+}
+
+func TestWorkbookCoordinationWaitsThenRunsHandlerOnce(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "run")
+	var stdout, stderr bytes.Buffer
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &stderr, coordination: manager}
+	time.AfterFunc(75*time.Millisecond, func() { _ = owner.Release() })
+	runs := 0
+	err := a.withWorkbookCoordination(context.Background(), "push", []string{identity.CanonicalPath}, func() error {
+		runs++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("waited command failed: %v", err)
+	}
+	if runs != 1 {
+		t.Fatalf("handler runs = %d, want 1", runs)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("JSON wait emitted progress: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestWorkbookCoordinationWaitTimeoutIsStructuredAndJSONPure(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "run")
+	defer func() { _ = owner.Release() }()
+	var stdout, stderr bytes.Buffer
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: 75 * time.Millisecond, stdout: &stdout, stderr: &stderr, coordination: manager}
+	err := a.withWorkbookCoordination(context.Background(), "push", []string{identity.CanonicalPath}, func() error {
+		t.Fatal("handler must not run after timeout")
+		return nil
+	})
+	assertCoordinationWaitFailure(t, err, stdout.Bytes(), coordination.WorkbookBusyTimeoutCode, "75ms")
+	if stderr.Len() != 0 {
+		t.Fatalf("JSON wait emitted stderr progress: %q", stderr.String())
+	}
+}
+
+func TestWorkbookCoordinationWaitCancellationIsStructured(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "run")
+	defer func() { _ = owner.Release() }()
+	var stdout bytes.Buffer
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &bytes.Buffer{}, coordination: manager}
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(50*time.Millisecond, cancel)
+	err := a.withWorkbookCoordination(ctx, "push", []string{identity.CanonicalPath}, func() error {
+		t.Fatal("handler must not run after cancellation")
+		return nil
+	})
+	assertCoordinationWaitFailure(t, err, stdout.Bytes(), coordination.WorkbookBusyCancelledCode, "1s")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context cancellation", err)
+	}
+}
+
+func TestWorkbookCoordinationHumanWaitMessageAppearsOnlyAfterContention(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "run")
+	defer func() { _ = owner.Release() }()
+	var stdout, stderr bytes.Buffer
+	a := &app{cwd: rootDir, wait: true, waitTimeout: 50 * time.Millisecond, stdout: &stdout, stderr: &stderr, coordination: manager}
+	_ = a.withWorkbookCoordination(context.Background(), "push", []string{identity.CanonicalPath}, func() error { return nil })
+	if !strings.Contains(stderr.String(), "Waiting up to 50ms") || !strings.Contains(stderr.String(), identity.CanonicalPath) {
+		t.Fatalf("wait message = %q", stderr.String())
+	}
+	if strings.Count(stderr.String(), "\n") != 1 {
+		t.Fatalf("wait message should be exactly one line: %q", stderr.String())
+	}
+}
+
+func TestWorkbookCoordinationWithoutContentionEmitsNoWaitMessage(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir := t.TempDir()
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	a := &app{cwd: rootDir, wait: true, waitTimeout: time.Second, stdout: &bytes.Buffer{}, stderr: &stderr, coordination: manager}
+	if err := a.withWorkbookCoordination(context.Background(), "push", []string{filepath.Join(rootDir, "book.xlsm")}, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("uncontended wait emitted progress: %q", stderr.String())
+	}
+}
+
+func TestWorkbookCoordinationNonWaitCancellationKeepsSetupFailureCode(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir := t.TempDir()
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	a := &app{cwd: rootDir, json: true, stdout: &stdout, stderr: &bytes.Buffer{}, coordination: manager}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runErr := a.withWorkbookCoordination(ctx, "push", []string{filepath.Join(rootDir, "book.xlsm")}, func() error { return nil })
+	if output.ExitCode(runErr) != output.ExitEnvironment {
+		t.Fatalf("exit code = %d, want %d (err=%v)", output.ExitCode(runErr), output.ExitEnvironment, runErr)
+	}
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("decode JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	if env.Error == nil || env.Error.Code != "coordination_acquire_failed" {
+		t.Fatalf("non-wait cancellation error = %#v", env.Error)
+	}
+}
+
+func TestWorkbookCoordinationTimeoutReleasesEarlierMultiTargetLease(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir := t.TempDir()
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstPath := filepath.Join(rootDir, "first.xlsm")
+	secondPath := filepath.Join(rootDir, "second.xlsm")
+	firstIdentity, _ := coordination.NewWorkbookIdentity(rootDir, firstPath)
+	secondIdentity, _ := coordination.NewWorkbookIdentity(rootDir, secondPath)
+	if firstIdentity.LockID > secondIdentity.LockID {
+		firstPath, secondPath = secondPath, firstPath
+		firstIdentity, secondIdentity = secondIdentity, firstIdentity
+	}
+	descriptor, _ := coordination.Lookup("diff")
+	owner, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: secondIdentity, Command: "run", OperationKind: coordination.OperationExecute, ResourceScope: coordination.ResourceWorkbook})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = owner.Release() }()
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: 75 * time.Millisecond, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
+	if err := a.withWorkbookCoordination(context.Background(), descriptor.ID, []string{firstPath, secondPath}, func() error { return nil }); output.ExitCode(err) != output.ExitEnvironment {
+		t.Fatalf("timeout error = %v", err)
+	}
+	lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: firstIdentity, Command: descriptor.ID, OperationKind: descriptor.Policy.OperationKind, ResourceScope: descriptor.Policy.ResourceScope})
+	if err != nil {
+		t.Fatalf("earlier target remained locked: %v", err)
+	}
+	_ = lease.Release()
+}
+
+func TestWorkbookCoordinationUsesOneTimeoutBudgetAcrossMultipleTargets(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir := t.TempDir()
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstPath := filepath.Join(rootDir, "first.xlsm")
+	secondPath := filepath.Join(rootDir, "second.xlsm")
+	firstIdentity, _ := coordination.NewWorkbookIdentity(rootDir, firstPath)
+	secondIdentity, _ := coordination.NewWorkbookIdentity(rootDir, secondPath)
+	if firstIdentity.LockID > secondIdentity.LockID {
+		firstPath, secondPath = secondPath, firstPath
+		firstIdentity, secondIdentity = secondIdentity, firstIdentity
+	}
+	request := func(identity coordination.WorkbookIdentity) coordination.AcquireRequest {
+		return coordination.AcquireRequest{Identity: identity, Command: "run", OperationKind: coordination.OperationExecute, ResourceScope: coordination.ResourceWorkbook}
+	}
+	firstOwner, err := manager.Acquire(context.Background(), request(firstIdentity))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondOwner, err := manager.Acquire(context.Background(), request(secondIdentity))
+	if err != nil {
+		_ = firstOwner.Release()
+		t.Fatal(err)
+	}
+	defer func() { _ = firstOwner.Release() }()
+	defer func() { _ = secondOwner.Release() }()
+
+	const waitBudget = 220 * time.Millisecond
+	time.AfterFunc(120*time.Millisecond, func() { _ = firstOwner.Release() })
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: waitBudget, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
+	started := time.Now()
+	err = a.withWorkbookCoordination(context.Background(), "diff", []string{firstPath, secondPath}, func() error {
+		t.Fatal("handler must not run after the shared timeout expires")
+		return nil
+	})
+	elapsed := time.Since(started)
+	if output.ExitCode(err) != output.ExitEnvironment {
+		t.Fatalf("timeout error = %v", err)
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Fatalf("multi-target acquisition took %s; timeout budget appears to have restarted per target", elapsed)
+	}
+}
+
+func TestWorkbookCoordinationTimeoutDoesNotCoverHandlerRuntime(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir := t.TempDir()
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &app{cwd: rootDir, wait: true, waitTimeout: 20 * time.Millisecond, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
+	err = a.withWorkbookCoordination(context.Background(), "push", []string{filepath.Join(rootDir, "book.xlsm")}, func() error {
+		time.Sleep(60 * time.Millisecond)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("handler runtime was covered by wait timeout: %v", err)
+	}
+}
+
+func setupHeldCoordinationLock(t *testing.T, command coordination.CommandID) (string, *coordination.Manager, coordination.WorkbookIdentity, *coordination.Lease) {
+	t.Helper()
+	rootDir := t.TempDir()
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := coordination.NewWorkbookIdentity(rootDir, filepath.Join(rootDir, "book.xlsm"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: identity, Command: command, OperationKind: coordination.OperationExecute, ResourceScope: coordination.ResourceWorkbook})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rootDir, manager, identity, lease
+}
+
+func assertCoordinationWaitFailure(t *testing.T, err error, body []byte, code, timeout string) {
+	t.Helper()
+	if output.ExitCode(err) != output.ExitEnvironment {
+		t.Fatalf("exit code = %d, want %d (err=%v)", output.ExitCode(err), output.ExitEnvironment, err)
+	}
+	var env output.Envelope
+	if decodeErr := json.Unmarshal(body, &env); decodeErr != nil {
+		t.Fatalf("decode JSON: %v\n%s", decodeErr, body)
+	}
+	if env.Error == nil || env.Error.Code != code || env.Error.Phase != "coordination.acquire" {
+		t.Fatalf("error payload = %#v", env.Error)
+	}
+	details, ok := env.Error.Details.(map[string]any)
+	if !ok || details["wait_timeout"] != timeout || details["retryable"] != true {
+		t.Fatalf("wait details = %#v", env.Error.Details)
 	}
 }
 

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -126,6 +126,17 @@ func TestCoordinationWaitDefaultIsThirtySeconds(t *testing.T) {
 	}
 }
 
+func TestCoordinationWaitOptionsAllowGeneratedCobraCommands(t *testing.T) {
+	var stdout bytes.Buffer
+	a := &app{cwd: t.TempDir(), rawArgs: []string{"--wait", "help"}, stdout: &stdout, stderr: &bytes.Buffer{}}
+	root := a.rootCommand()
+	root.SetOut(&stdout)
+	root.SetArgs(a.rawArgs)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("generated help command rejected --wait: %v", err)
+	}
+}
+
 func TestWorkbookCoordinationWaitsThenRunsHandlerOnce(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows LockFileEx coordination")
@@ -174,8 +185,8 @@ func TestWorkbookCoordinationWaitCancellationIsStructured(t *testing.T) {
 	}
 	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "run")
 	defer func() { _ = owner.Release() }()
-	var stdout bytes.Buffer
-	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &bytes.Buffer{}, coordination: manager}
+	var stdout, stderr bytes.Buffer
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &stderr, coordination: manager}
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(50*time.Millisecond, cancel)
 	err := a.withWorkbookCoordination(ctx, "push", []string{identity.CanonicalPath}, func() error {
@@ -185,6 +196,9 @@ func TestWorkbookCoordinationWaitCancellationIsStructured(t *testing.T) {
 	assertCoordinationWaitFailure(t, err, stdout.Bytes(), coordination.WorkbookBusyCancelledCode, "1s")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want context cancellation", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("JSON cancellation emitted stderr progress: %q", stderr.String())
 	}
 }
 
@@ -273,10 +287,10 @@ func TestWorkbookCoordinationTimeoutReleasesEarlierMultiTargetLease(t *testing.T
 		t.Fatal(err)
 	}
 	defer func() { _ = owner.Release() }()
-	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: 75 * time.Millisecond, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
-	if err := a.withWorkbookCoordination(context.Background(), descriptor.ID, []string{firstPath, secondPath}, func() error { return nil }); output.ExitCode(err) != output.ExitEnvironment {
-		t.Fatalf("timeout error = %v", err)
-	}
+	var stdout bytes.Buffer
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: 75 * time.Millisecond, stdout: &stdout, stderr: &bytes.Buffer{}, coordination: manager}
+	err = a.withWorkbookCoordination(context.Background(), descriptor.ID, []string{firstPath, secondPath}, func() error { return nil })
+	assertCoordinationWaitFailure(t, err, stdout.Bytes(), coordination.WorkbookBusyTimeoutCode, "75ms")
 	lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: firstIdentity, Command: descriptor.ID, OperationKind: descriptor.Policy.OperationKind, ResourceScope: descriptor.Policy.ResourceScope})
 	if err != nil {
 		t.Fatalf("earlier target remained locked: %v", err)
@@ -318,15 +332,17 @@ func TestWorkbookCoordinationUsesOneTimeoutBudgetAcrossMultipleTargets(t *testin
 
 	const waitBudget = 220 * time.Millisecond
 	time.AfterFunc(120*time.Millisecond, func() { _ = firstOwner.Release() })
-	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: waitBudget, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
+	var stdout bytes.Buffer
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: waitBudget, stdout: &stdout, stderr: &bytes.Buffer{}, coordination: manager}
 	started := time.Now()
 	err = a.withWorkbookCoordination(context.Background(), "diff", []string{firstPath, secondPath}, func() error {
 		t.Fatal("handler must not run after the shared timeout expires")
 		return nil
 	})
 	elapsed := time.Since(started)
-	if output.ExitCode(err) != output.ExitEnvironment {
-		t.Fatalf("timeout error = %v", err)
+	assertCoordinationWaitFailure(t, err, stdout.Bytes(), coordination.WorkbookBusyTimeoutCode, waitBudget.String())
+	if elapsed < 180*time.Millisecond {
+		t.Fatalf("multi-target acquisition timed out too early after %s", elapsed)
 	}
 	if elapsed >= 300*time.Millisecond {
 		t.Fatalf("multi-target acquisition took %s; timeout budget appears to have restarted per target", elapsed)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -52,6 +52,8 @@ import (
 type app struct {
 	json           bool
 	bridge         string
+	wait           bool
+	waitTimeout    time.Duration
 	cwd            string
 	rawArgs        []string
 	stdout         io.Writer
@@ -181,11 +183,16 @@ func (a *app) rootCommand() *cobra.Command {
 			if err := a.requireCoordinationPolicy(cmd); err != nil {
 				return err
 			}
+			if err := a.validateCoordinationWaitOptions(cmd); err != nil {
+				return err
+			}
 			return a.delegateWSLCommand(cmd)
 		},
 	}
 	root.PersistentFlags().BoolVar(&a.json, "json", false, "write machine-readable JSON output")
 	root.PersistentFlags().StringVar(&a.bridge, "bridge", "", "Excel bridge mode: auto, dotnet")
+	root.PersistentFlags().BoolVar(&a.wait, "wait", false, "wait for a busy workbook before starting the command")
+	root.PersistentFlags().DurationVar(&a.waitTimeout, "wait-timeout", 30*time.Second, "maximum time to wait for workbook coordination")
 	root.AddCommand(
 		a.newCommand(),
 		a.initCommand(),

--- a/internal/cli/wsl_delegation_test.go
+++ b/internal/cli/wsl_delegation_test.go
@@ -224,10 +224,9 @@ func TestDelegateWSLCommandPreservesCoordinationWaitOptions(t *testing.T) {
 			newDelegatedCommand = delegatedHelperCommand
 			var stdout bytes.Buffer
 			a := &app{cwd: t.TempDir(), rawArgs: args, stdout: &stdout, stderr: &bytes.Buffer{}, buildInfo: BuildInfo{Version: "1.2.3"}}
-			root := &cobra.Command{Use: "xlflow"}
-			push := &cobra.Command{Use: "push"}
-			root.AddCommand(push)
-			err := a.delegateWSLCommand(push)
+			root := a.rootCommand()
+			root.SetArgs(args)
+			err := root.Execute()
 			if !errors.Is(err, errWSLDelegated) || output.ExitCode(err) != output.ExitSuccess {
 				t.Fatalf("delegation error = %v, exit=%d", err, output.ExitCode(err))
 			}

--- a/internal/cli/wsl_delegation_test.go
+++ b/internal/cli/wsl_delegation_test.go
@@ -207,6 +207,37 @@ func TestDelegateWSLCommandPreservesStreamsArgumentsAndExitCode(t *testing.T) {
 	}
 }
 
+func TestDelegateWSLCommandPreservesCoordinationWaitOptions(t *testing.T) {
+	for _, args := range [][]string{
+		{"--json", "--wait", "--wait-timeout", "45s", "push"},
+		{"--json", "--wait", "--wait-timeout=45s", "push"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			restore := stubWSLDelegationGlobals(t)
+			defer restore()
+			t.Setenv("GO_WANT_WSL_HELPER_PROCESS", "1")
+			t.Setenv("WSL_HELPER_MODE", "echo")
+			isWSL = func() bool { return true }
+			translateWSLPath = func(context.Context, string) (string, error) { return `C:\dev\project`, nil }
+			resolveWindowsExecutable = func(context.Context) (string, string, error) { return "ignored.exe", `C:\tools\xlflow.exe`, nil }
+			translateWSLArgs = func(_ context.Context, got []string) ([]string, error) { return append([]string{}, got...), nil }
+			newDelegatedCommand = delegatedHelperCommand
+			var stdout bytes.Buffer
+			a := &app{cwd: t.TempDir(), rawArgs: args, stdout: &stdout, stderr: &bytes.Buffer{}, buildInfo: BuildInfo{Version: "1.2.3"}}
+			root := &cobra.Command{Use: "xlflow"}
+			push := &cobra.Command{Use: "push"}
+			root.AddCommand(push)
+			err := a.delegateWSLCommand(push)
+			if !errors.Is(err, errWSLDelegated) || output.ExitCode(err) != output.ExitSuccess {
+				t.Fatalf("delegation error = %v, exit=%d", err, output.ExitCode(err))
+			}
+			if want := "ARGS=" + strings.Join(args, "|"); !strings.Contains(stdout.String(), want) {
+				t.Fatalf("wait args were not preserved, want %q:\n%s", want, stdout.String())
+			}
+		})
+	}
+}
+
 func TestDelegateWSLCommandStopsLocalRunEAfterSuccessfulDelegation(t *testing.T) {
 	restore := stubWSLDelegationGlobals(t)
 	defer restore()

--- a/internal/coordination/lock.go
+++ b/internal/coordination/lock.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	WorkbookBusyCode = "workbook_busy"
-	ownerSchemaV1    = 1
-	operationByte    = int64(0)
-	publicationByte  = int64(1)
+	WorkbookBusyCode          = "workbook_busy"
+	WorkbookBusyTimeoutCode   = "workbook_busy_timeout"
+	WorkbookBusyCancelledCode = "workbook_busy_cancelled"
+	ownerSchemaV1             = 1
+	operationByte             = int64(0)
+	publicationByte           = int64(1)
 )
 
 var (

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,16 @@
+# Issue #322: Optional workbook wait and timeout
+
+- [x] Define the opt-in 30-second wait contract and ADR
+- [x] Add global wait options and policy-based validation
+- [x] Add total acquisition timeout, cancellation, and partial lease cleanup
+- [x] Keep JSON output progress-free and human wait output concise
+- [x] Add focused wait, timeout, cancellation, and multi-target tests
+- [x] Verify WSL argument forwarding
+- [x] Run full tests, lint, docs build, and self-review
+- [ ] Create, review, and merge PR #322
+
+---
+
 # Issues #320, #321, #323: Workbook operation coordination
 
 ## Implementation

--- a/vitepress/commands/index.md
+++ b/vitepress/commands/index.md
@@ -1,9 +1,10 @@
 # Commands
 
-xlflow exposes a Cobra-based CLI. Every command accepts the global `--json` flag for machine-readable output.
+xlflow exposes a Cobra-based CLI. Every command accepts the global `--json` flag for machine-readable output. Retryable workbook commands also accept `--wait` and `--wait-timeout <duration>`; waiting is opt-in and defaults to a 30-second limit.
 
 ```bash
 xlflow [command] --json
+xlflow [command] --wait --wait-timeout 45s
 ```
 
 Use command pages for workflow guidance and the canonical CLI contract in [JSON Output](../reference/json-output).

--- a/vitepress/reference/error-codes.md
+++ b/vitepress/reference/error-codes.md
@@ -8,6 +8,14 @@ Common examples:
   coordination lock. The command fails immediately by default; JSON details
   include the workbook, attempted operation, and whether retrying is supported.
   Current owner metadata is included when available but is not authoritative.
+- `workbook_busy_timeout`: an explicit `--wait` did not acquire every required
+  workbook lock within the 30-second default or supplied `--wait-timeout`.
+- `workbook_busy_cancelled`: Ctrl+C or caller cancellation stopped an explicit
+  workbook wait before the command body started.
+- `coordination_wait_args_invalid`: `--wait-timeout` was used without `--wait`,
+  or the timeout was not positive.
+- `coordination_wait_unsupported`: the selected command is not a retryable,
+  non-parallel-safe workbook operation.
 - `vbide_access_denied`
 - `macro_failed`
 - `macro_not_found`

--- a/vitepress/reference/exit-codes.md
+++ b/vitepress/reference/exit-codes.md
@@ -4,7 +4,7 @@
 | ---: | ----------------------------------------------------------------------------- |
 |  `0` | Success                                                                       |
 |  `1` | Validation or user-code failure (`fmt --check` found unformatted files, etc.) |
-|  `2` | CLI argument or configuration error (invalid `fmt` mode combinations, etc.)   |
-|  `3` | Operational or environment failure (including `workbook_busy`)                |
+|  `2` | CLI argument or configuration error (including invalid wait combinations)     |
+|  `3` | Operational or environment failure (including workbook busy/wait outcomes)    |
 
 `diff` returns `0` when differences are found. Inspect `diff.summary.total_diffs` in JSON.

--- a/vitepress/reference/json-output.md
+++ b/vitepress/reference/json-output.md
@@ -33,6 +33,12 @@ diagnostic `owner` metadata such as `pid`, stable command name, operation kind,
 and start time. Owner metadata can be missing after a crash or during cleanup;
 the error code, not the presence of `owner`, is the stable contention signal.
 
+Retryable workbook commands may add global `--wait`. Waiting defaults to 30
+seconds and can be changed with `--wait-timeout`. Timeout and cancellation use
+`workbook_busy_timeout` and `workbook_busy_cancelled`; their details include
+`wait_timeout`. JSON mode never writes wait progress to stderr or mixes it into
+stdout, so the result remains one valid envelope.
+
 Unknown commands are also structured when `--json` appears before the invalid command:
 
 ```json


### PR DESCRIPTION
## Summary
- add opt-in global `--wait` / `--wait-timeout` flags with a 30s default
- use one cancellation-aware budget across sorted workbook lock acquisition and preserve JSON purity
- document the public diagnostics and ADR-0019 decision

## Verification
- focused coordination and WSL delegation tests
- `task test`
- `task lint`
- `pnpm docs:build`
- `git diff --check`

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in `--wait` support for coordinated workbook operations.
  - Added configurable `--wait-timeout`, defaulting to 30 seconds.
  - Waiting can be cancelled with Ctrl+C.
  - Added structured timeout and cancellation errors, including JSON output details.
  - Preserved wait options when running through WSL.

- **Documentation**
  - Updated CLI usage, error-code, exit-code, JSON-output, and workbook coordination documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->