### PR TITLE
Expose workbook coordination in session status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to xlflow will be documented in this file.
   WSL-delegated commands.
 - Added opt-in `--wait` and `--wait-timeout` workbook coordination with a finite
   30-second default, Ctrl+C cancellation, and structured timeout/cancel errors.
+- Added an observational top-level `coordination` section to `session status`,
+  including current workbook busy state and guarded public owner metadata when
+  available without changing existing session fields or failure behavior.
 - Changed new-project scaffolds and `module install` to place bundled `Xlflow*.bas` helpers under `src/modules/Xlflow/`; existing root-level helper files are not moved, and `module install` now refuses those legacy collisions rather than creating duplicate VBA components.
 - Fixed .NET `push` to stop before importing when Excel cannot remove an existing VBA component and to reject Excel-renamed imports, preventing duplicate modules with a `1` suffix; every removal/import failure poisons a partial session replacement, managed sessions discard the unsafe unsaved state on stop, and external sessions receive owner-correct recovery guidance.
 - Fixed .NET bridge workbook persistence so transient `__XLFLOW_MODE__`, related runtime/UI/debug defined names, and generated helper modules are removed before save, including after a timed-out session run or a macro that saves and then edits again, preventing manually opened workbooks from remaining in headless mode or retaining temporary harness code.

--- a/docs/adr/ADR-0018-windows-workbook-lock-and-owner-metadata.md
+++ b/docs/adr/ADR-0018-windows-workbook-lock-and-owner-metadata.md
@@ -70,6 +70,32 @@ details omitted when no trustworthy current record is available.
 The detailed acquisition, metadata, and diagnostic contracts live in
 `docs/specs/workbook-coordination.md` and `docs/specs/cli-contract.md`.
 
+## Implementation Follow-up: Session Status Coordination (#324)
+
+`xlflow session status` now samples the authoritative workbook lock through
+`Manager.Probe` before it invokes the Excel bridge. This ordering preserves the
+command-start observation when a long-running session macro delays the COM
+status call until after the workbook owner has released its lease.
+
+The result is exposed as an additive top-level `coordination` object. It always
+contains `busy` when observation succeeds and flattens only the public owner
+fields `resource_scope`, `operation_kind`, `command`, `pid`, and `started_at`
+when guarded current metadata is available. Generation tokens, metadata schema
+fields, canonical workbook paths, and raw arguments remain internal. Missing or
+malformed owner metadata still reports `busy: true` from the OS lock alone.
+
+This status is observational rather than an authorization check and may change
+immediately after sampling. A probe failure does not fail session status or
+replace bridge warnings; xlflow omits `coordination` and adds the
+`coordination_status_unavailable` warning. The CLI lock remains the final
+authority for every workbook operation.
+
+The Deferred consequence below records the state when this ADR was originally
+accepted. ADR-0019 and issue #322 subsequently implemented public bounded wait
+flags, while this follow-up and issue #324 implement the `session status`
+coordination fields. FIFO fairness and `excel_instance` coordination remain
+deferred.
+
 ## Consequences
 
 - Positive: independent Windows and WSL-delegated processes cannot overlap
@@ -116,4 +142,4 @@ The detailed acquisition, metadata, and diagnostic contracts live in
 - `docs/specs/workbook-coordination.md`
 - `docs/specs/cli-contract.md`
 - `internal/coordination`
-- xlflow issues #311, #320, #321, and #323
+- xlflow issues #311, #320, #321, #323, and #324

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -422,7 +422,8 @@ Command-specific fields are added at the top level:
 - `edit` for `edit`
 - `process` for `process list` (array of process objects) and `process cleanup` (cleanup result object)
 - `project`, `session`, `state`, `warnings`, and `hints` for `status`
-- `session` for session status metadata
+- `session` and additive `coordination` for session status metadata and the
+  command-start workbook lock observation
 - `runner` for persistent runner module status
 - `version` for `version`
 - `gui_boundaries` for `inspect-gui`, `run --headless` preflight failures, and `doctor` source summaries
@@ -469,7 +470,7 @@ Command-specific fields are added at the top level:
 
 `rollback` success results add top-level `rollback`, plus the normal `target`, `warnings`, and `hints`. `rollback.restored_from` contains `id`, `path`, `reason`, and `created_at` for the restored backup. `rollback.safety_backup` contains `id` and `path` for the safety backup created before restore. `rollback.target.path` identifies the restored workbook path.
 
-Workbook-state-aware commands may return top-level `target`, `session`, `warnings`, and `hints`. `target.kind` uses the fixed vocabulary `source`, `file`, or `live_session`. `target` may also include `path`, `description`, `note`, and command-specific fields such as `sheet`, `range`, `form`, and `capture_state`. `session` may include `active`, `workbook_path`, `workbook_name`, `dirty`, `save_required`, `live_newer_than_disk`, `source_of_truth`, `userforms_present`, `userform_count`, and `mode`; `session status` also keeps `running`, `workbook_open`, and `metadata`. Warning and hint objects contain `code` and `message`. `push`, `pull`, `run`, `save`, `session`, `macros`, `inspect`, `export-image`, `form build`, `form export-image`, and `edit` should use these fields to make workbook state explicit without removing the existing compatibility fields under `workbook`.
+Workbook-state-aware commands may return top-level `target`, `session`, `warnings`, and `hints`. `target.kind` uses the fixed vocabulary `source`, `file`, or `live_session`. `target` may also include `path`, `description`, `note`, and command-specific fields such as `sheet`, `range`, `form`, and `capture_state`. `session` may include `active`, `workbook_path`, `workbook_name`, `dirty`, `save_required`, `live_newer_than_disk`, `source_of_truth`, `userforms_present`, `userform_count`, and `mode`; `session status` also keeps `running`, `workbook_open`, and `metadata` unchanged and adds top-level `coordination`. A successful observation is `{busy:false}`, `{busy:true}`, or `{busy:true,resource_scope,operation_kind,command,pid,started_at}` when current owner metadata is available. It is sampled before the bridge call, may change immediately, and never authorizes a later operation. Probe failure omits the field and adds `coordination_status_unavailable` without changing the session status exit code. Warning and hint objects contain `code` and `message`. `push`, `pull`, `run`, `save`, `session`, `macros`, `inspect`, `export-image`, `form build`, `form export-image`, and `edit` should use these fields to make workbook state explicit without removing the existing compatibility fields under `workbook`.
 
 ### `status`
 

--- a/docs/specs/workbook-coordination.md
+++ b/docs/specs/workbook-coordination.md
@@ -328,12 +328,29 @@ wait timeout, and map to operational exit code `3`. The underlying workbook
 operation is never retried. Polling is cancellation-aware but does not guarantee
 FIFO ordering.
 
+## Session Status Observation
+
+`session status` observes the configured workbook identity through
+`Manager.Probe` before calling the Excel bridge. It never infers ownership from
+session metadata or the owner metadata file alone. The top-level result is
+`coordination: {"busy": false}` when the OS lock is free and
+`coordination: {"busy": true}` when it is held but guarded owner metadata is
+unavailable. When current owner metadata is available, the object additionally
+contains `resource_scope`, `operation_kind`, `command`, `pid`, and an RFC 3339
+UTC `started_at`. Internal generation, schema, workbook-path, and argv fields
+are not exposed.
+
+The observation represents command-start state and may change before the
+status response is returned. It is advisory and does not reserve the workbook;
+later commands must still rely on normal CLI lock acquisition. If identity,
+manager, or lock probing fails, session status preserves its bridge result,
+omits `coordination`, and adds warning `coordination_status_unavailable`.
+
 ## Out of Scope for This Version
 
 This contract does not add:
 
 - FIFO queue behavior;
-- coordination fields in `session status`;
 - an `excel_instance` lock primitive;
 - a public policy/capabilities endpoint or serialized bridge schema; or
 - a separate UserForm Designer lock outside workbook coordination.

--- a/internal/cli/coordination.go
+++ b/internal/cli/coordination.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -20,9 +21,19 @@ import (
 )
 
 const (
-	coordinationWaitArgsInvalidCode = "coordination_wait_args_invalid"
-	coordinationWaitUnsupportedCode = "coordination_wait_unsupported"
+	coordinationWaitArgsInvalidCode   = "coordination_wait_args_invalid"
+	coordinationWaitUnsupportedCode   = "coordination_wait_unsupported"
+	coordinationStatusUnavailableCode = "coordination_status_unavailable"
 )
+
+type sessionCoordinationStatus struct {
+	Busy          bool   `json:"busy"`
+	ResourceScope string `json:"resource_scope,omitempty"`
+	OperationKind string `json:"operation_kind,omitempty"`
+	Command       string `json:"command,omitempty"`
+	PID           int    `json:"pid,omitempty"`
+	StartedAt     string `json:"started_at,omitempty"`
+}
 
 func (a *app) validateCoordinationWaitOptions(cmd *cobra.Command) error {
 	timeoutChanged := false
@@ -215,12 +226,9 @@ func (a *app) acquireWorkbookCoordination(ctx context.Context, commandID coordin
 		lockIDs = append(lockIDs, lockID)
 	}
 	sort.Strings(lockIDs)
-	manager := a.coordination
-	if manager == nil {
-		manager, err = coordination.NewDefaultManager()
-		if err != nil {
-			return nil, a.writeFailure(string(commandID), output.ExitEnvironment, "coordination_init_failed", err)
-		}
+	manager, err := a.coordinationManager()
+	if err != nil {
+		return nil, a.writeFailure(string(commandID), output.ExitEnvironment, "coordination_init_failed", err)
 	}
 
 	acquireCtx := ctx
@@ -278,6 +286,57 @@ func (a *app) acquireWorkbookCoordination(ctx context.Context, commandID coordin
 		leases = append(leases, lease)
 	}
 	return release, nil
+}
+
+func (a *app) coordinationManager() (*coordination.Manager, error) {
+	if a.coordination != nil {
+		return a.coordination, nil
+	}
+	return coordination.NewDefaultManager()
+}
+
+func (a *app) runSessionStatus(ctx context.Context, cfg config.Config, run func() (output.Envelope, int, error)) (output.Envelope, int, error) {
+	status, unavailable := a.observeSessionCoordination(ctx, cfg)
+	env, code, err := run()
+	if status != nil {
+		env.Coordination = status
+	}
+	if unavailable {
+		appendUniqueMessage(&env.Warnings, coordinationStatusUnavailableCode, "Workbook coordination status could not be observed; session status is still available.")
+	}
+	return env, code, err
+}
+
+func (a *app) observeSessionCoordination(ctx context.Context, cfg config.Config) (*sessionCoordinationStatus, bool) {
+	if runtime.GOOS != "windows" {
+		return nil, false
+	}
+	identity, err := coordination.NewWorkbookIdentity(a.cwd, cfg.Excel.Path)
+	if err != nil {
+		return nil, true
+	}
+	manager, err := a.coordinationManager()
+	if err != nil {
+		return nil, true
+	}
+	result, err := manager.Probe(ctx, identity)
+	if err != nil {
+		return nil, true
+	}
+	return sessionCoordinationStatusFromProbe(result), false
+}
+
+func sessionCoordinationStatusFromProbe(result coordination.ProbeResult) *sessionCoordinationStatus {
+	status := &sessionCoordinationStatus{Busy: result.Busy}
+	if !result.Busy || result.Owner == nil {
+		return status
+	}
+	status.ResourceScope = string(result.Owner.ResourceScope)
+	status.OperationKind = string(result.Owner.OperationKind)
+	status.Command = string(result.Owner.Command)
+	status.PID = result.Owner.PID
+	status.StartedAt = result.Owner.StartedAt.UTC().Format(time.RFC3339Nano)
+	return status
 }
 
 func (a *app) writeWorkbookWaitFailure(descriptor coordination.Descriptor, identity coordination.WorkbookIdentity, code, message string, cause error) error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3666,7 +3666,16 @@ func (a *app) sessionCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				env, code, err := a.excelRunnerForConfig(cfg).Session(cfg, action)
+				run := func() (output.Envelope, int, error) {
+					return a.excelRunnerForConfig(cfg).Session(cfg, action)
+				}
+				var env output.Envelope
+				var code int
+				if action == "status" {
+					env, code, err = a.runSessionStatus(cmd.Context(), cfg, run)
+				} else {
+					env, code, err = run()
+				}
 				if err != nil {
 					return err
 				}

--- a/internal/cli/session_coordination_test.go
+++ b/internal/cli/session_coordination_test.go
@@ -1,0 +1,220 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/coordination"
+	"github.com/harumiWeb/xlflow/internal/output"
+)
+
+func TestSessionCoordinationStatusPayload(t *testing.T) {
+	startedAt := time.Date(2026, time.July, 15, 9, 30, 0, 123456789, time.FixedZone("JST", 9*60*60))
+	tests := []struct {
+		name   string
+		probe  coordination.ProbeResult
+		fields map[string]any
+	}{
+		{
+			name:   "idle ignores owner",
+			probe:  coordination.ProbeResult{Owner: &coordination.OwnerMetadata{Command: "run"}},
+			fields: map[string]any{"busy": false},
+		},
+		{
+			name:   "busy without owner",
+			probe:  coordination.ProbeResult{Busy: true},
+			fields: map[string]any{"busy": true},
+		},
+		{
+			name: "busy with public owner fields",
+			probe: coordination.ProbeResult{Busy: true, Owner: &coordination.OwnerMetadata{
+				SchemaVersion: 99,
+				Generation:    "internal-generation",
+				Workbook:      `C:\private\Book.xlsm`,
+				PID:           12345,
+				Command:       "run",
+				OperationKind: coordination.OperationExecute,
+				ResourceScope: coordination.ResourceWorkbook,
+				StartedAt:     startedAt,
+			}},
+			fields: map[string]any{
+				"busy":           true,
+				"resource_scope": "workbook",
+				"operation_kind": "execute",
+				"command":        "run",
+				"pid":            float64(12345),
+				"started_at":     "2026-07-15T00:30:00.123456789Z",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(sessionCoordinationStatusFromProbe(tt.probe))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.fields) {
+				t.Fatalf("coordination payload = %#v, want %#v", got, tt.fields)
+			}
+			for _, internal := range []string{"schema_version", "generation", "workbook", "argv"} {
+				if _, ok := got[internal]; ok {
+					t.Fatalf("coordination payload exposed internal field %q: %#v", internal, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRunSessionStatusProbesBeforeBridgeAndPreservesSession(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir := t.TempDir()
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	cfg.Excel.Path = filepath.Join("build", "Book.xlsm")
+	identity, err := coordination.NewWorkbookIdentity(rootDir, cfg.Excel.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{
+		Identity:      identity,
+		Command:       "run",
+		OperationKind: coordination.OperationExecute,
+		ResourceScope: coordination.ResourceWorkbook,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+
+	wantSession := map[string]any{"active": true, "running": true, "metadata": map[string]any{"owner": "managed"}}
+	runs := 0
+	a := &app{cwd: rootDir, coordination: manager}
+	env, code, err := a.runSessionStatus(context.Background(), cfg, func() (output.Envelope, int, error) {
+		runs++
+		if err := lease.Release(); err != nil {
+			t.Fatal(err)
+		}
+		env := output.New("session")
+		env.Session = wantSession
+		return env, output.ExitSuccess, nil
+	})
+	if err != nil || code != output.ExitSuccess {
+		t.Fatalf("runSessionStatus() = code %d, err %v", code, err)
+	}
+	if runs != 1 {
+		t.Fatalf("bridge runs = %d, want 1", runs)
+	}
+	if !reflect.DeepEqual(env.Session, wantSession) {
+		t.Fatalf("session payload changed: %#v", env.Session)
+	}
+	status := cliObjectMap(env.Coordination)
+	if status["busy"] != true || status["command"] != "run" || status["operation_kind"] != "execute" || status["resource_scope"] != "workbook" {
+		t.Fatalf("coordination payload = %#v", status)
+	}
+	if status["pid"] != float64(os.Getpid()) || status["started_at"] == "" {
+		t.Fatalf("coordination owner = %#v", status)
+	}
+	probeAfter, err := manager.Probe(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if probeAfter.Busy {
+		t.Fatal("test bridge callback did not release workbook lease")
+	}
+}
+
+func TestRunSessionStatusKeepsFailureEnvelopeWhenProbeUnavailable(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir := t.TempDir()
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	wantError := &output.Error{Code: "session_failed", Message: "bridge status failed"}
+	a := &app{cwd: rootDir, coordination: manager}
+	env, code, err := a.runSessionStatus(ctx, cfg, func() (output.Envelope, int, error) {
+		env := output.Failure("session", *wantError)
+		env.Session = map[string]any{"active": false}
+		env.Warnings = []map[string]any{{"code": "existing_warning", "message": "preserve me"}}
+		return env, output.ExitEnvironment, nil
+	})
+	if err != nil || code != output.ExitEnvironment {
+		t.Fatalf("runSessionStatus() = code %d, err %v", code, err)
+	}
+	if env.Status != output.StatusFailed || !reflect.DeepEqual(env.Error, wantError) {
+		t.Fatalf("failure envelope changed: %#v", env)
+	}
+	if env.Coordination != nil {
+		t.Fatalf("unavailable probe reported coordination: %#v", env.Coordination)
+	}
+	warnings := anySlice(env.Warnings)
+	if len(warnings) != 2 || cliObjectMap(warnings[0])["code"] != "existing_warning" || cliObjectMap(warnings[1])["code"] != coordinationStatusUnavailableCode {
+		t.Fatalf("warnings = %#v", warnings)
+	}
+
+	appendUniqueMessage(&env.Warnings, coordinationStatusUnavailableCode, "duplicate")
+	if got := len(anySlice(env.Warnings)); got != 2 {
+		t.Fatalf("coordination warning was duplicated: %#v", env.Warnings)
+	}
+}
+
+func TestObserveSessionCoordinationTreatsMissingWorkbookAsIdle(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	cfg.Excel.Path = filepath.Join("missing", "Book.xlsm")
+	a := &app{cwd: t.TempDir(), coordination: manager}
+	status, unavailable := a.observeSessionCoordination(context.Background(), cfg)
+	if unavailable || status == nil || status.Busy {
+		t.Fatalf("missing workbook observation = status %#v, unavailable %v", status, unavailable)
+	}
+}
+
+func TestRunSessionStatusReturnsBridgeExecutionErrorAfterObservation(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("bridge execution failed")
+	a := &app{cwd: t.TempDir(), coordination: manager}
+	env, code, err := a.runSessionStatus(context.Background(), config.Default(), func() (output.Envelope, int, error) {
+		return output.Envelope{}, output.ExitEnvironment, wantErr
+	})
+	if !errors.Is(err, wantErr) || code != output.ExitEnvironment {
+		t.Fatalf("runSessionStatus() = code %d, err %v", code, err)
+	}
+	status := cliObjectMap(env.Coordination)
+	if status["busy"] != false {
+		t.Fatalf("pre-bridge observation was not retained: %#v", env.Coordination)
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -59,6 +59,7 @@ type Envelope struct {
 	Debug          any `json:"debug,omitempty"`
 	UI             any `json:"ui,omitempty"`
 	Session        any `json:"session,omitempty"`
+	Coordination   any `json:"coordination,omitempty"`
 	Runner         any `json:"runner,omitempty"`
 	Analysis       any `json:"analysis,omitempty"`
 	Check          any `json:"check,omitempty"`
@@ -3330,7 +3331,8 @@ func (r renderer) renderCreated(env Envelope) string {
 func (r renderer) renderSession(env Envelope) string {
 	session := objectMap(env.Session)
 	workbook := objectMap(env.Workbook)
-	if len(session) == 0 && len(workbook) == 0 {
+	coordination := objectMap(env.Coordination)
+	if len(session) == 0 && len(workbook) == 0 && len(coordination) == 0 {
 		return r.renderLogs(env)
 	}
 	var b strings.Builder
@@ -3343,6 +3345,31 @@ func (r renderer) renderSession(env Envelope) string {
 	}
 	if open, ok := boolValueOK(session, "workbook_open"); ok {
 		b.WriteString(kv("Workbook open", fmt.Sprintf("%t", open)))
+	}
+	if busy, ok := boolValueOK(coordination, "busy"); ok {
+		value := "idle"
+		if busy {
+			value = "busy"
+		}
+		b.WriteString(kv("Coordination", value))
+		if busy {
+			owner := make([]string, 0, 4)
+			if command := stringValue(coordination, "command"); command != "" {
+				owner = append(owner, command)
+			}
+			if kind := stringValue(coordination, "operation_kind"); kind != "" {
+				owner = append(owner, "kind "+kind)
+			}
+			if pid, ok := numberValue(coordination, "pid"); ok {
+				owner = append(owner, fmt.Sprintf("PID %d", int(pid)))
+			}
+			if started := stringValue(coordination, "started_at"); started != "" {
+				owner = append(owner, "since "+started)
+			}
+			if len(owner) > 0 {
+				b.WriteString(kv("Coordination owner", strings.Join(owner, ", ")))
+			}
+		}
 	}
 	if source := stringValue(session, "source_of_truth"); source != "" {
 		b.WriteString(kv("Source of truth", source))

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1290,15 +1290,66 @@ func TestWriteWithOptionsRendersSessionStatusSaveRequirement(t *testing.T) {
 	env := New("session")
 	env.Session = map[string]any{"running": true, "workbook_open": true, "needs_save": true, "live_newer_than_disk": true, "source_of_truth": "live_workbook", "userforms_present": true, "userform_count": 2}
 	env.Workbook = map[string]any{"path": "build/Book.xlsm", "needs_save": true}
+	env.Coordination = map[string]any{"busy": true, "resource_scope": "workbook", "operation_kind": "execute", "command": "run", "pid": 12345, "started_at": "2026-07-15T09:30:00Z"}
 	var buf bytes.Buffer
 	if err := WriteWithOptions(&buf, env, Options{}); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
-	for _, want := range []string{"Running:", "Workbook open:", "SAVE REQUIRED", "live workbook is newer than disk", "Source of truth:", "live_workbook", "UserForms:", "true (2)", "xlflow save before session stop"} {
+	for _, want := range []string{"Running:", "Workbook open:", "Coordination:", "busy", "Coordination owner:", "run, kind execute, PID 12345, since 2026-07-15T09:30:00Z", "SAVE REQUIRED", "live workbook is newer than disk", "Source of truth:", "live_workbook", "UserForms:", "true (2)", "xlflow save before session stop"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("session status output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestWriteWithOptionsRendersIdleAndOwnerlessSessionCoordination(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		coordination map[string]any
+		want         string
+	}{
+		{name: "idle", coordination: map[string]any{"busy": false}, want: "idle"},
+		{name: "ownerless busy", coordination: map[string]any{"busy": true}, want: "busy"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			env := New("session")
+			env.Session = map[string]any{"running": true, "workbook_open": true}
+			env.Coordination = tt.coordination
+			var buf bytes.Buffer
+			if err := WriteWithOptions(&buf, env, Options{}); err != nil {
+				t.Fatal(err)
+			}
+			got := buf.String()
+			if !strings.Contains(got, "Coordination:") || !strings.Contains(got, tt.want) {
+				t.Fatalf("coordination output missing %q:\n%s", tt.want, got)
+			}
+			if strings.Contains(got, "Coordination owner:") {
+				t.Fatalf("ownerless coordination rendered owner details:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestWriteWithOptionsSerializesTopLevelSessionCoordination(t *testing.T) {
+	env := New("session")
+	env.Session = map[string]any{"active": true, "running": true}
+	env.Coordination = map[string]any{"busy": false}
+	var buf bytes.Buffer
+	if err := WriteWithOptions(&buf, env, Options{JSON: true}); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	coordination := objectMap(got["coordination"])
+	if coordination["busy"] != false {
+		t.Fatalf("coordination = %#v", coordination)
+	}
+	session := objectMap(got["session"])
+	if session["active"] != true || session["running"] != true {
+		t.Fatalf("session payload changed: %#v", session)
 	}
 }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,21 @@
+# Issue #324: Session status coordination
+
+- [x] Probe the canonical configured workbook lock before bridge status
+- [x] Add the additive top-level coordination payload and fallback warning
+- [x] Preserve existing success/failure session envelopes and warnings
+- [x] Render idle, busy, ownerless, and public owner details
+- [x] Add focused payload, ordering, warning, JSON, and human-output tests
+- [x] Run full tests, lint, docs build, and Windows Excel E2E
+  - Workspace: `C:\dev\go\xlflow\tmp_workspaces\issue-324-e2e`
+  - During `run Main.HoldCoordination --session`, status reported busy owner
+    `run` / `execute`; after completion it reported `busy:false`
+  - Repeated without `--session`; run reported `session.mode=auto`, status
+    reported the same busy owner, and returned to idle after completion
+  - Live `Sheet1!A1` observed `coordination-finished`; session saved and stopped
+- [ ] Create, review, and merge PR #324
+
+---
+
 # Issue #322: Optional workbook wait and timeout
 
 - [x] Define the opt-in 30-second wait contract and ADR
@@ -7,7 +25,7 @@
 - [x] Add focused wait, timeout, cancellation, and multi-target tests
 - [x] Verify WSL argument forwarding
 - [x] Run full tests, lint, docs build, and self-review
-- [ ] Create, review, and merge PR #322
+- [x] Create, review, and merge PR #322
 
 ---
 

--- a/vitepress/commands/session.md
+++ b/vitepress/commands/session.md
@@ -55,10 +55,25 @@ Successful `--json` output uses the xlflow envelope plus command-specific fields
 ```json
 {
   "status": "ok",
-  "command": "session status",
-  "session": { "name": "default", "running": true, "dirty": false }
+  "command": "session",
+  "session": { "name": "default", "running": true, "dirty": false },
+  "coordination": {
+    "busy": true,
+    "resource_scope": "workbook",
+    "operation_kind": "execute",
+    "command": "run",
+    "pid": 12345,
+    "started_at": "2026-07-15T09:30:00Z"
+  }
 }
 ```
+
+`coordination` is a point-in-time observation taken when `session status`
+starts. Idle workbooks return `{ "busy": false }`; a busy workbook may omit
+owner fields when current metadata is unavailable. The value can change before
+the response is returned and does not replace the CLI lock check performed by
+later workbook commands. If the lock cannot be observed, status remains
+available and returns warning `coordination_status_unavailable` instead.
 
 ## Related
 

--- a/vitepress/reference/error-codes.md
+++ b/vitepress/reference/error-codes.md
@@ -16,6 +16,9 @@ Common examples:
   or the timeout was not positive.
 - `coordination_wait_unsupported`: the selected command is not a retryable,
   non-parallel-safe workbook operation.
+- `coordination_status_unavailable` (warning): `session status` could not probe
+  the workbook OS lock. Existing session status fields and exit behavior remain
+  available, while the top-level `coordination` field is omitted.
 - `vbide_access_denied`
 - `macro_failed`
 - `macro_not_found`

--- a/vitepress/reference/json-output.md
+++ b/vitepress/reference/json-output.md
@@ -54,7 +54,13 @@ Unknown commands are also structured when `--json` appears before the invalid co
 }
 ```
 
-Command-specific fields are top-level fields such as `issues`, `analysis`, `macro`, `macros`, `tests`, `diff`, `inspect`, `ui`, `debug`, `backups`, `backup_prune`, `rollback`, `target`, `session`, `warnings`, `hints`, `output`, `forms`, `edit`, `runner`, and `version`. `output` carries `fmt` result summaries, `export-image` output paths, and `form` command artifacts.
+Command-specific fields are top-level fields such as `issues`, `analysis`, `macro`, `macros`, `tests`, `diff`, `inspect`, `ui`, `debug`, `backups`, `backup_prune`, `rollback`, `target`, `session`, `coordination`, `warnings`, `hints`, `output`, `forms`, `edit`, `runner`, and `version`. `output` carries `fmt` result summaries, `export-image` output paths, and `form` command artifacts.
+
+`session status` adds top-level `coordination` without changing `session`.
+Successful observation returns `{"busy":false}`, `{"busy":true}`, or a busy
+object with `resource_scope`, `operation_kind`, `command`, `pid`, and
+`started_at`. The value is observational command-start state. Probe failure
+omits the field and adds warning `coordination_status_unavailable`.
 
 `backup_prune` is returned by `xlflow backup prune` and may also appear on successful `push` or `rollback` when automatic retention deleted entries, skipped invalid or legacy entries, or encountered a pruning failure. Automatic results include `"automatic": true`; pruning failures are warnings and do not change the successful workbook operation status.
 


### PR DESCRIPTION
Summary: Probe the canonical workbook OS lock before the session-status bridge call; add the backward-compatible top-level coordination payload and coordination_status_unavailable warning; render idle, busy, and public owner details; document the observational contract in ADR-0018, specs, and user docs. Verification: task test; task lint; pnpm docs:build; focused status tests repeated 10 times; git diff --check. Excel E2E workspace: C:\dev\go\xlflow\tmp_workspaces\issue-324-e2e. Explicit-session and auto-reused runs both reported busy owner run/execute during Main.HoldCoordination and busy:false afterward; auto reuse reported session.mode=auto; live Sheet1!A1 was coordination-finished; session was saved and stopped. Closes #324