### PR TITLE
Cover UserForm and Designer workbook coordination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to xlflow will be documented in this file.
 - Added an observational top-level `coordination` section to `session status`,
   including current workbook busy state and guarded public owner metadata when
   available without changing existing session fields or failure behavior.
+- Documented and exhaustively tested UserForm/Designer coordination so migration,
+  snapshot, build/apply, image export, form inspection/listing, pull, and push all
+  converge on the same canonical workbook lock before Excel or VBIDE starts.
 - Changed new-project scaffolds and `module install` to place bundled `Xlflow*.bas` helpers under `src/modules/Xlflow/`; existing root-level helper files are not moved, and `module install` now refuses those legacy collisions rather than creating duplicate VBA components.
 - Fixed .NET `push` to stop before importing when Excel cannot remove an existing VBA component and to reject Excel-renamed imports, preventing duplicate modules with a `1` suffix; every removal/import failure poisons a partial session replacement, managed sessions discard the unsafe unsaved state on stop, and external sessions receive owner-correct recovery guidance.
 - Fixed .NET bridge workbook persistence so transient `__XLFLOW_MODE__`, related runtime/UI/debug defined names, and generated helper modules are removed before save, including after a timed-out session run or a macro that saves and then edits again, preventing manually opened workbooks from remaining in headless mode or retaining temporary harness code.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -398,6 +398,13 @@ returns `workbook_busy_cancelled`. Both use phase `coordination.acquire`, includ
 wait progress text; human output prints one concise line after contention is
 actually observed.
 
+For UserForms, `form migrate sidecar`, `form snapshot`, `form build`, hidden
+`form apply`, `form export-image`, `inspect form`, `list forms`, `pull`, and
+`push` all use this standard workbook coordination contract and may opt into
+bounded waiting. A busy result is returned before the leaf handler or Excel
+bridge starts. `form new` and source-only rename/delete are intentionally not
+wait-capable; the later `push` is the coordinated workbook boundary.
+
 Command-specific fields are added at the top level:
 
 - `diagnostics` for `doctor` (includes `excel.com_activation` which indicates successful `Excel.Application` creation on the STA thread, plus `.NET` bridge `excel.systemprofile_desktop` readiness with per-path `status` values of `exists`, `missing`, `access_denied`, or `unknown`; `doctor --workbook` additionally opens the configured workbook and reports `workbook_openable`; WSL adds `host`, `windows`, and `path_translation`)

--- a/docs/specs/workbook-coordination.md
+++ b/docs/specs/workbook-coordination.md
@@ -3,7 +3,7 @@
 This spec defines the command-policy, canonical workbook-identity,
 cross-process lock, and owner-metadata contracts used by workbook operation
 coordination. Public waiting options and coordination status output build on
-these contracts but remain outside the current implementation.
+these contracts.
 
 See ADR-0016 for the policy and identity rationale and ADR-0018 for the Windows
 lock and metadata decisions.
@@ -87,6 +87,29 @@ The registry classifies commands conservatively:
 - Environment checks, active-workbook attachment, and Excel process cleanup use
   `resource_scope: excel_instance` when they inspect or mutate state broader than
   one configured workbook.
+
+### UserForm and Designer Coverage
+
+The configured workbook lock is the only exclusion primitive for UserForm work;
+there is no separate Designer lock. The Designer-classified command IDs are
+`form.migrate.sidecar`, `form.snapshot`, `form.build`, `form.apply`,
+`form.export-image`, and `inspect.form`. `list.forms` and `pull` use workbook
+read policy, while `push` uses workbook mutate policy. All nine operations use
+the same canonical workbook identity and therefore conflict with Designer,
+execution, test, synchronization, and other workbook operations on that file.
+
+The CLI lease surrounds the complete leaf handler. For migration and snapshot
+this includes Designer inspection plus sidecar/spec writes; for build and push
+it includes VBIDE mutation, `.frm`/`.frx` synchronization, save/restore, and
+cleanup. Direct Runner calls for `form-write`, `inspect-form`,
+`form-export-image`, list/forms, pull, and push resolve the same central
+descriptors before starting a bridge provider. CLI-owned Runner calls skip the
+second acquisition only while the outer lease remains held.
+
+`form.new`, source rename, and source delete remain `resource_scope: none` and
+do not open or lock a workbook. Their later workbook application occurs through
+coordinated `push`. Under WSL the source-only steps remain local; workbook-backed
+UserForm commands are delegated and acquire the lock in the Windows CLI.
 
 ## Canonical Workbook Identity
 

--- a/internal/agentskill/templates/xlflow/references/forms.md
+++ b/internal/agentskill/templates/xlflow/references/forms.md
@@ -21,6 +21,18 @@ Load this reference when the task depends on `xlflow list forms`, `xlflow inspec
 - In `sidecar` mode, run `pull` before reviewing or editing `src/forms/code/<FormName>.bas`; `form snapshot` does not emit code-behind.
 - `form apply` is hidden and should not be used for sidecar-aware UserForm workflows; prefer `form build --overwrite`.
 
+## Workbook Coordination
+
+Workbook-backed form, inspect, list, pull, and push commands share one canonical
+workbook lock with run and test. Do not launch them concurrently for the same
+workbook. Treat `workbook_busy` as a retryable operational result: retry after
+the owner completes, or explicitly add global `--wait --wait-timeout <duration>`
+for a bounded acquisition wait. Waiting does not retry the command body.
+
+`form new` and source-only UserForm rename/delete steps do not lock Excel. Their
+workbook boundary is the later coordinated `push`. A prior idle `session status`
+is advisory only; the command's own lock acquisition remains authoritative.
+
 ## Persisted Spec Contract
 
 `form snapshot` persists an `xlflow.userform` spec. `form build` consumes the same contract.

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -250,7 +250,7 @@ func TestDesignerCoordinationWaitsThenPublishesDesignerOwner(t *testing.T) {
 	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "form.build")
 	var stdout, stderr bytes.Buffer
 	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &stderr, coordination: manager}
-	time.AfterFunc(75*time.Millisecond, func() { _ = owner.Release() })
+	time.AfterFunc(150*time.Millisecond, func() { _ = owner.Release() })
 	runs := 0
 	err := a.withWorkbookCoordination(context.Background(), "form.snapshot", []string{identity.CanonicalPath}, func() error {
 		runs++

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -81,6 +82,86 @@ func TestWorkbookContentionStopsCLILeafWithStructuredBusyFailure(t *testing.T) {
 	}
 }
 
+func TestWorkbookContentionStopsEveryUserFormLeafBeforeHandler(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	tests := []struct {
+		name      string
+		operation coordination.CommandID
+		args      func(string) []string
+		output    func(string) string
+	}{
+		{name: "migrate sidecar", operation: "form.migrate.sidecar", args: func(string) []string { return []string{"--json", "form", "migrate", "sidecar"} }},
+		{name: "snapshot", operation: "form.snapshot", args: func(root string) []string {
+			return []string{"--json", "form", "snapshot", "UserForm1", "--out", filepath.Join(root, "snapshot.yaml")}
+		}, output: func(root string) string { return filepath.Join(root, "snapshot.yaml") }},
+		{name: "build", operation: "form.build", args: func(root string) []string {
+			return []string{"--json", "form", "build", filepath.Join(root, "missing.yaml")}
+		}},
+		{name: "hidden apply", operation: "form.apply", args: func(root string) []string {
+			return []string{"--json", "form", "apply", filepath.Join(root, "missing.yaml")}
+		}},
+		{name: "export image", operation: "form.export-image", args: func(root string) []string {
+			return []string{"--json", "form", "export-image", "UserForm1", "--out", filepath.Join(root, "form.png")}
+		}, output: func(root string) string { return filepath.Join(root, "form.png") }},
+		{name: "inspect form", operation: "inspect.form", args: func(string) []string { return []string{"--json", "inspect", "form", "UserForm1", "--designer"} }},
+		{name: "list forms", operation: "list.forms", args: func(string) []string { return []string{"--json", "list", "forms"} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+			cfg := config.Default()
+			if err := config.Write(filepath.Join(rootDir, config.FileName), cfg); err != nil {
+				t.Fatal(err)
+			}
+			manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			identity, err := coordination.NewWorkbookIdentity(rootDir, cfg.Excel.Path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			owner, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: identity, Command: "run", OperationKind: coordination.OperationExecute, ResourceScope: coordination.ResourceWorkbook})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = owner.Release() }()
+
+			args := tt.args(rootDir)
+			var stdout bytes.Buffer
+			a := &app{cwd: rootDir, rawArgs: args, stdout: &stdout, stderr: &bytes.Buffer{}, coordination: manager}
+			root := a.rootCommand()
+			root.SetArgs(args)
+			runErr := root.Execute()
+			if output.ExitCode(runErr) != output.ExitEnvironment || !errors.Is(runErr, coordination.ErrWorkbookBusy) {
+				t.Fatalf("result = exit %d, err %v; want workbook_busy exit 3", output.ExitCode(runErr), runErr)
+			}
+			var env output.Envelope
+			if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+				t.Fatalf("decode JSON: %v\n%s", err, stdout.String())
+			}
+			if env.Error == nil || env.Error.Code != coordination.WorkbookBusyCode {
+				t.Fatalf("error payload = %#v", env.Error)
+			}
+			details, ok := env.Error.Details.(map[string]any)
+			if !ok || details["operation"] != string(tt.operation) {
+				t.Fatalf("busy details = %#v", env.Error.Details)
+			}
+			ownerDetails, ok := details["owner"].(map[string]any)
+			if !ok || ownerDetails["command"] != "run" || ownerDetails["operation_kind"] != string(coordination.OperationExecute) {
+				t.Fatalf("owner details = %#v", details["owner"])
+			}
+			if tt.output != nil {
+				if _, statErr := os.Stat(tt.output(rootDir)); !os.IsNotExist(statErr) {
+					t.Fatalf("handler side effect exists after contention: %v", statErr)
+				}
+			}
+		})
+	}
+}
+
 func TestCoordinationWaitOptionsValidation(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -91,6 +172,7 @@ func TestCoordinationWaitOptionsValidation(t *testing.T) {
 		{name: "timeout must be positive", args: []string{"--json", "--wait", "--wait-timeout", "0s", "push"}, wantCode: coordinationWaitArgsInvalidCode},
 		{name: "timeout cannot be negative", args: []string{"--json", "--wait", "--wait-timeout", "-1s", "push"}, wantCode: coordinationWaitArgsInvalidCode},
 		{name: "source command cannot wait", args: []string{"--json", "--wait", "lint"}, wantCode: coordinationWaitUnsupportedCode},
+		{name: "source-only form new cannot wait", args: []string{"--json", "--wait", "form", "new", "UserForm1"}, wantCode: coordinationWaitUnsupportedCode},
 		{name: "parallel observer cannot wait", args: []string{"--json", "--wait", "session", "status"}, wantCode: coordinationWaitUnsupportedCode},
 		{name: "excel instance command cannot wait", args: []string{"--json", "--wait", "doctor"}, wantCode: coordinationWaitUnsupportedCode},
 	}
@@ -144,7 +226,7 @@ func TestWorkbookCoordinationWaitsThenRunsHandlerOnce(t *testing.T) {
 	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "run")
 	var stdout, stderr bytes.Buffer
 	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &stderr, coordination: manager}
-	time.AfterFunc(75*time.Millisecond, func() { _ = owner.Release() })
+	time.AfterFunc(150*time.Millisecond, func() { _ = owner.Release() })
 	runs := 0
 	err := a.withWorkbookCoordination(context.Background(), "push", []string{identity.CanonicalPath}, func() error {
 		runs++
@@ -158,6 +240,101 @@ func TestWorkbookCoordinationWaitsThenRunsHandlerOnce(t *testing.T) {
 	}
 	if stdout.Len() != 0 || stderr.Len() != 0 {
 		t.Fatalf("JSON wait emitted progress: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestDesignerCoordinationWaitsThenPublishesDesignerOwner(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "form.build")
+	var stdout, stderr bytes.Buffer
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &stderr, coordination: manager}
+	time.AfterFunc(75*time.Millisecond, func() { _ = owner.Release() })
+	runs := 0
+	err := a.withWorkbookCoordination(context.Background(), "form.snapshot", []string{identity.CanonicalPath}, func() error {
+		runs++
+		probe, probeErr := manager.Probe(context.Background(), identity)
+		if probeErr != nil {
+			return probeErr
+		}
+		if !probe.Busy || probe.Owner == nil || probe.Owner.Command != "form.snapshot" || probe.Owner.OperationKind != coordination.OperationDesigner {
+			t.Fatalf("designer owner = %#v", probe.Owner)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("waited Designer command failed: %v", err)
+	}
+	if runs != 1 || stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("runs=%d stdout=%q stderr=%q", runs, stdout.String(), stderr.String())
+	}
+}
+
+func TestDesignerCoordinationConflictsWithDesignerExecutionAndSourceUpdates(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	for _, ownerCommand := range []coordination.CommandID{"form.build", "run", "test", "push"} {
+		t.Run(string(ownerCommand), func(t *testing.T) {
+			rootDir, manager, identity, owner := setupHeldCoordinationLock(t, ownerCommand)
+			defer func() { _ = owner.Release() }()
+			var stdout bytes.Buffer
+			a := &app{cwd: rootDir, json: true, stdout: &stdout, stderr: &bytes.Buffer{}, coordination: manager}
+			runs := 0
+			err := a.withWorkbookCoordination(context.Background(), "form.snapshot", []string{identity.CanonicalPath}, func() error { runs++; return nil })
+			if output.ExitCode(err) != output.ExitEnvironment || !errors.Is(err, coordination.ErrWorkbookBusy) {
+				t.Fatalf("result = exit %d, err %v; want workbook_busy exit 3", output.ExitCode(err), err)
+			}
+			if runs != 0 {
+				t.Fatalf("handler runs = %d, want 0", runs)
+			}
+			var env output.Envelope
+			if decodeErr := json.Unmarshal(stdout.Bytes(), &env); decodeErr != nil {
+				t.Fatalf("decode JSON: %v\n%s", decodeErr, stdout.String())
+			}
+			if env.Error == nil || env.Error.Code != coordination.WorkbookBusyCode {
+				t.Fatalf("error payload = %#v", env.Error)
+			}
+			details, ok := env.Error.Details.(map[string]any)
+			ownerDetails, ownerOK := details["owner"].(map[string]any)
+			if !ok || !ownerOK || details["operation"] != "form.snapshot" || ownerDetails["command"] != string(ownerCommand) {
+				t.Fatalf("busy details = %#v", env.Error.Details)
+			}
+		})
+	}
+}
+
+func TestDesignerCoordinationTimeoutAndCancellationNeverRunHandler(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
+	tests := []struct {
+		name    string
+		code    string
+		context func() context.Context
+		timeout time.Duration
+	}{
+		{name: "timeout", code: coordination.WorkbookBusyTimeoutCode, context: func() context.Context { return context.Background() }, timeout: 250 * time.Millisecond},
+		{name: "cancel", code: coordination.WorkbookBusyCancelledCode, context: func() context.Context {
+			ctx, cancel := context.WithCancel(context.Background())
+			time.AfterFunc(150*time.Millisecond, cancel)
+			return ctx
+		}, timeout: time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "run")
+			defer func() { _ = owner.Release() }()
+			var stdout, stderr bytes.Buffer
+			a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: tt.timeout, stdout: &stdout, stderr: &stderr, coordination: manager}
+			runs := 0
+			err := a.withWorkbookCoordination(tt.context(), "form.snapshot", []string{identity.CanonicalPath}, func() error { runs++; return nil })
+			assertCoordinationWaitFailure(t, err, stdout.Bytes(), tt.code, tt.timeout.String())
+			if runs != 0 || stderr.Len() != 0 {
+				t.Fatalf("handler runs=%d stderr=%q", runs, stderr.String())
+			}
+		})
 	}
 }
 
@@ -379,7 +556,11 @@ func setupHeldCoordinationLock(t *testing.T, command coordination.CommandID) (st
 	if err != nil {
 		t.Fatal(err)
 	}
-	lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: identity, Command: command, OperationKind: coordination.OperationExecute, ResourceScope: coordination.ResourceWorkbook})
+	descriptor, err := coordination.Lookup(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: identity, Command: command, OperationKind: descriptor.Policy.OperationKind, ResourceScope: descriptor.Policy.ResourceScope})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/wsl_delegation_test.go
+++ b/internal/cli/wsl_delegation_test.go
@@ -110,19 +110,31 @@ func TestShouldNotDelegateBackupSubcommands(t *testing.T) {
 	}
 }
 
-func TestShouldDelegateFormNewCommand(t *testing.T) {
-	root := &cobra.Command{Use: "xlflow"}
-	formCmd := &cobra.Command{Use: "form"}
-	newCmd := &cobra.Command{Use: "new"}
-	buildCmd := &cobra.Command{Use: "build"}
-	root.AddCommand(formCmd)
-	formCmd.AddCommand(newCmd, buildCmd)
-
-	if shouldDelegateCommand(newCmd, topLevelCommandName(newCmd)) {
-		t.Fatal("form new should remain local because it only creates source files")
+func TestShouldDelegateWorkbookBackedUserFormCommandsOnly(t *testing.T) {
+	root := (&app{}).rootCommand()
+	tests := []struct {
+		path     []string
+		delegate bool
+	}{
+		{path: []string{"form", "migrate", "sidecar"}, delegate: true},
+		{path: []string{"form", "snapshot"}, delegate: true},
+		{path: []string{"form", "build"}, delegate: true},
+		{path: []string{"form", "apply"}, delegate: true},
+		{path: []string{"form", "export-image"}, delegate: true},
+		{path: []string{"inspect", "form"}, delegate: true},
+		{path: []string{"list", "forms"}, delegate: true},
+		{path: []string{"form", "new"}, delegate: false},
+		{path: []string{"module", "rename"}, delegate: false},
+		{path: []string{"module", "remove"}, delegate: false},
 	}
-	if !shouldDelegateCommand(buildCmd, topLevelCommandName(buildCmd)) {
-		t.Fatal("form build should remain delegated because it writes workbook UserForms")
+	for _, tt := range tests {
+		cmd, _, err := root.Find(tt.path)
+		if err != nil {
+			t.Fatalf("find %v: %v", tt.path, err)
+		}
+		if got := shouldDelegateCommand(cmd, topLevelCommandName(cmd)); got != tt.delegate {
+			t.Errorf("%s delegation = %t, want %t", cmd.CommandPath(), got, tt.delegate)
+		}
 	}
 }
 

--- a/internal/coordination/registry_test.go
+++ b/internal/coordination/registry_test.go
@@ -72,6 +72,10 @@ func TestLookupBridgeUsesPayloadSelectors(t *testing.T) {
 	}{
 		{"run", nil, "run"},
 		{"FORM-WRITE", map[string]string{"action": "BUILD", "SpecPath": "form.yaml"}, "form.build"},
+		{"form-write", map[string]string{"Action": "apply", "SpecPath": "form.yaml"}, "form.apply"},
+		{"inspect-form", map[string]string{"Name": "UserForm1"}, "inspect.form"},
+		{"form-export-image", map[string]string{"Name": "UserForm1"}, "form.export-image"},
+		{"list", map[string]string{"Action": "forms"}, "list.forms"},
 		{"edit", map[string]string{"Action": "formula"}, "edit.formula"},
 		{"inspect", map[string]string{"Target": "used-range"}, "inspect.used-range"},
 		{"session", map[string]string{"Action": "status"}, "session.status"},
@@ -93,6 +97,7 @@ func TestUnknownSelectorsFailClosed(t *testing.T) {
 		func() error { _, err := Lookup("future.command"); return err },
 		func() error { _, err := LookupCLI("future command"); return err },
 		func() error { _, err := LookupBridge("edit", map[string]string{"Action": "future"}); return err },
+		func() error { _, err := LookupBridge("form-write", map[string]string{"Action": "future"}); return err },
 		func() error { _, err := LookupBridge("session", nil); return err },
 	}
 	for _, lookup := range tests {
@@ -146,26 +151,43 @@ func TestAllIsStableAndDefensive(t *testing.T) {
 	}
 }
 
-func TestImportantCommandsHaveConservativePolicies(t *testing.T) {
+func TestUserFormCommandsHaveExplicitCoordinationPolicies(t *testing.T) {
 	tests := []struct {
-		path string
-		kind OperationKind
+		id        CommandID
+		path      string
+		scope     ResourceScope
+		kind      OperationKind
+		parallel  bool
+		retryable bool
 	}{
-		{"push", OperationMutate},
-		{"run", OperationExecute},
-		{"test", OperationExecute},
-		{"form build", OperationDesigner},
-		{"form apply", OperationDesigner},
-		{"form snapshot", OperationDesigner},
-		{"inspect form", OperationDesigner},
+		{"form.migrate.sidecar", "form migrate sidecar", ResourceWorkbook, OperationDesigner, false, true},
+		{"form.snapshot", "form snapshot", ResourceWorkbook, OperationDesigner, false, true},
+		{"form.build", "form build", ResourceWorkbook, OperationDesigner, false, true},
+		{"form.apply", "form apply", ResourceWorkbook, OperationDesigner, false, true},
+		{"form.export-image", "form export-image", ResourceWorkbook, OperationDesigner, false, true},
+		{"inspect.form", "inspect form", ResourceWorkbook, OperationDesigner, false, true},
+		{"list.forms", "list forms", ResourceWorkbook, OperationRead, false, true},
+		{"pull", "pull", ResourceWorkbook, OperationRead, false, true},
+		{"push", "push", ResourceWorkbook, OperationMutate, false, true},
+		{"run", "run", ResourceWorkbook, OperationExecute, false, true},
+		{"test", "test", ResourceWorkbook, OperationExecute, false, true},
+		{"form.new", "form new", ResourceNone, OperationMutate, true, false},
+		{"module.rename", "module rename", ResourceNone, OperationMutate, true, false},
+		{"module.remove", "module remove", ResourceNone, OperationMutate, true, false},
 	}
 	for _, test := range tests {
-		descriptor, err := LookupCLI(test.path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if descriptor.Policy.ResourceScope != ResourceWorkbook || descriptor.Policy.OperationKind != test.kind || descriptor.Policy.ParallelSafe {
-			t.Errorf("%s policy = %+v", test.path, descriptor.Policy)
-		}
+		t.Run(string(test.id), func(t *testing.T) {
+			descriptor, err := LookupCLI(test.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if descriptor.ID != test.id {
+				t.Fatalf("%s ID = %q, want %q", test.path, descriptor.ID, test.id)
+			}
+			policy := descriptor.Policy
+			if policy.ResourceScope != test.scope || policy.OperationKind != test.kind || policy.ParallelSafe != test.parallel || policy.RetryableWhenBusy != test.retryable || policy.DefaultWaitPolicy != WaitFail {
+				t.Errorf("%s policy = %+v", test.path, policy)
+			}
+		})
 	}
 }

--- a/internal/excel/coordination_test.go
+++ b/internal/excel/coordination_test.go
@@ -9,29 +9,101 @@ import (
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/coordination"
 	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
+	"github.com/harumiWeb/xlflow/internal/excel/forms"
 	"github.com/harumiWeb/xlflow/internal/output"
 )
 
-func TestRunnerWorkbookBusyStopsBeforeBridgeExecution(t *testing.T) {
+func TestRunnerWorkbookBusyStopsUserFormCommandsBeforeBridgeExecution(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows LockFileEx coordination")
 	}
-	root := t.TempDir()
+	spec := forms.FormSpec{SchemaVersion: 1, Kind: "xlflow.userform", Basis: "designer", Form: forms.FormSpecForm{Name: "UserForm1"}}
+	tests := []struct {
+		name      string
+		operation coordination.CommandID
+		invoke    func(Runner, config.Config, string) (output.Envelope, int, error)
+	}{
+		{name: "list forms", operation: "list.forms", invoke: func(r Runner, cfg config.Config, _ string) (output.Envelope, int, error) {
+			return r.ListForms(cfg, SessionCommandOptions{})
+		}},
+		{name: "inspect form", operation: "inspect.form", invoke: func(r Runner, cfg config.Config, _ string) (output.Envelope, int, error) {
+			return r.InspectForm(cfg, InspectFormOptions{Name: "UserForm1", Basis: "designer"})
+		}},
+		{name: "form build", operation: "form.build", invoke: func(r Runner, cfg config.Config, _ string) (output.Envelope, int, error) {
+			return r.FormWrite(cfg, FormWriteOptions{Action: "build", SpecPath: "UserForm1.yaml", Spec: spec})
+		}},
+		{name: "form apply", operation: "form.apply", invoke: func(r Runner, cfg config.Config, _ string) (output.Envelope, int, error) {
+			return r.FormWrite(cfg, FormWriteOptions{Action: "apply", SpecPath: "UserForm1.yaml", Spec: spec})
+		}},
+		{name: "form export image", operation: "form.export-image", invoke: func(r Runner, cfg config.Config, root string) (output.Envelope, int, error) {
+			return r.FormExportImage(cfg, FormExportImageOptions{Name: "UserForm1", OutPath: filepath.Join(root, "UserForm1.png")})
+		}},
+		{name: "pull", operation: "pull", invoke: func(r Runner, cfg config.Config, _ string) (output.Envelope, int, error) {
+			return r.PullWithOptions(cfg, SessionCommandOptions{})
+		}},
+		{name: "push", operation: "push", invoke: func(r Runner, cfg config.Config, _ string) (output.Envelope, int, error) {
+			return r.PushWithOptions(cfg, PushOptions{})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg := config.Default()
+			identity, err := coordination.NewWorkbookIdentity(root, cfg.Excel.Path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: identity, Command: "run", OperationKind: coordination.OperationExecute, ResourceScope: coordination.ResourceWorkbook})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = lease.Release() }()
+
+			original := bridgeProviderForMode
+			t.Cleanup(func() { bridgeProviderForMode = original })
+			callCount := 0
+			bridgeProviderForMode = func(string, excelbridge.Mode) excelbridge.Provider {
+				return trackingBridgeProvider{name: "dotnet", supports: true, callCount: &callCount}
+			}
+
+			env, code, err := tt.invoke(Runner{RootDir: root, BridgeMode: "dotnet", Coordination: manager}, cfg, root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if code != output.ExitEnvironment || env.Error == nil || env.Error.Code != coordination.WorkbookBusyCode {
+				t.Fatalf("result = code %d, error %#v", code, env.Error)
+			}
+			if callCount != 0 {
+				t.Fatalf("bridge calls = %d, want 0", callCount)
+			}
+			details, ok := env.Error.Details.(map[string]any)
+			if !ok || details["operation"] != tt.operation || details["retryable"] != true {
+				t.Fatalf("details = %#v", env.Error.Details)
+			}
+		})
+	}
+}
+
+func TestRunnerUserFormCoordinationDoesNotConflictAcrossWorkbooks(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows LockFileEx coordination")
+	}
 	manager, err := coordination.NewManager(filepath.Join(t.TempDir(), "coordination"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	cfg := config.Default()
-	identity, err := coordination.NewWorkbookIdentity(root, cfg.Excel.Path)
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	identityA, err := coordination.NewWorkbookIdentity(rootA, cfg.Excel.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{
-		Identity:      identity,
-		Command:       "run",
-		OperationKind: coordination.OperationExecute,
-		ResourceScope: coordination.ResourceWorkbook,
-	})
+	lease, err := manager.Acquire(context.Background(), coordination.AcquireRequest{Identity: identityA, Command: "form.build", OperationKind: coordination.OperationDesigner, ResourceScope: coordination.ResourceWorkbook})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,21 +113,13 @@ func TestRunnerWorkbookBusyStopsBeforeBridgeExecution(t *testing.T) {
 	t.Cleanup(func() { bridgeProviderForMode = original })
 	callCount := 0
 	bridgeProviderForMode = func(string, excelbridge.Mode) excelbridge.Provider {
-		return trackingBridgeProvider{name: "dotnet", supports: true, callCount: &callCount}
+		return trackingBridgeProvider{name: "dotnet", supports: true, callCount: &callCount, response: excelbridge.Response{Stdout: []byte(`{"protocol_version":1,"status":"ok","command":"inspect-form","logs":[]}`)}}
 	}
-
-	env, code, err := (Runner{RootDir: root, BridgeMode: "dotnet", Coordination: manager}).PushWithOptions(cfg, PushOptions{})
+	env, code, err := (Runner{RootDir: rootB, BridgeMode: "dotnet", Coordination: manager}).InspectForm(cfg, InspectFormOptions{Name: "UserForm1", Basis: "designer"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if code != output.ExitEnvironment || env.Error == nil || env.Error.Code != coordination.WorkbookBusyCode {
-		t.Fatalf("result = code %d, error %#v", code, env.Error)
-	}
-	if callCount != 0 {
-		t.Fatalf("bridge calls = %d, want 0", callCount)
-	}
-	details, ok := env.Error.Details.(map[string]any)
-	if !ok || details["operation"] != coordination.CommandID("push") || details["retryable"] != true {
-		t.Fatalf("details = %#v", env.Error.Details)
+	if code != output.ExitSuccess || env.Error != nil || callCount != 1 {
+		t.Fatalf("different workbook result = code %d, error %#v, bridge calls %d", code, env.Error, callCount)
 	}
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,47 @@
+# Issue #325: UserForm/Designer coordination coverage
+
+- [x] Confirm all workbook-backed UserForm leaves use the shared workbook lock
+- [x] Add exhaustive central policy and bridge-selector coverage
+- [x] Add held-lock CLI and direct Runner tests that stop before handlers/bridge
+- [x] Cover Designer owner metadata, bounded wait, cancellation, and timeout
+- [x] Cover different-workbook independence and WSL delegation classification
+- [x] Update coordination specs, user docs, agent guidance, and changelog
+- [x] Run Windows Excel UserForm/Designer E2E
+  - Primary workspace: `C:\dev\go\xlflow\tmp_workspaces\issue-325-e2e`
+  - Independent workbook: `C:\dev\go\xlflow\tmp_workspaces\issue-325-e2e-other`
+  - Installed the paired Go CLI and .NET bridge with `task install`
+  - Exercised JSON commands `new`, `form new`, `session start`, `form build`,
+    `push --fast --session --no-save`, `save --session`, `form snapshot`,
+    `inspect form --designer`, `form build --overwrite`, `form export-image`,
+    `run`, `pull`, `lint`, and `session stop`
+  - Initial push before the first build correctly failed preflight because the
+    new spec had no generated `.frm`; build created the artifacts and the
+    subsequent push succeeded
+  - Build/snapshot/inspect observed caption `Coordination Form`, two controls,
+    width 240, and height 150; overwrite succeeded and PNG export produced a
+    382x241 image
+  - `.frm` / `.frx` survived save/stop/pull at 603 / 2584 bytes, and pull
+    exported one sidecar code-behind file; lint reported no issues
+  - During `run Main.HoldWorkbook --session`, status reported busy owner
+    `run` / `execute`; immediate `form snapshot` returned exit 3
+    `workbook_busy`, operation `form.snapshot`, and created no output file
+  - `--wait --wait-timeout 15s form snapshot` succeeded after release and
+    created `artifacts/waited.yaml`; the macro wrote and live Excel inspection
+    observed `Sheet1!A1 = coordination-finished`
+  - While the primary workbook was busy, snapshotting `OtherForm` in the
+    independent workbook succeeded and created `artifacts/other.yaml`
+  - Not repeated on a physical WSL host; WSL source/workbook delegation is
+    covered by the expanded command table. Actual simultaneous Designer COM
+    calls were replaced with deterministic held-lease Designer-owner tests.
+- [x] Run full tests, lint, docs build, and diff check
+  - `task test`, `task lint`, `pnpm docs:build`, and `git diff --check` passed
+- [x] Complete final staff-level diff review
+  - No High/Medium findings; restored explicit run/test policy assertions and
+    widened new wait-test timing margins from the two Low findings
+- [ ] Create, review, and merge PR #325
+
+---
+
 # Issue #324: Session status coordination
 
 - [x] Probe the canonical configured workbook lock before bridge status
@@ -12,7 +56,7 @@
   - Repeated without `--session`; run reported `session.mode=auto`, status
     reported the same busy owner, and returned to idle after completion
   - Live `Sheet1!A1` observed `coordination-finished`; session saved and stopped
-- [ ] Create, review, and merge PR #324
+- [x] Create, review, and merge PR #324
 
 ---
 

--- a/vitepress/commands/form.md
+++ b/vitepress/commands/form.md
@@ -6,10 +6,10 @@ Manage UserForms through sidecar scaffolds, Designer snapshots, rebuilds, and im
 
 ```bash
 xlflow form new <name>
-xlflow form migrate sidecar [FormName] [--overwrite]
-xlflow form snapshot <name> --out <path>
-xlflow form build <spec> [--overwrite]
-xlflow form export-image <name> --out <png>
+xlflow [--wait] form migrate sidecar [FormName] [--overwrite]
+xlflow [--wait] form snapshot <name> --out <path>
+xlflow [--wait] form build <spec> [--overwrite]
+xlflow [--wait] form export-image <name> --out <png>
 ```
 
 ## Options and Arguments
@@ -26,10 +26,17 @@ xlflow form export-image <name> --out <png>
 | `--session`            | Operate against the managed live session workbook.              | false   |
 | `--no-save`            | Leave session-backed build changes unsaved until `xlflow save`. | false   |
 | `--initializer <mode>` | Control initializer execution for image export.                 | default |
+| `--wait`               | Wait up to 30 seconds for the configured workbook lock.         | false   |
+| `--wait-timeout <d>`   | Override the positive bounded wait duration; requires `--wait`. | 30s     |
 
 `form snapshot` reads the design-time Designer state without loading the form at runtime or running workbook VBA. Controls created only by runtime code are visible through runtime inspection or image export, not through snapshot.
 
 `form new` is source-only and requires `[userform].code_source = "sidecar"`. It creates `[src].forms/code/<Name>.bas` and `[src].forms/specs/<Name>.yaml` (defaulting to `src/forms/...`); it does not create `.frm` or `.frx` artifacts.
+
+All other workbook-backed form commands share the configured workbook lock with
+`run`, `test`, `push`, `pull`, and Designer inspection. Contention returns
+`workbook_busy` before Excel or VBIDE starts. Use global `--wait` for an explicit
+bounded retry; `form new` rejects waiting because it changes source files only.
 
 `form migrate sidecar` converts existing tracked `src/forms/*.frm` UserForms to the sidecar layout. It extracts code-behind to `src/forms/code/<Name>.bas`, writes a non-executing Designer spec to `src/forms/specs/<Name>.yaml`, and switches `[userform].code_source` to `"sidecar"` after all selected forms succeed. Pass a form name to migrate one form. Existing Designer spec files always require `--overwrite`; existing sidecar code can be skipped only when it already matches the extracted `.frm` code.
 
@@ -44,6 +51,7 @@ xlflow form migrate sidecar CalendarForm --overwrite --json
 xlflow form snapshot CalendarForm --out src/forms/specs/CalendarForm.yaml --json
 xlflow form build src/forms/specs/CalendarForm.yaml --overwrite --json
 xlflow form export-image CalendarForm --out artifacts/CalendarForm.png --json
+xlflow --wait --wait-timeout 15s form snapshot CalendarForm --out artifacts/CalendarForm.yaml --json
 ```
 
 ## Notes

--- a/vitepress/commands/inspect.md
+++ b/vitepress/commands/inspect.md
@@ -48,6 +48,7 @@ xlflow inspect workbook --json
 xlflow inspect range --sheet Result --address A1:F20 --json
 xlflow inspect range --sheet Result --address A1:F20 --session --include-style --json
 xlflow inspect form CalendarForm --both --json
+xlflow --wait --wait-timeout 15s inspect form CalendarForm --designer --json
 xlflow inspect calls --json
 xlflow inspect calls --from Main.Run --to BuildReport
 xlflow inspect symbols --json
@@ -61,6 +62,12 @@ Most `inspect` commands read the saved workbook by default. Add `--session` when
 :::
 
 `inspect calls` and `inspect symbols` are source-only. They parse exported `.bas`, `.cls`, and `.frm` files with tree-sitter-vba and do not open Excel.
+
+`inspect form` is a conservative Designer operation and shares the configured
+workbook lock with execution, synchronization, and other UserForm commands. It
+returns `workbook_busy` before Excel/VBIDE starts, or accepts global `--wait` for
+a bounded acquisition wait. The lock remains the final authority even if a
+preceding `session status` observation appeared idle.
 
 `inspect calls` reports syntax-level call sites with caller module/procedure context, callee text, argument count, named arguments, source range, parse recovery state, and conservative resolution status. It does not perform full VBA name binding, COM type-library resolution, host object model inference, overload resolution, or dynamic dispatch resolution.
 

--- a/vitepress/commands/list.md
+++ b/vitepress/commands/list.md
@@ -5,7 +5,7 @@ List workbook resources. The public resource command is `list forms`.
 ## Usage
 
 ```bash
-xlflow list forms [--session]
+xlflow [--wait] list forms [--session]
 ```
 
 ## Options and Arguments
@@ -15,12 +15,14 @@ xlflow list forms [--session]
 | `forms`           | List UserForms and expected source paths.    | required |
 | `--session`       | Read from the managed live workbook session. | false    |
 | `--json`          | Return form metadata for scripts.            | false    |
+| `--wait`          | Wait up to 30 seconds for the workbook lock. | false    |
 
 ## Examples
 
 ```bash
 xlflow list forms
 xlflow list forms --session --json
+xlflow --wait --wait-timeout 15s list forms --json
 ```
 
 ## Notes
@@ -33,6 +35,9 @@ Use `list forms` before `form snapshot`, `form build`, or `form export-image` to
 > Listing forms is metadata-oriented; it does not execute UserForm runtime code.
 
 `list forms` uses the `.NET` bridge on Windows in `auto` mode.
+It shares the configured workbook lock with Designer, execution, pull, and push
+operations. Contention returns `workbook_busy`; global `--wait` performs an
+explicit bounded acquisition wait without retrying the list handler itself.
 
 ## JSON Output Example
 


### PR DESCRIPTION
## Summary

- lock every workbook-backed UserForm/Designer path through the existing canonical workbook coordination mechanism
- add exhaustive policy, CLI leaf, direct Runner, owner, wait/timeout/cancel, different-workbook, and WSL delegation coverage
- document the single workbook-lock contract for form, inspect, list, pull, push, and source-only exceptions

No production locking code or separate Designer lock is added.

## Verification

- focused coordination tests: 10 consecutive runs
- `task test`
- `task lint`
- `pnpm docs:build`
- `git diff --check`

### Windows + Excel E2E

Installed with `task install` and used the session-first workflow.

Primary workspace:
`C:\dev\go\xlflow\tmp_workspaces\issue-325-e2e`

Independent workbook:
`C:\dev\go\xlflow\tmp_workspaces\issue-325-e2e-other`

Observed:

- form build, Designer snapshot/inspect, overwrite, and runtime PNG export succeeded
- snapshot/inspect returned caption `Coordination Form`, two controls, width 240, and height 150
- `.frm` / `.frx` survived save/stop/pull at 603 / 2584 bytes; sidecar pull and lint succeeded
- while `run Main.HoldWorkbook --session` owned the workbook, immediate `form snapshot` returned exit 3 / `workbook_busy`, operation `form.snapshot`, owner `run`, and created no file
- `--wait --wait-timeout 15s form snapshot` succeeded after release and created the snapshot
- Excel inspection observed `Sheet1!A1 = coordination-finished`
- while the primary workbook remained busy, the independent workbook completed its Designer snapshot successfully

Not repeated on a physical WSL host; expanded WSL classification tests cover all Designer/source-only paths. Deterministic held-lease tests cover Designer-versus-Designer instead of racing two real COM Designer calls.

Closes #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bounded `--wait` and `--wait-timeout` support for workbook-backed UserForm and Designer commands, including form migration, snapshots, builds, exports, inspection, and listing.
  - Related commands now share consistent workbook coordination, preventing operations from starting while another workbook activity is in progress.
  - Cross-workbook operations remain independent.

- **Documentation**
  - Clarified `workbook_busy` behavior, retry guidance, lock scope, and Designer coordination.
  - Documented that source-only `form new` does not support waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->