### PR TITLE
Cache semantic tokens by document version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to xlflow will be documented in this file.
 ## Unreleased
 
 - Added opt-in structured LSP performance logging through `xlflow lsp --performance-log`, including operation timing and result metadata for diagnostics and language features.
+- Improved LSP semantic token performance by reusing document and workspace symbol data within each request and caching encoded tokens for unchanged document versions.
 - Improved LSP responsiveness by caching document source symbols per document version and content, sharing the result across symbols, completion, hover, CodeLens, semantic tokens, and type inference while preserving unsaved-buffer and UserForm freshness.
 - Coalesced debounced LSP diagnostics so each open document uses at most one worker, obsolete generations are never published, and closing a document leaves an empty diagnostics result as the final notification.
 

--- a/internal/lspserver/performance_test.go
+++ b/internal/lspserver/performance_test.go
@@ -3,6 +3,7 @@ package lspserver
 import (
 	"bytes"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -185,6 +186,52 @@ func TestDocumentSymbolCachePerformanceReportsMissThenHit(t *testing.T) {
 	} {
 		if !strings.Contains(logOutput, expected) {
 			t.Fatalf("document symbol cache log missing %q:\n%s", expected, logOutput)
+		}
+	}
+}
+
+func TestSemanticTokenCachePerformanceReportsMissHitAndGenerationTime(t *testing.T) {
+	var output bytes.Buffer
+	s, cleanup, err := New(Options{
+		RootDir:        t.TempDir(),
+		Config:         config.Default(),
+		Stderr:         &output,
+		PerformanceLog: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	path := filepath.Join(t.TempDir(), "Main.bas")
+	uri := pathToFileURI(path)
+	if _, err := s.docs.open(uri, "Option Explicit\n", 3); err != nil {
+		t.Fatal(err)
+	}
+	s.semanticTokenGenerator = func(intel.Document, []intel.Document) ([]intel.SemanticToken, error) {
+		return []intel.SemanticToken{{
+			Range: intel.Range{Start: intel.Position{}, End: intel.Position{Character: 6}},
+			Type:  intel.SemanticTokenKeyword,
+		}}, nil
+	}
+	params := &protocol.SemanticTokensParams{TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)}}
+	if _, err := s.semanticTokensFull(nil, params); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.semanticTokensFull(nil, params); err != nil {
+		t.Fatal(err)
+	}
+
+	logOutput := output.String()
+	for _, expected := range []string{
+		`operation="semanticTokens/cache"`,
+		`cache="miss"`,
+		`cache="hit"`,
+		`operation="textDocument/semanticTokens/full"`,
+		`elapsed_ms=`,
+		`version=3`,
+	} {
+		if !strings.Contains(logOutput, expected) {
+			t.Fatalf("semantic token performance log missing %q:\n%s", expected, logOutput)
 		}
 	}
 }

--- a/internal/lspserver/semantic_token_cache.go
+++ b/internal/lspserver/semantic_token_cache.go
@@ -2,6 +2,7 @@ package lspserver
 
 import (
 	"crypto/sha256"
+	"errors"
 	"sync"
 
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
@@ -22,15 +23,12 @@ type cachedSemanticTokens struct {
 }
 
 type semanticTokenCall struct {
-	done chan struct{}
-	data []protocol.UInteger
-	err  error
-}
-
-type semanticTokenWorkKey struct {
-	identity   string
+	done       chan struct{}
 	generation uint64
 	signature  semanticTokenSignature
+	data       []protocol.UInteger
+	err        error
+	waiters    int
 }
 
 type semanticTokenCache struct {
@@ -38,14 +36,16 @@ type semanticTokenCache struct {
 	generation uint64
 	signatures map[string]semanticTokenSignature
 	entries    map[string]cachedSemanticTokens
-	inflight   map[semanticTokenWorkKey]*semanticTokenCall
+	inflight   map[string]*semanticTokenCall
 }
+
+var errSemanticTokensSuperseded = errors.New("semantic token generation superseded")
 
 func newSemanticTokenCache() *semanticTokenCache {
 	return &semanticTokenCache{
 		signatures: make(map[string]semanticTokenSignature),
 		entries:    make(map[string]cachedSemanticTokens),
-		inflight:   make(map[semanticTokenWorkKey]*semanticTokenCall),
+		inflight:   make(map[string]*semanticTokenCall),
 	}
 }
 
@@ -73,43 +73,56 @@ func (c *semanticTokenCache) get(
 	}
 
 	c.mu.Lock()
-	if generation == c.generation {
-		c.signatures[identity] = signature
-		if entry, ok := c.entries[identity]; ok &&
-			entry.generation == generation && entry.signature == signature {
-			out := cloneSemanticTokenData(entry.data)
-			c.mu.Unlock()
-			return out, true, nil
-		}
+	if generation != c.generation {
+		c.mu.Unlock()
+		return nil, false, errSemanticTokensSuperseded
 	}
-	workKey := semanticTokenWorkKey{identity: identity, generation: generation, signature: signature}
-	if call, ok := c.inflight[workKey]; ok {
+	c.signatures[identity] = signature
+	if entry, ok := c.entries[identity]; ok &&
+		entry.generation == generation && entry.signature == signature {
+		out := cloneSemanticTokenData(entry.data)
+		c.mu.Unlock()
+		return out, true, nil
+	}
+	if call, ok := c.inflight[identity]; ok {
+		call.waiters++
 		c.mu.Unlock()
 		<-call.done
-		return cloneSemanticTokenData(call.data), call.err == nil, call.err
+		if call.generation == generation && call.signature == signature {
+			return cloneSemanticTokenData(call.data), call.err == nil, call.err
+		}
+		return nil, false, errSemanticTokensSuperseded
 	}
-	call := &semanticTokenCall{done: make(chan struct{})}
-	c.inflight[workKey] = call
+	call := &semanticTokenCall{done: make(chan struct{}), generation: generation, signature: signature}
+	c.inflight[identity] = call
 	c.mu.Unlock()
 
 	data, err := load()
 	cloned := cloneSemanticTokenData(data)
 
 	c.mu.Lock()
-	delete(c.inflight, workKey)
-	if err == nil && generation == c.generation && c.signatures[identity] == signature {
+	delete(c.inflight, identity)
+	current := generation == c.generation && c.signatures[identity] == signature
+	if err == nil && current {
 		c.entries[identity] = cachedSemanticTokens{
 			generation: generation,
 			signature:  signature,
 			data:       cloneSemanticTokenData(cloned),
 		}
 	}
+	resultErr := err
+	if resultErr == nil && !current {
+		resultErr = errSemanticTokensSuperseded
+	}
 	call.data = cloned
-	call.err = err
+	call.err = resultErr
 	close(call.done)
 	c.mu.Unlock()
 
-	return cloneSemanticTokenData(cloned), false, err
+	if resultErr != nil {
+		return nil, false, resultErr
+	}
+	return cloneSemanticTokenData(cloned), false, nil
 }
 
 func (c *semanticTokenCache) invalidateAll() {

--- a/internal/lspserver/semantic_token_cache.go
+++ b/internal/lspserver/semantic_token_cache.go
@@ -1,0 +1,125 @@
+package lspserver
+
+import (
+	"crypto/sha256"
+	"sync"
+
+	"github.com/harumiWeb/xlflow/internal/vba/intel"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+type semanticTokenSignature struct {
+	version    int32
+	sourceHash [sha256.Size]byte
+	moduleKind string
+	uri        string
+}
+
+type cachedSemanticTokens struct {
+	generation uint64
+	signature  semanticTokenSignature
+	data       []protocol.UInteger
+}
+
+type semanticTokenCall struct {
+	done chan struct{}
+	data []protocol.UInteger
+	err  error
+}
+
+type semanticTokenWorkKey struct {
+	identity   string
+	generation uint64
+	signature  semanticTokenSignature
+}
+
+type semanticTokenCache struct {
+	mu         sync.Mutex
+	generation uint64
+	signatures map[string]semanticTokenSignature
+	entries    map[string]cachedSemanticTokens
+	inflight   map[semanticTokenWorkKey]*semanticTokenCall
+}
+
+func newSemanticTokenCache() *semanticTokenCache {
+	return &semanticTokenCache{
+		signatures: make(map[string]semanticTokenSignature),
+		entries:    make(map[string]cachedSemanticTokens),
+		inflight:   make(map[semanticTokenWorkKey]*semanticTokenCall),
+	}
+}
+
+func (c *semanticTokenCache) begin() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.generation
+}
+
+func (c *semanticTokenCache) get(
+	doc intel.Document,
+	generation uint64,
+	load func() ([]protocol.UInteger, error),
+) ([]protocol.UInteger, bool, error) {
+	identity := documentSymbolKey(doc)
+	if identity == "" {
+		data, err := load()
+		return cloneSemanticTokenData(data), false, err
+	}
+	signature := semanticTokenSignature{
+		version:    doc.Version,
+		sourceHash: sha256.Sum256([]byte(doc.Source)),
+		moduleKind: doc.ModuleKind,
+		uri:        doc.URI,
+	}
+
+	c.mu.Lock()
+	if generation == c.generation {
+		c.signatures[identity] = signature
+		if entry, ok := c.entries[identity]; ok &&
+			entry.generation == generation && entry.signature == signature {
+			out := cloneSemanticTokenData(entry.data)
+			c.mu.Unlock()
+			return out, true, nil
+		}
+	}
+	workKey := semanticTokenWorkKey{identity: identity, generation: generation, signature: signature}
+	if call, ok := c.inflight[workKey]; ok {
+		c.mu.Unlock()
+		<-call.done
+		return cloneSemanticTokenData(call.data), call.err == nil, call.err
+	}
+	call := &semanticTokenCall{done: make(chan struct{})}
+	c.inflight[workKey] = call
+	c.mu.Unlock()
+
+	data, err := load()
+	cloned := cloneSemanticTokenData(data)
+
+	c.mu.Lock()
+	delete(c.inflight, workKey)
+	if err == nil && generation == c.generation && c.signatures[identity] == signature {
+		c.entries[identity] = cachedSemanticTokens{
+			generation: generation,
+			signature:  signature,
+			data:       cloneSemanticTokenData(cloned),
+		}
+	}
+	call.data = cloned
+	call.err = err
+	close(call.done)
+	c.mu.Unlock()
+
+	return cloneSemanticTokenData(cloned), false, err
+}
+
+func (c *semanticTokenCache) invalidateAll() {
+	c.mu.Lock()
+	c.generation++
+	c.signatures = make(map[string]semanticTokenSignature)
+	c.entries = make(map[string]cachedSemanticTokens)
+	c.mu.Unlock()
+}
+
+func cloneSemanticTokenData(data []protocol.UInteger) []protocol.UInteger {
+	return append([]protocol.UInteger(nil), data...)
+}

--- a/internal/lspserver/semantic_token_cache_test.go
+++ b/internal/lspserver/semantic_token_cache_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -124,15 +126,50 @@ func TestSemanticTokenCacheCoalescesMissesAndRejectsInvalidatedResult(t *testing
 	}()
 	<-staleStarted
 	staleCache.invalidateAll()
-	close(staleRelease)
-	if err := <-staleDone; err != nil {
-		t.Fatal(err)
+	newerDoc := doc
+	newerDoc.Version++
+	newerDoc.Source = "Option Explicit\nSub Newer()\nEnd Sub\n"
+	newerGeneration := staleCache.begin()
+	var newerLoads atomic.Int32
+	newerDone := make(chan error, 1)
+	go func() {
+		_, _, err := staleCache.get(newerDoc, newerGeneration, func() ([]protocol.UInteger, error) {
+			newerLoads.Add(1)
+			return []protocol.UInteger{0, 0, 2, 12, 0}, nil
+		})
+		newerDone <- err
+	}()
+	identity := documentSymbolKey(doc)
+	deadline := time.Now().Add(time.Second)
+	for {
+		staleCache.mu.Lock()
+		call := staleCache.inflight[identity]
+		waiting := call != nil && call.waiters > 0
+		staleCache.mu.Unlock()
+		if waiting {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("newer generation did not wait for the active obsolete generation")
+		}
+		runtime.Gosched()
 	}
-	fresh, hit, err := staleCache.get(doc, staleCache.begin(), func() ([]protocol.UInteger, error) {
+	if newerLoads.Load() != 0 {
+		t.Fatalf("newer loads started while obsolete generation was active: %d", newerLoads.Load())
+	}
+	close(staleRelease)
+	if err := <-staleDone; !errors.Is(err, errSemanticTokensSuperseded) {
+		t.Fatalf("stale generation error = %v, want superseded", err)
+	}
+	if err := <-newerDone; !errors.Is(err, errSemanticTokensSuperseded) {
+		t.Fatalf("waiting newer generation error = %v, want retry notification", err)
+	}
+	fresh, hit, err := staleCache.get(newerDoc, staleCache.begin(), func() ([]protocol.UInteger, error) {
+		newerLoads.Add(1)
 		return []protocol.UInteger{0, 0, 2, 12, 0}, nil
 	})
-	if err != nil || hit || fresh[2] != 2 {
-		t.Fatalf("fresh get = (%v, hit=%v, err=%v), want uncached fresh data", fresh, hit, err)
+	if err != nil || hit || fresh[2] != 2 || newerLoads.Load() != 1 {
+		t.Fatalf("fresh get = (%v, hit=%v, err=%v, loads=%d), want one uncached latest load", fresh, hit, err, newerLoads.Load())
 	}
 }
 
@@ -209,5 +246,102 @@ func TestSemanticTokensFullCachesAndInvalidatesOnDocumentLifecycle(t *testing.T)
 	}
 	if _, err := s.semanticTokensFull(nil, params); err != nil || generations.Load() != 4 {
 		t.Fatalf("close/reopen invalidation = (err=%v, generations=%d), want regeneration", err, generations.Load())
+	}
+}
+
+func TestSemanticTokensFullSerializesObsoleteGenerationAndRetriesLatest(t *testing.T) {
+	root := t.TempDir()
+	s, cleanup, err := New(Options{RootDir: root, Config: config.Default()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	s.diagnostics = func(context.Context, intel.Document) []intel.Diagnostic { return nil }
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var generations atomic.Int32
+	var active atomic.Int32
+	var maximum atomic.Int32
+	s.semanticTokenGenerator = func(doc intel.Document, _ []intel.Document) ([]intel.SemanticToken, error) {
+		generation := generations.Add(1)
+		current := active.Add(1)
+		for {
+			observed := maximum.Load()
+			if current <= observed || maximum.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		if generation == 1 {
+			close(started)
+			<-release
+		}
+		active.Add(-1)
+		return []intel.SemanticToken{{
+			Range: intel.Range{Start: intel.Position{}, End: intel.Position{Character: len(doc.Source)}},
+			Type:  intel.SemanticTokenKeyword,
+		}}, nil
+	}
+	ctx := &glsp.Context{Notify: func(string, any) {}}
+	path := filepath.Join(root, "src", "modules", "Main.bas")
+	uri := pathToFileURI(path)
+	if err := s.didOpen(ctx, &protocol.DidOpenTextDocumentParams{TextDocument: protocol.TextDocumentItem{
+		URI: protocol.DocumentUri(uri), LanguageID: "vba", Version: 1, Text: "A",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	params := &protocol.SemanticTokensParams{TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)}}
+	type result struct {
+		tokens *protocol.SemanticTokens
+		err    error
+	}
+	results := make(chan result, 2)
+	go func() {
+		tokens, err := s.semanticTokensFull(nil, params)
+		results <- result{tokens: tokens, err: err}
+	}()
+	<-started
+	if err := s.didChange(ctx, &protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)}, Version: 2,
+		},
+		ContentChanges: []any{protocol.TextDocumentContentChangeEventWhole{Text: "AB"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		tokens, err := s.semanticTokensFull(nil, params)
+		results <- result{tokens: tokens, err: err}
+	}()
+	identity := documentSymbolKey(intel.Document{Path: path, URI: uri})
+	deadline := time.Now().Add(time.Second)
+	for {
+		s.semanticTokens.mu.Lock()
+		call := s.semanticTokens.inflight[identity]
+		waiting := call != nil && call.waiters > 0
+		s.semanticTokens.mu.Unlock()
+		if waiting {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("latest semantic request did not wait for obsolete generation")
+		}
+		runtime.Gosched()
+	}
+	close(release)
+	for range 2 {
+		select {
+		case got := <-results:
+			if got.err != nil {
+				t.Fatal(got.err)
+			}
+			if got.tokens == nil || len(got.tokens.Data) != 5 || got.tokens.Data[2] != 2 {
+				t.Fatalf("retried semantic tokens = %+v, want latest version length 2", got.tokens)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("semantic token retry did not complete")
+		}
+	}
+	if generations.Load() != 2 || maximum.Load() != 1 {
+		t.Fatalf("generation stats = calls:%d max_active:%d, want 2 calls and one active", generations.Load(), maximum.Load())
 	}
 }

--- a/internal/lspserver/semantic_token_cache_test.go
+++ b/internal/lspserver/semantic_token_cache_test.go
@@ -1,0 +1,213 @@
+package lspserver
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/intel"
+)
+
+func TestSemanticTokenCacheUsesVersionContentAndFullIdentity(t *testing.T) {
+	cache := newSemanticTokenCache()
+	root := t.TempDir()
+	doc := intel.Document{
+		URI:        pathToFileURI(filepath.Join(root, "first", "Main.bas")),
+		Path:       filepath.Join(root, "first", "Main.bas"),
+		Source:     "Option Explicit\n",
+		ModuleKind: "standard",
+		Version:    7,
+	}
+	var loads atomic.Int32
+	load := func() ([]protocol.UInteger, error) {
+		loads.Add(1)
+		return []protocol.UInteger{0, 0, 6, 12, 0}, nil
+	}
+
+	first, hit, err := cache.get(doc, cache.begin(), load)
+	if err != nil || hit || len(first) != 5 {
+		t.Fatalf("first get = (%v, hit=%v, err=%v), want miss", first, hit, err)
+	}
+	first[0] = 99
+	second, hit, err := cache.get(doc, cache.begin(), load)
+	if err != nil || !hit || loads.Load() != 1 || second[0] != 0 {
+		t.Fatalf("second get = (%v, hit=%v, err=%v, loads=%d), want isolated hit", second, hit, err, loads.Load())
+	}
+
+	doc.Source = "Option Explicit\nSub Changed()\nEnd Sub\n"
+	if _, hit, err := cache.get(doc, cache.begin(), load); err != nil || hit || loads.Load() != 2 {
+		t.Fatalf("same-version source change = (hit=%v, err=%v, loads=%d), want miss", hit, err, loads.Load())
+	}
+	doc.Version++
+	if _, hit, err := cache.get(doc, cache.begin(), load); err != nil || hit || loads.Load() != 3 {
+		t.Fatalf("version change = (hit=%v, err=%v, loads=%d), want miss", hit, err, loads.Load())
+	}
+
+	other := doc
+	other.Path = filepath.Join(root, "second", "Main.bas")
+	other.URI = pathToFileURI(other.Path)
+	if _, hit, err := cache.get(other, cache.begin(), load); err != nil || hit || loads.Load() != 4 {
+		t.Fatalf("same basename other directory = (hit=%v, err=%v, loads=%d), want miss", hit, err, loads.Load())
+	}
+
+	failing := errors.New("semantic generation failed")
+	errorDoc := doc
+	errorDoc.Source = "broken"
+	errorLoad := func() ([]protocol.UInteger, error) { return nil, failing }
+	if _, _, err := cache.get(errorDoc, cache.begin(), errorLoad); !errors.Is(err, failing) {
+		t.Fatalf("first error = %v, want %v", err, failing)
+	}
+	if _, hit, err := cache.get(errorDoc, cache.begin(), errorLoad); !errors.Is(err, failing) || hit {
+		t.Fatalf("second error = (hit=%v, err=%v), want uncached error", hit, err)
+	}
+}
+
+func TestSemanticTokenCacheCoalescesMissesAndRejectsInvalidatedResult(t *testing.T) {
+	cache := newSemanticTokenCache()
+	doc := intel.Document{URI: "file:///C:/work/Main.bas", Path: `C:\work\Main.bas`, Source: "Option Explicit\n", Version: 1}
+	generation := cache.begin()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	var loads atomic.Int32
+	load := func() ([]protocol.UInteger, error) {
+		loads.Add(1)
+		once.Do(func() { close(started) })
+		<-release
+		return []protocol.UInteger{0, 0, 6, 12, 0}, nil
+	}
+
+	const requests = 12
+	start := make(chan struct{})
+	results := make(chan error, requests)
+	for range requests {
+		go func() {
+			<-start
+			data, _, err := cache.get(doc, generation, load)
+			if err == nil && len(data) != 5 {
+				err = errors.New("unexpected token data")
+			}
+			results <- err
+		}()
+	}
+	close(start)
+	<-started
+	close(release)
+	for range requests {
+		if err := <-results; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if loads.Load() != 1 {
+		t.Fatalf("concurrent loads = %d, want 1", loads.Load())
+	}
+
+	staleCache := newSemanticTokenCache()
+	staleGeneration := staleCache.begin()
+	staleStarted := make(chan struct{})
+	staleRelease := make(chan struct{})
+	staleDone := make(chan error, 1)
+	go func() {
+		_, _, err := staleCache.get(doc, staleGeneration, func() ([]protocol.UInteger, error) {
+			close(staleStarted)
+			<-staleRelease
+			return []protocol.UInteger{0, 0, 1, 12, 0}, nil
+		})
+		staleDone <- err
+	}()
+	<-staleStarted
+	staleCache.invalidateAll()
+	close(staleRelease)
+	if err := <-staleDone; err != nil {
+		t.Fatal(err)
+	}
+	fresh, hit, err := staleCache.get(doc, staleCache.begin(), func() ([]protocol.UInteger, error) {
+		return []protocol.UInteger{0, 0, 2, 12, 0}, nil
+	})
+	if err != nil || hit || fresh[2] != 2 {
+		t.Fatalf("fresh get = (%v, hit=%v, err=%v), want uncached fresh data", fresh, hit, err)
+	}
+}
+
+func TestSemanticTokensFullCachesAndInvalidatesOnDocumentLifecycle(t *testing.T) {
+	root := t.TempDir()
+	s, cleanup, err := New(Options{RootDir: root, Config: config.Default()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	s.diagnostics = func(context.Context, intel.Document) []intel.Diagnostic { return nil }
+	var generations atomic.Int32
+	s.semanticTokenGenerator = func(doc intel.Document, _ []intel.Document) ([]intel.SemanticToken, error) {
+		generations.Add(1)
+		length := 1
+		if len(doc.Source) > 1 {
+			length = 2
+		}
+		return []intel.SemanticToken{{
+			Range: intel.Range{Start: intel.Position{}, End: intel.Position{Character: length}},
+			Type:  intel.SemanticTokenKeyword,
+		}}, nil
+	}
+	ctx := &glsp.Context{Notify: func(string, any) {}}
+	path := filepath.Join(root, "src", "modules", "Main.bas")
+	uri := pathToFileURI(path)
+	if err := s.didOpen(ctx, &protocol.DidOpenTextDocumentParams{TextDocument: protocol.TextDocumentItem{
+		URI: protocol.DocumentUri(uri), LanguageID: "vba", Version: 1, Text: "A",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	params := &protocol.SemanticTokensParams{TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)}}
+	first, err := s.semanticTokensFull(nil, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.Data[2] = 99
+	second, err := s.semanticTokensFull(nil, params)
+	if err != nil || generations.Load() != 1 || second.Data[2] != 1 {
+		t.Fatalf("cached result = (%v, err=%v, generations=%d), want isolated hit", second.Data, err, generations.Load())
+	}
+
+	if err := s.didChange(ctx, &protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)}, Version: 2,
+		},
+		ContentChanges: []any{protocol.TextDocumentContentChangeEventWhole{Text: "AB"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := s.semanticTokensFull(nil, params)
+	if err != nil || generations.Load() != 2 || changed.Data[2] != 2 {
+		t.Fatalf("changed result = (%v, err=%v, generations=%d), want regenerated data", changed.Data, err, generations.Load())
+	}
+
+	otherPath := filepath.Join(root, "src", "classes", "Other.cls")
+	otherURI := pathToFileURI(otherPath)
+	if err := s.didOpen(ctx, &protocol.DidOpenTextDocumentParams{TextDocument: protocol.TextDocumentItem{
+		URI: protocol.DocumentUri(otherURI), LanguageID: "vba", Version: 1, Text: "Class Other",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.semanticTokensFull(nil, params); err != nil || generations.Load() != 3 {
+		t.Fatalf("cross-document invalidation = (err=%v, generations=%d), want regeneration", err, generations.Load())
+	}
+
+	if err := s.didClose(ctx, &protocol.DidCloseTextDocumentParams{TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.didOpen(ctx, &protocol.DidOpenTextDocumentParams{TextDocument: protocol.TextDocumentItem{
+		URI: protocol.DocumentUri(uri), LanguageID: "vba", Version: 2, Text: "AB",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.semanticTokensFull(nil, params); err != nil || generations.Load() != 4 {
+		t.Fatalf("close/reopen invalidation = (err=%v, generations=%d), want regeneration", err, generations.Load())
+	}
+}

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -55,6 +55,8 @@ type Server struct {
 	logger                   *log.Logger
 	symbols                  *workspaceSymbolCache
 	documentSymbols          *documentSymbolCache
+	semanticTokens           *semanticTokenCache
+	semanticTokenGenerator   func(intel.Document, []intel.Document) ([]intel.SemanticToken, error)
 	codeLensConfig           intel.CodeLensConfig
 	diagnostics              func(context.Context, intel.Document) []intel.Diagnostic
 	diagnosticsDebounce      time.Duration
@@ -137,12 +139,14 @@ func New(opts Options) (*Server, func(), error) {
 		logger:          logger,
 		symbols:         newWorkspaceSymbolCache(),
 		documentSymbols: newDocumentSymbolCache(),
+		semanticTokens:  newSemanticTokenCache(),
 		codeLensConfig:  intel.DefaultCodeLensConfig(),
 		diagStates:      make(map[string]*diagnosticState),
 		docLifecycles:   make(map[string]*sync.Mutex),
 	}
 	s.analyzer.DocumentSymbolsFunc = s.cachedDocumentSourceSymbols
 	s.analyzer.WorkspaceSymbolsFunc = s.cachedWorkspaceSymbols
+	s.semanticTokenGenerator = s.analyzer.SemanticTokens
 	s.diagnostics = s.analyzer.DiagnosticsContext
 	s.diagnosticsDebounce = diagnosticsDebounce
 	s.diagnosticsAfterFunc = func(delay time.Duration, callback func()) diagnosticTimer {
@@ -294,6 +298,7 @@ func (s *Server) didOpen(ctx *glsp.Context, params *protocol.DidOpenTextDocument
 		return err
 	}
 	s.documentSymbols.invalidate(doc)
+	s.semanticTokens.invalidateAll()
 	done := s.openDiagnostics(ctx, doc)
 	unlock()
 	if done != nil {
@@ -318,6 +323,7 @@ func (s *Server) didChange(ctx *glsp.Context, params *protocol.DidChangeTextDocu
 		return err
 	}
 	s.documentSymbols.invalidate(doc)
+	s.semanticTokens.invalidateAll()
 	s.scheduleDiagnostics(ctx, doc)
 	return nil
 }
@@ -342,6 +348,7 @@ func (s *Server) didClose(ctx *glsp.Context, params *protocol.DidCloseTextDocume
 	defer unlock()
 	s.closeDiagnostics(ctx, uri)
 	s.docs.close(uri)
+	s.semanticTokens.invalidateAll()
 	if path, err := fileURIToPath(uri); err == nil {
 		s.documentSymbols.invalidate(intel.Document{URI: uri, Path: path})
 	}
@@ -668,19 +675,28 @@ func (s *Server) formatting(_ *glsp.Context, params *protocol.DocumentFormatting
 
 func (s *Server) semanticTokensFull(_ *glsp.Context, params *protocol.SemanticTokensParams) (*protocol.SemanticTokens, error) {
 	measurement := s.startPerformanceURI("textDocument/semanticTokens/full", string(params.TextDocument.URI))
+	generation := s.semanticTokens.begin()
 	doc, err := s.docs.getOrRead(string(params.TextDocument.URI))
 	if err != nil {
 		measurement.finish(0, err)
 		return nil, err
 	}
 	measurement.setDocument(doc)
-	tokens, err := s.analyzer.SemanticTokens(doc, s.docs.openDocuments())
+	cacheStarted := time.Now()
+	data, hit, err := s.semanticTokens.get(doc, generation, func() ([]protocol.UInteger, error) {
+		tokens, err := s.semanticTokenGenerator(doc, s.docs.openDocuments())
+		if err != nil {
+			return nil, err
+		}
+		return encodeSemanticTokens(tokens), nil
+	})
+	s.logDocumentCachePerformance("semanticTokens/cache", cacheStatus(hit), doc, len(data)/5, cacheStarted, err)
 	if err != nil {
 		measurement.finish(0, err)
 		return nil, err
 	}
-	result := &protocol.SemanticTokens{Data: encodeSemanticTokens(tokens)}
-	measurement.finish(len(tokens), nil)
+	result := &protocol.SemanticTokens{Data: data}
+	measurement.finish(len(data)/5, nil)
 	return result, nil
 }
 

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -2,6 +2,7 @@ package lspserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -675,29 +676,34 @@ func (s *Server) formatting(_ *glsp.Context, params *protocol.DocumentFormatting
 
 func (s *Server) semanticTokensFull(_ *glsp.Context, params *protocol.SemanticTokensParams) (*protocol.SemanticTokens, error) {
 	measurement := s.startPerformanceURI("textDocument/semanticTokens/full", string(params.TextDocument.URI))
-	generation := s.semanticTokens.begin()
-	doc, err := s.docs.getOrRead(string(params.TextDocument.URI))
-	if err != nil {
-		measurement.finish(0, err)
-		return nil, err
-	}
-	measurement.setDocument(doc)
-	cacheStarted := time.Now()
-	data, hit, err := s.semanticTokens.get(doc, generation, func() ([]protocol.UInteger, error) {
-		tokens, err := s.semanticTokenGenerator(doc, s.docs.openDocuments())
+	for {
+		generation := s.semanticTokens.begin()
+		doc, err := s.docs.getOrRead(string(params.TextDocument.URI))
 		if err != nil {
+			measurement.finish(0, err)
 			return nil, err
 		}
-		return encodeSemanticTokens(tokens), nil
-	})
-	s.logDocumentCachePerformance("semanticTokens/cache", cacheStatus(hit), doc, len(data)/5, cacheStarted, err)
-	if err != nil {
-		measurement.finish(0, err)
-		return nil, err
+		measurement.setDocument(doc)
+		cacheStarted := time.Now()
+		data, hit, err := s.semanticTokens.get(doc, generation, func() ([]protocol.UInteger, error) {
+			tokens, err := s.semanticTokenGenerator(doc, s.docs.openDocuments())
+			if err != nil {
+				return nil, err
+			}
+			return encodeSemanticTokens(tokens), nil
+		})
+		if errors.Is(err, errSemanticTokensSuperseded) {
+			continue
+		}
+		s.logDocumentCachePerformance("semanticTokens/cache", cacheStatus(hit), doc, len(data)/5, cacheStarted, err)
+		if err != nil {
+			measurement.finish(0, err)
+			return nil, err
+		}
+		result := &protocol.SemanticTokens{Data: data}
+		measurement.finish(len(data)/5, nil)
+		return result, nil
 	}
-	result := &protocol.SemanticTokens{Data: data}
-	measurement.finish(len(data)/5, nil)
-	return result, nil
 }
 
 func (s *Server) codeLens(_ *glsp.Context, params *protocol.CodeLensParams) ([]protocol.CodeLens, error) {

--- a/internal/lspserver/server_benchmark_test.go
+++ b/internal/lspserver/server_benchmark_test.go
@@ -431,6 +431,8 @@ func BenchmarkLSPSemanticTokens(b *testing.B) {
 	b.Run("Cold", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
+			s.symbols = newWorkspaceSymbolCache()
+			s.documentSymbols = newDocumentSymbolCache()
 			s.semanticTokens = newSemanticTokenCache()
 			if _, err := s.semanticTokensFull(nil, params); err != nil {
 				b.Fatal(err)

--- a/internal/lspserver/server_benchmark_test.go
+++ b/internal/lspserver/server_benchmark_test.go
@@ -428,13 +428,44 @@ func BenchmarkLSPSemanticTokens(b *testing.B) {
 	fixture := makeLSPBenchmarkFixture(b)
 	s := newLSPBenchmarkServer(b, fixture)
 	params := &protocol.SemanticTokensParams{TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(fixture.largeURI)}}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	b.Run("Cold", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s.semanticTokens = newSemanticTokenCache()
+			if _, err := s.semanticTokensFull(nil, params); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("Warm", func(b *testing.B) {
 		if _, err := s.semanticTokensFull(nil, params); err != nil {
 			b.Fatal(err)
 		}
-	}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := s.semanticTokensFull(nil, params); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("AfterEdit", func(b *testing.B) {
+		changed := strings.Replace(fixture.largeSource, "    localSheet.Ra\n", "    localSheet.Ran\n", 1)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			source := fixture.largeSource
+			if i%2 == 0 {
+				source = changed
+			}
+			if _, err := s.docs.change(fixture.largeURI, source, int32(i+1)); err != nil {
+				b.Fatal(err)
+			}
+			s.semanticTokens.invalidateAll()
+			if _, err := s.semanticTokensFull(nil, params); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func BenchmarkLSPDocumentSymbols(b *testing.B) {

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -2874,7 +2874,10 @@ func currentProcedureRangeForDocument(doc Document, pos Position) (Range, bool) 
 }
 
 func currentProcedureForDocument(doc Document, pos Position) (string, *Range) {
-	lines := normalizedLines(doc.Source)
+	return currentProcedureForLines(normalizedLines(doc.Source), pos)
+}
+
+func currentProcedureForLines(lines []string, pos Position) (string, *Range) {
 	depth := 0
 	current := ""
 	var scope *Range
@@ -2916,6 +2919,85 @@ func currentProcedureForDocument(doc Document, pos Position) (string, *Range) {
 		}
 	}
 	return current, scope
+}
+
+type procedureScope struct {
+	name   string
+	range_ Range
+}
+
+type documentTypeContext struct {
+	lines           []string
+	symbols         []Symbol
+	procedures      []procedureScope
+	procedureByLine []int
+}
+
+func newDocumentTypeContext(lines []string, symbols []Symbol) *documentTypeContext {
+	ctx := &documentTypeContext{
+		lines:           lines,
+		symbols:         symbols,
+		procedureByLine: make([]int, len(lines)),
+	}
+	for i := range ctx.procedureByLine {
+		ctx.procedureByLine[i] = -1
+	}
+	depth := 0
+	active := -1
+	for lineNo, line := range lines {
+		text := strings.TrimSpace(line[:codeLimit(line)])
+		if text == "" {
+			continue
+		}
+		lower := strings.ToLower(text)
+		switch {
+		case strings.HasPrefix(lower, "end sub") || strings.HasPrefix(lower, "end function") || strings.HasPrefix(lower, "end property"):
+			if depth > 0 {
+				depth--
+			}
+			if depth == 0 && active >= 0 {
+				ctx.procedures[active].range_.End = Position{Line: lineNo, Character: utf16Len(line)}
+				active = -1
+			}
+		case procedureStartLine(lower):
+			depth++
+			if depth == 1 {
+				name := procedureNameFromLine(text)
+				if name != "" {
+					ctx.procedures = append(ctx.procedures, procedureScope{
+						name:   name,
+						range_: Range{Start: Position{Line: lineNo}, End: Position{Line: len(lines)}},
+					})
+					active = len(ctx.procedures) - 1
+				}
+			}
+		}
+	}
+	for index, procedure := range ctx.procedures {
+		lastLine := min(procedure.range_.End.Line, len(ctx.procedureByLine)-1)
+		for lineNo := procedure.range_.Start.Line; lineNo <= lastLine; lineNo++ {
+			ctx.procedureByLine[lineNo] = index
+		}
+	}
+	return ctx
+}
+
+func (c *documentTypeContext) procedureAt(pos Position) (string, *Range) {
+	if c == nil {
+		return "", nil
+	}
+	if pos.Line < 0 || pos.Line >= len(c.procedureByLine) {
+		return "", nil
+	}
+	index := c.procedureByLine[pos.Line]
+	if index < 0 || index >= len(c.procedures) {
+		return "", nil
+	}
+	scope := &c.procedures[index]
+	if comparePosition(scope.range_.Start, pos) <= 0 && comparePosition(pos, scope.range_.End) <= 0 {
+		return scope.name, &scope.range_
+	}
+	return "", nil
 }
 
 func procedureNameFromLine(text string) string {
@@ -2981,11 +3063,15 @@ type inferredType struct {
 }
 
 func (a Analyzer) inferWordTypeAt(doc Document, word string, offset int) (string, bool) {
-	inferred, ok := a.inferWordTypeInfoAt(doc, word, offset)
+	inferred, ok := a.inferWordTypeInfoAtContext(doc, word, offset, nil)
 	return inferred.Type, ok
 }
 
 func (a Analyzer) inferWordTypeInfoAt(doc Document, word string, offset int) (inferredType, bool) {
+	return a.inferWordTypeInfoAtContext(doc, word, offset, nil)
+}
+
+func (a Analyzer) inferWordTypeInfoAtContext(doc Document, word string, offset int, ctx *documentTypeContext) (inferredType, bool) {
 	if strings.EqualFold(word, "Me") {
 		if instance, ok := a.currentInstanceType(doc); ok {
 			return inferredType{Type: instance.Type, Source: instance.Source}, true
@@ -2999,12 +3085,12 @@ func (a Analyzer) inferWordTypeInfoAt(doc Document, word string, offset int) (in
 	}
 	var declared string
 	if offset >= 0 {
-		if inferred, ok := a.visibleSymbolTypeInfoAt(doc, word, offset); ok {
+		if inferred, ok := a.visibleSymbolTypeInfoAtContext(doc, word, offset, ctx); ok {
 			declared = inferred.Type
 			if !isObjectFallbackType(inferred.Type) {
 				return inferred, true
 			}
-		} else if currentProcedureNameForDocument(doc, positionForByteOffset(doc.Source, offset)) != "" {
+		} else if currentProcedureNameAt(doc, positionForByteOffset(doc.Source, offset), ctx) != "" {
 			return inferredType{}, false
 		}
 	}
@@ -3031,7 +3117,7 @@ func (a Analyzer) inferWordTypeInfoAt(doc Document, word string, offset int) (in
 		}
 	}
 	if expr, exprOffset, ok := bestSetAssignmentExpression(doc.Source, word, offset); ok {
-		if typ, ok := a.resolveDocumentExpressionTypeAt(doc, expr, exprOffset); ok {
+		if typ, ok := a.resolveDocumentExpressionTypeAtContext(doc, expr, exprOffset, ctx); ok {
 			return inferredType{Type: typ, Source: "inferred from Set assignment"}, true
 		}
 	}
@@ -3041,12 +3127,18 @@ func (a Analyzer) inferWordTypeInfoAt(doc Document, word string, offset int) (in
 	return inferredType{}, false
 }
 
-func (a Analyzer) visibleSymbolTypeInfoAt(doc Document, word string, offset int) (inferredType, bool) {
+func (a Analyzer) visibleSymbolTypeInfoAtContext(doc Document, word string, offset int, ctx *documentTypeContext) (inferredType, bool) {
 	pos := positionForByteOffset(doc.Source, offset)
-	currentProcedure := currentProcedureNameForDocument(doc, pos)
-	syms, err := a.DocumentSymbols(doc)
-	if err != nil {
-		return inferredType{}, false
+	currentProcedure := currentProcedureNameAt(doc, pos, ctx)
+	var syms []Symbol
+	if ctx != nil {
+		syms = ctx.symbols
+	} else {
+		var err error
+		syms, err = a.DocumentSymbols(doc)
+		if err != nil {
+			return inferredType{}, false
+		}
 	}
 	var fallback inferredType
 	for _, sym := range syms {
@@ -3065,6 +3157,14 @@ func (a Analyzer) visibleSymbolTypeInfoAt(doc Document, word string, offset int)
 		return fallback, true
 	}
 	return inferredType{}, false
+}
+
+func currentProcedureNameAt(doc Document, pos Position, ctx *documentTypeContext) string {
+	if ctx != nil {
+		name, _ := ctx.procedureAt(pos)
+		return name
+	}
+	return currentProcedureNameForDocument(doc, pos)
 }
 
 func isObjectFallbackType(name string) bool {
@@ -3171,14 +3271,18 @@ func (a Analyzer) ResolveExpressionType(expr string) (string, bool) {
 }
 
 func (a Analyzer) resolveDocumentExpressionTypeAt(doc Document, expr string, offset int) (string, bool) {
-	return a.resolveExpressionTypeAt(doc, expr, true, offset)
+	return a.resolveDocumentExpressionTypeAtContext(doc, expr, offset, nil)
+}
+
+func (a Analyzer) resolveDocumentExpressionTypeAtContext(doc Document, expr string, offset int, ctx *documentTypeContext) (string, bool) {
+	return a.resolveExpressionTypeAtContext(doc, expr, true, offset, ctx)
 }
 
 func (a Analyzer) resolveExpressionType(doc Document, expr string, useDocument bool) (string, bool) {
-	return a.resolveExpressionTypeAt(doc, expr, useDocument, -1)
+	return a.resolveExpressionTypeAtContext(doc, expr, useDocument, -1, nil)
 }
 
-func (a Analyzer) resolveExpressionTypeAt(doc Document, expr string, useDocument bool, offset int) (string, bool) {
+func (a Analyzer) resolveExpressionTypeAtContext(doc Document, expr string, useDocument bool, offset int, ctx *documentTypeContext) (string, bool) {
 	parts := splitMemberExpression(expr)
 	if len(parts) == 0 {
 		return "", false
@@ -3201,8 +3305,8 @@ func (a Analyzer) resolveExpressionTypeAt(doc Document, expr string, useDocument
 	} else if typ, ok := a.DB.ResolveType(base); ok {
 		current = typ.Name
 	} else if useDocument {
-		if typ, ok := a.inferWordTypeAt(doc, base, offset); ok {
-			current = typ
+		if inferred, ok := a.inferWordTypeInfoAtContext(doc, base, offset, ctx); ok {
+			current = inferred.Type
 		} else {
 			return "", false
 		}
@@ -3284,7 +3388,14 @@ func sheetsDefaultExpression(expr string) bool {
 }
 
 func (a Analyzer) withBlockTypeAt(doc Document, pos Position, offset int) (string, bool) {
+	return a.withBlockTypeAtContext(doc, pos, offset, nil)
+}
+
+func (a Analyzer) withBlockTypeAtContext(doc Document, pos Position, offset int, ctx *documentTypeContext) (string, bool) {
 	lines := normalizedLines(doc.Source)
+	if ctx != nil {
+		lines = ctx.lines
+	}
 	if pos.Line <= 0 || pos.Line > len(lines) {
 		return "", false
 	}
@@ -3304,7 +3415,7 @@ func (a Analyzer) withBlockTypeAt(doc Document, pos Position, offset int) (strin
 		if len(m) == 0 {
 			continue
 		}
-		if typ, ok := a.resolveWithExpressionTypeAt(doc, strings.TrimSpace(m[1]), stack, offset); ok {
+		if typ, ok := a.resolveWithExpressionTypeAtContext(doc, strings.TrimSpace(m[1]), stack, offset, ctx); ok {
 			stack = append(stack, typ)
 		} else {
 			stack = append(stack, "")
@@ -3318,7 +3429,7 @@ func (a Analyzer) withBlockTypeAt(doc Document, pos Position, offset int) (strin
 	return "", false
 }
 
-func (a Analyzer) resolveWithExpressionTypeAt(doc Document, expr string, stack []string, offset int) (string, bool) {
+func (a Analyzer) resolveWithExpressionTypeAtContext(doc Document, expr string, stack []string, offset int, ctx *documentTypeContext) (string, bool) {
 	expr = strings.TrimSpace(expr)
 	if strings.HasPrefix(expr, ".") {
 		if len(stack) == 0 || stack[len(stack)-1] == "" {
@@ -3326,7 +3437,7 @@ func (a Analyzer) resolveWithExpressionTypeAt(doc Document, expr string, stack [
 		}
 		return a.resolveMemberChainFromType(stack[len(stack)-1], expr)
 	}
-	return a.resolveDocumentExpressionTypeAt(doc, expr, offset)
+	return a.resolveDocumentExpressionTypeAtContext(doc, expr, offset, ctx)
 }
 
 func (a Analyzer) resolveMemberChainFromType(baseType, expr string) (string, bool) {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -3533,6 +3533,113 @@ End Sub
 	}
 }
 
+func TestSemanticTokensRetrieveSymbolsOncePerRequest(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	source := `Option Explicit
+Public Sub Run(ByVal value As String)
+    Dim ws As Worksheet
+    Set ws = Worksheets("Input")
+    Debug.Print value
+    ws.Range("A1").Value = 1
+End Sub
+`
+	doc := Document{
+		URI:        "file:///project/Main.bas",
+		Path:       filepath.Join(t.TempDir(), "Main.bas"),
+		ModuleKind: "standard",
+		Source:     source,
+		Version:    1,
+	}
+	var documentCalls, workspaceCalls int
+	analyzer.DocumentSymbolsFunc = func(_ Document, load DocumentSymbolLoader) ([]Symbol, error) {
+		documentCalls++
+		return load()
+	}
+	analyzer.WorkspaceSymbolsFunc = func(_ []Document, _ string) ([]Symbol, error) {
+		workspaceCalls++
+		return nil, nil
+	}
+
+	tokens, err := analyzer.SemanticTokens(doc, []Document{doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if documentCalls != 1 || workspaceCalls != 1 {
+		t.Fatalf("symbol retrievals = document:%d workspace:%d, want 1 each", documentCalls, workspaceCalls)
+	}
+	if !hasSemanticTokenAt(tokens, SemanticTokenParameter, "value", source, lineIndex(source, "Debug.Print value")) {
+		t.Fatalf("parameter token missing after symbol reuse: %+v", tokens)
+	}
+	if !hasSemanticTokenAt(tokens, SemanticTokenProperty, "Value", source, lineIndex(source, "ws.Range")) {
+		t.Fatalf("member token missing after symbol reuse: %+v", tokens)
+	}
+}
+
+func TestSemanticTokensPreferUnsavedDocumentOverRelativeWorkspaceSymbol(t *testing.T) {
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(moduleDir, "Main.bas")
+	saved := `Option Explicit
+Public Sub OldCall()
+End Sub
+
+Public Sub Run()
+    OldCall
+End Sub
+`
+	if err := os.WriteFile(path, []byte(saved), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	live := `Option Explicit
+Public Sub Run()
+    OldCall
+End Sub
+`
+	analyzer := newTestAnalyzer(t)
+	analyzer.RootDir = root
+	doc := Document{
+		URI:        "file:///live/Main.bas",
+		Path:       path,
+		ModuleKind: "standard",
+		Source:     live,
+		Version:    2,
+	}
+
+	tokens, err := analyzer.SemanticTokens(doc, []Document{doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasSemanticTokenAt(tokens, SemanticTokenFunction, "OldCall", live, lineIndex(live, "    OldCall")) {
+		t.Fatalf("stale saved procedure colored an unresolved live-buffer call: %+v", tokens)
+	}
+}
+
+func TestNormalizeSemanticTokensPreservesPriorityAndRemovesOverlap(t *testing.T) {
+	rangeAt := func(start, end int) Range {
+		return Range{Start: Position{Line: 1, Character: start}, End: Position{Line: 1, Character: end}}
+	}
+	tokens := []SemanticToken{
+		{Range: rangeAt(0, 3), Type: SemanticTokenKeyword},
+		{Range: rangeAt(0, 3), Type: SemanticTokenFunction},
+		{Range: rangeAt(2, 5), Type: SemanticTokenVariable},
+		{Range: rangeAt(6, 8), Type: SemanticTokenNumber},
+	}
+
+	got := normalizeSemanticTokens(tokens)
+	if len(got) != 2 {
+		t.Fatalf("normalized tokens = %+v, want 2 non-overlapping tokens", got)
+	}
+	if got[0].Type != SemanticTokenFunction || got[0].Range != rangeAt(0, 3) {
+		t.Fatalf("first normalized token = %+v, want symbol priority winner", got[0])
+	}
+	if got[1].Type != SemanticTokenNumber || got[1].Range != rangeAt(6, 8) {
+		t.Fatalf("second normalized token = %+v, want trailing token", got[1])
+	}
+}
+
 func newTestAnalyzer(t *testing.T) Analyzer {
 	t.Helper()
 	db, err := vbadb.LoadBuiltin()

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -3478,6 +3478,40 @@ End Function
 	}
 }
 
+func TestSemanticTokensKeepPropertyParametersScopedToAccessor(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	source := `Option Explicit
+Private value As String
+
+Public Property Get Foo() As String
+    Debug.Print value
+    Foo = value
+End Property
+
+Public Property Let Foo(ByVal value As String)
+    Debug.Print value
+End Property
+`
+	doc := Document{
+		Path:       filepath.Join(t.TempDir(), "Main.bas"),
+		ModuleKind: "standard",
+		Source:     source,
+	}
+
+	tokens, err := analyzer.SemanticTokens(doc, []Document{doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	getterLine := lineIndex(source, "Public Property Get Foo") + 1
+	setterLine := lineIndex(source, "Public Property Let Foo") + 1
+	if hasSemanticTokenAt(tokens, SemanticTokenParameter, "value", source, getterLine) {
+		t.Fatalf("Property Let parameter leaked into Property Get tokens: %+v", tokens)
+	}
+	if !hasSemanticTokenAt(tokens, SemanticTokenParameter, "value", source, setterLine) {
+		t.Fatalf("Property Let parameter use should receive a parameter token: %+v", tokens)
+	}
+}
+
 func TestSemanticTokensCoverUserFormControlsAndMalformedSource(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	source := `VERSION 5.00
@@ -3572,6 +3606,44 @@ End Sub
 	}
 	if !hasSemanticTokenAt(tokens, SemanticTokenProperty, "Value", source, lineIndex(source, "ws.Range")) {
 		t.Fatalf("member token missing after symbol reuse: %+v", tokens)
+	}
+}
+
+func TestSemanticTokensDoNotMutateWorkspaceSymbolProviderSlice(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		URI:        "file:///project/Main.bas",
+		Path:       filepath.Join(t.TempDir(), "Main.bas"),
+		ModuleKind: "standard",
+		Source:     "Option Explicit\nPublic Sub Run()\nEnd Sub\n",
+	}
+	workspaceSymbols := []Symbol{
+		{Name: "Current", Kind: "sub", File: doc.URI},
+		{Name: "External", Kind: "sub", File: "file:///project/Other.bas"},
+	}
+	want := append([]Symbol(nil), workspaceSymbols...)
+	analyzer.WorkspaceSymbolsFunc = func(_ []Document, _ string) ([]Symbol, error) {
+		return workspaceSymbols, nil
+	}
+
+	if _, err := analyzer.SemanticTokens(doc, []Document{doc}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(workspaceSymbols, want) {
+		t.Fatalf("workspace symbol provider slice mutated:\ngot  %+v\nwant %+v", workspaceSymbols, want)
+	}
+}
+
+func TestSameSemanticDocumentComparesURIExactly(t *testing.T) {
+	analyzer := Analyzer{}
+	upper := Document{URI: "file:///project/Foo.bas"}
+	lower := Document{URI: "file:///project/foo.bas"}
+
+	if analyzer.sameSemanticDocument(upper, lower) {
+		t.Fatal("case-distinct URIs should identify different semantic documents")
+	}
+	if !analyzer.sameSemanticDocument(upper, upper) {
+		t.Fatal("identical URIs should identify the same semantic document")
 	}
 }
 

--- a/internal/vba/intel/semantic.go
+++ b/internal/vba/intel/semantic.go
@@ -73,9 +73,16 @@ type SemanticToken struct {
 }
 
 type semanticBuilder struct {
-	analyzer Analyzer
-	doc      Document
-	tokens   []SemanticToken
+	analyzer           Analyzer
+	doc                Document
+	lines              []string
+	documentSymbols    []Symbol
+	documentSymbolsOK  bool
+	workspaceSymbols   []Symbol
+	workspaceSymbolsOK bool
+	identifiers        [][]byteSpan
+	typeContext        *documentTypeContext
+	tokens             []SemanticToken
 }
 
 var semanticKeywords = map[string]bool{
@@ -108,13 +115,43 @@ var propertyDeclRe = regexp.MustCompile(`(?i)\b(?:Public|Private|Friend|Static)?
 var projectTypeReferenceRe = regexp.MustCompile(`(?i)\b(?:As\s+(?:New\s+)?|New\s+|Implements\s+)(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*([A-Za-z_][A-Za-z0-9_]*)`)
 
 func (a Analyzer) SemanticTokens(doc Document, open []Document) ([]SemanticToken, error) {
-	builder := semanticBuilder{analyzer: a, doc: doc}
+	documentSymbols, documentSymbolsErr := a.DocumentSymbols(doc)
+	workspaceOpen := make([]Document, 0, len(open))
+	for _, candidate := range open {
+		if !a.sameSemanticDocument(doc, candidate) {
+			workspaceOpen = append(workspaceOpen, candidate)
+		}
+	}
+	workspaceSymbols, workspaceSymbolsErr := a.WorkspaceSymbols(workspaceOpen, "")
+	filteredWorkspace := workspaceSymbols[:0]
+	for _, sym := range workspaceSymbols {
+		if !a.sameDocumentSymbol(doc, sym) {
+			filteredWorkspace = append(filteredWorkspace, sym)
+		}
+	}
+	workspaceSymbols = append(filteredWorkspace, documentSymbols...)
+	lines := normalizedLines(doc.Source)
+	identifiers := make([][]byteSpan, len(lines))
+	for lineNo, line := range lines {
+		identifiers[lineNo] = codeIdentifierSpans(line)
+	}
+	builder := semanticBuilder{
+		analyzer:           a,
+		doc:                doc,
+		lines:              lines,
+		documentSymbols:    documentSymbols,
+		documentSymbolsOK:  documentSymbolsErr == nil,
+		workspaceSymbols:   workspaceSymbols,
+		workspaceSymbolsOK: workspaceSymbolsErr == nil,
+		identifiers:        identifiers,
+		typeContext:        newDocumentTypeContext(lines, documentSymbols),
+	}
 	builder.addLexicalTokens()
-	builder.addSymbolTokens(open)
+	builder.addSymbolTokens()
 	builder.addParameterReferenceTokens()
-	builder.addProjectTypeReferenceTokens(open)
-	builder.addProjectProcedureReferenceTokens(open)
-	builder.addKnownIdentifierTokens(open)
+	builder.addProjectTypeReferenceTokens()
+	builder.addProjectProcedureReferenceTokens()
+	builder.addKnownIdentifierTokens()
 	builder.addMemberTokens()
 	builder.addUserFormControlTokens()
 	return normalizeSemanticTokens(builder.tokens), nil
@@ -125,28 +162,41 @@ func (a Analyzer) SemanticTokens(doc Document, open []Document) ([]SemanticToken
 // recognize only the declaration; these tokens keep the two appearances
 // visually consistent without confusing members or named arguments.
 func (b *semanticBuilder) addParameterReferenceTokens() {
-	syms, err := b.analyzer.DocumentSymbols(b.doc)
-	if err != nil {
+	if !b.documentSymbolsOK {
 		return
 	}
-	for _, sym := range syms {
+	parameters := make(map[string]bool)
+	for _, sym := range b.documentSymbols {
 		if !strings.EqualFold(sym.Kind, "parameter") || sym.Name == "" {
 			continue
 		}
-		scope, ok := currentProcedureRangeForDocument(b.doc, sym.Selection.Start)
-		if !ok {
-			continue
-		}
-		for _, rng := range codeIdentifierRanges(b.doc.Source, sym.Name) {
-			if rangeContains(scope, rng) && b.isParameterReference(rng) {
+		parameters[procedureLocalKey(sym.Parent, sym.Name)] = true
+	}
+	for lineNo, spans := range b.identifiers {
+		procedure, _ := b.typeContext.procedureAt(Position{Line: lineNo})
+		for _, span := range spans {
+			name := b.lines[lineNo][span.start:span.end]
+			if !parameters[procedureLocalKey(procedure, name)] {
+				continue
+			}
+			rng := byteRange(lineNo, b.lines[lineNo], span.start, span.end)
+			if b.isParameterReference(rng) {
 				b.add(rng, SemanticTokenParameter)
 			}
 		}
 	}
 }
 
+func (a Analyzer) sameSemanticDocument(left, right Document) bool {
+	if left.URI != "" && right.URI != "" && strings.EqualFold(left.URI, right.URI) {
+		return true
+	}
+	leftKeys := keySet(a.workspacePathKeys(left.Path))
+	return len(leftKeys) > 0 && hasAnyPathKey(leftKeys, a.workspacePathKeys(right.Path))
+}
+
 func (b *semanticBuilder) isParameterReference(rng Range) bool {
-	line := lineAt(b.doc.Source, rng.Start.Line)
+	line := b.line(rng.Start.Line)
 	start := byteIndexForUTF16(line, rng.Start.Character)
 	end := byteIndexForUTF16(line, rng.End.Character)
 	if start > 0 && line[start-1] == '.' {
@@ -159,20 +209,19 @@ func (b *semanticBuilder) isParameterReference(rng Range) bool {
 // and "New Invoice" for types declared in the current workspace. Restricting
 // this to explicit type contexts avoids mistaking an ordinary variable that
 // happens to share a name with a type for a type reference.
-func (b *semanticBuilder) addProjectTypeReferenceTokens(open []Document) {
-	syms, err := b.analyzer.WorkspaceSymbols(open, "")
-	if err != nil {
+func (b *semanticBuilder) addProjectTypeReferenceTokens() {
+	if !b.workspaceSymbolsOK {
 		return
 	}
 	types := make(map[string]string)
-	for _, sym := range syms {
+	for _, sym := range b.workspaceSymbols {
 		tokenType := semanticTypeForProjectTypeSymbol(sym)
 		if tokenType == "" || !b.analyzer.visibleCompletionSymbol(b.doc, "", sym) {
 			continue
 		}
 		types[strings.ToLower(sym.Name)] = tokenType
 	}
-	for lineNo, line := range normalizedLines(b.doc.Source) {
+	for lineNo, line := range b.lines {
 		limit := codeLimit(line)
 		for _, match := range projectTypeReferenceRe.FindAllStringSubmatchIndex(line[:limit], -1) {
 			if len(match) < 4 || match[2] < 0 || match[3] < 0 {
@@ -206,13 +255,12 @@ func semanticTypeForProjectTypeSymbol(sym Symbol) string {
 // Function declarations. Declarations are already covered by addSymbolTokens;
 // this supplies the same function color for bare Sub calls and Functions used
 // in expressions.
-func (b *semanticBuilder) addProjectProcedureReferenceTokens(open []Document) {
-	syms, err := b.analyzer.WorkspaceSymbols(open, "")
-	if err != nil {
+func (b *semanticBuilder) addProjectProcedureReferenceTokens() {
+	if !b.workspaceSymbolsOK || !b.documentSymbolsOK {
 		return
 	}
 	procedures := make(map[string]bool)
-	for _, sym := range syms {
+	for _, sym := range b.workspaceSymbols {
 		if !isProjectProcedureSymbol(sym) || !b.analyzer.visibleCompletionSymbol(b.doc, "", sym) {
 			continue
 		}
@@ -222,14 +270,10 @@ func (b *semanticBuilder) addProjectProcedureReferenceTokens(open []Document) {
 		return
 	}
 
-	docSyms, err := b.analyzer.DocumentSymbols(b.doc)
-	if err != nil {
-		return
-	}
 	declarations := make(map[string]bool)
 	locals := make(map[string]bool)
 	functions := make(map[string]bool)
-	for _, sym := range docSyms {
+	for _, sym := range b.documentSymbols {
 		if isProjectProcedureSymbol(sym) {
 			declarations[semanticRangeKey(b.symbolNameRange(sym))] = true
 		}
@@ -240,8 +284,8 @@ func (b *semanticBuilder) addProjectProcedureReferenceTokens(open []Document) {
 			locals[procedureLocalKey(sym.Parent, sym.Name)] = true
 		}
 	}
-	for lineNo, line := range normalizedLines(b.doc.Source) {
-		for _, span := range codeIdentifierSpans(line) {
+	for lineNo, line := range b.lines {
+		for _, span := range b.identifiers[lineNo] {
 			name := line[span.start:span.end]
 			if !procedures[strings.ToLower(name)] {
 				continue
@@ -250,7 +294,7 @@ func (b *semanticBuilder) addProjectProcedureReferenceTokens(open []Document) {
 			if declarations[semanticRangeKey(rng)] || !b.isProjectProcedureReference(rng) {
 				continue
 			}
-			procedure := currentProcedureNameForDocument(b.doc, rng.Start)
+			procedure, _ := b.typeContext.procedureAt(rng.Start)
 			if strings.EqualFold(procedure, name) && functions[strings.ToLower(procedure)] && b.isAssignment(rng) {
 				continue
 			}
@@ -276,7 +320,7 @@ func procedureLocalKey(procedure, name string) string {
 }
 
 func (b *semanticBuilder) isProjectProcedureReference(rng Range) bool {
-	line := lineAt(b.doc.Source, rng.Start.Line)
+	line := b.line(rng.Start.Line)
 	start := byteIndexForUTF16(line, rng.Start.Character)
 	end := byteIndexForUTF16(line, rng.End.Character)
 	before := strings.TrimSpace(line[:start])
@@ -287,13 +331,13 @@ func (b *semanticBuilder) isProjectProcedureReference(rng Range) bool {
 }
 
 func (b *semanticBuilder) isAssignment(rng Range) bool {
-	line := lineAt(b.doc.Source, rng.Start.Line)
+	line := b.line(rng.Start.Line)
 	end := byteIndexForUTF16(line, rng.End.Character)
 	return strings.HasPrefix(strings.TrimSpace(line[end:]), "=")
 }
 
 func (b *semanticBuilder) addLexicalTokens() {
-	for lineNo, line := range normalizedLines(b.doc.Source) {
+	for lineNo, line := range b.lines {
 		limit := len(line)
 		for i := 0; i < limit; {
 			r, size := firstRune(line[i:])
@@ -354,12 +398,11 @@ func (b *semanticBuilder) addLexicalTokens() {
 	}
 }
 
-func (b *semanticBuilder) addSymbolTokens(open []Document) {
-	syms, err := b.analyzer.DocumentSymbols(b.doc)
-	if err != nil {
+func (b *semanticBuilder) addSymbolTokens() {
+	if !b.documentSymbolsOK {
 		return
 	}
-	for _, sym := range syms {
+	for _, sym := range b.documentSymbols {
 		if sym.Name == "" || sym.Selection == (Range{}) {
 			continue
 		}
@@ -377,23 +420,20 @@ func (b *semanticBuilder) addSymbolTokens(open []Document) {
 		}
 		b.add(rng, tokenType, mods...)
 	}
-	if all, err := b.analyzer.WorkspaceSymbols(open, ""); err == nil {
-		for _, sym := range all {
-			if !sameDocumentSymbol(sym, b.doc) {
-				continue
-			}
-			tokenType := semanticTypeForSymbol(sym)
-			if tokenType != "" {
-				b.add(b.symbolNameRange(sym), tokenType, SemanticModifierDeclaration, SemanticModifierDefinition)
-			}
+	for _, sym := range b.workspaceSymbols {
+		if !sameDocumentSymbol(sym, b.doc) {
+			continue
+		}
+		tokenType := semanticTypeForSymbol(sym)
+		if tokenType != "" {
+			b.add(b.symbolNameRange(sym), tokenType, SemanticModifierDeclaration, SemanticModifierDefinition)
 		}
 	}
 	b.addProcedureDeclarationFallbackTokens()
 }
 
-func (b *semanticBuilder) addKnownIdentifierTokens(open []Document) {
-	_ = open
-	for lineNo, line := range normalizedLines(b.doc.Source) {
+func (b *semanticBuilder) addKnownIdentifierTokens() {
+	for lineNo, line := range b.lines {
 		limit := codeLimit(line)
 		for start := 0; start < limit; {
 			r, size := firstRune(line[start:limit])
@@ -445,7 +485,7 @@ func (b *semanticBuilder) addMemberTokens() {
 	if b.analyzer.DB == nil {
 		return
 	}
-	for lineNo, line := range normalizedLines(b.doc.Source) {
+	for lineNo, line := range b.lines {
 		limit := codeLimit(line)
 		for _, match := range memberExprRe.FindAllStringSubmatchIndex(line[:limit], -1) {
 			if len(match) < 6 || match[2] < 0 || match[3] < 0 || match[4] < 0 || match[5] < 0 {
@@ -455,10 +495,10 @@ func (b *semanticBuilder) addMemberTokens() {
 			memberName := line[match[4]:match[5]]
 			pos := Position{Line: lineNo, Character: utf16Len(line[:match[4]])}
 			offset := byteOffsetForPosition(b.doc.Source, pos)
-			receiverType, ok := b.analyzer.resolveDocumentExpressionTypeAt(b.doc, receiverExpr, offset)
+			receiverType, ok := b.analyzer.resolveDocumentExpressionTypeAtContext(b.doc, receiverExpr, offset, b.typeContext)
 			if !ok {
 				if strings.HasPrefix(strings.TrimSpace(receiverExpr), ".") {
-					receiverType, ok = b.analyzer.withBlockTypeAt(b.doc, pos, offset)
+					receiverType, ok = b.analyzer.withBlockTypeAtContext(b.doc, pos, offset, b.typeContext)
 				}
 			}
 			if !ok {
@@ -485,7 +525,7 @@ func (b *semanticBuilder) addMemberTokens() {
 }
 
 func (b *semanticBuilder) addProcedureDeclarationFallbackTokens() {
-	for lineNo, line := range normalizedLines(b.doc.Source) {
+	for lineNo, line := range b.lines {
 		limit := codeLimit(line)
 		for _, match := range procedureDeclRe.FindAllStringSubmatchIndex(line[:limit], -1) {
 			if len(match) >= 6 && match[4] >= 0 && match[5] >= 0 {
@@ -505,7 +545,7 @@ func (b *semanticBuilder) symbolNameRange(sym Symbol) Range {
 	if lineNo < 0 {
 		return sym.Selection
 	}
-	line := lineAt(b.doc.Source, lineNo)
+	line := b.line(lineNo)
 	if line == "" || sym.Name == "" {
 		return sym.Selection
 	}
@@ -529,6 +569,13 @@ func (b *semanticBuilder) symbolNameRange(sym Symbol) Range {
 		}
 	}
 	return sym.Selection
+}
+
+func (b *semanticBuilder) line(lineNo int) string {
+	if lineNo < 0 || lineNo >= len(b.lines) {
+		return ""
+	}
+	return b.lines[lineNo]
 }
 
 func (b *semanticBuilder) addUserFormControlTokens() {

--- a/internal/vba/intel/semantic.go
+++ b/internal/vba/intel/semantic.go
@@ -123,7 +123,7 @@ func (a Analyzer) SemanticTokens(doc Document, open []Document) ([]SemanticToken
 		}
 	}
 	workspaceSymbols, workspaceSymbolsErr := a.WorkspaceSymbols(workspaceOpen, "")
-	filteredWorkspace := workspaceSymbols[:0]
+	filteredWorkspace := make([]Symbol, 0, len(workspaceSymbols)+len(documentSymbols))
 	for _, sym := range workspaceSymbols {
 		if !a.sameDocumentSymbol(doc, sym) {
 			filteredWorkspace = append(filteredWorkspace, sym)
@@ -170,13 +170,16 @@ func (b *semanticBuilder) addParameterReferenceTokens() {
 		if !strings.EqualFold(sym.Kind, "parameter") || sym.Name == "" {
 			continue
 		}
-		parameters[procedureLocalKey(sym.Parent, sym.Name)] = true
+		_, scope := b.typeContext.procedureAt(sym.Selection.Start)
+		if key := procedureParameterKey(scope, sym.Name); key != "" {
+			parameters[key] = true
+		}
 	}
 	for lineNo, spans := range b.identifiers {
-		procedure, _ := b.typeContext.procedureAt(Position{Line: lineNo})
+		_, scope := b.typeContext.procedureAt(Position{Line: lineNo})
 		for _, span := range spans {
 			name := b.lines[lineNo][span.start:span.end]
-			if !parameters[procedureLocalKey(procedure, name)] {
+			if !parameters[procedureParameterKey(scope, name)] {
 				continue
 			}
 			rng := byteRange(lineNo, b.lines[lineNo], span.start, span.end)
@@ -187,8 +190,15 @@ func (b *semanticBuilder) addParameterReferenceTokens() {
 	}
 }
 
+func procedureParameterKey(scope *Range, name string) string {
+	if scope == nil || name == "" {
+		return ""
+	}
+	return semanticRangeKey(*scope) + "\x00" + strings.ToLower(name)
+}
+
 func (a Analyzer) sameSemanticDocument(left, right Document) bool {
-	if left.URI != "" && right.URI != "" && strings.EqualFold(left.URI, right.URI) {
+	if left.URI != "" && right.URI != "" && left.URI == right.URI {
 		return true
 	}
 	leftKeys := keySet(a.workspacePathKeys(left.Path))


### PR DESCRIPTION
## Summary

- reuse document symbols, workspace symbols, normalized lines, and procedure/local lookup data across semantic token builder stages
- cache encoded full semantic token responses by document identity, version, content, and workspace generation
- coalesce concurrent requests per document, serialize obsolete generations, and retry callers against the latest snapshot
- invalidate semantic token results across document open/change/close lifecycle events
- preserve unsaved-buffer precedence over stale workspace symbols

## Impact

Repeated `textDocument/semanticTokens/full` requests for unchanged documents now skip analysis and LSP encoding. With all dependent caches reset, the large-module benchmark measured a cold request at about 173.19 ms and 489,462 allocations, versus a warm request at about 17.63 µs and 8 allocations.

## Validation

- `task test`
- `task lint`
- `go test -race ./internal/lspserver ./internal/vba/intel`
- `BenchmarkLSPSemanticTokens` with Cold, Warm, and AfterEdit cases
- regression coverage for obsolete-generation serialization, accessor-scoped parameters, exact URI identity, and provider-slice immutability

Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Semantic highlighting requests are faster by reusing symbol information and caching results for unchanged documents.
  - Concurrent requests can share in-progress semantic-token generation.

- **Bug Fixes**
  - Semantic tokens now refresh correctly after edits, document changes, and reopen events.
  - Unsaved document content takes precedence over outdated saved information.
  - Improved VBA type and expression resolution within procedure and block contexts.
  - Overlapping semantic tokens are normalized while preserving the highest-priority classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->