### PR TITLE
Share parsed VBA documents across LSP analysis paths

### DIFF
--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -145,6 +145,7 @@ type parsedFile struct {
 	Path   string
 	Lines  []string
 	Module string
+	Source []byte
 	Root   *tree_sitter.Node
 	Result *vbaast.ParseResult
 }
@@ -212,6 +213,7 @@ func (a Analyzer) RunResult() (Result, error) {
 			Path:   file,
 			Lines:  normalizedSourceLines(string(parsed.Source)),
 			Module: strings.TrimSuffix(filepath.Base(file), filepath.Ext(file)),
+			Source: parsed.Source,
 			Root:   parsed.Root,
 			Result: parsed,
 		})
@@ -245,33 +247,40 @@ func SourceNonShortCircuitObjectGuardFindings(rootDir, path string, cfg config.C
 	if !cfg.Analyze.DetectNonShortCircuitObjectGuard {
 		return nil, nil
 	}
-	parser, err := vbaast.NewParser()
+	doc, err := vbaast.ParseDocument(path, source)
 	if err != nil {
 		return nil, err
 	}
-	defer parser.Close()
-	parsed := parser.Parse(path, source)
-	defer parsed.Close()
-	file := parsedFile{
-		Path:   path,
-		Lines:  normalizedSourceLines(string(source)),
-		Module: strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)),
-		Root:   parsed.Root,
-		Result: parsed,
-	}
-	analyzer := Analyzer{RootDir: rootDir, Config: cfg}
+	defer doc.Close()
+	return SourceNonShortCircuitObjectGuardFindingsParsed(rootDir, cfg, doc)
+}
+
+// SourceNonShortCircuitObjectGuardFindingsParsed analyzes a caller-owned
+// parsed VBA document without closing it or retaining tree-sitter nodes.
+func SourceNonShortCircuitObjectGuardFindingsParsed(rootDir string, cfg config.Config, doc *vbaast.ParsedDocument) ([]Finding, error) {
 	var findings []Finding
-	procedures := sourceProceduresFromAST(file.Root, file.Result.Source)
-	for _, proc := range procedures {
-		findings = append(findings, analyzer.nonShortCircuitObjectGuardFindings(file, proc)...)
-	}
-	if len(procedures) == 0 {
-		findings = append(findings, analyzer.nonShortCircuitObjectGuardFindings(file, sourceProcedure{StartLine: 1, EndLine: len(file.Lines)})...)
-	}
-	sortFindings(findings)
-	directives, _ := suppression.DirectivesForSource(rootDir, path, string(source))
-	findings, _ = applyInlineSuppressions(findings, directives)
-	return findings, nil
+	err := doc.Read(func(view vbaast.ParsedView) error {
+		file := parsedFile{
+			Path:   view.Path,
+			Lines:  normalizedSourceLines(string(view.Source)),
+			Module: strings.TrimSuffix(filepath.Base(view.Path), filepath.Ext(view.Path)),
+			Source: view.Source,
+			Root:   view.Root,
+		}
+		analyzer := Analyzer{RootDir: rootDir, Config: cfg}
+		procedures := sourceProceduresFromAST(file.Root, file.Source)
+		for _, proc := range procedures {
+			findings = append(findings, analyzer.nonShortCircuitObjectGuardFindings(file, proc)...)
+		}
+		if len(procedures) == 0 {
+			findings = append(findings, analyzer.nonShortCircuitObjectGuardFindings(file, sourceProcedure{StartLine: 1, EndLine: len(file.Lines)})...)
+		}
+		sortFindings(findings)
+		directives, _ := suppression.DirectivesForSource(rootDir, view.Path, string(view.Source))
+		findings, _ = applyInlineSuppressions(findings, directives)
+		return nil
+	})
+	return findings, err
 }
 
 func SourceRealtimeFindings(rootDir, path string, cfg config.Config, source []byte) ([]Finding, error) {
@@ -282,34 +291,48 @@ func SourceRealtimeFindings(rootDir, path string, cfg config.Config, source []by
 		!cfg.Analyze.DetectNonShortCircuitObjectGuard {
 		return nil, nil
 	}
-	parser, err := vbaast.NewParser()
+	doc, err := vbaast.ParseDocument(path, source)
 	if err != nil {
 		return nil, err
 	}
-	defer parser.Close()
-	parsed := parser.Parse(path, source)
-	defer parsed.Close()
-	file := parsedFile{
-		Path:   path,
-		Lines:  normalizedSourceLines(string(source)),
-		Module: strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)),
-		Root:   parsed.Root,
-		Result: parsed,
-	}
-	analyzer := Analyzer{RootDir: rootDir, Config: cfg}
-	procedures := sourceProceduresFromAST(file.Root, file.Result.Source)
-	moduleDecls := moduleDeclarations(file.Lines, procedures)
-	if len(procedures) == 0 {
-		procedures = []sourceProcedure{{StartLine: 1, EndLine: len(file.Lines)}}
+	defer doc.Close()
+	return SourceRealtimeFindingsParsed(rootDir, cfg, doc)
+}
+
+// SourceRealtimeFindingsParsed runs real-time source analysis against a
+// caller-owned parsed VBA document. It does not close doc or retain nodes.
+func SourceRealtimeFindingsParsed(rootDir string, cfg config.Config, doc *vbaast.ParsedDocument) ([]Finding, error) {
+	if !cfg.Analyze.DetectRangeFindNothingCheck &&
+		!cfg.Analyze.DetectErrorHandlerFallthrough &&
+		!cfg.Analyze.DetectRedimPreserveDimension &&
+		!cfg.Analyze.DetectObjectArrayComparison &&
+		!cfg.Analyze.DetectNonShortCircuitObjectGuard {
+		return nil, nil
 	}
 	var findings []Finding
-	for _, proc := range procedures {
-		findings = append(findings, analyzer.sourceRealtimeProcedureFindings(file, proc, moduleDecls)...)
-	}
-	sortFindings(findings)
-	directives, _ := suppression.DirectivesForSource(rootDir, path, string(source))
-	findings, _ = applyInlineSuppressions(findings, directives)
-	return findings, nil
+	err := doc.Read(func(view vbaast.ParsedView) error {
+		file := parsedFile{
+			Path:   view.Path,
+			Lines:  normalizedSourceLines(string(view.Source)),
+			Module: strings.TrimSuffix(filepath.Base(view.Path), filepath.Ext(view.Path)),
+			Source: view.Source,
+			Root:   view.Root,
+		}
+		analyzer := Analyzer{RootDir: rootDir, Config: cfg}
+		procedures := sourceProceduresFromAST(file.Root, file.Source)
+		moduleDecls := moduleDeclarations(file.Lines, procedures)
+		if len(procedures) == 0 {
+			procedures = []sourceProcedure{{StartLine: 1, EndLine: len(file.Lines)}}
+		}
+		for _, proc := range procedures {
+			findings = append(findings, analyzer.sourceRealtimeProcedureFindings(file, proc, moduleDecls)...)
+		}
+		sortFindings(findings)
+		directives, _ := suppression.DirectivesForSource(rootDir, view.Path, string(view.Source))
+		findings, _ = applyInlineSuppressions(findings, directives)
+		return nil
+	})
+	return findings, err
 }
 
 func (a Analyzer) sourceRealtimeProcedureFindings(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration) []Finding {
@@ -414,7 +437,7 @@ func (a Analyzer) shouldIncludeFile(path string) bool {
 func (a Analyzer) buildContext(files []parsedFile) analysisContext {
 	ctx := analysisContext{functionReturns: map[string]string{}, procedures: map[string]procedureSignature{}}
 	for _, file := range files {
-		for _, proc := range sourceProceduresFromAST(file.Root, file.Result.Source) {
+		for _, proc := range sourceProceduresFromAST(file.Root, file.Source) {
 			if isObjectType(proc.ReturnType) {
 				ctx.functionReturns[strings.ToLower(proc.Name)] = proc.ReturnType
 			}
@@ -432,7 +455,7 @@ func (a Analyzer) buildContext(files []parsedFile) analysisContext {
 func (a Analyzer) analyzeParsedFile(file parsedFile, ctx analysisContext) []Finding {
 	reportedMissingHelpers := map[string]bool{}
 	var findings []Finding
-	procedures := sourceProceduresFromAST(file.Root, file.Result.Source)
+	procedures := sourceProceduresFromAST(file.Root, file.Source)
 	moduleDecls := moduleDeclarations(file.Lines, procedures)
 	appStateProcedures := applicationStateProcedureSummaries(file.Lines, procedures)
 	for _, proc := range procedures {
@@ -1222,11 +1245,11 @@ func (a Analyzer) nonShortCircuitObjectGuardFindings(file parsedFile, proc sourc
 		}
 		r := vbaast.NodeRange(node)
 		if r.StartLine >= proc.StartLine && (proc.EndLine == 0 || r.StartLine <= proc.EndLine) &&
-			isBooleanBinaryExpression(node) && hasTopLevelAndOrOperator(node, file.Result.Source) {
+			isBooleanBinaryExpression(node) && hasTopLevelAndOrOperator(node, file.Source) {
 			guards := map[string]string{}
 			accesses := map[string]string{}
-			collectNothingGuards(node, file.Result.Source, guards)
-			collectDirectMemberAccesses(node, file.Result.Source, accesses)
+			collectNothingGuards(node, file.Source, guards)
+			collectDirectMemberAccesses(node, file.Source, accesses)
 			for key, name := range guards {
 				if _, ok := accesses[key]; !ok {
 					continue

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -3,11 +3,36 @@ package analyze
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 )
+
+func TestSourceRealtimeFindingsParsedMatchesSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Main.bas")
+	source := []byte("Option Explicit\nPublic Sub Run()\n  Dim found As Range\n  Set found = Range(\"A1\").Find(What:=\"x\")\n  Debug.Print found.Value\nEnd Sub\n")
+	cfg := config.Default()
+	want, err := SourceRealtimeFindings(dir, path, cfg, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := vbaast.ParseDocument(path, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+	got, err := SourceRealtimeFindingsParsed(dir, cfg, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SourceRealtimeFindingsParsed = %+v, want %+v", got, want)
+	}
+}
 
 func TestAnalyzerFindsMissingSetForObjectVariable(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -186,30 +186,65 @@ func (l Linter) LintSource(path string, source []byte) ([]Issue, error) {
 	return l.lintSource(path, source, false)
 }
 
+// LintParsed runs file-local lint rules against a caller-owned parsed VBA
+// document. It does not close doc or retain tree-sitter nodes beyond each read.
+func (l Linter) LintParsed(doc *vbaast.ParsedDocument) ([]Issue, error) {
+	return l.lintParsed(doc, false)
+}
+
 func (l Linter) lintSource(path string, source []byte, includeFilesystemRules bool) ([]Issue, error) {
+	doc, err := vbaast.ParseDocument(path, source)
+	if err != nil {
+		return nil, err
+	}
+	defer doc.Close()
+	return l.lintParsed(doc, includeFilesystemRules)
+}
+
+func (l Linter) lintParsed(doc *vbaast.ParsedDocument, includeFilesystemRules bool) ([]Issue, error) {
+	var path string
+	var source []byte
+	if err := doc.Read(func(view vbaast.ParsedView) error {
+		path = view.Path
+		source = append([]byte(nil), view.Source...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
 	issues, err := l.textSafetyIssues(path, string(source))
 	if err != nil {
 		return nil, err
 	}
 	issues = append(issues, l.standardModuleAttributeIssues(path, string(source))...)
 
-	parser, err := vbaast.NewParser()
-	if err != nil {
+	var sourceSymbols *symbols.FileResult
+	if sourceHasOptionExplicit(string(source)) || l.Config.Lint.DetectUnusedLocalVariables {
+		file, inspectErr := symbols.InspectParsed(symbols.SourceOptions{
+			RootDir:        l.RootDir,
+			Path:           path,
+			IncludePrivate: true,
+			IncludeLabels:  false,
+		}, doc)
+		if inspectErr == nil {
+			sourceSymbols = &file
+		}
+	}
+	if err := doc.Read(func(view vbaast.ParsedView) error {
+		ctx := astLintContext{linter: l, path: path, source: source}
+		ctx.lint(view.Root)
+		issues = append(issues, ctx.issues...)
+		if shouldReportParseIssue(view.HasError, view.HasMissing, view.Root, issues) {
+			issues = append(issues, ctx.parseIssue(view.Root))
+		}
+		issues = append(issues, l.flowIssues(path, string(source), view.Root)...)
+		if sourceSymbols != nil {
+			issues = append(issues, l.undeclaredVariableIssues(path, string(source), view.Root, *sourceSymbols)...)
+			issues = append(issues, l.unusedLocalVariableIssues(path, string(source), *sourceSymbols)...)
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
-	defer parser.Close()
-	parsed := parser.Parse(path, source)
-	defer parsed.Close()
-
-	ctx := astLintContext{linter: l, path: path, source: source}
-	ctx.lint(parsed.Root)
-	issues = append(issues, ctx.issues...)
-	if shouldReportParseIssue(parsed, issues) {
-		issues = append(issues, ctx.parseIssue(parsed.Root))
-	}
-	issues = append(issues, l.flowIssues(path, string(source), parsed.Root)...)
-	issues = append(issues, l.undeclaredVariableIssues(path, string(source), parsed.Root)...)
-	issues = append(issues, l.unusedLocalVariableIssues(path, string(source))...)
 
 	if includeFilesystemRules && l.Config.Lint.ForbidInteractiveInput {
 		boundaries, err := gui.Analyzer{RootDir: l.RootDir, Config: l.Config}.AnalyzeFile(path)
@@ -553,17 +588,8 @@ func (l Linter) flowIssues(path string, source string, root *tree_sitter.Node) [
 	return issues
 }
 
-func (l Linter) undeclaredVariableIssues(path string, source string, root *tree_sitter.Node) []Issue {
+func (l Linter) undeclaredVariableIssues(path string, source string, root *tree_sitter.Node, file symbols.FileResult) []Issue {
 	if !sourceHasOptionExplicit(source) {
-		return nil
-	}
-	file, err := symbols.InspectSource(symbols.SourceOptions{
-		RootDir:        l.RootDir,
-		Path:           path,
-		IncludePrivate: true,
-		IncludeLabels:  false,
-	}, []byte(source))
-	if err != nil {
 		return nil
 	}
 	scope := declarationScopeFromSymbols(file.Symbols)
@@ -1301,17 +1327,8 @@ func (l Linter) symbolScopeIssues(result *symbols.Result) []Issue {
 	return issues
 }
 
-func (l Linter) unusedLocalVariableIssues(path, source string) []Issue {
+func (l Linter) unusedLocalVariableIssues(path, source string, file symbols.FileResult) []Issue {
 	if !l.Config.Lint.DetectUnusedLocalVariables {
-		return nil
-	}
-	file, err := symbols.InspectSource(symbols.SourceOptions{
-		RootDir:        l.RootDir,
-		Path:           path,
-		IncludePrivate: true,
-		IncludeLabels:  false,
-	}, []byte(source))
-	if err != nil {
 		return nil
 	}
 	var issues []Issue
@@ -1590,11 +1607,11 @@ func hasSpecificSyntaxIssue(issues []Issue) bool {
 	return false
 }
 
-func shouldReportParseIssue(parsed *vbaast.ParseResult, issues []Issue) bool {
-	if parsed == nil || (!parsed.HasError && !parsed.HasMissing) || hasSpecificSyntaxIssue(issues) {
+func shouldReportParseIssue(hasError, hasMissing bool, root *tree_sitter.Node, issues []Issue) bool {
+	if (!hasError && !hasMissing) || hasSpecificSyntaxIssue(issues) {
 		return false
 	}
-	problemLines := parseProblemLines(parsed.Root)
+	problemLines := parseProblemLines(root)
 	if len(problemLines) == 0 {
 		return true
 	}

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -3,11 +3,13 @@ package lint
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 )
 
 func TestLinterFindsMVPRules(t *testing.T) {
@@ -1447,6 +1449,29 @@ func TestLinterLintSourceUsesUnsavedContent(t *testing.T) {
 	assertIssue(t, issues, "VB002", 2)
 	assertIssue(t, issues, "VB005", 3)
 	assertIssue(t, issues, "VB020", 3)
+}
+
+func TestLinterLintParsedMatchesLintSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "src", "modules", "Main.bas")
+	source := []byte("Option Explicit\nPublic Sub Run()\n    Dim value\n    Range(\"A1\").Select\nEnd Sub\n")
+	linter := Linter{RootDir: dir, Config: config.Default()}
+	want, err := linter.LintSource(path, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := vbaast.ParseDocument(path, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+	got, err := linter.LintParsed(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("LintParsed issues = %+v, want %+v", got, want)
+	}
 }
 
 func TestLinterLintSourceAppliesInlineSuppressions(t *testing.T) {

--- a/internal/lspserver/server_benchmark_test.go
+++ b/internal/lspserver/server_benchmark_test.go
@@ -199,6 +199,7 @@ func BenchmarkLSPDiagnostics(b *testing.B) {
 
 	b.Run("First", func(b *testing.B) {
 		b.ReportAllocs()
+		var parses uint64
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
 			s := newLSPBenchmarkServer(b, fixture)
@@ -206,9 +207,12 @@ func BenchmarkLSPDiagnostics(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
+			before := doc.Snapshot.ParseCount()
 			b.StartTimer()
 			_ = s.analyzer.Diagnostics(doc)
+			parses += doc.Snapshot.ParseCount() - before
 		}
+		b.ReportMetric(float64(parses)/float64(b.N), "parses/op")
 	})
 	b.Run("Repeated", func(b *testing.B) {
 		s := newLSPBenchmarkServer(b, fixture)
@@ -217,11 +221,13 @@ func BenchmarkLSPDiagnostics(b *testing.B) {
 			b.Fatal(err)
 		}
 		_ = s.analyzer.Diagnostics(doc)
+		before := doc.Snapshot.ParseCount()
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = s.analyzer.Diagnostics(doc)
 		}
+		b.ReportMetric(float64(doc.Snapshot.ParseCount()-before)/float64(b.N), "parses/op")
 	})
 }
 

--- a/internal/vba/ast/ast.go
+++ b/internal/vba/ast/ast.go
@@ -1,11 +1,17 @@
 package ast
 
 import (
+	"errors"
 	"os"
+	"sync"
 
 	tree_sitter_vba "github.com/harumiWeb/tree-sitter-vba/bindings/go"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
+
+// ErrParsedDocumentClosed reports an attempt to read a document whose owner
+// has retired it. A parsed document never reopens after Close.
+var ErrParsedDocumentClosed = errors.New("parsed VBA document is closed")
 
 type ParseResult struct {
 	Path       string
@@ -14,6 +20,101 @@ type ParseResult struct {
 	Root       *tree_sitter.Node
 	HasError   bool
 	HasMissing bool
+}
+
+// ParsedView is the read-only tree-sitter state exposed during a
+// ParsedDocument.Read callback. Root and Source are valid only for the
+// callback's duration and must not be retained or mutated by callers.
+type ParsedView struct {
+	Path       string
+	Source     []byte
+	Root       *tree_sitter.Node
+	HasError   bool
+	HasMissing bool
+}
+
+// ParsedDocument owns one ParseResult and its tree-sitter tree. ParseDocument
+// creates and closes the parser; this type alone owns and closes the resulting
+// tree. Tree-sitter trees are not thread safe, so Read serializes tree access
+// for this document. Close is idempotent, rejects new reads, and releases the
+// tree exactly once after every in-flight read callback returns.
+type ParsedDocument struct {
+	mu      sync.Mutex
+	treeMu  sync.Mutex
+	result  *ParseResult
+	readers int
+	closed  bool
+}
+
+// ParseDocument parses immutable source into a document-owned tree. The
+// supplied source is copied so callers cannot mutate the bytes backing a
+// shared parsed document after construction.
+func ParseDocument(path string, source []byte) (*ParsedDocument, error) {
+	parser, err := NewParser()
+	if err != nil {
+		return nil, err
+	}
+	defer parser.Close()
+	return &ParsedDocument{result: parser.Parse(path, append([]byte(nil), source...))}, nil
+}
+
+// Read serializes access to the document tree and invokes visit with its
+// read-only view. Callers must finish all tree and node work before visit
+// returns; retaining nodes beyond the callback is invalid.
+func (d *ParsedDocument) Read(visit func(ParsedView) error) error {
+	if d == nil {
+		return ErrParsedDocumentClosed
+	}
+	d.mu.Lock()
+	if d.closed || d.result == nil {
+		d.mu.Unlock()
+		return ErrParsedDocumentClosed
+	}
+	d.readers++
+	result := d.result
+	d.mu.Unlock()
+
+	d.treeMu.Lock()
+	defer d.treeMu.Unlock()
+	defer d.releaseRead()
+	return visit(ParsedView{
+		Path:       result.Path,
+		Source:     result.Source,
+		Root:       result.Root,
+		HasError:   result.HasError,
+		HasMissing: result.HasMissing,
+	})
+}
+
+func (d *ParsedDocument) releaseRead() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.readers--
+	if d.closed && d.readers == 0 {
+		d.closeResultLocked()
+	}
+}
+
+// Close retires the document. It is safe to call more than once and never
+// closes a tree while a Read callback can still access it.
+func (d *ParsedDocument) Close() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.closed = true
+	if d.readers == 0 {
+		d.closeResultLocked()
+	}
+}
+
+func (d *ParsedDocument) closeResultLocked() {
+	if d.result == nil {
+		return
+	}
+	d.result.Close()
+	d.result = nil
 }
 
 type Range struct {

--- a/internal/vba/ast/ast_test.go
+++ b/internal/vba/ast/ast_test.go
@@ -1,6 +1,9 @@
 package ast
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestParserParsesVBAAndReportsLocations(t *testing.T) {
 	parser, err := NewParser()
@@ -41,4 +44,40 @@ func TestParserReportsErrorAndMissingRecovery(t *testing.T) {
 	if !result.HasMissing {
 		t.Fatal("expected missing-node recovery")
 	}
+}
+
+func TestParsedDocumentOwnsRecoveryStateAndClosesAfterReaders(t *testing.T) {
+	doc, err := ParseDocument("Broken.bas", []byte("Public Function Foo(ByVal x As String\nEnd Function\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- doc.Read(func(view ParsedView) error {
+			if !view.HasError || !view.HasMissing || view.Root == nil || view.Path != "Broken.bas" {
+				t.Errorf("view = %+v", view)
+			}
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+	<-started
+	doc.Close()
+	if err := doc.Read(func(ParsedView) error { return nil }); !errors.Is(err, ErrParsedDocumentClosed) {
+		t.Fatalf("read after close = %v, want ErrParsedDocumentClosed", err)
+	}
+	if doc.result == nil {
+		t.Fatal("close released a tree while a reader still owned it")
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if doc.result != nil {
+		t.Fatal("tree was not released after the final reader")
+	}
+	doc.Close()
 }

--- a/internal/vba/intel/analysis_snapshot.go
+++ b/internal/vba/intel/analysis_snapshot.go
@@ -3,10 +3,15 @@ package intel
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/harumiWeb/xlflow/internal/vba/ast"
 )
+
+var errAnalysisSnapshotRetired = errors.New("analysis snapshot is retired")
 
 // ProcedureInfo describes the source range occupied by a VBA procedure.
 type ProcedureInfo struct {
@@ -15,7 +20,10 @@ type ProcedureInfo struct {
 }
 
 // AnalysisSnapshot is the immutable source state for one document revision.
-// Derived values are initialized once and may be read concurrently.
+// Derived Go values are initialized once and may be read concurrently. Its
+// lazily-created ParsedDocument owns the revision's tree-sitter result; tree
+// access is serialized by ParsedDocument because tree-sitter trees are not
+// thread safe. Retire closes that document after its in-flight readers finish.
 type AnalysisSnapshot struct {
 	uri        string
 	path       string
@@ -36,6 +44,12 @@ type AnalysisSnapshot struct {
 	semanticOnce        sync.Once
 	semanticIdentifiers [][]byteSpan
 
+	parsedMu       sync.Mutex
+	parsedDocument *ast.ParsedDocument
+	parsedErr      error
+	parseDocument  func(string, []byte) (*ast.ParsedDocument, error)
+	parseCount     atomic.Uint64
+
 	retired atomic.Bool
 }
 
@@ -45,13 +59,14 @@ func NewAnalysisSnapshot(doc Document) *AnalysisSnapshot {
 	normalized := strings.ReplaceAll(source, "\r\n", "\n")
 	normalized = strings.ReplaceAll(normalized, "\r", "\n")
 	return &AnalysisSnapshot{
-		uri:        doc.URI,
-		path:       doc.Path,
-		version:    doc.Version,
-		moduleKind: doc.ModuleKind,
-		source:     source,
-		sourceHash: sha256.Sum256([]byte(source)),
-		lines:      strings.Split(normalized, "\n"),
+		uri:           doc.URI,
+		path:          doc.Path,
+		version:       doc.Version,
+		moduleKind:    doc.ModuleKind,
+		source:        source,
+		sourceHash:    sha256.Sum256([]byte(source)),
+		lines:         strings.Split(normalized, "\n"),
+		parseDocument: ast.ParseDocument,
 	}
 }
 
@@ -201,12 +216,52 @@ func (s *AnalysisSnapshot) identifiers() [][]byteSpan {
 	return s.semanticIdentifiers
 }
 
+// ParsedDocument returns the snapshot-owned tree-sitter state, creating it at
+// most once for this document revision. Callers must not close the returned
+// document; the snapshot owns its lifecycle and retires it exactly once.
+func (s *AnalysisSnapshot) ParsedDocument() (*ast.ParsedDocument, error) {
+	if s == nil {
+		return nil, errAnalysisSnapshotRetired
+	}
+	s.parsedMu.Lock()
+	defer s.parsedMu.Unlock()
+	if s.parsedDocument != nil || s.parsedErr != nil {
+		return s.parsedDocument, s.parsedErr
+	}
+	if s.retired.Load() {
+		return nil, errAnalysisSnapshotRetired
+	}
+	parse := s.parseDocument
+	if parse == nil {
+		parse = ast.ParseDocument
+	}
+	s.parsedDocument, s.parsedErr = parse(s.path, []byte(s.source))
+	if s.parsedDocument != nil {
+		s.parseCount.Add(1)
+	}
+	return s.parsedDocument, s.parsedErr
+}
+
+// ParseCount reports how many document-owned parses this snapshot created.
+// It exists for diagnostics benchmarking and regression tests.
+func (s *AnalysisSnapshot) ParseCount() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.parseCount.Load()
+}
+
 // Retire marks the snapshot as no longer owned by its publisher.
 // It is idempotent and is the cleanup boundary for future owned resources.
 func (s *AnalysisSnapshot) Retire() {
-	if s != nil {
-		s.retired.Store(true)
+	if s == nil || !s.retired.CompareAndSwap(false, true) {
+		return
 	}
+	s.parsedMu.Lock()
+	if s.parsedDocument != nil {
+		s.parsedDocument.Close()
+	}
+	s.parsedMu.Unlock()
 }
 
 func (s *AnalysisSnapshot) Retired() bool { return s != nil && s.retired.Load() }
@@ -216,6 +271,18 @@ func analysisSnapshotForDocument(doc Document) *AnalysisSnapshot {
 		return doc.Snapshot
 	}
 	return nil
+}
+
+func parsedDocumentForDocument(doc Document) (*ast.ParsedDocument, func(), error) {
+	if snapshot := analysisSnapshotForDocument(doc); snapshot != nil {
+		parsed, err := snapshot.ParsedDocument()
+		return parsed, func() {}, err
+	}
+	parsed, err := ast.ParseDocument(doc.Path, []byte(doc.Source))
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return parsed, parsed.Close, nil
 }
 
 func documentLines(doc Document) []string {

--- a/internal/vba/intel/analysis_snapshot_test.go
+++ b/internal/vba/intel/analysis_snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/doccomments"
 )
 
@@ -129,5 +130,32 @@ func TestAnalysisSnapshotCachesDeterministicSymbolErrorAndRetires(t *testing.T) 
 	snapshot.Retire()
 	if !snapshot.Retired() {
 		t.Fatal("snapshot was not retired")
+	}
+}
+
+func TestAnalysisSnapshotSharesOneParsedDocumentAcrossDiagnosticsSymbolsAndSemanticTokens(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{
+		URI:        "file:///Main.bas",
+		Path:       "Main.bas",
+		ModuleKind: "standard",
+		Version:    1,
+		Source:     "Attribute VB_Name = \"Main\"\nOption Explicit\nPublic Sub Run()\n  Dim found As Range\n  Set found = Range(\"A1\").Find(What:=\"x\")\n  Debug.Print found.Value\nEnd Sub\n",
+	})
+	var parses atomic.Int32
+	snapshot.parseDocument = func(path string, source []byte) (*vbaast.ParsedDocument, error) {
+		parses.Add(1)
+		return vbaast.ParseDocument(path, source)
+	}
+	doc := snapshot.Document()
+	analyzer := newTestAnalyzer(t)
+	_ = analyzer.Diagnostics(doc)
+	if _, err := analyzer.DocumentSymbols(doc); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := analyzer.SemanticTokens(doc, []Document{doc}); err != nil {
+		t.Fatal(err)
+	}
+	if parses.Load() != 1 || snapshot.ParseCount() != 1 {
+		t.Fatalf("parsed documents = factory:%d snapshot:%d, want 1", parses.Load(), snapshot.ParseCount())
 	}
 }

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -164,7 +164,12 @@ func (a Analyzer) DiagnosticsContext(ctx context.Context, doc Document) []Diagno
 	if ctx.Err() != nil {
 		return nil
 	}
-	issues, err := lint.Linter{RootDir: a.RootDir, Config: a.Config}.LintSource(doc.Path, []byte(doc.Source))
+	parsed, closeParsed, err := parsedDocumentForDocument(doc)
+	if err != nil {
+		return []Diagnostic{lineDiagnostic("VBA000", "error", 0, err.Error())}
+	}
+	defer closeParsed()
+	issues, err := lint.Linter{RootDir: a.RootDir, Config: a.Config}.LintParsed(parsed)
 	if ctx.Err() != nil {
 		return nil
 	}
@@ -184,7 +189,7 @@ func (a Analyzer) DiagnosticsContext(ctx context.Context, doc Document) []Diagno
 	if ctx.Err() != nil {
 		return nil
 	}
-	findings, err := analyze.SourceRealtimeFindings(a.RootDir, doc.Path, a.Config, []byte(doc.Source))
+	findings, err := analyze.SourceRealtimeFindingsParsed(a.RootDir, a.Config, parsed)
 	if ctx.Err() != nil {
 		return nil
 	}
@@ -222,7 +227,7 @@ func (a Analyzer) DiagnosticsContext(ctx context.Context, doc Document) []Diagno
 	if ctx.Err() != nil {
 		return nil
 	}
-	out = append(out, a.documentationDiagnostics(doc)...)
+	out = append(out, a.documentationDiagnosticsParsed(doc, parsed)...)
 	if ctx.Err() != nil {
 		return nil
 	}
@@ -230,8 +235,17 @@ func (a Analyzer) DiagnosticsContext(ctx context.Context, doc Document) []Diagno
 }
 
 func (a Analyzer) DocumentSymbols(doc Document) ([]Symbol, error) {
+	parsed, closeParsed, err := parsedDocumentForDocument(doc)
+	if err != nil {
+		return nil, err
+	}
+	defer closeParsed()
+	return a.documentSymbolsParsed(doc, parsed)
+}
+
+func (a Analyzer) documentSymbolsParsed(doc Document, parsed *ast.ParsedDocument) ([]Symbol, error) {
 	load := func() ([]Symbol, error) {
-		return a.inspectDocumentSourceSymbols(doc)
+		return a.inspectDocumentSourceSymbols(doc, parsed)
 	}
 	var sourceSymbols []Symbol
 	var err error
@@ -252,14 +266,14 @@ func (a Analyzer) DocumentSymbols(doc Document) ([]Symbol, error) {
 	return out, nil
 }
 
-func (a Analyzer) inspectDocumentSourceSymbols(doc Document) ([]Symbol, error) {
-	file, err := symbols.InspectSource(symbols.SourceOptions{
+func (a Analyzer) inspectDocumentSourceSymbols(doc Document, parsed *ast.ParsedDocument) ([]Symbol, error) {
+	file, err := symbols.InspectParsed(symbols.SourceOptions{
 		RootDir:        a.RootDir,
 		Path:           doc.Path,
 		ModuleKind:     doc.ModuleKind,
 		IncludePrivate: true,
 		IncludeLabels:  true,
-	}, []byte(doc.Source))
+	}, parsed)
 	if err != nil {
 		return nil, err
 	}
@@ -1268,8 +1282,8 @@ func (line logicalCallAnalysisLine) positionForOffset(offset int) (int, int) {
 	return segment.Line, utf16Len(segment.Text[:column])
 }
 
-func (a Analyzer) documentationDiagnostics(doc Document) []Diagnostic {
-	syms, err := a.DocumentSymbols(doc)
+func (a Analyzer) documentationDiagnosticsParsed(doc Document, parsed *ast.ParsedDocument) []Diagnostic {
+	syms, err := a.documentSymbolsParsed(doc, parsed)
 	if err != nil {
 		return nil
 	}

--- a/internal/vba/symbols/symbols.go
+++ b/internal/vba/symbols/symbols.go
@@ -188,6 +188,21 @@ func Inspect(opts Options) (*Result, error) {
 }
 
 func InspectSource(opts SourceOptions, source []byte) (FileResult, error) {
+	path := opts.Path
+	if strings.TrimSpace(path) == "" {
+		path = "Untitled.bas"
+	}
+	doc, err := vbaast.ParseDocument(path, source)
+	if err != nil {
+		return FileResult{}, err
+	}
+	defer doc.Close()
+	return InspectParsed(opts, doc)
+}
+
+// InspectParsed extracts symbols from a caller-owned parsed VBA document. It
+// does not close doc or retain tree-sitter nodes after its read callback.
+func InspectParsed(opts SourceOptions, doc *vbaast.ParsedDocument) (FileResult, error) {
 	rootDir := opts.RootDir
 	if rootDir == "" {
 		rootDir = "."
@@ -196,50 +211,48 @@ func InspectSource(opts SourceOptions, source []byte) (FileResult, error) {
 	if err != nil {
 		return FileResult{}, err
 	}
-	path := opts.Path
-	if strings.TrimSpace(path) == "" {
-		path = "Untitled.bas"
-	}
-	moduleKind := opts.ModuleKind
-	if moduleKind == "" {
-		moduleKind = kindForPath(rootDir, config.Config{}, path)
-	}
-	parser, err := vbaast.NewParser()
-	if err != nil {
-		return FileResult{}, err
-	}
-	defer parser.Close()
-	parsed := parser.Parse(path, source)
-	defer parsed.Close()
-	rel := displayPath(rootDir, path)
-	if !filepath.IsAbs(path) {
-		rel = filepath.ToSlash(path)
-	}
-	moduleName, attrs := moduleMetadata(path, parsed.Source)
-	ext := extractor{
-		opts: Options{
-			RootDir:        rootDir,
-			IncludePrivate: opts.IncludePrivate,
-			IncludeLabels:  opts.IncludeLabels,
-		},
-		rootDir:     rootDir,
-		source:      parsed.Source,
-		sourceLines: doccomments.NormalizedLines(string(parsed.Source)),
-		file:        rel,
-		moduleName:  moduleName,
-		moduleKind:  moduleKind,
-		attrs:       attrs,
-	}
-	return FileResult{
-		Path:       rel,
-		ModuleName: moduleName,
-		ModuleKind: moduleKind,
-		Parse: ParseSummary{
-			HasError:   parsed.HasError,
-			HasMissing: parsed.HasMissing,
-		},
-		Symbols: ext.extract(parsed.Root),
-	}, nil
+	var result FileResult
+	err = doc.Read(func(view vbaast.ParsedView) error {
+		path := opts.Path
+		if strings.TrimSpace(path) == "" {
+			path = view.Path
+		}
+		if strings.TrimSpace(path) == "" {
+			path = "Untitled.bas"
+		}
+		moduleKind := opts.ModuleKind
+		if moduleKind == "" {
+			moduleKind = kindForPath(rootDir, config.Config{}, path)
+		}
+		rel := displayPath(rootDir, path)
+		if !filepath.IsAbs(path) {
+			rel = filepath.ToSlash(path)
+		}
+		moduleName, attrs := moduleMetadata(path, view.Source)
+		ext := extractor{
+			opts: Options{
+				RootDir:        rootDir,
+				IncludePrivate: opts.IncludePrivate,
+				IncludeLabels:  opts.IncludeLabels,
+			},
+			rootDir:     rootDir,
+			source:      view.Source,
+			sourceLines: doccomments.NormalizedLines(string(view.Source)),
+			file:        rel,
+			moduleName:  moduleName,
+			moduleKind:  moduleKind,
+			attrs:       attrs,
+		}
+		result = FileResult{
+			Path:       rel,
+			ModuleName: moduleName,
+			ModuleKind: moduleKind,
+			Parse:      ParseSummary{HasError: view.HasError, HasMissing: view.HasMissing},
+			Symbols:    ext.extract(view.Root),
+		}
+		return nil
+	})
+	return result, err
 }
 
 func discoverFiles(opts Options) ([]fileCandidate, error) {

--- a/internal/vba/symbols/symbols_test.go
+++ b/internal/vba/symbols/symbols_test.go
@@ -4,11 +4,35 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 )
+
+func TestInspectParsedMatchesInspectSource(t *testing.T) {
+	dir := t.TempDir()
+	opts := SourceOptions{RootDir: dir, Path: "Main.bas", ModuleKind: "standard", IncludePrivate: true, IncludeLabels: true}
+	source := []byte("Attribute VB_Name = \"Main\"\nOption Explicit\nPublic Sub Run()\n10: Debug.Print \"ok\"\nEnd Sub\n")
+	want, err := InspectSource(opts, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := vbaast.ParseDocument(opts.Path, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+	got, err := InspectParsed(opts, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("InspectParsed = %+v, want %+v", got, want)
+	}
+}
 
 func TestInspectExtractsRepresentativeStandardModuleSymbols(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Add lifecycle-managed parsed VBA documents with serialized tree access
- Reuse one parsed document across diagnostics, linting, analysis, and symbol extraction
- Add regression tests and parse-count benchmark metrics

## Testing
- Added unit tests verifying parsed and source APIs produce identical results
- Added unit tests for document lifecycle, snapshot reuse, and shared parsing