### PR TITLE
Add indexed procedure, assignment, and With block lookups

### DIFF
--- a/internal/vba/intel/analysis_snapshot.go
+++ b/internal/vba/intel/analysis_snapshot.go
@@ -41,6 +41,10 @@ type AnalysisSnapshot struct {
 	symbols     []Symbol
 	symbolsErr  error
 
+	indexOnce sync.Once
+	index     *documentIndex
+	indexErr  error
+
 	semanticOnce        sync.Once
 	semanticIdentifiers [][]byteSpan
 
@@ -201,6 +205,30 @@ func (s *AnalysisSnapshot) SourceSymbols(load DocumentSymbolLoader) ([]Symbol, b
 		s.symbolsErr = err
 	})
 	return cloneAnalysisSymbols(s.symbols), initialized, s.symbolsErr
+}
+
+// documentIndex returns the immutable lookup index for this snapshot. The
+// caller supplies the same symbol loader used by document analysis so custom
+// analyzers and the normal source-symbol cache retain identical semantics.
+func (s *AnalysisSnapshot) documentIndex(load DocumentSymbolLoader) (*documentIndex, bool, error) {
+	if s == nil {
+		return nil, false, errAnalysisSnapshotRetired
+	}
+	initialized := true
+	s.indexOnce.Do(func() {
+		initialized = false
+		s.initProcedures()
+		_, _, err := s.SourceSymbols(load)
+		if err != nil {
+			s.indexErr = err
+			return
+		}
+		// SourceSymbols returns a defensive copy to public callers. The snapshot
+		// owns s.symbols and never mutates it after symbolsOnce completes, so the
+		// internal index can safely avoid a second full clone.
+		s.index = buildDocumentIndex(s.source, s.lines, s.procedures, s.procedureLines, s.symbols)
+	})
+	return s.index, initialized, s.indexErr
 }
 
 func (s *AnalysisSnapshot) identifiers() [][]byteSpan {

--- a/internal/vba/intel/analysis_snapshot_test.go
+++ b/internal/vba/intel/analysis_snapshot_test.go
@@ -159,3 +159,39 @@ func TestAnalysisSnapshotSharesOneParsedDocumentAcrossDiagnosticsSymbolsAndSeman
 		t.Fatalf("parsed documents = factory:%d snapshot:%d, want 1", parses.Load(), snapshot.ParseCount())
 	}
 }
+
+func TestAnalysisSnapshotDocumentIndexIsLazyAndReused(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{
+		URI: "file:///Main.bas", Path: "Main.bas", Version: 7,
+		Source: "Sub First()\n  Dim item As Object\n  Set item = New Collection\n  With item\n    .Count\n  End With\nEnd Sub\n",
+	})
+	var loads atomic.Int32
+	load := func() ([]Symbol, error) {
+		loads.Add(1)
+		return []Symbol{{
+			Name: "item", Kind: "local_variable", Parent: "First", ReturnType: "Object",
+			Range: Range{Start: Position{Line: 1}, End: Position{Line: 1, Character: 17}},
+		}}, nil
+	}
+	first, hit, err := snapshot.documentIndex(load)
+	if err != nil || hit {
+		t.Fatalf("first document index = (hit=%v, err=%v)", hit, err)
+	}
+	second, hit, err := snapshot.documentIndex(load)
+	if err != nil || !hit || first != second {
+		t.Fatalf("reused document index = (same=%v, hit=%v, err=%v)", first == second, hit, err)
+	}
+	if loads.Load() != 1 {
+		t.Fatalf("symbol loads = %d, want 1", loads.Load())
+	}
+	if got := first.symbolsByName["item"]; len(got) != 1 || got[0].Parent != "First" {
+		t.Fatalf("indexed declarations = %+v", got)
+	}
+	first.initAssignments()
+	if got := first.assignmentsByName["item"]; len(got) != 1 || got[0].expression != "New Collection" || got[0].procedure != "First" {
+		t.Fatalf("indexed assignments = %+v", got)
+	}
+	if block, ok := first.withBlockAt(Position{Line: 4}); !ok || first.withBlocks[block].receiver != "item" {
+		t.Fatalf("indexed With block = (%d, %v, %+v)", block, ok, first.withBlocks)
+	}
+}

--- a/internal/vba/intel/document_index.go
+++ b/internal/vba/intel/document_index.go
@@ -1,0 +1,228 @@
+package intel
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var (
+	setAssignmentIndexRe = regexp.MustCompile(`(?im)\bSet\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([^\r\n:]+)`)
+	withStartIndexRe     = regexp.MustCompile(`(?i)^With\s+(.+)$`)
+	withEndIndexRe       = regexp.MustCompile(`(?i)^End\s+With\b`)
+	newAssignmentExprRe  = regexp.MustCompile(`(?i)^New\s+([A-Za-z_][A-Za-z0-9_.]*)\b`)
+	createObjectExprRe   = regexp.MustCompile(`(?i)^CreateObject\s*\(\s*"([^"]+)"\s*\)`)
+)
+
+// documentIndex lazily initializes each derived lookup at most once and never
+// mutates it afterward. All lookup keys are folded because VBA identifiers are
+// case-insensitive.
+type documentIndex struct {
+	source         string
+	procedures     []ProcedureInfo
+	procedureLines []int
+
+	symbolsByName map[string][]Symbol
+	withBlocks    []withBlockRange
+	withByLine    []int
+
+	assignmentsOnce   sync.Once
+	assignmentsByName map[string][]typedAssignment
+}
+
+type typedAssignment struct {
+	name       string
+	procedure  string
+	position   Position
+	offset     int
+	expression string
+}
+
+type withBlockRange struct {
+	receiver string
+	parent   int
+	range_   Range
+}
+
+func indexName(name string) string { return strings.ToLower(strings.TrimSpace(name)) }
+
+func buildDocumentIndex(source string, lines []string, procedures []ProcedureInfo, procedureLines []int, symbols []Symbol) *documentIndex {
+	idx := &documentIndex{
+		source:         source,
+		procedures:     append([]ProcedureInfo(nil), procedures...),
+		procedureLines: append([]int(nil), procedureLines...),
+		symbolsByName:  make(map[string][]Symbol),
+		withByLine:     make([]int, len(lines)),
+	}
+	for i := range idx.withByLine {
+		idx.withByLine[i] = -1
+	}
+	for _, sym := range symbols {
+		idx.addSymbol(sym)
+		if procedureReturnSymbol(sym) {
+			idx.addSymbol(Symbol{
+				Name:       sym.Name,
+				Kind:       "function_return",
+				ReturnType: sym.ReturnType,
+				File:       sym.File,
+				Parent:     sym.Name,
+				Range:      sym.Range,
+				Selection:  sym.Selection,
+			})
+		}
+	}
+	idx.buildWithBlocks(lines)
+	return idx
+}
+
+func (idx *documentIndex) initAssignments() {
+	if idx == nil {
+		return
+	}
+	idx.assignmentsOnce.Do(func() {
+		idx.assignmentsByName = make(map[string][]typedAssignment)
+		for _, match := range setAssignmentIndexRe.FindAllStringSubmatchIndex(idx.source, -1) {
+			if len(match) < 6 || match[2] < 0 || match[3] < 0 || match[4] < 0 || match[5] < 0 {
+				continue
+			}
+			raw := stripLineComment(idx.source[match[4]:match[5]])
+			expr := strings.TrimSpace(raw)
+			if expr == "" {
+				continue
+			}
+			exprOffset := match[4] + strings.Index(raw, expr)
+			name := idx.source[match[2]:match[3]]
+			position := positionForByteOffset(idx.source, match[0])
+			idx.assignmentsByName[indexName(name)] = append(idx.assignmentsByName[indexName(name)], typedAssignment{
+				name:       name,
+				procedure:  procedureNameAt(idx.procedures, idx.procedureLines, position),
+				position:   position,
+				offset:     exprOffset,
+				expression: expr,
+			})
+		}
+	})
+}
+
+func (idx *documentIndex) addSymbol(sym Symbol) {
+	if idx == nil || indexName(sym.Name) == "" {
+		return
+	}
+	key := indexName(sym.Name)
+	idx.symbolsByName[key] = append(idx.symbolsByName[key], sym)
+}
+
+func procedureReturnSymbol(sym Symbol) bool {
+	return sym.ReturnType != "" && (strings.EqualFold(sym.Kind, "function") || strings.EqualFold(sym.Kind, "property_get"))
+}
+
+func (idx *documentIndex) buildWithBlocks(lines []string) {
+	stack := make([]int, 0)
+	for lineNo, line := range lines {
+		if len(stack) > 0 {
+			idx.withByLine[lineNo] = stack[len(stack)-1]
+		}
+		text := strings.TrimSpace(stripLineComment(line))
+		if text == "" {
+			continue
+		}
+		if withEndIndexRe.MatchString(text) {
+			if len(stack) > 0 {
+				block := stack[len(stack)-1]
+				idx.withBlocks[block].range_.End = Position{Line: lineNo, Character: utf16Len(line)}
+				stack = stack[:len(stack)-1]
+			}
+			continue
+		}
+		match := withStartIndexRe.FindStringSubmatch(text)
+		if len(match) == 0 {
+			continue
+		}
+		parent := -1
+		if len(stack) > 0 {
+			parent = stack[len(stack)-1]
+		}
+		idx.withBlocks = append(idx.withBlocks, withBlockRange{
+			receiver: strings.TrimSpace(match[1]), parent: parent,
+			range_: Range{Start: Position{Line: lineNo}, End: Position{Line: len(lines)}},
+		})
+		stack = append(stack, len(idx.withBlocks)-1)
+	}
+}
+
+func (idx *documentIndex) withBlockAt(pos Position) (int, bool) {
+	if idx == nil || pos.Line < 0 || pos.Line >= len(idx.withByLine) {
+		return 0, false
+	}
+	block := idx.withByLine[pos.Line]
+	if block < 0 || block >= len(idx.withBlocks) {
+		return 0, false
+	}
+	return block, true
+}
+
+func (idx *documentIndex) nearestAssignment(name, procedure string, pos Position) (typedAssignment, bool) {
+	if idx == nil {
+		return typedAssignment{}, false
+	}
+	idx.initAssignments()
+	assignments := idx.assignmentsByName[indexName(name)]
+	for i := len(assignments) - 1; i >= 0; i-- {
+		if comparePosition(assignments[i].position, pos) <= 0 && (procedure == "" || assignments[i].procedure == "" || strings.EqualFold(assignments[i].procedure, procedure)) {
+			return assignments[i], true
+		}
+	}
+	return typedAssignment{}, false
+}
+
+func procedureNameAt(procedures []ProcedureInfo, procedureLines []int, pos Position) string {
+	if pos.Line < 0 || pos.Line >= len(procedureLines) {
+		return ""
+	}
+	index := procedureLines[pos.Line]
+	if index < 0 || index >= len(procedures) {
+		return ""
+	}
+	return procedures[index].Name
+}
+
+func procedureIndexForLines(lines []string) ([]ProcedureInfo, []int) {
+	procedureLines := make([]int, len(lines))
+	for i := range procedureLines {
+		procedureLines[i] = -1
+	}
+	procedures := make([]ProcedureInfo, 0)
+	depth, active := 0, -1
+	for lineNo, line := range lines {
+		text := strings.TrimSpace(line[:codeLimit(line)])
+		if text == "" {
+			continue
+		}
+		lower := strings.ToLower(text)
+		switch {
+		case strings.HasPrefix(lower, "end sub") || strings.HasPrefix(lower, "end function") || strings.HasPrefix(lower, "end property"):
+			if depth > 0 {
+				depth--
+			}
+			if depth == 0 && active >= 0 {
+				procedures[active].Range.End = Position{Line: lineNo, Character: utf16Len(line)}
+				active = -1
+			}
+		case procedureStartLine(lower):
+			depth++
+			if depth == 1 {
+				if name := procedureNameFromLine(text); name != "" {
+					procedures = append(procedures, ProcedureInfo{Name: name, Range: Range{Start: Position{Line: lineNo}, End: Position{Line: len(lines)}}})
+					active = len(procedures) - 1
+				}
+			}
+		}
+	}
+	for index, procedure := range procedures {
+		lastLine := min(procedure.Range.End.Line, len(procedureLines)-1)
+		for lineNo := procedure.Range.Start.Line; lineNo <= lastLine && lineNo >= 0; lineNo++ {
+			procedureLines[lineNo] = index
+		}
+	}
+	return procedures, procedureLines
+}

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -3155,7 +3155,14 @@ func (a Analyzer) inferWordTypeInfoAtContext(doc Document, word string, offset i
 		index = ctx.index
 	}
 	if index == nil {
-		index, _ = a.documentIndexFor(doc)
+		var ok bool
+		index, ok = a.documentIndexFor(doc)
+		if !ok || index == nil {
+			if declared != "" {
+				return inferredType{Type: declared, Source: "declaration"}, true
+			}
+			return inferredType{}, false
+		}
 	}
 	lookupOffset := offset
 	if lookupOffset < 0 {
@@ -3200,7 +3207,7 @@ func (a Analyzer) visibleSymbolTypeInfoAtContext(doc Document, word string, offs
 	}
 	var fallback inferredType
 	for _, sym := range syms {
-		if sym.ReturnType == "" || !a.visibleDefinitionSymbol(doc, currentProcedure, sym) {
+		if !strings.EqualFold(sym.Name, word) || sym.ReturnType == "" || !a.visibleDefinitionSymbol(doc, currentProcedure, sym) {
 			continue
 		}
 		inferred := inferredType{Type: sym.ReturnType, Source: "declaration"}
@@ -3455,7 +3462,11 @@ func (a Analyzer) withBlockTypeAtContext(doc Document, pos Position, offset int,
 		index = ctx.index
 	}
 	if index == nil {
-		index, _ = a.documentIndexFor(doc)
+		var ok bool
+		index, ok = a.documentIndexFor(doc)
+		if !ok || index == nil {
+			return "", false
+		}
 	}
 	block, ok := index.withBlockAt(pos)
 	if !ok {

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -2951,13 +2951,15 @@ type documentTypeContext struct {
 	symbols         []Symbol
 	procedures      []procedureScope
 	procedureByLine []int
+	index           *documentIndex
 }
 
-func newDocumentTypeContext(doc Document, lines []string, symbols []Symbol) *documentTypeContext {
+func newDocumentTypeContext(doc Document, lines []string, symbols []Symbol, index *documentIndex) *documentTypeContext {
 	ctx := &documentTypeContext{
 		lines:           lines,
 		symbols:         symbols,
 		procedureByLine: make([]int, len(lines)),
+		index:           index,
 	}
 	for i := range ctx.procedureByLine {
 		ctx.procedureByLine[i] = -1
@@ -3009,6 +3011,28 @@ func newDocumentTypeContext(doc Document, lines []string, symbols []Symbol) *doc
 		}
 	}
 	return ctx
+}
+
+func (a Analyzer) documentIndexFor(doc Document) (*documentIndex, bool) {
+	load := func() ([]Symbol, error) {
+		parsed, closeParsed, err := parsedDocumentForDocument(doc)
+		if err != nil {
+			return nil, err
+		}
+		defer closeParsed()
+		return a.inspectDocumentSourceSymbols(doc, parsed)
+	}
+	if snapshot := analysisSnapshotForDocument(doc); snapshot != nil {
+		index, _, err := snapshot.documentIndex(load)
+		return index, err == nil && index != nil
+	}
+	syms, err := load()
+	if err != nil {
+		return nil, false
+	}
+	lines := documentLines(doc)
+	procedures, procedureLines := procedureIndexForLines(lines)
+	return buildDocumentIndex(doc.Source, lines, procedures, procedureLines, syms), true
 }
 
 func (c *documentTypeContext) procedureAt(pos Position) (string, *Range) {
@@ -3123,30 +3147,31 @@ func (a Analyzer) inferWordTypeInfoAtContext(doc Document, word string, offset i
 			return inferredType{}, false
 		}
 	}
-	declRe := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(word) + `\b(?:\s*\([^)]*\))?\s+As\s+(?:New\s+)?([A-Za-z_][A-Za-z0-9_.]*)`)
-	if declared == "" {
-		if typ, ok := bestTypeMatch(doc.Source, declRe, offset, 1); ok {
-			declared = typ
-			if !isObjectFallbackType(declared) {
-				return inferredType{Type: declared, Source: "declaration"}, true
-			}
-		}
-	}
 	if declared != "" && !isObjectFallbackType(declared) {
 		return inferredType{Type: declared, Source: "declaration"}, true
 	}
-	newRe := regexp.MustCompile(`(?i)\bSet\s+` + regexp.QuoteMeta(word) + `\s*=\s*New\s+([A-Za-z_][A-Za-z0-9_.]*)`)
-	if typ, ok := bestTypeMatch(doc.Source, newRe, offset, 1); ok {
-		return inferredType{Type: typ, Source: "inferred from Set New"}, true
+	index := (*documentIndex)(nil)
+	if ctx != nil {
+		index = ctx.index
 	}
-	createRe := regexp.MustCompile(`(?i)\bSet\s+` + regexp.QuoteMeta(word) + `\s*=\s*CreateObject\s*\(\s*"([^"]+)"\s*\)`)
-	if progID, ok := bestTypeMatch(doc.Source, createRe, offset, 1); ok {
-		if typ, ok := a.DB.ResolveProgID(progID); ok {
-			return inferredType{Type: typ.Name, Source: "inferred from CreateObject"}, true
+	if index == nil {
+		index, _ = a.documentIndexFor(doc)
+	}
+	lookupOffset := offset
+	if lookupOffset < 0 {
+		lookupOffset = len(doc.Source)
+	}
+	lookupPosition := positionForByteOffset(doc.Source, lookupOffset)
+	if assignment, ok := index.nearestAssignment(word, currentProcedureNameAt(doc, lookupPosition, ctx), lookupPosition); ok {
+		if match := newAssignmentExprRe.FindStringSubmatch(assignment.expression); len(match) == 2 {
+			return inferredType{Type: match[1], Source: "inferred from Set New"}, true
 		}
-	}
-	if expr, exprOffset, ok := bestSetAssignmentExpression(doc.Source, word, offset); ok {
-		if typ, ok := a.resolveDocumentExpressionTypeAtContext(doc, expr, exprOffset, ctx); ok {
+		if match := createObjectExprRe.FindStringSubmatch(assignment.expression); len(match) == 2 {
+			if typ, ok := a.DB.ResolveProgID(match[1]); ok {
+				return inferredType{Type: typ.Name, Source: "inferred from CreateObject"}, true
+			}
+		}
+		if typ, ok := a.resolveDocumentExpressionTypeAtContext(doc, assignment.expression, assignment.offset, ctx); ok {
 			return inferredType{Type: typ, Source: "inferred from Set assignment"}, true
 		}
 	}
@@ -3161,21 +3186,25 @@ func (a Analyzer) visibleSymbolTypeInfoAtContext(doc Document, word string, offs
 	currentProcedure := currentProcedureNameAt(doc, pos, ctx)
 	var syms []Symbol
 	if ctx != nil {
-		syms = ctx.symbols
+		if ctx.index != nil {
+			syms = ctx.index.symbolsByName[indexName(word)]
+		} else {
+			syms = ctx.symbols
+		}
 	} else {
-		var err error
-		syms, err = a.DocumentSymbols(doc)
-		if err != nil {
+		index, ok := a.documentIndexFor(doc)
+		if !ok {
 			return inferredType{}, false
 		}
+		syms = index.symbolsByName[indexName(word)]
 	}
 	var fallback inferredType
 	for _, sym := range syms {
-		if !strings.EqualFold(sym.Name, word) || sym.ReturnType == "" || !a.visibleDefinitionSymbol(doc, currentProcedure, sym) {
+		if sym.ReturnType == "" || !a.visibleDefinitionSymbol(doc, currentProcedure, sym) {
 			continue
 		}
 		inferred := inferredType{Type: sym.ReturnType, Source: "declaration"}
-		if isLocalSymbol(sym) {
+		if isLocalSymbol(sym) || strings.EqualFold(sym.Kind, "function_return") {
 			return inferred, true
 		}
 		if fallback.Type == "" {
@@ -3421,34 +3450,31 @@ func (a Analyzer) withBlockTypeAt(doc Document, pos Position, offset int) (strin
 }
 
 func (a Analyzer) withBlockTypeAtContext(doc Document, pos Position, offset int, ctx *documentTypeContext) (string, bool) {
-	lines := documentLines(doc)
+	index := (*documentIndex)(nil)
 	if ctx != nil {
-		lines = ctx.lines
+		index = ctx.index
 	}
-	if pos.Line <= 0 || pos.Line > len(lines) {
+	if index == nil {
+		index, _ = a.documentIndexFor(doc)
+	}
+	block, ok := index.withBlockAt(pos)
+	if !ok {
 		return "", false
 	}
+	chain := make([]int, 0, 4)
+	for block >= 0 {
+		chain = append(chain, block)
+		block = index.withBlocks[block].parent
+	}
 	var stack []string
-	for lineNo := 0; lineNo < pos.Line; lineNo++ {
-		trimmed := strings.TrimSpace(stripLineComment(lines[lineNo]))
-		if trimmed == "" {
-			continue
-		}
-		if regexp.MustCompile(`(?i)^End\s+With\b`).MatchString(trimmed) {
-			if len(stack) > 0 {
-				stack = stack[:len(stack)-1]
-			}
-			continue
-		}
-		m := regexp.MustCompile(`(?i)^With\s+(.+)$`).FindStringSubmatch(trimmed)
-		if len(m) == 0 {
-			continue
-		}
-		if typ, ok := a.resolveWithExpressionTypeAtContext(doc, strings.TrimSpace(m[1]), stack, offset, ctx); ok {
-			stack = append(stack, typ)
-		} else {
+	for i := len(chain) - 1; i >= 0; i-- {
+		candidate := index.withBlocks[chain[i]]
+		typ, found := a.resolveWithExpressionTypeAtContext(doc, candidate.receiver, stack, offset, ctx)
+		if !found {
 			stack = append(stack, "")
+			continue
 		}
+		stack = append(stack, typ)
 	}
 	for i := len(stack) - 1; i >= 0; i-- {
 		if stack[i] != "" {
@@ -3511,53 +3537,6 @@ func stripLineComment(line string) string {
 		}
 	}
 	return line
-}
-
-func bestTypeMatch(source string, re *regexp.Regexp, offset int, group int) (string, bool) {
-	matches := re.FindAllStringSubmatchIndex(source, -1)
-	bestStart := -1
-	bestType := ""
-	for _, match := range matches {
-		if len(match) <= group*2+1 || match[group*2] < 0 || match[group*2+1] < 0 {
-			continue
-		}
-		start := match[0]
-		if offset >= 0 && start > offset {
-			continue
-		}
-		if bestStart < 0 || start > bestStart {
-			bestStart = start
-			bestType = source[match[group*2]:match[group*2+1]]
-		}
-	}
-	return bestType, bestType != ""
-}
-
-func bestSetAssignmentExpression(source, word string, offset int) (string, int, bool) {
-	re := regexp.MustCompile(`(?im)\bSet\s+` + regexp.QuoteMeta(word) + `\s*=\s*([^\r\n:]+)`)
-	matches := re.FindAllStringSubmatchIndex(source, -1)
-	bestStart := -1
-	bestExpr := ""
-	bestExprOffset := -1
-	for _, match := range matches {
-		if len(match) < 4 || match[2] < 0 || match[3] < 0 {
-			continue
-		}
-		start := match[0]
-		if offset >= 0 && start > offset {
-			continue
-		}
-		expr := strings.TrimSpace(stripLineComment(source[match[2]:match[3]]))
-		if expr == "" {
-			continue
-		}
-		if bestStart < 0 || start > bestStart {
-			bestStart = start
-			bestExpr = expr
-			bestExprOffset = match[2]
-		}
-	}
-	return bestExpr, bestExprOffset, bestExpr != ""
 }
 
 func (a Analyzer) collectionDefaultType(name string) (string, bool) {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -2,6 +2,7 @@ package intel
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2028,6 +2029,34 @@ End Sub
 	latestOffset := byteOffsetForPosition(source, Position{Line: 20, Character: utf16Len("    item")})
 	if got, ok := analyzer.inferWordTypeAt(doc, "item", latestOffset); !ok || got != "Scripting.Dictionary" {
 		t.Fatalf("latest item assignment type = %q, %v, want Scripting.Dictionary", got, ok)
+	}
+}
+
+func TestIndexedInferenceGracefullyHandlesUnavailableIndex(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	snapshot := NewAnalysisSnapshot(Document{
+		Path: "Main.bas", Version: 1,
+		Source: "Sub Test()\n    Dim item As Object\n    With item\n        .Value\n    End With\nEnd Sub\n",
+	})
+	want := errors.New("indexed symbols unavailable")
+	snapshot.indexOnce.Do(func() { snapshot.indexErr = want })
+	doc := snapshot.Document()
+	if got, ok := analyzer.inferWordTypeAt(doc, "item", len(doc.Source)); ok || got != "" {
+		t.Fatalf("inference with unavailable index = %q, %v, want no inference", got, ok)
+	}
+	if got, ok := analyzer.withBlockTypeAt(doc, Position{Line: 3}, len(doc.Source)); ok || got != "" {
+		t.Fatalf("With lookup with unavailable index = %q, %v, want no type", got, ok)
+	}
+}
+
+func TestVisibleSymbolTypeContextFallbackFiltersRequestedName(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{Path: "Main.bas", Source: "Sub Test()\nEnd Sub\n"}
+	ctx := newDocumentTypeContext(doc, documentLines(doc), []Symbol{{
+		Name: "other", Kind: "local_variable", Parent: "Test", ReturnType: "Excel.Range", File: "Main.bas",
+	}}, nil)
+	if got, ok := analyzer.visibleSymbolTypeInfoAtContext(doc, "target", 0, ctx); ok || got.Type != "" {
+		t.Fatalf("unrelated context symbol inferred %q, %v", got.Type, ok)
 	}
 }
 

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -1990,6 +1990,47 @@ End Sub
 	}
 }
 
+func TestIndexedInferenceRespectsProcedureScopeAssignmentsAndFunctionReturns(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	source := `Option Explicit
+Sub First()
+    Dim item As Object
+    Set item = New Collection
+End Sub
+
+Sub Second()
+    Dim item As Object
+    item.Co
+End Sub
+
+Function Build() As Object
+    Set Build = New Collection
+    Build.Co
+End Function
+
+Sub LatestAssignment()
+    Dim item As Object
+    Set item = New Collection
+    Set item = CreateObject("Scripting.Dictionary")
+    item.Ex
+End Sub
+`
+	doc := NewAnalysisSnapshot(Document{Path: filepath.Join(t.TempDir(), "Main.bas"), Source: source, Version: 1}).Document()
+
+	secondOffset := byteOffsetForPosition(source, Position{Line: 8, Character: utf16Len("    item")})
+	if got, ok := analyzer.inferWordTypeAt(doc, "item", secondOffset); !ok || got != "Object" {
+		t.Fatalf("Second.item type = %q, %v, want Object without First assignment", got, ok)
+	}
+	returnOffset := byteOffsetForPosition(source, Position{Line: 13, Character: utf16Len("    Build")})
+	if got, ok := analyzer.inferWordTypeAt(doc, "Build", returnOffset); !ok || got != "Collection" {
+		t.Fatalf("function return type = %q, %v, want Collection", got, ok)
+	}
+	latestOffset := byteOffsetForPosition(source, Position{Line: 20, Character: utf16Len("    item")})
+	if got, ok := analyzer.inferWordTypeAt(doc, "item", latestOffset); !ok || got != "Scripting.Dictionary" {
+		t.Fatalf("latest item assignment type = %q, %v, want Scripting.Dictionary", got, ok)
+	}
+}
+
 func TestPracticalWorkbookFileSystemAndWorksheetChains(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	source := `Option Explicit

--- a/internal/vba/intel/semantic.go
+++ b/internal/vba/intel/semantic.go
@@ -139,6 +139,7 @@ func (a Analyzer) SemanticTokens(doc Document, open []Document) ([]SemanticToken
 			identifiers[lineNo] = codeIdentifierSpans(line)
 		}
 	}
+	typeIndex, _ := a.documentIndexFor(doc)
 	builder := semanticBuilder{
 		analyzer:           a,
 		doc:                doc,
@@ -148,7 +149,7 @@ func (a Analyzer) SemanticTokens(doc Document, open []Document) ([]SemanticToken
 		workspaceSymbols:   workspaceSymbols,
 		workspaceSymbolsOK: workspaceSymbolsErr == nil,
 		identifiers:        identifiers,
-		typeContext:        newDocumentTypeContext(doc, lines, documentSymbols),
+		typeContext:        newDocumentTypeContext(doc, lines, documentSymbols, typeIndex),
 	}
 	builder.addLexicalTokens()
 	builder.addSymbolTokens()

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -75,3 +75,4 @@
 - Performance measurements for protocol handlers must include response encoding and serialization work performed before returning, not only the underlying analysis call.
 - Keep duplicated public capability lists synchronized with the server handler registration and advertised capabilities.
 - Work computed outside a cache/store lock must capture and validate a per-key publication generation before publishing. Compare document versions only inside the same open lifecycle; close/reopen boundaries and concurrent disk I/O need separate lifecycle/generation tokens so stale candidates cannot overwrite newer state.
+- When replacing repeated scans with a lazy index, treat index construction as fallible at every caller. Check both the returned status and pointer before lookup, and retain a safe declared-type fallback where one already exists.


### PR DESCRIPTION
## Summary
- Add lazy, reusable document indexes for symbols, assignments, procedures, and With blocks
- Make type inference respect procedure scope, latest assignments, function returns, and nested With blocks
- Reuse the index during semantic token analysis
- Gracefully fall back when a document index cannot be built

## Testing
- Added unit tests covering index reuse, scoped type inference, unavailable-index handling, and symbol-name filtering
- go test ./...

## Performance
Measured on Windows / 12th Gen Intel Core i7-12700 with go test ./internal/lspserver -run '^$' -bench 'BenchmarkLSP(Diagnostics|SemanticTokens)/(First|Repeated|Cold|AfterEdit)$' -benchmem -count=3.

| Benchmark | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Diagnostics / repeated | ~174 ms/op | ~65 ms/op | ~63% faster |
| Semantic tokens / cold | ~178 ms/op | ~171 ms/op | ~4% faster |
| Semantic tokens / after edit | ~35.5 ms/op | ~33.4 ms/op | ~6% faster |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved VBA type inference for object assignments, function returns, and repeated reassignments.
  * Analysis now respects procedure boundaries, preventing type information from leaking between procedures.
  * Improved symbol resolution and handling of nested With blocks.
  * Semantic highlighting and related analysis now provide more accurate results across complex documents.

* **Tests**
  * Added coverage for procedure-scoped assignments, function return values, symbol lookup, and With block detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
