### PR TITLE
Validate procedure-name constants against procedure names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.25.0
+
+- Added opt-in `VB044` lint diagnostics for local `PROCEDURE_NAME`-style constants whose direct string literals drift from their enclosing `Sub`, `Function`, or `Property` name. The `[lint.procedure_name_constant]` configuration supports standard, class, document, and UserForm modules; the LSP supplies a Quick Fix that updates only the string literal, while `xlflow lint` remains read-only.
 - Added opt-in `[vba.line_numbers].enabled` instrumentation for meaningful VBA `Erl` diagnostics: `push` injects fixed-width, space-padded physical line numbers only into temporary import copies, while `pull` strips recognized generated labels to keep tracked source unnumbered. Unsafe existing numeric labels and numeric `GoTo` / `GoSub` / `Resume` targets stop the operation without transformation; no new CLI flags were added.
 - Added LSP semantic-token delta responses with stable result IDs, a bounded per-open-document history, and automatic full-response fallback when a delta base is unavailable or not smaller on the wire.
 - Changed VBA LSP document synchronization to incremental UTF-16 ranged edits while retaining full-document replacements for client compatibility; document-version snapshots invalidate only the changed document, while semantic-token caches refresh when workspace symbols change.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -340,6 +340,11 @@ disabled_rules = []
 # Other project-wide lint rules remain disabled by default.
 # detect_unused_private_procedures = true # VB021
 
+# Optional local procedure-name constant check (VB044).
+# [lint.procedure_name_constant]
+# enabled = true
+# constant_name = "PROCEDURE_NAME"
+
 [analyze]
 disabled_rules = []
 ```
@@ -790,6 +795,7 @@ Core declaration, member-access, error-handling, Excel object, and procedure-sco
 - `VB041`: documentation comment lists duplicate or case-only duplicate parameters
 - `VB042`: documentation comment has `Returns:` on a `Sub`
 - `VB043`: documentation comment is not associated with any declaration
+- `VB044`: an enabled local procedure-name string constant does not exactly match its enclosing procedure name. The constant name comparison is case-insensitive; only direct string literals are checked.
 
 Projects that intentionally use interactive GUI entrypoints may set `[lint].disabled_rules = ["VB007"]` to suppress `VB007`. This changes lint behavior only; `run --headless` still rejects GUI boundaries during preflight.
 
@@ -803,7 +809,7 @@ Preflight-blocking diagnostics cannot be suppressed inline: `VB008` through `VB0
 
 Unknown inline suppression IDs are reported in command `warnings` as `unknown_inline_suppression_rule`. Known suppressions that do not suppress a diagnostic for the current command family are reported as `unused_inline_suppression`; `lint` evaluates `VB...` usage and `analyze` evaluates `VBA...` usage. Config-level `disabled_rules` remain global, while inline suppression is local to the annotated source line.
 
-Configurable lint rule IDs map to legacy keys as follows: `VB001` = `require_option_explicit`, `VB002` = `forbid_select`, `VB003` = `forbid_activate`, `VB004` = `forbid_on_error_resume_next`, `VB005` = `detect_implicit_variant`, `VB006` = `forbid_public_module_fields`, `VB007` = `forbid_interactive_input`, `VB018` = `detect_scope_shadowing`, `VB019` = `detect_multiple_declarator_clarity`, `VB020` = `detect_unused_local_variables`, `VB021` = `detect_unused_private_procedures`, `VB022` = `detect_confusing_call_syntax`, `VB023` = `detect_for_each_control_type`, `VB026` = `detect_dangerous_resume`, and `VB027` = `detect_nested_with_ambiguity`.
+Configurable lint rule IDs map to legacy keys as follows: `VB001` = `require_option_explicit`, `VB002` = `forbid_select`, `VB003` = `forbid_activate`, `VB004` = `forbid_on_error_resume_next`, `VB005` = `detect_implicit_variant`, `VB006` = `forbid_public_module_fields`, `VB007` = `forbid_interactive_input`, `VB018` = `detect_scope_shadowing`, `VB019` = `detect_multiple_declarator_clarity`, `VB020` = `detect_unused_local_variables`, `VB021` = `detect_unused_private_procedures`, `VB022` = `detect_confusing_call_syntax`, `VB023` = `detect_for_each_control_type`, `VB026` = `detect_dangerous_resume`, and `VB027` = `detect_nested_with_ambiguity`. `VB044` uses `[lint.procedure_name_constant]` instead of a legacy boolean; it is disabled by default, requires `constant_name` when enabled, and may be disabled through `[lint].disabled_rules`.
 
 Higher-signal lint rules `VB019`, `VB020`, `VB022`, `VB023`, and `VB026` are enabled by default. Heavier project-wide lint rules `VB018`, `VB021`, and `VB027` are disabled by default and can still be enabled with their legacy `[lint]` booleans during the compatibility window.
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.8.0
+
 - Added the `xlflow.lsp.performanceLogging` setting to opt into structured language server performance measurements.
 
 ## v0.7.0

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v0.8.0
 
 - Added the `xlflow.lsp.performanceLogging` setting to opt into structured language server performance measurements.
+- Restart the language server when `xlflow.toml` is created, changed, or deleted so project configuration changes apply immediately.
 
 ## v0.7.0
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xlflow-vscode",
   "displayName": "%extension.displayName%",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "%extension.description%",
   "categories": [
     "Formatters",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -133,6 +133,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const refreshFormulas = () => {
     void sidebar?.refreshFormulas();
   };
+  const refreshAfterConfigChange = () => {
+    void (async () => {
+      // The language server loads xlflow.toml at startup, so a project
+      // configuration change needs a full restart rather than only a view refresh.
+      await clientManager?.restart();
+      await refreshSelectedProject();
+    })();
+  };
   context.subscriptions.push(
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
       lastSelectedWorkspaceKey = selectedWorkspaceKey();
@@ -151,15 +159,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     configWatcher,
     formulasManifestWatcher,
     formulasJsonlWatcher,
-    configWatcher.onDidCreate(() => {
-      void refreshSelectedProject();
-    }),
-    configWatcher.onDidChange(() => {
-      void refreshSelectedProject();
-    }),
-    configWatcher.onDidDelete(() => {
-      void refreshSelectedProject();
-    }),
+    configWatcher.onDidCreate(refreshAfterConfigChange),
+    configWatcher.onDidChange(refreshAfterConfigChange),
+    configWatcher.onDidDelete(refreshAfterConfigChange),
     formulasManifestWatcher.onDidCreate(refreshFormulas),
     formulasManifestWatcher.onDidChange(refreshFormulas),
     formulasManifestWatcher.onDidDelete(refreshFormulas),

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -133,13 +133,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const refreshFormulas = () => {
     void sidebar?.refreshFormulas();
   };
+  let configRefreshPromise: Promise<void> = Promise.resolve();
   const refreshAfterConfigChange = () => {
-    void (async () => {
+    configRefreshPromise = configRefreshPromise.then(async () => {
       // The language server loads xlflow.toml at startup, so a project
       // configuration change needs a full restart rather than only a view refresh.
-      await clientManager?.restart();
-      await refreshSelectedProject();
-    })();
+      try {
+        await clientManager?.restart();
+      } catch (error) {
+        channels.output.error(`xlflow configuration refresh failed: ${String(error)}`);
+      }
+      try {
+        await refreshSelectedProject();
+      } catch (error) {
+        channels.output.error(`xlflow project refresh failed: ${String(error)}`);
+      }
+    });
   };
   context.subscriptions.push(
     vscode.workspace.onDidChangeWorkspaceFolders(() => {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/BurntSushi/toml"
 	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
@@ -88,22 +89,30 @@ type FmtConfig struct {
 }
 
 type LintConfig struct {
-	DisabledRules                   []string `toml:"disabled_rules"`
-	RequireOptionExplicit           bool     `toml:"require_option_explicit"`
-	ForbidSelect                    bool     `toml:"forbid_select"`
-	ForbidActivate                  bool     `toml:"forbid_activate"`
-	ForbidOnErrorResumeNext         bool     `toml:"forbid_on_error_resume_next"`
-	DetectImplicitVariant           bool     `toml:"detect_implicit_variant"`
-	ForbidPublicModuleFields        bool     `toml:"forbid_public_module_fields"`
-	ForbidInteractiveInput          bool     `toml:"forbid_interactive_input"`
-	DetectScopeShadowing            bool     `toml:"detect_scope_shadowing"`
-	DetectMultipleDeclaratorClarity bool     `toml:"detect_multiple_declarator_clarity"`
-	DetectUnusedLocalVariables      bool     `toml:"detect_unused_local_variables"`
-	DetectUnusedPrivateProcedures   bool     `toml:"detect_unused_private_procedures"`
-	DetectConfusingCallSyntax       bool     `toml:"detect_confusing_call_syntax"`
-	DetectForEachControlType        bool     `toml:"detect_for_each_control_type"`
-	DetectDangerousResume           bool     `toml:"detect_dangerous_resume"`
-	DetectNestedWithAmbiguity       bool     `toml:"detect_nested_with_ambiguity"`
+	DisabledRules                   []string                    `toml:"disabled_rules"`
+	RequireOptionExplicit           bool                        `toml:"require_option_explicit"`
+	ForbidSelect                    bool                        `toml:"forbid_select"`
+	ForbidActivate                  bool                        `toml:"forbid_activate"`
+	ForbidOnErrorResumeNext         bool                        `toml:"forbid_on_error_resume_next"`
+	DetectImplicitVariant           bool                        `toml:"detect_implicit_variant"`
+	ForbidPublicModuleFields        bool                        `toml:"forbid_public_module_fields"`
+	ForbidInteractiveInput          bool                        `toml:"forbid_interactive_input"`
+	DetectScopeShadowing            bool                        `toml:"detect_scope_shadowing"`
+	DetectMultipleDeclaratorClarity bool                        `toml:"detect_multiple_declarator_clarity"`
+	DetectUnusedLocalVariables      bool                        `toml:"detect_unused_local_variables"`
+	DetectUnusedPrivateProcedures   bool                        `toml:"detect_unused_private_procedures"`
+	DetectConfusingCallSyntax       bool                        `toml:"detect_confusing_call_syntax"`
+	DetectForEachControlType        bool                        `toml:"detect_for_each_control_type"`
+	DetectDangerousResume           bool                        `toml:"detect_dangerous_resume"`
+	DetectNestedWithAmbiguity       bool                        `toml:"detect_nested_with_ambiguity"`
+	ProcedureNameConstant           ProcedureNameConstantConfig `toml:"procedure_name_constant"`
+}
+
+// ProcedureNameConstantConfig controls the opt-in check that keeps a local
+// procedure-name constant aligned with its enclosing VBA procedure.
+type ProcedureNameConstantConfig struct {
+	Enabled      bool   `toml:"enabled"`
+	ConstantName string `toml:"constant_name"`
 }
 
 type AnalyzeConfig struct {
@@ -154,6 +163,7 @@ var configurableLintRules = []lintRuleConfig{
 	{ID: "VB023", Key: "detect_for_each_control_type", Default: true, Get: func(c LintConfig) bool { return c.DetectForEachControlType }, Set: func(c *LintConfig, v bool) { c.DetectForEachControlType = v }},
 	{ID: "VB026", Key: "detect_dangerous_resume", Default: true, Get: func(c LintConfig) bool { return c.DetectDangerousResume }, Set: func(c *LintConfig, v bool) { c.DetectDangerousResume = v }},
 	{ID: "VB027", Key: "detect_nested_with_ambiguity", Default: false, Get: func(c LintConfig) bool { return c.DetectNestedWithAmbiguity }, Set: func(c *LintConfig, v bool) { c.DetectNestedWithAmbiguity = v }},
+	{ID: "VB044", Key: "procedure_name_constant", Default: false, Get: func(c LintConfig) bool { return c.ProcedureNameConstant.Enabled }, Set: func(c *LintConfig, v bool) { c.ProcedureNameConstant.Enabled = v }},
 }
 
 var configurableAnalyzeRules = []analyzeRuleConfig{
@@ -342,6 +352,7 @@ func load(cwd string, allowInvalidExcelBridge bool) (Config, error) {
 
 func applyDefaults(cfg *Config) {
 	defaults := Default()
+	cfg.Lint.ProcedureNameConstant.ConstantName = strings.TrimSpace(cfg.Lint.ProcedureNameConstant.ConstantName)
 	if cfg.Project.Name == "" {
 		cfg.Project.Name = defaults.Project.Name
 	}
@@ -403,7 +414,31 @@ func validate(cfg Config) error {
 	if cfg.Backup.Retention.MaxCount > 0 && cfg.Backup.Retention.MinKeep > cfg.Backup.Retention.MaxCount {
 		return errors.New("backup.retention.min_keep must be less than or equal to backup.retention.max_count when max_count is enabled")
 	}
+	if cfg.Lint.ProcedureNameConstant.Enabled {
+		name := strings.TrimSpace(cfg.Lint.ProcedureNameConstant.ConstantName)
+		if name == "" {
+			return errors.New("lint.procedure_name_constant.constant_name is required when enabled")
+		}
+		if !validVBAIdentifier(name) {
+			return fmt.Errorf("lint.procedure_name_constant.constant_name must be a VBA identifier: %q", name)
+		}
+	}
 	return nil
+}
+
+func validVBAIdentifier(name string) bool {
+	for i, r := range []rune(name) {
+		if i == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return false
+			}
+			continue
+		}
+		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) && !unicode.IsMark(r) {
+			return false
+		}
+	}
+	return name != ""
 }
 
 func indexLintRulesByID() map[string]lintRuleConfig {
@@ -430,6 +465,9 @@ func applyLintRuleConfig(cfg *Config, meta toml.MetaData) error {
 	cfg.Lint.DisabledRules = disabled
 	warnings := make([]map[string]any, 0)
 	for _, rule := range configurableLintRules {
+		if rule.ID == "VB044" {
+			continue
+		}
 		if !meta.IsDefined("lint", rule.Key) {
 			continue
 		}
@@ -455,6 +493,22 @@ func applyLintRuleConfig(cfg *Config, meta toml.MetaData) error {
 				},
 			)
 		}
+	}
+	if cfg.Lint.ProcedureNameConstant.Enabled && disabledSet["VB044"] {
+		warnings = append(warnings,
+			map[string]any{
+				"code":    "conflicting_lint_rule_config",
+				"message": "lint rule VB044 is enabled by [lint.procedure_name_constant] but also listed in [lint].disabled_rules.",
+				"rule":    "VB044",
+				"key":     "procedure_name_constant",
+			},
+			map[string]any{
+				"code":    "disabled_rules_precedence",
+				"message": "[lint].disabled_rules takes precedence.",
+				"rule":    "VB044",
+				"key":     "procedure_name_constant",
+			},
+		)
 	}
 	for id := range disabledSet {
 		rule := lintRuleByID[id]
@@ -634,6 +688,18 @@ func renderLintConfig(cfg LintConfig) string {
 			b.WriteString(" = true\n")
 		}
 	}
+	if cfg.ProcedureNameConstant.Enabled {
+		b.WriteString("\n[lint.procedure_name_constant]\n")
+		b.WriteString("enabled = true\n")
+		b.WriteString("constant_name = ")
+		b.WriteString(strconv.Quote(cfg.ProcedureNameConstant.ConstantName))
+		b.WriteString("\n")
+	} else {
+		b.WriteString("\n# Optional local procedure-name constant check (VB044).\n")
+		b.WriteString("# [lint.procedure_name_constant]\n")
+		b.WriteString("# enabled = true\n")
+		b.WriteString("# constant_name = \"PROCEDURE_NAME\"\n")
+	}
 	return b.String()
 }
 
@@ -662,6 +728,9 @@ func disabledLintRuleIDsForWrite(cfg LintConfig) []string {
 func legacyOptInLintRulesForWrite(cfg LintConfig) []lintRuleConfig {
 	var out []lintRuleConfig
 	for _, rule := range configurableLintRules {
+		if rule.ID == "VB044" {
+			continue
+		}
 		if !rule.Default && rule.Get(cfg) {
 			out = append(out, rule)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -427,18 +427,16 @@ func validate(cfg Config) error {
 }
 
 func validVBAIdentifier(name string) bool {
-	for i, r := range []rune(name) {
-		if i == 0 {
-			if r != '_' && !unicode.IsLetter(r) {
-				return false
-			}
-			continue
-		}
-		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) && !unicode.IsMark(r) {
+	runes := []rune(name)
+	if len(runes) == 0 || len(runes) > 255 || !unicode.IsLetter(runes[0]) {
+		return false
+	}
+	for _, r := range runes[1:] {
+		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
 			return false
 		}
 	}
-	return name != ""
+	return true
 }
 
 func indexLintRulesByID() map[string]lintRuleConfig {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -481,8 +481,11 @@ constant_name = " procedure_name "
 
 func TestLoadRejectsInvalidProcedureNameConstantConfig(t *testing.T) {
 	for name, constantName := range map[string]string{
-		"missing": "",
-		"invalid": "PROCEDURE NAME",
+		"missing":            "",
+		"invalid_character":  "PROCEDURE NAME",
+		"leading_underscore": "_PROCEDURE_NAME",
+		"combining_mark":     "PROCEDURE\u0301_NAME",
+		"too_long":           strings.Repeat("A", 256),
 	} {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -500,6 +503,21 @@ constant_name = "` + constantName + `"
 				t.Fatalf("expected constant-name validation error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestValidVBAIdentifier(t *testing.T) {
+	for name, valid := range map[string]bool{
+		"PROCEDURE_NAME":         true,
+		"手続き名":                   true,
+		strings.Repeat("A", 255): true,
+		"_PROCEDURE_NAME":        false,
+		"PROCEDURE\u0301_NAME":   false,
+		strings.Repeat("A", 256): false,
+	} {
+		if got := validVBAIdentifier(name); got != valid {
+			t.Errorf("validVBAIdentifier(%q) = %t, want %t", name, got, valid)
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,9 @@ path = "build/Sales.xlsm"
 		cfg.Lint.DetectNestedWithAmbiguity {
 		t.Fatalf("expected false-positive-prone AST lint defaults to be opt-in: %+v", cfg.Lint)
 	}
+	if cfg.Lint.ProcedureNameConstant.Enabled || cfg.Lint.ProcedureNameConstant.ConstantName != "" {
+		t.Fatalf("procedure-name constant lint rule must default to disabled: %+v", cfg.Lint.ProcedureNameConstant)
+	}
 	if !cfg.Analyze.DetectRangeFindNothingCheck || !cfg.Analyze.DetectObjectUseBeforeSet ||
 		!cfg.Analyze.DetectApplicationStateRestore || !cfg.Analyze.DetectErrorHandlerFallthrough ||
 		!cfg.Analyze.ForbidUnqualifiedExcelObjects || !cfg.Analyze.DetectRedimPreserveDimension ||
@@ -449,6 +452,57 @@ disabled_rules = ["` + ruleID + `"]
 	}
 }
 
+func TestLoadProcedureNameConstantConfig(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[lint]
+disabled_rules = ["VB044"]
+
+[lint.procedure_name_constant]
+enabled = true
+constant_name = " procedure_name "
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Lint.ProcedureNameConstant.Enabled || cfg.Lint.ProcedureNameConstant.ConstantName != "procedure_name" {
+		t.Fatalf("disabled_rules should override the enabled procedure-name constant rule: %+v", cfg.Lint.ProcedureNameConstant)
+	}
+	if !hasConfigWarning(cfg.Warnings, "conflicting_lint_rule_config", "VB044") || !hasConfigWarning(cfg.Warnings, "disabled_rules_precedence", "VB044") {
+		t.Fatalf("expected VB044 conflict warnings, got %+v", cfg.Warnings)
+	}
+}
+
+func TestLoadRejectsInvalidProcedureNameConstantConfig(t *testing.T) {
+	for name, constantName := range map[string]string{
+		"missing": "",
+		"invalid": "PROCEDURE NAME",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := []byte(`[project]
+entry = "Main.Run"
+
+[lint.procedure_name_constant]
+enabled = true
+constant_name = "` + constantName + `"
+`)
+			if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Load(dir); err == nil || !strings.Contains(err.Error(), "lint.procedure_name_constant.constant_name") {
+				t.Fatalf("expected constant-name validation error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadRejectsNonConfigurableDisabledAnalyzeRule(t *testing.T) {
 	dir := t.TempDir()
 	body := []byte(`[project]
@@ -783,6 +837,8 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 		"# VB020 unused-local-variable warnings are enabled by default.",
 		"# Add \"VB020\" to disabled_rules if a project intentionally keeps scratch locals.",
 		"# detect_unused_private_procedures = true # VB021",
+		"# [lint.procedure_name_constant]",
+		"# constant_name = \"PROCEDURE_NAME\"",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("generated config missing %q:\n%s", want, text)
@@ -828,6 +884,30 @@ func TestWriteProducesReadableConfig(t *testing.T) {
 	}
 	if loaded.Analyze.ForbidUnqualifiedExcelObjects {
 		t.Fatal("expected forbid_unqualified_excel_objects=false")
+	}
+}
+
+func TestWriteProcedureNameConstantConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Default()
+	cfg.Lint.ProcedureNameConstant = ProcedureNameConstantConfig{Enabled: true, ConstantName: "PROCEDURE_NAME"}
+	p := filepath.Join(dir, FileName)
+	if err := Write(p, cfg); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "[lint.procedure_name_constant]\nenabled = true\nconstant_name = \"PROCEDURE_NAME\"") {
+		t.Fatalf("generated config missing enabled procedure-name constant rule:\n%s", body)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.Lint.ProcedureNameConstant.Enabled || loaded.Lint.ProcedureNameConstant.ConstantName != "PROCEDURE_NAME" {
+		t.Fatalf("procedure-name constant config did not round-trip: %+v", loaded.Lint.ProcedureNameConstant)
 	}
 }
 

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -237,6 +237,7 @@ func (l Linter) lintParsed(doc *vbaast.ParsedDocument, includeFilesystemRules bo
 			issues = append(issues, ctx.parseIssue(view.Root))
 		}
 		issues = append(issues, l.flowIssues(path, string(source), view.Root)...)
+		issues = append(issues, l.procedureNameConstantIssues(path, view.Root, source)...)
 		if sourceSymbols != nil {
 			issues = append(issues, l.undeclaredVariableIssues(path, string(source), view.Root, *sourceSymbols)...)
 			issues = append(issues, l.unusedLocalVariableIssues(path, string(source), *sourceSymbols)...)

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -1726,6 +1726,134 @@ func hasWarning(warnings []map[string]any, code string, rule string) bool {
 	return false
 }
 
+func TestLinterProcedureNameConstantRule(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.Lint.ProcedureNameConstant = config.ProcedureNameConstantConfig{Enabled: true, ConstantName: "procedure_name"}
+	source := `Option Explicit
+Const PROCEDURE_NAME As String = "ModuleLevel"
+
+Public Sub Matching()
+    Const PROCEDURE_NAME As String = "Matching"
+End Sub
+
+Public Function CaseOnly() As String
+    Const PROCEDURE_NAME As String = "caseonly"
+End Function
+
+Public Sub Multiple()
+    Const PROCEDURE_NAME As String = "OldMultiple", OTHER_NAME As String = "ignored"
+End Sub
+
+Public Sub DynamicValue()
+    Const PROCEDURE_NAME As String = "Dynamic" & "Value"
+End Sub
+
+Public Property Get Caption() As String
+    Const PROCEDURE_NAME As String = "OldGet"
+End Property
+
+Public Property Let Caption(ByVal value As String)
+    Const PROCEDURE_NAME As String = "OldLet"
+End Property
+
+Public Property Set Caption(ByVal value As Object)
+    Const PROCEDURE_NAME As String = "OldSet"
+End Property
+`
+	issues, err := (Linter{RootDir: root, Config: cfg}).LintSource(filepath.Join(root, "Main.bas"), []byte(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := issuesByCode(issues, procedureNameConstantRuleID)
+	if len(got) != 5 {
+		t.Fatalf("VB044 issues = %d, want 5: %+v", len(got), got)
+	}
+	want := map[string]string{
+		"caseonly":    "CaseOnly",
+		"OldMultiple": "Multiple",
+		"OldGet":      "Caption",
+		"OldLet":      "Caption",
+		"OldSet":      "Caption",
+	}
+	for _, issue := range got {
+		matched := false
+		for current, expected := range want {
+			if strings.Contains(issue.Message, current) && strings.Contains(issue.Message, expected) {
+				matched = issue.Kind == "procedure_name_constant" && issue.Symbol == "PROCEDURE_NAME" && issue.Column > 0
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("unexpected VB044 issue: %+v", issue)
+		}
+	}
+}
+
+func TestLinterProcedureNameConstantRuleScansModuleKinds(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.UserForm.CodeSource = "frm"
+	cfg.Lint.ProcedureNameConstant = config.ProcedureNameConstantConfig{Enabled: true, ConstantName: "PROCEDURE_NAME"}
+	files := map[string]string{
+		"src/modules/Main.bas": `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub StandardProcedure()
+    Const PROCEDURE_NAME As String = "OldStandard"
+End Sub
+`,
+		"src/classes/Worker.cls": `Attribute VB_Name = "Worker"
+Option Explicit
+Public Sub ClassProcedure()
+    Const PROCEDURE_NAME As String = "OldClass"
+End Sub
+`,
+		"src/workbook/ThisWorkbook.cls": `Attribute VB_Name = "ThisWorkbook"
+Option Explicit
+Private Sub Workbook_Open()
+    Const PROCEDURE_NAME As String = "OldWorkbook"
+End Sub
+`,
+		"src/forms/Dialog.frm": `VERSION 5.00
+Begin VB.UserForm Dialog
+End
+Attribute VB_Name = "Dialog"
+Option Explicit
+Private Sub UserForm_Initialize()
+    Const PROCEDURE_NAME As String = "OldForm"
+End Sub
+`,
+	}
+	for name, body := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	issues, err := (Linter{RootDir: root, Config: cfg}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := issuesByCode(issues, procedureNameConstantRuleID)
+	if len(got) != 4 {
+		t.Fatalf("VB044 issues = %d, want 4: %+v", len(got), got)
+	}
+	wantFiles := map[string]bool{
+		"src/modules/Main.bas":          true,
+		"src/classes/Worker.cls":        true,
+		"src/workbook/ThisWorkbook.cls": true,
+		"src/forms/Dialog.frm":          true,
+	}
+	for _, issue := range got {
+		if !wantFiles[issue.File] {
+			t.Fatalf("unexpected VB044 file: %+v", issue)
+		}
+	}
+}
+
 func writeLintModule(t *testing.T, dir, name, body string) {
 	t.Helper()
 	src := filepath.Join(dir, "src", "modules")

--- a/internal/lint/procedure_name_constant.go
+++ b/internal/lint/procedure_name_constant.go
@@ -1,0 +1,225 @@
+package lint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const procedureNameConstantRuleID = "VB044"
+
+// ProcedureNameConstantFix identifies the string literal that should be
+// replaced when a configured procedure-name constant has drifted.
+// Byte offsets are relative to the UTF-8 source buffer supplied to the linter.
+type ProcedureNameConstantFix struct {
+	StartByte    int
+	EndByte      int
+	Line         int
+	Column       int
+	ConstantName string
+	CurrentValue string
+	ExpectedName string
+}
+
+// ProcedureNameConstantFixesParsed reports source edits for configured local
+// procedure-name constants. It never modifies the source document.
+func (l Linter) ProcedureNameConstantFixesParsed(doc *vbaast.ParsedDocument) ([]ProcedureNameConstantFix, error) {
+	if !l.Config.Lint.ProcedureNameConstant.Enabled {
+		return nil, nil
+	}
+	var fixes []ProcedureNameConstantFix
+	err := doc.Read(func(view vbaast.ParsedView) error {
+		fixes = procedureNameConstantFixes(view.Root, view.Source, l.Config.Lint.ProcedureNameConstant)
+		return nil
+	})
+	return fixes, err
+}
+
+func (l Linter) procedureNameConstantIssues(path string, root *tree_sitter.Node, source []byte) []Issue {
+	fixes := procedureNameConstantFixes(root, source, l.Config.Lint.ProcedureNameConstant)
+	issues := make([]Issue, 0, len(fixes))
+	for _, fix := range fixes {
+		issue := l.issueAt(path, sourceByteRange(source, fix.StartByte, fix.EndByte), procedureNameConstantRuleID, "warning", fmt.Sprintf("Local constant %q is %q but its enclosing procedure is %q.", fix.ConstantName, fix.CurrentValue, fix.ExpectedName))
+		issue.Kind = "procedure_name_constant"
+		issue.Symbol = fix.ConstantName
+		issue.Suggestion = fmt.Sprintf("Update the string literal to %q.", fix.ExpectedName)
+		issues = append(issues, issue)
+	}
+	return issues
+}
+
+func procedureNameConstantFixes(root *tree_sitter.Node, source []byte, cfg config.ProcedureNameConstantConfig) []ProcedureNameConstantFix {
+	if root == nil || !cfg.Enabled || strings.TrimSpace(cfg.ConstantName) == "" {
+		return nil
+	}
+	var fixes []ProcedureNameConstantFix
+	collectProcedureNameConstantFixes(root, source, cfg.ConstantName, &fixes)
+	return fixes
+}
+
+func collectProcedureNameConstantFixes(node *tree_sitter.Node, source []byte, constantName string, fixes *[]ProcedureNameConstantFix) {
+	if node == nil {
+		return
+	}
+	if procedureNameConstantProcedure(node.Kind()) {
+		procedureName := procedureNameConstantProcedureName(node, source)
+		if procedureName != "" {
+			for i := uint(0); i < node.NamedChildCount(); i++ {
+				collectProcedureLocalConstantFixes(node.NamedChild(i), source, constantName, procedureName, fixes)
+			}
+		}
+		return
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		collectProcedureNameConstantFixes(node.NamedChild(i), source, constantName, fixes)
+	}
+}
+
+func procedureNameConstantProcedure(kind string) bool {
+	switch kind {
+	case "sub_declaration", "function_declaration", "property_declaration", "property_get_declaration", "property_let_declaration", "property_set_declaration":
+		return true
+	default:
+		return false
+	}
+}
+
+func procedureNameConstantProcedureName(node *tree_sitter.Node, source []byte) string {
+	if name := childByFieldNameAny(node, "name"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	if name := firstNamedChildKind(node, "identifier"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	return ""
+}
+
+func collectProcedureLocalConstantFixes(node *tree_sitter.Node, source []byte, constantName, procedureName string, fixes *[]ProcedureNameConstantFix) {
+	if node == nil {
+		return
+	}
+	if procedureNameConstantProcedure(node.Kind()) {
+		return
+	}
+	if node.Kind() == "const_declaration" {
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			declarator := node.NamedChild(i)
+			if declarator == nil || declarator.Kind() != "const_declarator" {
+				continue
+			}
+			name := procedureNameConstantDeclaratorName(declarator, source)
+			if !strings.EqualFold(name, constantName) {
+				continue
+			}
+			start, end, current, ok := procedureNameConstantLiteral(declarator, source)
+			if !ok || current == procedureName {
+				continue
+			}
+			r := sourceByteRange(source, start, end)
+			*fixes = append(*fixes, ProcedureNameConstantFix{
+				StartByte:    start,
+				EndByte:      end,
+				Line:         r.StartLine,
+				Column:       r.StartColumn,
+				ConstantName: name,
+				CurrentValue: current,
+				ExpectedName: procedureName,
+			})
+		}
+		return
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child != nil && !procedureNameConstantProcedure(child.Kind()) {
+			collectProcedureLocalConstantFixes(child, source, constantName, procedureName, fixes)
+		}
+	}
+}
+
+func procedureNameConstantDeclaratorName(node *tree_sitter.Node, source []byte) string {
+	if name := childByFieldNameAny(node, "name"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	if name := firstNamedChildKind(node, "identifier"); name != nil {
+		return cleanIdentifier(name.Utf8Text(source))
+	}
+	return ""
+}
+
+func procedureNameConstantLiteral(node *tree_sitter.Node, source []byte) (int, int, string, bool) {
+	if value := childByFieldNameAny(node, "value", "initializer", "default_value"); value != nil {
+		if start, end, text, ok := directVBAStringLiteral(value, source); ok {
+			return start, end, text, true
+		}
+	}
+	return directVBAStringLiteral(node, source)
+}
+
+func directVBAStringLiteral(node *tree_sitter.Node, source []byte) (int, int, string, bool) {
+	if node == nil {
+		return 0, 0, "", false
+	}
+	start, end := int(node.StartByte()), int(node.EndByte())
+	if start < 0 || end < start || end > len(source) {
+		return 0, 0, "", false
+	}
+	raw := string(source[start:end])
+	leading := len(raw) - len(strings.TrimLeft(raw, " \t\r\n"))
+	text := strings.TrimSpace(raw)
+	if value, ok := decodeVBAStringLiteral(text); ok {
+		return start + leading, start + leading + len(text), value, true
+	}
+	equals := strings.Index(raw, "=")
+	if equals < 0 {
+		return 0, 0, "", false
+	}
+	rawValue := raw[equals+1:]
+	leading = equals + 1 + len(rawValue) - len(strings.TrimLeft(rawValue, " \t\r\n"))
+	text = strings.TrimSpace(rawValue)
+	value, ok := decodeVBAStringLiteral(text)
+	if !ok {
+		return 0, 0, "", false
+	}
+	return start + leading, start + leading + len(text), value, true
+}
+
+func decodeVBAStringLiteral(text string) (string, bool) {
+	if len(text) < 2 || text[0] != '"' || text[len(text)-1] != '"' {
+		return "", false
+	}
+	for i := 1; i < len(text)-1; i++ {
+		if text[i] != '"' {
+			continue
+		}
+		if i+1 >= len(text)-1 || text[i+1] != '"' {
+			return "", false
+		}
+		i++
+	}
+	return strings.ReplaceAll(text[1:len(text)-1], `""`, `"`), true
+}
+
+func sourceByteRange(source []byte, start, end int) vbaast.Range {
+	start = max(0, min(start, len(source)))
+	end = max(start, min(end, len(source)))
+	line, column := 1, 1
+	startLine, startColumn := line, column
+	for i := 0; i < end; i++ {
+		if i == start {
+			startLine, startColumn = line, column
+		}
+		if source[i] == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	if start == end {
+		startLine, startColumn = line, column
+	}
+	return vbaast.Range{StartLine: startLine, StartColumn: startColumn, EndLine: line, EndColumn: column, StartByte: start, EndByte: end}
+}

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -605,14 +605,17 @@ func (s *Server) codeAction(_ *glsp.Context, params *protocol.CodeActionParams) 
 	if err != nil {
 		return nil, err
 	}
-	actions, err := s.analyzer.DocumentationCodeActions(doc, fromProtocolRange(params.Range))
+	actions, err := s.analyzer.CodeActions(doc, fromProtocolRange(params.Range))
 	if err != nil {
 		return nil, err
 	}
-	kind := protocol.CodeActionKindRefactorRewrite
 	out := make([]protocol.CodeAction, 0, len(actions))
 	requestURI := protocol.DocumentUri(params.TextDocument.URI)
 	for _, action := range actions {
+		kind := protocol.CodeActionKindRefactorRewrite
+		if action.Kind == "quickfix" {
+			kind = protocol.CodeActionKindQuickFix
+		}
 		out = append(out, protocol.CodeAction{
 			Title: action.Title,
 			Kind:  &kind,

--- a/internal/lspserver/server_test.go
+++ b/internal/lspserver/server_test.go
@@ -985,6 +985,95 @@ func TestJSONRPCPublishesArgumentDiagnostics(t *testing.T) {
 	t.Fatalf("VB030 publishDiagnostics missing: %+v", recorder.publishDiagnostics())
 }
 
+func TestJSONRPCPublishesProcedureNameConstantDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.Lint.ProcedureNameConstant = config.ProcedureNameConstantConfig{Enabled: true, ConstantName: "PROCEDURE_NAME"}
+	s, cleanup, err := New(Options{RootDir: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serverSide, clientSide := net.Pipe()
+	serverConn := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(serverSide, jsonrpc2.VSCodeObjectCodec{}), rpcHandler{handler: &s.handler})
+	recorder := &rpcRecorder{}
+	clientConn := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(clientSide, jsonrpc2.VSCodeObjectCodec{}), recorder)
+	defer func() { _ = clientConn.Close() }()
+
+	var initResult protocol.InitializeResult
+	if err := clientConn.Call(ctx, string(protocol.MethodInitialize), protocol.InitializeParams{}, &initResult); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(root, "src", "modules", "Main.bas")
+	uri := pathToFileURI(path)
+	mismatch := "Option Explicit\nPublic Sub Foo()\n    Const PROCEDURE_NAME As String = \"OldName\"\nEnd Sub\n"
+	if err := clientConn.Notify(ctx, string(protocol.MethodTextDocumentDidOpen), protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: protocol.DocumentUri(uri), LanguageID: "vba", Version: 1, Text: mismatch},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	seenMismatch := false
+	for time.Now().Before(deadline) {
+		for _, params := range recorder.publishDiagnostics() {
+			for _, diag := range params.Diagnostics {
+				if strings.Contains(diag.Message, `Local constant "PROCEDURE_NAME" is "OldName" but its enclosing procedure is "Foo".`) {
+					seenMismatch = true
+					break
+				}
+			}
+			if seenMismatch {
+				break
+			}
+		}
+		if seenMismatch {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !seenMismatch {
+		_ = serverConn.Close()
+		t.Fatalf("VB044 publishDiagnostics missing: %+v", recorder.publishDiagnostics())
+	}
+	before := len(recorder.publishDiagnostics())
+	matching := "Option Explicit\nPublic Sub Foo()\n    Const PROCEDURE_NAME As String = \"Foo\"\nEnd Sub\n"
+	if err := clientConn.Notify(ctx, string(protocol.MethodTextDocumentDidChange), protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)},
+			Version:                2,
+		},
+		ContentChanges: []any{map[string]any{"text": matching}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		published := recorder.publishDiagnostics()
+		if len(published) > before {
+			latest := published[len(published)-1]
+			hasVB044 := false
+			for _, diag := range latest.Diagnostics {
+				if strings.Contains(diag.Message, "enclosing procedure") {
+					hasVB044 = true
+					break
+				}
+			}
+			if !hasVB044 {
+				_ = serverConn.Close()
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_ = serverConn.Close()
+	t.Fatalf("VB044 diagnostic did not clear after didChange: %+v", recorder.publishDiagnostics())
+}
+
 func TestJSONRPCPublishesAnalyzerDiagnostics(t *testing.T) {
 	root := t.TempDir()
 	s, cleanup, err := New(Options{RootDir: root, Config: config.Default()})

--- a/internal/lspserver/server_test.go
+++ b/internal/lspserver/server_test.go
@@ -779,6 +779,89 @@ func TestCodeActionGeneratesDocumentationComment(t *testing.T) {
 	}
 }
 
+func TestCodeActionFixesProcedureNameConstantInUnsavedDocument(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.Lint.ProcedureNameConstant = config.ProcedureNameConstantConfig{Enabled: true, ConstantName: "PROCEDURE_NAME"}
+	s, cleanup, err := New(Options{RootDir: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	path := filepath.Join(root, "src", "modules", "Main.bas")
+	uri := pathToFileURI(path)
+	source := "Option Explicit\nPublic Sub Foo()\n    Const PROCEDURE_NAME As String = \"OldName\"\nEnd Sub\n"
+	if _, err := s.docs.open(uri, source); err != nil {
+		t.Fatal(err)
+	}
+	line := `    Const PROCEDURE_NAME As String = "OldName"`
+	start := strings.Index(line, `"OldName"`)
+	result, err := s.codeAction(nil, &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 2, Character: protocol.UInteger(utf16Len(line[:start]))},
+			End:   protocol.Position{Line: 2, Character: protocol.UInteger(utf16Len(line[:start+len(`"OldName"`)]))},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions, ok := result.([]protocol.CodeAction)
+	if !ok {
+		t.Fatalf("code actions = %T, want []protocol.CodeAction", result)
+	}
+	var fix *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Kind != nil && *actions[i].Kind == protocol.CodeActionKindQuickFix {
+			fix = &actions[i]
+			break
+		}
+	}
+	if fix == nil || fix.Edit == nil || !strings.Contains(fix.Title, "PROCEDURE_NAME") {
+		t.Fatalf("procedure-name quick fix missing: %+v", actions)
+	}
+	edits := fix.Edit.Changes[protocol.DocumentUri(uri)]
+	if len(edits) != 1 || edits[0].NewText != `"Foo"` || edits[0].Range.Start.Line != 2 || edits[0].Range.Start.Character != protocol.UInteger(utf16Len(line[:start])) || edits[0].Range.End.Character != protocol.UInteger(utf16Len(line[:start+len(`"OldName"`)])) {
+		t.Fatalf("unexpected procedure-name edit: %+v", edits)
+	}
+}
+
+func TestCodeActionOmitsSuppressedProcedureNameConstantFix(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.Lint.ProcedureNameConstant = config.ProcedureNameConstantConfig{Enabled: true, ConstantName: "PROCEDURE_NAME"}
+	s, cleanup, err := New(Options{RootDir: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	path := filepath.Join(root, "src", "modules", "Main.bas")
+	uri := pathToFileURI(path)
+	source := "Option Explicit\nPublic Sub Foo()\n    Const PROCEDURE_NAME As String = \"OldName\" ' xlflow:disable-line VB044\nEnd Sub\n"
+	if _, err := s.docs.open(uri, source); err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.codeAction(nil, &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 2, Character: 0},
+			End:   protocol.Position{Line: 2, Character: 60},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions, ok := result.([]protocol.CodeAction)
+	if !ok {
+		t.Fatalf("code actions = %T, want []protocol.CodeAction", result)
+	}
+	for _, action := range actions {
+		if action.Kind != nil && *action.Kind == protocol.CodeActionKindQuickFix {
+			t.Fatalf("suppressed VB044 must not offer a quick fix: %+v", actions)
+		}
+	}
+}
+
 func TestSignatureHelpReturnsActiveParameter(t *testing.T) {
 	root := t.TempDir()
 	s, cleanup, err := New(Options{RootDir: root, Config: config.Default()})

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -5131,20 +5131,24 @@ func utf16Prefix(line string, character int) string {
 }
 
 func byteOffsetForPosition(source string, pos Position) int {
-	lines := normalizedLines(source)
 	if pos.Line < 0 {
 		return 0
 	}
-	offset := 0
-	for lineNo, line := range lines {
+	lineStart := 0
+	for lineNo := 0; ; lineNo++ {
+		lineEnd, nextLineStart := rawLineBounds(source, lineStart)
 		if lineNo == pos.Line {
+			line := source[lineStart:lineEnd]
 			idx := byteIndexForUTF16(line, pos.Character)
 			if idx > len(line) {
 				idx = len(line)
 			}
-			return offset + idx
+			return lineStart + idx
 		}
-		offset += len(line) + 1
+		if nextLineStart == len(source) {
+			break
+		}
+		lineStart = nextLineStart
 	}
 	return len(source)
 }
@@ -5153,20 +5157,40 @@ func positionForByteOffset(source string, offset int) Position {
 	if offset <= 0 {
 		return Position{}
 	}
-	lines := normalizedLines(source)
-	seen := 0
-	for lineNo, line := range lines {
-		lineEnd := seen + len(line)
+	lineStart := 0
+	for lineNo := 0; ; lineNo++ {
+		lineEnd, nextLineStart := rawLineBounds(source, lineStart)
 		if offset <= lineEnd {
-			return Position{Line: lineNo, Character: utf16Len(line[:max(0, min(offset-seen, len(line)))])}
+			line := source[lineStart:lineEnd]
+			return Position{Line: lineNo, Character: utf16Len(line[:max(0, min(offset-lineStart, len(line)))])}
 		}
-		seen = lineEnd + 1
+		if offset < nextLineStart {
+			line := source[lineStart:lineEnd]
+			return Position{Line: lineNo, Character: utf16Len(line)}
+		}
+		if nextLineStart == len(source) {
+			return Position{Line: lineNo + 1}
+		}
+		lineStart = nextLineStart
 	}
-	if len(lines) == 0 {
-		return Position{}
+}
+
+// rawLineBounds returns the end of the current line's text and the start of
+// the following line without normalizing the source. Byte offsets from the
+// parser refer to this original representation, including CRLF line endings.
+func rawLineBounds(source string, lineStart int) (lineEnd, nextLineStart int) {
+	for i := lineStart; i < len(source); i++ {
+		switch source[i] {
+		case '\n':
+			return i, i + 1
+		case '\r':
+			if i+1 < len(source) && source[i+1] == '\n' {
+				return i, i + 2
+			}
+			return i, i + 1
+		}
 	}
-	last := lines[len(lines)-1]
-	return Position{Line: len(lines) - 1, Character: utf16Len(last)}
+	return len(source), len(source)
 }
 
 func byteIndexForUTF16(s string, character int) int {

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -808,18 +808,31 @@ func (a Analyzer) SignatureHelp(doc Document, pos Position, open []Document) (*S
 	}, nil
 }
 
-type DocumentationAction struct {
+type CodeAction struct {
 	Title   string
+	Kind    string
 	Range   Range
 	NewText string
 }
 
-func (a Analyzer) DocumentationCodeActions(doc Document, selection Range) ([]DocumentationAction, error) {
+func (a Analyzer) CodeActions(doc Document, selection Range) ([]CodeAction, error) {
+	out, err := a.documentationCodeActions(doc, selection)
+	if err != nil {
+		return nil, err
+	}
+	procedureActions, err := a.procedureNameConstantCodeActions(doc, selection)
+	if err != nil {
+		return nil, err
+	}
+	return append(out, procedureActions...), nil
+}
+
+func (a Analyzer) documentationCodeActions(doc Document, selection Range) ([]CodeAction, error) {
 	syms, err := a.DocumentSymbols(doc)
 	if err != nil {
 		return nil, err
 	}
-	var out []DocumentationAction
+	var out []CodeAction
 	for _, sym := range syms {
 		if !documentationSnippetSymbol(sym) || doccomments.HasDocumentation(sym.Documentation) {
 			continue
@@ -832,9 +845,60 @@ func (a Analyzer) DocumentationCodeActions(doc Document, selection Range) ([]Doc
 			continue
 		}
 		insert := Range{Start: Position{Line: sym.Range.Start.Line, Character: 0}, End: Position{Line: sym.Range.Start.Line, Character: 0}}
-		out = append(out, DocumentationAction{Title: snippet.Label, Range: insert, NewText: snippet.Text + "\n"})
+		out = append(out, CodeAction{Title: snippet.Label, Kind: "refactor.rewrite", Range: insert, NewText: snippet.Text + "\n"})
 	}
 	return out, nil
+}
+
+func (a Analyzer) procedureNameConstantCodeActions(doc Document, selection Range) ([]CodeAction, error) {
+	parsed, closeParsed, err := parsedDocumentForDocument(doc)
+	if err != nil {
+		return nil, err
+	}
+	defer closeParsed()
+	linter := lint.Linter{RootDir: a.RootDir, Config: a.Config}
+	issues, err := linter.LintParsed(parsed)
+	if err != nil {
+		return nil, err
+	}
+	visible := make(map[string]bool)
+	for _, issue := range issues {
+		if issue.Code == "VB044" {
+			visible[procedureNameConstantIssueKey(issue.Line, issue.Column)] = true
+		}
+	}
+	fixes, err := linter.ProcedureNameConstantFixesParsed(parsed)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CodeAction, 0, len(fixes))
+	for _, fix := range fixes {
+		if !visible[procedureNameConstantIssueKey(fix.Line, fix.Column)] {
+			continue
+		}
+		editRange := Range{
+			Start: positionForByteOffset(doc.Source, fix.StartByte),
+			End:   positionForByteOffset(doc.Source, fix.EndByte),
+		}
+		if !rangeIntersects(selection, editRange) {
+			continue
+		}
+		out = append(out, CodeAction{
+			Title:   fmt.Sprintf("Update %s to %q", fix.ConstantName, fix.ExpectedName),
+			Kind:    "quickfix",
+			Range:   editRange,
+			NewText: vbaStringLiteral(fix.ExpectedName),
+		})
+	}
+	return out, nil
+}
+
+func procedureNameConstantIssueKey(line, column int) string {
+	return fmt.Sprintf("%d:%d", line, column)
+}
+
+func vbaStringLiteral(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }
 
 func (a Analyzer) documentationSnippetCompletions(doc Document, pos Position) ([]Completion, bool, error) {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -121,6 +121,40 @@ End Sub
 	}
 }
 
+func TestProcedureNameConstantQuickFixPreservesCRLFRange(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	analyzer.Config.Lint.ProcedureNameConstant = config.ProcedureNameConstantConfig{
+		Enabled:      true,
+		ConstantName: "PROCEDURE_NAME",
+	}
+	line := "    Const PROCEDURE_NAME As String = \"OldName\""
+	source := "Option Explicit\r\nPublic Sub Foo()\r\n" + line + "\r\nEnd Sub\r\n"
+	start := strings.Index(line, "\"OldName\"")
+	if start < 0 {
+		t.Fatal("test literal missing")
+	}
+	wantRange := Range{
+		Start: Position{Line: 2, Character: utf16Len(line[:start])},
+		End:   Position{Line: 2, Character: utf16Len(line[:start+len("\"OldName\"")])},
+	}
+	actions, err := analyzer.CodeActions(Document{
+		Path:   filepath.Join(t.TempDir(), "Main.bas"),
+		Source: source,
+	}, wantRange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, action := range actions {
+		if action.Kind == "quickfix" {
+			if action.Range != wantRange || action.NewText != "\"Foo\"" {
+				t.Fatalf("quick fix = %+v, want range %+v and replacement %q", action, wantRange, "\"Foo\"")
+			}
+			return
+		}
+	}
+	t.Fatalf("VB044 quick fix missing: %+v", actions)
+}
+
 func TestDiagnosticsIncludeAnalyzerNonShortCircuitObjectGuard(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	doc := Document{

--- a/vitepress/commands/lint.md
+++ b/vitepress/commands/lint.md
@@ -61,6 +61,7 @@ Use `lint --json` in agent loops before `push` to catch source problems while Ex
 | `VB029` | error    | `Option Explicit` is present and an assignment target or loop control variable is not declared.                            |
 | `VB031` | error    | Standard `.bas` module is missing `Attribute VB_Name`.                                                                     |
 | `VB032` | error    | Repeated `?` Debug.Print shorthand such as `?? "hoge"`.                                                                    |
+| `VB044` | warning  | Configured local procedure-name string constant does not match its enclosing procedure name.                               |
 
 Core declaration, member-access, error-handling, and procedure-scope checks are AST-backed. They ignore comments and strings, distinguish module-level declarations from procedure-local declarations, and report individual declarators such as `a` in `Dim a, b As Long`.
 
@@ -87,6 +88,16 @@ Multiple IDs may be listed with spaces. Unknown IDs, unsupported preflight-block
 Safety diagnostics `VB008` through `VB015`, `VB028`, `VB029`, `VB031`, and `VB032` are always enabled and cannot be suppressed inline because they prevent VBE compile dialogs before `push` or `run` opens Excel.
 
 Rules `VB019`, `VB020`, `VB022`, `VB023`, and `VB026` are enabled by default. Disable `VB020` with `disabled_rules = ["VB020"]` when a project intentionally keeps scratch locals. Heavier project-wide rules such as `detect_unused_private_procedures = true` (`VB021`) stay conservative opt-ins; new `xlflow.toml` files include commented examples. Use [`analyze`](./analyze) for semantic runtime-risk checks such as unqualified Excel access, error-handler fallthrough, Application state leaks, `Range.Find` `Nothing` guards, and object `Nothing` guards combined with dereferences in non-short-circuit boolean expressions.
+
+To keep runtime-error diagnostics useful after procedure renames, opt into `VB044` with a local constant convention:
+
+```toml
+[lint.procedure_name_constant]
+enabled = true
+constant_name = "PROCEDURE_NAME"
+```
+
+The rule checks existing direct string literals only; it never inserts a missing constant or rewrites source during `xlflow lint`. It supports `Sub`, `Function`, and all `Property` procedures in standard, class, document, and UserForm modules. The LSP offers a Quick Fix that updates only the mismatched string literal.
 
 ## JSON Output Example
 

--- a/vitepress/commands/lsp.md
+++ b/vitepress/commands/lsp.md
@@ -40,7 +40,7 @@ Rename support is conservative and scope-aware. It works for high-confidence VBA
 
 Diagnostics reuse xlflow's file-local VBA lint rules against the current in-memory editor buffer and publish stable `VB...` codes with `source="xlflow"`. Opening a document starts diagnostics immediately. Changes are debounced and coalesced so a document never has more than one active diagnostics worker, and only the newest open version can publish results. Slow documents do not prevent other documents from being analyzed. Closing a document cancels its pending work and publishes a final empty diagnostics result; an older analysis cannot publish afterward. Project-wide and filesystem-only lint checks remain available through `xlflow lint`.
 
-For an enabled `VB044` procedure-name constant mismatch, `textDocument/codeAction` offers a `quickfix` that replaces only the direct string literal with the enclosing procedure name. This does not add missing constants or change procedure rename behavior.
+For an enabled `VB044` procedure-name constant mismatch, diagnostics are published for the current editor buffer on open and after edits. `textDocument/codeAction` offers a `quickfix` that replaces only the direct string literal with the enclosing procedure name. This does not add missing constants or change procedure rename behavior.
 
 The LSP also publishes editor-first argument diagnostics such as `VB030` for missing required arguments, excessive arguments, and unknown named arguments when the target signature is known from project symbols or the built-in VBA/COM database. These diagnostics are intentionally LSP-only for now and are not yet part of the `xlflow lint` CLI contract.
 

--- a/vitepress/commands/lsp.md
+++ b/vitepress/commands/lsp.md
@@ -40,6 +40,8 @@ Rename support is conservative and scope-aware. It works for high-confidence VBA
 
 Diagnostics reuse xlflow's file-local VBA lint rules against the current in-memory editor buffer and publish stable `VB...` codes with `source="xlflow"`. Opening a document starts diagnostics immediately. Changes are debounced and coalesced so a document never has more than one active diagnostics worker, and only the newest open version can publish results. Slow documents do not prevent other documents from being analyzed. Closing a document cancels its pending work and publishes a final empty diagnostics result; an older analysis cannot publish afterward. Project-wide and filesystem-only lint checks remain available through `xlflow lint`.
 
+For an enabled `VB044` procedure-name constant mismatch, `textDocument/codeAction` offers a `quickfix` that replaces only the direct string literal with the enclosing procedure name. This does not add missing constants or change procedure rename behavior.
+
 The LSP also publishes editor-first argument diagnostics such as `VB030` for missing required arguments, excessive arguments, and unknown named arguments when the target signature is known from project symbols or the built-in VBA/COM database. These diagnostics are intentionally LSP-only for now and are not yet part of the `xlflow lint` CLI contract.
 
 The built-in VBA/COM database includes practical Excel, MSForms, Scripting, ADODB, VBIDE, Office, and VBA constant metadata for hover, completion, and basic type inference.

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -83,6 +83,11 @@ disabled_rules = []
 # detect_unused_private_procedures = true # VB021
 # detect_nested_with_ambiguity = true    # VB027
 
+# Optional local procedure-name constant check (VB044).
+# [lint.procedure_name_constant]
+# enabled = true
+# constant_name = "PROCEDURE_NAME"
+
 # Runtime-risk analysis rules.
 [analyze]
 # Disable specific analyzer rules by diagnostic ID.
@@ -168,6 +173,8 @@ Legacy per-rule booleans such as `forbid_select = false` remain accepted for com
 
 `VB020` unused-local-variable warnings are enabled by default and can be disabled with `disabled_rules = ["VB020"]`. Other project-wide lint rules such as `detect_unused_private_procedures = true` (`VB021`) remain disabled by default. New `xlflow.toml` files include commented examples so projects can opt in deliberately.
 
+`VB044` is disabled by default and uses the nested `[lint.procedure_name_constant]` table rather than a legacy boolean. When enabled, `constant_name` is required and must be a VBA identifier. xlflow compares matching procedure-local constants case-insensitively by name, but requires their direct string-literal values to match the enclosing procedure name exactly. `disabled_rules = ["VB044"]` takes precedence over `enabled = true`.
+
 Configurable lint rule IDs:
 
 | ID      | Legacy key                           |
@@ -187,6 +194,7 @@ Configurable lint rule IDs:
 | `VB023` | `detect_for_each_control_type`       |
 | `VB026` | `detect_dangerous_resume`            |
 | `VB027` | `detect_nested_with_ambiguity`       |
+| `VB044` | `[lint.procedure_name_constant]`     |
 
 Safety diagnostics `VB008` through `VB015`, `VB028`, `VB029`, `VB031`, and `VB032` are always enabled and cannot be disabled with `disabled_rules`.
 
@@ -199,6 +207,15 @@ Range("A2").Select ' xlflow:disable-line VB002
 ```
 
 Preflight-blocking lint diagnostics `VB008` through `VB015`, `VB028`, `VB029`, `VB031`, and `VB032` cannot be suppressed inline.
+
+### `[lint.procedure_name_constant]`
+
+| Key             | Type   | Required | Default | Description                                                              |
+| --------------- | ------ | -------- | ------- | ------------------------------------------------------------------------ |
+| `enabled`       | bool   | no       | `false` | Enable `VB044` checks for existing matching procedure-local constants.   |
+| `constant_name` | string | yes\*    | —       | Case-insensitive local constant name to check, such as `PROCEDURE_NAME`. |
+
+\* Required when `enabled = true`; the value must be a VBA identifier. The rule supports `Sub`, `Function`, `Property Get`, `Property Let`, and `Property Set` in standard, class, document, and UserForm code. It reports only direct string-literal values and leaves missing or expression-based constants alone.
 
 ### `[analyze]`
 

--- a/vitepress/reference/error-codes.md
+++ b/vitepress/reference/error-codes.md
@@ -54,4 +54,4 @@ Common examples:
 - `wsl_path_translation_failed`
 - `windows_xlflow_execution_failed`
 
-Lint codes include `VB001` through `VB015`, `VB018` through `VB023`, `VB026` through `VB029`, `VB031`, and `VB032`. Analyzer codes include `VBA101` through `VBA106` and runtime-risk findings `VBA201` through `VBA212`.
+Lint codes include `VB001` through `VB015`, `VB018` through `VB023`, `VB026` through `VB029`, `VB031`, `VB032`, and `VB044`. Analyzer codes include `VBA101` through `VBA106` and runtime-risk findings `VBA201` through `VBA212`.


### PR DESCRIPTION
## Summary

- Add lint validation for constants that reference VBA procedure names
- Expose the rule through CLI, LSP, VS Code, configuration, and documentation updates
- Add diagnostics, configuration, and integration coverage
- Update changelogs and error-code documentation

## Testing

- Added and updated unit and integration tests for configuration, linting, LSP, and IntelliSense behavior
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in VB044 linting to detect procedure-name constants that do not match their enclosing procedure.
  * Added editor diagnostics and Quick Fixes that update only the mismatched string literal.
  * Updated the VS Code extension to version 0.8.0.

* **Bug Fixes**
  * The language server now restarts when project configuration files change.

* **Documentation**
  * Documented VB044 configuration, behavior, supported modules, and editor actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->