### PR TITLE
Preserve generated worksheet provenance in VBA intelligence

### DIFF
--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -540,9 +540,9 @@ func TestWorkbookCoordinationTimeoutDoesNotCoverHandlerRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	a := &app{cwd: rootDir, wait: true, waitTimeout: 500 * time.Millisecond, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
+	a := &app{cwd: rootDir, wait: true, waitTimeout: 2 * time.Second, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, coordination: manager}
 	err = a.withWorkbookCoordination(context.Background(), "push", []string{filepath.Join(rootDir, "book.xlsm")}, func() error {
-		time.Sleep(600 * time.Millisecond)
+		time.Sleep(2200 * time.Millisecond)
 		return nil
 	})
 	if err != nil {

--- a/internal/typedb/typedb_test.go
+++ b/internal/typedb/typedb_test.go
@@ -119,10 +119,12 @@ func TestLoadForRuntimeLoadsGeneratedThenBuiltinOverlay(t *testing.T) {
       "properties": [{ "name": "Name", "return_type": "String" }]
     },
     {
-      "name": "Excel.Range",
+      "name": "Excel.Worksheet",
       "library": "Excel",
-      "kind": "class",
-      "properties": [{ "name": "Value", "return_type": "Long" }]
+      "kind": "interface",
+      "confidence": "generated",
+      "source": "typelib",
+      "properties": [{ "name": "GeneratedOnly", "return_type": "Long" }]
     }
   ]
 }`), 0o644); err != nil {
@@ -142,8 +144,15 @@ func TestLoadForRuntimeLoadsGeneratedThenBuiltinOverlay(t *testing.T) {
 	if member, ok := result.DB.ResolveMember("Vendor.Widget", "Name"); !ok || member.ReturnType != "String" {
 		t.Fatalf("generated member missing: %+v, %v", member, ok)
 	}
-	if member, ok := result.DB.ResolveMember("Excel.Range", "Value"); !ok || member.ReturnType != "Variant" {
-		t.Fatalf("built-in overlay should override generated Excel.Range.Value: %+v, %v", member, ok)
+	worksheet, ok := result.DB.ResolveType("Excel.Worksheet")
+	if !ok || worksheet.Source != "typelib" || worksheet.Confidence != "generated" {
+		t.Fatalf("built-in overlay should preserve generated Excel.Worksheet provenance: %+v, %v", worksheet, ok)
+	}
+	if member, ok := result.DB.ResolveMember("Excel.Worksheet", "GeneratedOnly"); !ok || member.ReturnType != "Long" {
+		t.Fatalf("built-in overlay should retain generated Excel.Worksheet members: %+v, %v", member, ok)
+	}
+	if member, ok := result.DB.ResolveMember("Excel.Worksheet", "Range"); !ok || member.ReturnType != "Excel.Range" {
+		t.Fatalf("built-in overlay should retain curated Excel.Worksheet members: %+v, %v", member, ok)
 	}
 }
 

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -485,6 +485,9 @@ func (a Analyzer) References(doc Document, pos Position, open []Document, includ
 	if err != nil {
 		return nil, err
 	}
+	if len(defSyms) == 0 {
+		return nil, nil
+	}
 	var localScope *Range
 	if hasLocalDefinitionSymbol(defSyms) {
 		if scope, ok := currentProcedureRangeForDocument(doc, pos); ok {
@@ -546,6 +549,9 @@ func (a Analyzer) References(doc Document, pos Position, open []Document, includ
 }
 
 func (a Analyzer) definitionSymbols(doc Document, pos Position, open []Document, word string) ([]Symbol, error) {
+	if a.unresolvedExternalMemberReference(doc, pos, word) {
+		return nil, nil
+	}
 	syms, err := a.WorkspaceSymbolsQuery(open, WorkspaceSymbolQuery{Text: word, Mode: WorkspaceSymbolQueryExact})
 	if err != nil {
 		return nil, err
@@ -562,6 +568,45 @@ func (a Analyzer) definitionSymbols(doc Document, pos Position, open []Document,
 		return local, nil
 	}
 	return out, nil
+}
+
+// unresolvedExternalMemberReference reports member access on a known host type
+// that is absent from the type database. Such an access must not fall back to a
+// same-named project declaration: a variable declared As Worksheet is not an
+// instance of the current worksheet's document module.
+func (a Analyzer) unresolvedExternalMemberReference(doc Document, pos Position, word string) bool {
+	if a.DB == nil {
+		return false
+	}
+	_, wordRange := WordAt(doc.Source, pos)
+	line := lineAt(doc.Source, wordRange.Start.Line)
+	if line == "" {
+		return false
+	}
+	startByte := byteIndexForUTF16(line, wordRange.Start.Character)
+	if startByte > len(line) {
+		startByte = len(line)
+	}
+	receiverExpr := ""
+	for _, match := range memberExprRe.FindAllStringSubmatchIndex(line, -1) {
+		if len(match) < 6 || match[4] > startByte || startByte >= match[5] {
+			continue
+		}
+		receiverExpr = strings.TrimSpace(line[match[2]:match[3]])
+		break
+	}
+	if receiverExpr == "" || strings.EqualFold(receiverExpr, "Me") {
+		return false
+	}
+	receiverType, ok := a.resolveDocumentExpressionTypeAt(doc, receiverExpr, byteOffsetForPosition(doc.Source, pos))
+	if !ok {
+		return false
+	}
+	if _, ok := a.DB.ResolveType(receiverType); !ok {
+		return false
+	}
+	_, found := a.DB.ResolveMember(receiverType, word)
+	return !found
 }
 
 func (a Analyzer) visibleDefinitionSymbol(doc Document, currentProcedure string, sym Symbol) bool {
@@ -626,6 +671,9 @@ func (a Analyzer) Hover(doc Document, pos Position, open []Document) (*Hover, er
 	}
 	if hover, ok := a.memberHover(doc, word, r, byteOffsetForPosition(doc.Source, pos)); ok {
 		return hover, nil
+	}
+	if a.unresolvedExternalMemberReference(doc, pos, word) {
+		return nil, nil
 	}
 	if control, ok := a.resolveFormControl(doc, word); ok {
 		return &Hover{Contents: variableHover(word, control.Type, "UserForm control"), Range: r}, nil

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -587,18 +587,36 @@ func (a Analyzer) unresolvedExternalMemberReference(doc Document, pos Position, 
 	if startByte > len(line) {
 		startByte = len(line)
 	}
+	offset := byteOffsetForPosition(doc.Source, pos)
+	var receiverType string
+	var ok bool
+	beforeWord := strings.TrimRight(line[:startByte], " \t")
+	beforeDot := strings.TrimSuffix(beforeWord, ".")
+	relativeMember := strings.HasSuffix(beforeWord, ".") && (strings.TrimSpace(beforeDot) == "" || strings.TrimRight(beforeDot, " \t") != beforeDot)
 	receiverExpr := ""
-	for _, match := range memberExprRe.FindAllStringSubmatchIndex(line, -1) {
-		if len(match) < 6 || match[4] > startByte || startByte >= match[5] {
-			continue
+	if !relativeMember {
+		for _, match := range memberExprRe.FindAllStringSubmatchIndex(line, -1) {
+			if len(match) < 6 || match[4] > startByte || startByte >= match[5] {
+				continue
+			}
+			receiverExpr = strings.TrimSpace(line[match[2]:match[3]])
+			break
 		}
-		receiverExpr = strings.TrimSpace(line[match[2]:match[3]])
-		break
 	}
-	if receiverExpr == "" || strings.EqualFold(receiverExpr, "Me") {
-		return false
+	if receiverExpr != "" {
+		if strings.EqualFold(receiverExpr, "Me") {
+			return false
+		}
+		receiverType, ok = a.resolveDocumentExpressionTypeAt(doc, receiverExpr, offset)
+	} else {
+		if !strings.HasSuffix(beforeWord, ".") {
+			return false
+		}
+		if receiver, found := a.withBlockReceiverAt(doc, pos); found && strings.EqualFold(receiver, "Me") {
+			return false
+		}
+		receiverType, ok = a.withBlockTypeAt(doc, pos, offset)
 	}
-	receiverType, ok := a.resolveDocumentExpressionTypeAt(doc, receiverExpr, byteOffsetForPosition(doc.Source, pos))
 	if !ok {
 		return false
 	}
@@ -607,6 +625,18 @@ func (a Analyzer) unresolvedExternalMemberReference(doc Document, pos Position, 
 	}
 	_, found := a.DB.ResolveMember(receiverType, word)
 	return !found
+}
+
+func (a Analyzer) withBlockReceiverAt(doc Document, pos Position) (string, bool) {
+	index, ok := a.documentIndexFor(doc)
+	if !ok || index == nil {
+		return "", false
+	}
+	block, ok := index.withBlockAt(pos)
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(index.withBlocks[block].receiver), true
 }
 
 func (a Analyzer) visibleDefinitionSymbol(doc Document, currentProcedure string, sym Symbol) bool {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -3519,6 +3519,9 @@ End Property
 
 Public Sub Hoge(ByRef TargetSheet As Worksheet)
     Debug.Print TargetSheet.LastRow
+    With TargetSheet
+        Debug.Print .LastRow
+    End With
 End Sub
 
 Public Sub ValidDocumentAccess()
@@ -3556,6 +3559,28 @@ End Sub
 	}
 	if _, err := analyzer.PrepareRename(doc, invalidPos, []Document{doc}); err == nil {
 		t.Fatal("PrepareRename unexpectedly accepted generic Worksheet member")
+	}
+	withInvalidLine := `        Debug.Print .LastRow`
+	withInvalidPos := Position{Line: lineIndex(source, withInvalidLine), Character: utf16Len(withInvalidLine[:strings.Index(withInvalidLine, "LastRow")+3])}
+	if typ, ok := analyzer.withBlockTypeAt(doc, withInvalidPos, byteOffsetForPosition(doc.Source, withInvalidPos)); !ok || typ != "Worksheet" {
+		t.Fatalf("With TargetSheet type = %q, %v; want Worksheet", typ, ok)
+	}
+	if !analyzer.unresolvedExternalMemberReference(doc, withInvalidPos, "LastRow") {
+		t.Fatal("With TargetSheet.LastRow should be recognized as an unresolved external member")
+	}
+	defs, err = analyzer.Definition(doc, withInvalidPos, []Document{doc}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(defs) != 0 {
+		t.Fatalf("With generic Worksheet member definition = %+v, want none", defs)
+	}
+	hover, err = analyzer.Hover(doc, withInvalidPos, []Document{doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hover != nil {
+		t.Fatalf("With generic Worksheet member hover = %+v, want none", hover)
 	}
 
 	validLine := `    Debug.Print Me.LastRow`

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -966,6 +966,36 @@ End Sub
 	}
 }
 
+func TestUnknownMemberDiagnosticsUseGeneratedExcelWorksheetType(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	if err := analyzer.DB.MergeJSON([]byte(`{
+  "types": [{
+    "name": "Excel.Worksheet",
+    "library": "Excel",
+    "kind": "interface",
+    "confidence": "generated",
+    "source": "typelib",
+    "properties": [{ "name": "Range", "return_type": "Excel.Range" }]
+  }]
+}`)); err != nil {
+		t.Fatal(err)
+	}
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Sub Test()
+    Dim ws As Excel.Worksheet
+    ws.LastRow
+End Sub
+`,
+	}
+
+	diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VB033")
+	if len(diagnostics) != 1 || !hasDiagnosticMessage(diagnostics, `Unknown member "LastRow" on Excel.Worksheet.`) {
+		t.Fatalf("generated Excel.Worksheet unknown-member diagnostic = %+v", diagnostics)
+	}
+}
+
 func TestUnknownMemberDiagnosticsSkipLowConfidenceReceivers(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	doc := Document{
@@ -3477,6 +3507,65 @@ End Sub
 	}
 	if len(withoutDecl) != 2 || withoutDecl[0].Range.Start.Line != 2 || withoutDecl[1].Range.Start.Line != 2 {
 		t.Fatalf("parameter references without declaration = %+v, want First body references only", withoutDecl)
+	}
+}
+
+func TestGenericWorksheetMemberDoesNotResolveDocumentProperty(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	source := `Option Explicit
+Public Property Get LastRow() As Long
+    LastRow = Me.UsedRange(Me.UsedRange.CountLarge).Row
+End Property
+
+Public Sub Hoge(ByRef TargetSheet As Worksheet)
+    Debug.Print TargetSheet.LastRow
+End Sub
+
+Public Sub ValidDocumentAccess()
+    Debug.Print Me.LastRow
+End Sub
+`
+	doc := Document{
+		Path:       filepath.Join(t.TempDir(), "Sheet1.bas"),
+		ModuleKind: "document",
+		Source:     source,
+	}
+	invalidLine := `    Debug.Print TargetSheet.LastRow`
+	invalidPos := Position{Line: lineIndex(source, invalidLine), Character: utf16Len(invalidLine[:strings.Index(invalidLine, "LastRow")+3])}
+
+	defs, err := analyzer.Definition(doc, invalidPos, []Document{doc}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(defs) != 0 {
+		t.Fatalf("generic Worksheet member definition = %+v, want none", defs)
+	}
+	hover, err := analyzer.Hover(doc, invalidPos, []Document{doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hover != nil {
+		t.Fatalf("generic Worksheet member hover = %+v, want none", hover)
+	}
+	refs, err := analyzer.References(doc, invalidPos, []Document{doc}, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("generic Worksheet member references = %+v, want none", refs)
+	}
+	if _, err := analyzer.PrepareRename(doc, invalidPos, []Document{doc}); err == nil {
+		t.Fatal("PrepareRename unexpectedly accepted generic Worksheet member")
+	}
+
+	validLine := `    Debug.Print Me.LastRow`
+	validPos := Position{Line: lineIndex(source, validLine), Character: utf16Len(validLine[:strings.Index(validLine, "LastRow")+3])}
+	defs, err = analyzer.Definition(doc, validPos, []Document{doc}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(defs) != 1 || defs[0].Range.Start.Line != 1 {
+		t.Fatalf("Me.LastRow definition = %+v, want document property", defs)
 	}
 }
 

--- a/internal/vbadb/db.go
+++ b/internal/vbadb/db.go
@@ -241,10 +241,10 @@ func mergeType(base, overlay TypeInfo) TypeInfo {
 	if overlay.Collection {
 		out.Collection = true
 	}
-	if overlay.Confidence != "" {
+	if overlay.Confidence != "" && !preserveGeneratedProvenance(base, overlay) {
 		out.Confidence = overlay.Confidence
 	}
-	if overlay.Source != "" {
+	if overlay.Source != "" && !preserveGeneratedProvenance(base, overlay) {
 		out.Source = overlay.Source
 	}
 	out.Aliases = mergeStrings(out.Aliases, overlay.Aliases)
@@ -253,6 +253,17 @@ func mergeType(base, overlay TypeInfo) TypeInfo {
 	out.Methods = mergeMembers(out.Methods, overlay.Methods)
 	out.Events = mergeMembers(out.Events, overlay.Events)
 	return out
+}
+
+// preserveGeneratedProvenance keeps a generated TypeLib type authoritative
+// when the embedded curated DB supplies convenience metadata or member
+// corrections. The curated overlay is intentionally loaded after generated
+// databases, but it must not make a complete generated member set look partial.
+func preserveGeneratedProvenance(base, overlay TypeInfo) bool {
+	return strings.EqualFold(base.Source, "typelib") &&
+		strings.EqualFold(base.Confidence, "generated") &&
+		strings.EqualFold(overlay.Source, "xlflow") &&
+		strings.EqualFold(overlay.Confidence, "curated")
 }
 
 func mergeStrings(base, overlay []string) []string {

--- a/internal/vbadb/db_test.go
+++ b/internal/vbadb/db_test.go
@@ -72,6 +72,49 @@ func TestMergeJSONPreservesParamArrayParameters(t *testing.T) {
 	}
 }
 
+func TestCuratedOverlayPreservesGeneratedTypeLibProvenance(t *testing.T) {
+	db := New()
+	if err := db.MergeJSON([]byte(`{
+  "types": [{
+    "name": "Excel.Worksheet",
+    "library": "Excel",
+    "kind": "interface",
+    "confidence": "generated",
+    "source": "typelib",
+    "properties": [{ "name": "GeneratedMember", "return_type": "String" }]
+  }]
+}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MergeJSON([]byte(`{
+  "types": [{
+    "name": "Excel.Worksheet",
+    "kind": "class",
+    "confidence": "curated",
+    "source": "xlflow",
+    "summary": "Curated worksheet summary.",
+    "properties": [{ "name": "CuratedMember", "return_type": "Long" }]
+  }]
+}`)); err != nil {
+		t.Fatal(err)
+	}
+	typ, ok := db.ResolveType("Excel.Worksheet")
+	if !ok {
+		t.Fatal("Excel.Worksheet missing after merge")
+	}
+	if typ.Source != "typelib" || typ.Confidence != "generated" {
+		t.Fatalf("generated provenance was downgraded: %+v", typ)
+	}
+	if typ.Kind != "class" || typ.Summary != "Curated worksheet summary." {
+		t.Fatalf("curated overlay metadata was not retained: %+v", typ)
+	}
+	for _, name := range []string{"GeneratedMember", "CuratedMember"} {
+		if _, ok := db.ResolveMember("Excel.Worksheet", name); !ok {
+			t.Fatalf("merged member %s missing", name)
+		}
+	}
+}
+
 func TestIsAssignableUsesExplicitRelationshipsOnly(t *testing.T) {
 	db := New()
 	if err := db.MergeJSON([]byte(`{


### PR DESCRIPTION
Closes #374 

## Summary
- Preserve generated TypeLib provenance when applying curated type overlays
- Prevent unresolved external worksheet members from resolving to document-module symbols
- Add regression coverage for member lookup, hover, references, rename, and merged type metadata

## Testing
- Added unit tests for generated worksheet diagnostics and curated overlay behavior
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unresolved external member access on known host types to prevent incorrect hover, definition, references, and rename results.
  * Preserved generated type provenance (source/confidence) when overlaying curated and generated type information.
  * Improved Excel worksheet type member resolution and unknown-member diagnostics.

* **Tests**
  * Added coverage for generated Excel worksheet unknown-member diagnostics, worksheet vs document property resolution behavior, and curated-over-generated provenance preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->