### PR TITLE
Add deterministic build source planning with exclusion globs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ coverage.out
 
 # xlflow
 .xlflow/
-build/
+/build/
 .worktrees/
 xlflow.toml
 /src/

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -328,6 +328,10 @@ default_component_folders = true
 [userform]
 code_source = "sidecar"
 
+[build]
+# Source paths are project-root-relative doublestar globs.
+exclude = ["src/modules/Tests/**"]
+
 # [backup.retention]
 # enabled = false
 # max_count = 20
@@ -350,6 +354,8 @@ disabled_rules = []
 [analyze]
 disabled_rules = []
 ```
+
+`[build].exclude` defines the source filtering policy used only by the forthcoming Excel-backed `build` command; it never changes `push` or `pack` source selection. Each entry is a project-root-relative `doublestar` glob. Paths and patterns are normalized to `/`, so Windows and WSL separators match identically; absolute paths and patterns that traverse outside the project root are invalid. Matching is component-level: standard, class, and document components match their source file, while a UserForm matches its `.frm` and any associated `.frx`, sidecar code, or persisted spec path. A matching UserForm artifact excludes the whole form component. The resolver reports unmatched patterns as stable `build_exclude_unmatched` warnings, but malformed patterns, unreadable configured source roots or files, incomplete UserForm artifacts, duplicate included VBA component names (case-insensitive across component types), and equal resolved base/output paths are errors before Excel is opened. Included and excluded lists are sorted by normalized source path for stable future human and JSON build output.
 
 `[backup.retention]` controls automatic pruning after successful backup-producing operations. It is disabled by default. `max_count <= 0`, `max_age_days <= 0`, and `max_total_size_mb <= 0` disable their respective limits. `min_keep` must be zero or greater and always protects the newest valid backups when automatic pruning is enabled. Negative values are configuration errors, and `min_keep > max_count` is invalid when `max_count > 0`. If all limits are disabled, automatic pruning performs no deletion, though invalid or legacy entries may still be reported as skipped.
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=

--- a/internal/build/plan.go
+++ b/internal/build/plan.go
@@ -97,7 +97,7 @@ func Plan(opts Options) (BuildPlan, error) {
 	if err != nil {
 		return BuildPlan{}, err
 	}
-	components, err := collectComponents(root, opts.Config)
+	components, err := collectComponents(root, opts.Config, patterns)
 	if err != nil {
 		return BuildPlan{}, err
 	}
@@ -202,7 +202,7 @@ func isDriveAbsolute(path string) bool {
 	return len(path) >= 2 && path[1] == ':' && ((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z'))
 }
 
-func collectComponents(root string, cfg config.Config) ([]BuildComponent, error) {
+func collectComponents(root string, cfg config.Config, patterns []string) ([]BuildComponent, error) {
 	components := make([]BuildComponent, 0)
 	for _, source := range []struct {
 		dir  string
@@ -219,7 +219,7 @@ func collectComponents(root string, cfg config.Config) ([]BuildComponent, error)
 		}
 		components = append(components, items...)
 	}
-	formComponents, err := collectFormComponents(root, cfg)
+	formComponents, err := collectFormComponents(root, cfg, patterns)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func collectCodeComponents(root, configured string, typ ComponentType, allowed m
 	return out, nil
 }
 
-func collectFormComponents(root string, cfg config.Config) ([]BuildComponent, error) {
+func collectFormComponents(root string, cfg config.Config, patterns []string) ([]BuildComponent, error) {
 	base, err := projectPath(root, cfg.Src.Forms)
 	if err != nil {
 		return nil, fmt.Errorf("resolve form source root: %w", err)
@@ -350,7 +350,8 @@ func collectFormComponents(root string, cfg config.Config) ([]BuildComponent, er
 	if err != nil {
 		return nil, err
 	}
-	if err := addFormArtifacts(root, base.absolute, byName, cfg.UserForm.CodeSource == "sidecar"); err != nil {
+	artifactForms := formsAfterPrimaryExclusions(root, byName, patterns)
+	if err := addFormArtifacts(root, base.absolute, artifactForms, byName, cfg.UserForm.CodeSource == "sidecar"); err != nil {
 		return nil, err
 	}
 	var out []BuildComponent
@@ -371,7 +372,22 @@ func collectFormComponents(root string, cfg config.Config) ([]BuildComponent, er
 	return out, nil
 }
 
-func addFormArtifacts(root, formsDir string, byName map[string][]*formFiles, sidecar bool) error {
+// formsAfterPrimaryExclusions limits flat sidecar/spec lookup to forms whose
+// own .frm path remains eligible. This lets a build exclude one of otherwise
+// same-named forms before resolving a single name-keyed sidecar.
+func formsAfterPrimaryExclusions(root string, byName map[string][]*formFiles, patterns []string) map[string][]*formFiles {
+	remaining := make(map[string][]*formFiles, len(byName))
+	for name, forms := range byName {
+		for _, form := range forms {
+			if form.frm == "" || len(matchingPatterns(BuildComponent{SourcePath: displayPath(root, form.frm)}, patterns)) == 0 {
+				remaining[name] = append(remaining[name], form)
+			}
+		}
+	}
+	return remaining
+}
+
+func addFormArtifacts(root, formsDir string, byName, allForms map[string][]*formFiles, sidecar bool) error {
 	locations := []struct {
 		dir     string
 		allowed map[string]bool
@@ -409,7 +425,10 @@ func addFormArtifacts(root, formsDir string, byName map[string][]*formFiles, sid
 			name := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
 			forms := byName[strings.ToLower(name)]
 			if len(forms) == 0 {
-				return fmt.Errorf("orphan UserForm sidecar %s has no matching .frm", displayPath(root, path))
+				forms = allForms[strings.ToLower(name)]
+				if len(forms) == 0 {
+					return fmt.Errorf("orphan UserForm sidecar %s has no matching .frm", displayPath(root, path))
+				}
 			}
 			if location.unique && len(forms) != 1 {
 				return fmt.Errorf("ambiguous UserForm sidecar %s matches multiple .frm artifacts", displayPath(root, path))

--- a/internal/build/plan.go
+++ b/internal/build/plan.go
@@ -1,0 +1,449 @@
+// Package build resolves the read-only source plan used by the Excel-backed
+// release build command. It deliberately has no dependency on CLI or Excel.
+package build
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/excel/forms"
+)
+
+type ComponentType string
+
+const (
+	ComponentStandard ComponentType = "standard"
+	ComponentClass    ComponentType = "class"
+	ComponentDocument ComponentType = "document"
+	ComponentForm     ComponentType = "form"
+)
+
+// BuildComponent is one VBA project component and every tracked UserForm
+// artifact that belongs to it. Paths are normalized relative to the project
+// root and use forward slashes.
+type BuildComponent struct {
+	SourcePath   string        `json:"source_path"`
+	Name         string        `json:"name"`
+	Type         ComponentType `json:"type"`
+	Reason       string        `json:"reason"`
+	RelatedPaths []string      `json:"related_paths,omitempty"`
+}
+
+type BuildWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// BuildPlan is deterministic and entirely read-only. BaseWorkbook and
+// OutputPath are normalized project-root-relative paths.
+type BuildPlan struct {
+	BaseWorkbook string           `json:"base_workbook"`
+	OutputPath   string           `json:"output_path"`
+	Included     []BuildComponent `json:"included"`
+	Excluded     []BuildComponent `json:"excluded"`
+	Warnings     []BuildWarning   `json:"warnings,omitempty"`
+}
+
+type Options struct {
+	Root         string
+	Config       config.Config
+	BaseWorkbook string
+	OutputPath   string
+}
+
+type formFiles struct {
+	frm     string
+	frx     string
+	related []string
+}
+
+// Plan resolves source inputs without opening Excel or modifying any source
+// or workbook. Empty BaseWorkbook uses excel.path; empty OutputPath uses
+// build/Release/<base filename>.
+func Plan(opts Options) (BuildPlan, error) {
+	root, err := filepath.Abs(opts.Root)
+	if err != nil {
+		return BuildPlan{}, fmt.Errorf("resolve project root: %w", err)
+	}
+	root = filepath.Clean(root)
+	if opts.BaseWorkbook == "" {
+		opts.BaseWorkbook = opts.Config.Excel.Path
+	}
+	base, err := projectPath(root, opts.BaseWorkbook)
+	if err != nil {
+		return BuildPlan{}, fmt.Errorf("resolve build base: %w", err)
+	}
+	if opts.OutputPath == "" {
+		opts.OutputPath = filepath.Join("build", "Release", filepath.Base(base.absolute))
+	}
+	output, err := projectPath(root, opts.OutputPath)
+	if err != nil {
+		return BuildPlan{}, fmt.Errorf("resolve build output: %w", err)
+	}
+	if sameFileIdentity(base.absolute, output.absolute) {
+		return BuildPlan{}, errors.New("build base and output must refer to different files")
+	}
+
+	patterns, err := normalizePatterns(opts.Config.Build.Exclude)
+	if err != nil {
+		return BuildPlan{}, err
+	}
+	components, err := collectComponents(root, opts.Config)
+	if err != nil {
+		return BuildPlan{}, err
+	}
+
+	matched := make(map[string]bool, len(patterns))
+	plan := BuildPlan{BaseWorkbook: base.relative, OutputPath: output.relative}
+	for _, component := range components {
+		pattern := firstMatch(component, patterns)
+		if pattern == "" {
+			component.Reason = "included"
+			plan.Included = append(plan.Included, component)
+			continue
+		}
+		matched[pattern] = true
+		component.Reason = "excluded by " + pattern
+		plan.Excluded = append(plan.Excluded, component)
+	}
+	if err := validateIncludedNames(plan.Included); err != nil {
+		return BuildPlan{}, err
+	}
+	for _, pattern := range patterns {
+		if !matched[pattern] {
+			plan.Warnings = append(plan.Warnings, BuildWarning{
+				Code: "build_exclude_unmatched", Pattern: pattern,
+				Message: fmt.Sprintf("build exclusion pattern %q did not match any source component", pattern),
+			})
+		}
+	}
+	return plan, nil
+}
+
+type resolvedPath struct{ absolute, relative string }
+
+func projectPath(root, value string) (resolvedPath, error) {
+	if strings.TrimSpace(value) == "" {
+		return resolvedPath{}, errors.New("path is required")
+	}
+	path := value
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(root, filepath.FromSlash(strings.ReplaceAll(path, "\\", "/")))
+	}
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return resolvedPath{}, fmt.Errorf("path %q must be inside the project root", value)
+	}
+	return resolvedPath{absolute: path, relative: filepath.ToSlash(rel)}, nil
+}
+
+func sameFileIdentity(a, b string) bool {
+	a = resolveExistingAncestor(a)
+	b = resolveExistingAncestor(b)
+	return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+}
+
+func resolveExistingAncestor(path string) string {
+	path = filepath.Clean(path)
+	var suffix []string
+	for {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err == nil {
+			for i := len(suffix) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, suffix[i])
+			}
+			return resolved
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return path
+		}
+		suffix = append(suffix, filepath.Base(path))
+		path = parent
+	}
+}
+
+func normalizePatterns(raw []string) ([]string, error) {
+	seen := map[string]bool{}
+	patterns := make([]string, 0, len(raw))
+	for _, value := range raw {
+		pattern := filepath.ToSlash(strings.TrimSpace(strings.ReplaceAll(value, "\\", "/")))
+		if pattern == "" {
+			return nil, errors.New("build.exclude must not contain an empty pattern")
+		}
+		if strings.HasPrefix(pattern, "/") || pattern == ".." || strings.HasPrefix(pattern, "../") || strings.Contains(pattern, "/../") {
+			return nil, fmt.Errorf("build exclusion pattern %q must be project-root-relative", value)
+		}
+		if !doublestar.ValidatePattern(pattern) {
+			return nil, fmt.Errorf("invalid build exclusion pattern %q", value)
+		}
+		if !seen[pattern] {
+			seen[pattern] = true
+			patterns = append(patterns, pattern)
+		}
+	}
+	sort.Strings(patterns)
+	return patterns, nil
+}
+
+func collectComponents(root string, cfg config.Config) ([]BuildComponent, error) {
+	components := make([]BuildComponent, 0)
+	for _, source := range []struct {
+		dir  string
+		typ  ComponentType
+		exts map[string]bool
+	}{
+		{cfg.Src.Modules, ComponentStandard, map[string]bool{".bas": true}},
+		{cfg.Src.Classes, ComponentClass, map[string]bool{".cls": true}},
+		{cfg.Src.Workbook, ComponentDocument, map[string]bool{".bas": true, ".cls": true}},
+	} {
+		items, err := collectCodeComponents(root, source.dir, source.typ, source.exts)
+		if err != nil {
+			return nil, err
+		}
+		components = append(components, items...)
+	}
+	forms, err := collectFormComponents(root, cfg)
+	if err != nil {
+		return nil, err
+	}
+	components = append(components, forms...)
+	sort.Slice(components, func(i, j int) bool {
+		if components[i].SourcePath != components[j].SourcePath {
+			return components[i].SourcePath < components[j].SourcePath
+		}
+		return components[i].Type < components[j].Type
+	})
+	return components, nil
+}
+
+func collectCodeComponents(root, configured string, typ ComponentType, allowed map[string]bool) ([]BuildComponent, error) {
+	base, err := projectPath(root, configured)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s source root: %w", typ, err)
+	}
+	info, err := os.Stat(base.absolute)
+	if err != nil {
+		return nil, fmt.Errorf("read %s source root %s: %w", typ, base.relative, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s source root %s is not a directory", typ, base.relative)
+	}
+	var out []BuildComponent
+	err = filepath.WalkDir(base.absolute, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if !allowed[ext] {
+			return fmt.Errorf("unsupported %s source file %s", typ, displayPath(root, path))
+		}
+		if _, err := os.ReadFile(path); err != nil {
+			return fmt.Errorf("read source %s: %w", displayPath(root, path), err)
+		}
+		name := strings.TrimSuffix(d.Name(), filepath.Ext(d.Name()))
+		if !validComponentName(name) {
+			return fmt.Errorf("invalid VBA component name %q in %s", name, displayPath(root, path))
+		}
+		out = append(out, BuildComponent{SourcePath: displayPath(root, path), Name: name, Type: typ})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func collectFormComponents(root string, cfg config.Config) ([]BuildComponent, error) {
+	base, err := projectPath(root, cfg.Src.Forms)
+	if err != nil {
+		return nil, fmt.Errorf("resolve form source root: %w", err)
+	}
+	if info, statErr := os.Stat(base.absolute); statErr != nil {
+		return nil, fmt.Errorf("read form source root %s: %w", base.relative, statErr)
+	} else if !info.IsDir() {
+		return nil, fmt.Errorf("form source root %s is not a directory", base.relative)
+	}
+
+	if cfg.UserForm.CodeSource == "sidecar" {
+		issues, validateErr := forms.ValidateUserFormCodeSidecars(base.absolute, nil)
+		if validateErr != nil {
+			return nil, validateErr
+		}
+		if len(issues) > 0 {
+			return nil, fmt.Errorf("invalid UserForm sidecar: %s", issues[0].Error())
+		}
+		artifactIssues, validateErr := forms.ValidateUserFormArtifactsAgainstSpecs(base.absolute, nil)
+		if validateErr != nil {
+			return nil, validateErr
+		}
+		if len(artifactIssues) > 0 {
+			return nil, fmt.Errorf("invalid UserForm artifact: %s", artifactIssues[0].Message)
+		}
+	}
+
+	byName := map[string]*formFiles{}
+	codeDir := filepath.Join(base.absolute, "code")
+	specDir := filepath.Join(base.absolute, "specs")
+	err = filepath.WalkDir(base.absolute, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if samePath(path, codeDir) || samePath(path, specDir) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if ext != ".frm" && ext != ".frx" {
+			return fmt.Errorf("unsupported UserForm source file %s", displayPath(root, path))
+		}
+		if _, err := os.ReadFile(path); err != nil {
+			return fmt.Errorf("read source %s: %w", displayPath(root, path), err)
+		}
+		name := strings.TrimSuffix(d.Name(), filepath.Ext(d.Name()))
+		if !validComponentName(name) {
+			return fmt.Errorf("invalid VBA component name %q in %s", name, displayPath(root, path))
+		}
+		key := strings.ToLower(name)
+		entry := byName[key]
+		if entry == nil {
+			entry = &formFiles{}
+			byName[key] = entry
+		}
+		switch ext {
+		case ".frm":
+			if entry.frm != "" {
+				return fmt.Errorf("ambiguous UserForm %q: %s and %s", name, displayPath(root, entry.frm), displayPath(root, path))
+			}
+			entry.frm = path
+		case ".frx":
+			if entry.frx != "" {
+				return fmt.Errorf("ambiguous UserForm companion for %q", name)
+			}
+			entry.frx = path
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if cfg.UserForm.CodeSource == "sidecar" {
+		if err := addSidecarArtifacts(root, base.absolute, byName); err != nil {
+			return nil, err
+		}
+	}
+	var out []BuildComponent
+	for key, entry := range byName {
+		if entry.frm == "" {
+			return nil, fmt.Errorf("incomplete UserForm %q: .frx has no matching .frm", key)
+		}
+		name := strings.TrimSuffix(filepath.Base(entry.frm), filepath.Ext(entry.frm))
+		related := append([]string{}, entry.related...)
+		if entry.frx != "" {
+			related = append(related, displayPath(root, entry.frx))
+		}
+		sort.Strings(related)
+		out = append(out, BuildComponent{SourcePath: displayPath(root, entry.frm), Name: name, Type: ComponentForm, RelatedPaths: related})
+	}
+	return out, nil
+}
+
+func addSidecarArtifacts(root, formsDir string, byName map[string]*formFiles) error {
+	for _, location := range []struct {
+		dir     string
+		allowed map[string]bool
+	}{
+		{filepath.Join(formsDir, "code"), map[string]bool{".bas": true}},
+		{filepath.Join(formsDir, "specs"), map[string]bool{".yaml": true, ".yml": true, ".json": true}},
+	} {
+		entries, err := os.ReadDir(location.dir)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				return fmt.Errorf("unsupported UserForm sidecar directory %s", displayPath(root, filepath.Join(location.dir, entry.Name())))
+			}
+			ext := strings.ToLower(filepath.Ext(entry.Name()))
+			if !location.allowed[ext] {
+				return fmt.Errorf("unsupported UserForm sidecar file %s", displayPath(root, filepath.Join(location.dir, entry.Name())))
+			}
+			path := filepath.Join(location.dir, entry.Name())
+			if _, err := os.ReadFile(path); err != nil {
+				return fmt.Errorf("read source %s: %w", displayPath(root, path), err)
+			}
+			name := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+			form := byName[strings.ToLower(name)]
+			if form == nil || form.frm == "" {
+				return fmt.Errorf("orphan UserForm sidecar %s has no matching .frm", displayPath(root, path))
+			}
+			form.related = append(form.related, displayPath(root, path))
+		}
+	}
+	return nil
+}
+
+func firstMatch(component BuildComponent, patterns []string) string {
+	paths := append([]string{component.SourcePath}, component.RelatedPaths...)
+	for _, pattern := range patterns {
+		for _, path := range paths {
+			matched, err := doublestar.Match(pattern, path)
+			if err == nil && matched {
+				return pattern
+			}
+		}
+	}
+	return ""
+}
+
+func validateIncludedNames(components []BuildComponent) error {
+	seen := map[string]BuildComponent{}
+	for _, component := range components {
+		key := strings.ToLower(component.Name)
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("duplicate included VBA component name %q: %s and %s", component.Name, previous.SourcePath, component.SourcePath)
+		}
+		seen[key] = component
+	}
+	return nil
+}
+
+func validComponentName(name string) bool {
+	runes := []rune(name)
+	if len(runes) == 0 || len(runes) > 255 || !unicode.IsLetter(runes[0]) {
+		return false
+	}
+	for _, r := range runes[1:] {
+		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func displayPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func samePath(a, b string) bool { return strings.EqualFold(filepath.Clean(a), filepath.Clean(b)) }

--- a/internal/build/plan.go
+++ b/internal/build/plan.go
@@ -60,6 +60,7 @@ type Options struct {
 }
 
 type formFiles struct {
+	name    string
 	frm     string
 	frx     string
 	related []string
@@ -104,14 +105,16 @@ func Plan(opts Options) (BuildPlan, error) {
 	matched := make(map[string]bool, len(patterns))
 	plan := BuildPlan{BaseWorkbook: base.relative, OutputPath: output.relative}
 	for _, component := range components {
-		pattern := firstMatch(component, patterns)
-		if pattern == "" {
+		componentPatterns := matchingPatterns(component, patterns)
+		if len(componentPatterns) == 0 {
 			component.Reason = "included"
 			plan.Included = append(plan.Included, component)
 			continue
 		}
-		matched[pattern] = true
-		component.Reason = "excluded by " + pattern
+		for _, pattern := range componentPatterns {
+			matched[pattern] = true
+		}
+		component.Reason = "excluded by " + componentPatterns[0]
 		plan.Excluded = append(plan.Excluded, component)
 	}
 	if err := validateIncludedNames(plan.Included); err != nil {
@@ -180,7 +183,7 @@ func normalizePatterns(raw []string) ([]string, error) {
 		if pattern == "" {
 			return nil, errors.New("build.exclude must not contain an empty pattern")
 		}
-		if strings.HasPrefix(pattern, "/") || pattern == ".." || strings.HasPrefix(pattern, "../") || strings.Contains(pattern, "/../") {
+		if strings.HasPrefix(pattern, "/") || isDriveAbsolute(pattern) || pattern == ".." || strings.HasPrefix(pattern, "../") || strings.Contains(pattern, "/../") {
 			return nil, fmt.Errorf("build exclusion pattern %q must be project-root-relative", value)
 		}
 		if !doublestar.ValidatePattern(pattern) {
@@ -193,6 +196,10 @@ func normalizePatterns(raw []string) ([]string, error) {
 	}
 	sort.Strings(patterns)
 	return patterns, nil
+}
+
+func isDriveAbsolute(path string) bool {
+	return len(path) >= 2 && path[1] == ':' && ((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z'))
 }
 
 func collectComponents(root string, cfg config.Config) ([]BuildComponent, error) {
@@ -212,11 +219,11 @@ func collectComponents(root string, cfg config.Config) ([]BuildComponent, error)
 		}
 		components = append(components, items...)
 	}
-	forms, err := collectFormComponents(root, cfg)
+	formComponents, err := collectFormComponents(root, cfg)
 	if err != nil {
 		return nil, err
 	}
-	components = append(components, forms...)
+	components = append(components, formComponents...)
 	sort.Slice(components, func(i, j int) bool {
 		if components[i].SourcePath != components[j].SourcePath {
 			return components[i].SourcePath < components[j].SourcePath
@@ -294,7 +301,8 @@ func collectFormComponents(root string, cfg config.Config) ([]BuildComponent, er
 		}
 	}
 
-	byName := map[string]*formFiles{}
+	byLocation := map[string]*formFiles{}
+	byName := map[string][]*formFiles{}
 	codeDir := filepath.Join(base.absolute, "code")
 	specDir := filepath.Join(base.absolute, "specs")
 	err = filepath.WalkDir(base.absolute, func(path string, d os.DirEntry, walkErr error) error {
@@ -318,16 +326,17 @@ func collectFormComponents(root string, cfg config.Config) ([]BuildComponent, er
 		if !validComponentName(name) {
 			return fmt.Errorf("invalid VBA component name %q in %s", name, displayPath(root, path))
 		}
-		key := strings.ToLower(name)
-		entry := byName[key]
+		key := formLocationKey(filepath.Dir(path), name)
+		entry := byLocation[key]
 		if entry == nil {
-			entry = &formFiles{}
-			byName[key] = entry
+			entry = &formFiles{name: name}
+			byLocation[key] = entry
+			byName[strings.ToLower(name)] = append(byName[strings.ToLower(name)], entry)
 		}
 		switch ext {
 		case ".frm":
 			if entry.frm != "" {
-				return fmt.Errorf("ambiguous UserForm %q: %s and %s", name, displayPath(root, entry.frm), displayPath(root, path))
+				return fmt.Errorf("ambiguous UserForm source %q: %s and %s", name, displayPath(root, entry.frm), displayPath(root, path))
 			}
 			entry.frm = path
 		case ".frx":
@@ -341,35 +350,43 @@ func collectFormComponents(root string, cfg config.Config) ([]BuildComponent, er
 	if err != nil {
 		return nil, err
 	}
-	if cfg.UserForm.CodeSource == "sidecar" {
-		if err := addSidecarArtifacts(root, base.absolute, byName); err != nil {
-			return nil, err
-		}
+	if err := addFormArtifacts(root, base.absolute, byName, cfg.UserForm.CodeSource == "sidecar"); err != nil {
+		return nil, err
 	}
 	var out []BuildComponent
-	for key, entry := range byName {
-		if entry.frm == "" {
-			return nil, fmt.Errorf("incomplete UserForm %q: .frx has no matching .frm", key)
+	for _, entries := range byName {
+		for _, entry := range entries {
+			if entry.frm == "" {
+				return nil, fmt.Errorf("incomplete UserForm %q: .frx has no matching .frm", entry.name)
+			}
+			name := strings.TrimSuffix(filepath.Base(entry.frm), filepath.Ext(entry.frm))
+			related := append([]string{}, entry.related...)
+			if entry.frx != "" {
+				related = append(related, displayPath(root, entry.frx))
+			}
+			sort.Strings(related)
+			out = append(out, BuildComponent{SourcePath: displayPath(root, entry.frm), Name: name, Type: ComponentForm, RelatedPaths: related})
 		}
-		name := strings.TrimSuffix(filepath.Base(entry.frm), filepath.Ext(entry.frm))
-		related := append([]string{}, entry.related...)
-		if entry.frx != "" {
-			related = append(related, displayPath(root, entry.frx))
-		}
-		sort.Strings(related)
-		out = append(out, BuildComponent{SourcePath: displayPath(root, entry.frm), Name: name, Type: ComponentForm, RelatedPaths: related})
 	}
 	return out, nil
 }
 
-func addSidecarArtifacts(root, formsDir string, byName map[string]*formFiles) error {
-	for _, location := range []struct {
+func addFormArtifacts(root, formsDir string, byName map[string][]*formFiles, sidecar bool) error {
+	locations := []struct {
 		dir     string
 		allowed map[string]bool
+		unique  bool
 	}{
-		{filepath.Join(formsDir, "code"), map[string]bool{".bas": true}},
-		{filepath.Join(formsDir, "specs"), map[string]bool{".yaml": true, ".yml": true, ".json": true}},
-	} {
+		{filepath.Join(formsDir, "specs"), map[string]bool{".yaml": true, ".yml": true, ".json": true}, false},
+	}
+	if sidecar {
+		locations = append(locations, struct {
+			dir     string
+			allowed map[string]bool
+			unique  bool
+		}{filepath.Join(formsDir, "code"), map[string]bool{".bas": true}, true})
+	}
+	for _, location := range locations {
 		entries, err := os.ReadDir(location.dir)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
@@ -390,27 +407,41 @@ func addSidecarArtifacts(root, formsDir string, byName map[string]*formFiles) er
 				return fmt.Errorf("read source %s: %w", displayPath(root, path), err)
 			}
 			name := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
-			form := byName[strings.ToLower(name)]
-			if form == nil || form.frm == "" {
+			forms := byName[strings.ToLower(name)]
+			if len(forms) == 0 {
 				return fmt.Errorf("orphan UserForm sidecar %s has no matching .frm", displayPath(root, path))
 			}
-			form.related = append(form.related, displayPath(root, path))
+			if location.unique && len(forms) != 1 {
+				return fmt.Errorf("ambiguous UserForm sidecar %s matches multiple .frm artifacts", displayPath(root, path))
+			}
+			for _, form := range forms {
+				if form.frm == "" {
+					return fmt.Errorf("orphan UserForm sidecar %s has no matching .frm", displayPath(root, path))
+				}
+				form.related = append(form.related, displayPath(root, path))
+			}
 		}
 	}
 	return nil
 }
 
-func firstMatch(component BuildComponent, patterns []string) string {
+func formLocationKey(dir, name string) string {
+	return strings.ToLower(filepath.Clean(dir)) + "\x00" + strings.ToLower(name)
+}
+
+func matchingPatterns(component BuildComponent, patterns []string) []string {
 	paths := append([]string{component.SourcePath}, component.RelatedPaths...)
+	var matches []string
 	for _, pattern := range patterns {
 		for _, path := range paths {
 			matched, err := doublestar.Match(pattern, path)
 			if err == nil && matched {
-				return pattern
+				matches = append(matches, pattern)
+				break
 			}
 		}
 	}
-	return ""
+	return matches
 }
 
 func validateIncludedNames(components []BuildComponent) error {

--- a/internal/build/plan_test.go
+++ b/internal/build/plan_test.go
@@ -68,6 +68,24 @@ func TestPlanAllowsExcludedDuplicateUserForm(t *testing.T) {
 	}
 }
 
+func TestPlanResolvesFlatSidecarAfterExcludingDuplicateUserForm(t *testing.T) {
+	root := writeSourceTree(t)
+	write(t, filepath.Join(root, "src", "forms", "alternate", "Login.frm"), "VERSION 5.00\nAttribute VB_Name = \"Login\"\nOption Explicit\n")
+	cfg := config.Default()
+	cfg.Build.Exclude = []string{"src/forms/alternate/Login.frm"}
+
+	plan, err := Plan(Options{Root: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := componentPaths(plan.Included), []string{"src/classes/Service.cls", "src/forms/Login.frm", "src/modules/Main.bas", "src/modules/Tests/TestMain.bas", "src/workbook/ThisWorkbook.bas"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("included = %#v, want %#v", got, want)
+	}
+	if got := plan.Included[1].RelatedPaths; !reflect.DeepEqual(got, []string{"src/forms/Login.frx", "src/forms/code/Login.bas"}) {
+		t.Fatalf("remaining form related paths = %#v", got)
+	}
+}
+
 func TestPlanMatchesPersistedSpecsInFRMMode(t *testing.T) {
 	root := writeSourceTree(t)
 	write(t, filepath.Join(root, "src", "forms", "specs", "Login.yaml"), "kind: xlflow.userform\n")

--- a/internal/build/plan_test.go
+++ b/internal/build/plan_test.go
@@ -1,0 +1,148 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+)
+
+func TestPlanFiltersComponentsDeterministicallyWithoutMutatingInputs(t *testing.T) {
+	root := writeSourceTree(t)
+	cfg := config.Default()
+	cfg.Build.Exclude = []string{"src\\modules\\Tests\\**", "src/forms/code/Login.bas", "src/missing/**"}
+	before := readTree(t, root)
+
+	plan, err := Plan(Options{Root: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.BaseWorkbook != "build/Book.xlsm" || plan.OutputPath != "build/Release/Book.xlsm" {
+		t.Fatalf("paths = %+v", plan)
+	}
+	if got, want := componentPaths(plan.Included), []string{"src/classes/Service.cls", "src/modules/Main.bas", "src/workbook/ThisWorkbook.bas"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("included = %#v, want %#v", got, want)
+	}
+	if got, want := componentPaths(plan.Excluded), []string{"src/forms/Login.frm", "src/modules/Tests/TestMain.bas"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("excluded = %#v, want %#v", got, want)
+	}
+	if got := plan.Excluded[0].RelatedPaths; !reflect.DeepEqual(got, []string{"src/forms/Login.frx", "src/forms/code/Login.bas"}) {
+		t.Fatalf("form related paths = %#v", got)
+	}
+	if len(plan.Warnings) != 1 || plan.Warnings[0].Pattern != "src/missing/**" {
+		t.Fatalf("warnings = %#v", plan.Warnings)
+	}
+	if after := readTree(t, root); !reflect.DeepEqual(before, after) {
+		t.Fatal("planner modified workspace inputs")
+	}
+}
+
+func TestPlanRejectsCrossTypeDuplicateIncludedNames(t *testing.T) {
+	root := writeSourceTree(t)
+	write(t, filepath.Join(root, "src", "classes", "Main.cls"), "Option Explicit")
+	_, err := Plan(Options{Root: root, Config: config.Default()})
+	if err == nil || !strings.Contains(err.Error(), "duplicate included VBA component name") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPlanRejectsInvalidLayoutsAndPaths(t *testing.T) {
+	t.Run("invalid pattern", func(t *testing.T) {
+		cfg := config.Default()
+		cfg.Build.Exclude = []string{"../outside/**"}
+		_, err := Plan(Options{Root: writeSourceTree(t), Config: cfg})
+		if err == nil || !strings.Contains(err.Error(), "project-root-relative") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("same base and output", func(t *testing.T) {
+		root := writeSourceTree(t)
+		_, err := Plan(Options{Root: root, Config: config.Default(), OutputPath: "build/Book.xlsm"})
+		if err == nil || !strings.Contains(err.Error(), "different files") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("missing source root", func(t *testing.T) {
+		root := writeSourceTree(t)
+		cfg := config.Default()
+		cfg.Src.Classes = "src/no-classes"
+		_, err := Plan(Options{Root: root, Config: cfg})
+		if err == nil || !strings.Contains(err.Error(), "read class source root") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("orphan sidecar", func(t *testing.T) {
+		root := writeSourceTree(t)
+		write(t, filepath.Join(root, "src", "forms", "code", "Missing.bas"), "Option Explicit")
+		_, err := Plan(Options{Root: root, Config: config.Default()})
+		if err == nil || !strings.Contains(err.Error(), "orphan UserForm sidecar") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("unsupported source", func(t *testing.T) {
+		root := writeSourceTree(t)
+		write(t, filepath.Join(root, "src", "modules", "notes.txt"), "not VBA")
+		_, err := Plan(Options{Root: root, Config: config.Default()})
+		if err == nil || !strings.Contains(err.Error(), "unsupported standard source file") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}
+
+func writeSourceTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	write(t, filepath.Join(root, "src", "modules", "Main.bas"), "Option Explicit")
+	write(t, filepath.Join(root, "src", "modules", "Tests", "TestMain.bas"), "Option Explicit")
+	write(t, filepath.Join(root, "src", "classes", "Service.cls"), "Option Explicit")
+	write(t, filepath.Join(root, "src", "workbook", "ThisWorkbook.bas"), "Option Explicit")
+	write(t, filepath.Join(root, "src", "forms", "Login.frm"), "VERSION 5.00\nAttribute VB_Name = \"Login\"\nOption Explicit\n")
+	write(t, filepath.Join(root, "src", "forms", "Login.frx"), "binary")
+	write(t, filepath.Join(root, "src", "forms", "code", "Login.bas"), "Option Explicit\n")
+	return root
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func componentPaths(components []BuildComponent) []string {
+	paths := make([]string, len(components))
+	for i, component := range components {
+		paths[i] = component.SourcePath
+	}
+	return paths
+}
+
+func readTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		out[filepath.ToSlash(rel)] = string(body)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/internal/build/plan_test.go
+++ b/internal/build/plan_test.go
@@ -49,10 +49,73 @@ func TestPlanRejectsCrossTypeDuplicateIncludedNames(t *testing.T) {
 	}
 }
 
+func TestPlanAllowsExcludedDuplicateUserForm(t *testing.T) {
+	root := writeSourceTree(t)
+	write(t, filepath.Join(root, "src", "forms", "alternate", "Login.frm"), "VERSION 5.00\nAttribute VB_Name = \"Login\"\nOption Explicit\n")
+	cfg := config.Default()
+	cfg.UserForm.CodeSource = "frm"
+	cfg.Build.Exclude = []string{"src/forms/alternate/Login.frm"}
+
+	plan, err := Plan(Options{Root: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := componentPaths(plan.Included), []string{"src/classes/Service.cls", "src/forms/Login.frm", "src/modules/Main.bas", "src/modules/Tests/TestMain.bas", "src/workbook/ThisWorkbook.bas"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("included = %#v, want %#v", got, want)
+	}
+	if got, want := componentPaths(plan.Excluded), []string{"src/forms/alternate/Login.frm"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("excluded = %#v, want %#v", got, want)
+	}
+}
+
+func TestPlanMatchesPersistedSpecsInFRMMode(t *testing.T) {
+	root := writeSourceTree(t)
+	write(t, filepath.Join(root, "src", "forms", "specs", "Login.yaml"), "kind: xlflow.userform\n")
+	cfg := config.Default()
+	cfg.UserForm.CodeSource = "frm"
+	cfg.Build.Exclude = []string{"src/forms/specs/Login.yaml"}
+
+	plan, err := Plan(Options{Root: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := componentPaths(plan.Excluded), []string{"src/forms/Login.frm"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("excluded = %#v, want %#v", got, want)
+	}
+	if got := plan.Excluded[0].RelatedPaths; !reflect.DeepEqual(got, []string{"src/forms/Login.frx", "src/forms/specs/Login.yaml"}) {
+		t.Fatalf("form related paths = %#v", got)
+	}
+}
+
+func TestPlanRecordsEveryMatchingExcludePattern(t *testing.T) {
+	root := writeSourceTree(t)
+	cfg := config.Default()
+	cfg.Build.Exclude = []string{"src/forms/Login.frm", "src/forms/code/Login.bas"}
+
+	plan, err := Plan(Options{Root: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Warnings) != 0 {
+		t.Fatalf("warnings = %#v", plan.Warnings)
+	}
+	if got, want := componentPaths(plan.Excluded), []string{"src/forms/Login.frm"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("excluded = %#v, want %#v", got, want)
+	}
+}
+
 func TestPlanRejectsInvalidLayoutsAndPaths(t *testing.T) {
 	t.Run("invalid pattern", func(t *testing.T) {
 		cfg := config.Default()
 		cfg.Build.Exclude = []string{"../outside/**"}
+		_, err := Plan(Options{Root: writeSourceTree(t), Config: cfg})
+		if err == nil || !strings.Contains(err.Error(), "project-root-relative") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("Windows absolute pattern", func(t *testing.T) {
+		cfg := config.Default()
+		cfg.Build.Exclude = []string{"C:\\repo\\src\\modules\\Tests\\**"}
 		_, err := Plan(Options{Root: writeSourceTree(t), Config: cfg})
 		if err == nil || !strings.Contains(err.Error(), "project-root-relative") {
 			t.Fatalf("err = %v", err)

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -249,8 +249,12 @@ func TestDesignerCoordinationWaitsThenPublishesDesignerOwner(t *testing.T) {
 	}
 	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "form.build")
 	var stdout, stderr bytes.Buffer
-	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &stderr, coordination: manager}
-	time.AfterFunc(150*time.Millisecond, func() { _ = owner.Release() })
+	// Leave ample room for timer delivery and metadata publication on loaded
+	// Windows CI runners while still proving the waiter acquires after release.
+	const releaseDelay = 500 * time.Millisecond
+	const waitBudget = 3 * time.Second
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: waitBudget, stdout: &stdout, stderr: &stderr, coordination: manager}
+	time.AfterFunc(releaseDelay, func() { _ = owner.Release() })
 	runs := 0
 	err := a.withWorkbookCoordination(context.Background(), "form.snapshot", []string{identity.CanonicalPath}, func() error {
 		runs++

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Src      SourceConfig     `toml:"src"`
 	VBA      VBAConfig        `toml:"vba"`
 	UserForm UserFormConfig   `toml:"userform"`
+	Build    BuildConfig      `toml:"build"`
 	Backup   BackupConfig     `toml:"backup"`
 	Fmt      FmtConfig        `toml:"fmt"`
 	Lint     LintConfig       `toml:"lint"`
@@ -67,6 +68,12 @@ type VBALineNumbersConfig struct {
 
 type UserFormConfig struct {
 	CodeSource string `toml:"code_source"`
+}
+
+// BuildConfig controls release-build source selection. It is intentionally
+// separate from push, which always synchronizes the complete source tree.
+type BuildConfig struct {
+	Exclude []string `toml:"exclude"`
 }
 
 type BackupConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -16,6 +17,9 @@ entry = "Main.Run"
 
 [excel]
 path = "build/Sales.xlsm"
+
+[build]
+exclude = ["src/modules/Tests/**"]
 `)
 	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
 		t.Fatal(err)
@@ -38,6 +42,9 @@ path = "build/Sales.xlsm"
 	}
 	if cfg.UserForm.CodeSource != "sidecar" {
 		t.Fatalf("unexpected userform defaults: %+v", cfg.UserForm)
+	}
+	if got, want := cfg.Build.Exclude, []string{"src/modules/Tests/**"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("build.exclude = %#v, want %#v", got, want)
 	}
 	if cfg.Backup.Retention.Enabled ||
 		cfg.Backup.Retention.MaxCount != 20 ||

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -63,6 +63,7 @@
 - Destructive VBIDE replacement must fail before import when any existing component cannot be removed or remains after `VBComponents.Remove`; partial best-effort deletion lets Excel silently auto-suffix colliding module names.
 - Once destructive VBIDE replacement begins, route every removal/import exception through the discard-poison path, preserve the attachment owner (`external` versus managed), and never emit `save_required` for state explicitly marked for discard.
 - Windows path tests must not assume the lexical path returned by `t.TempDir()` survives final-path resolution. Hosted runners may return an 8.3 path such as `RUNNER~1` while Windows canonicalization returns the long name; assert resolved identity or preserved path semantics instead.
+- When a validation rule is scoped to included build components, apply path exclusions before duplicate-name validation; when one component has multiple related source paths, record every matching exclusion pattern before emitting unmatched-pattern warnings.
 
 # DialogWatcher
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -65,6 +65,7 @@
 - Windows path tests must not assume the lexical path returned by `t.TempDir()` survives final-path resolution. Hosted runners may return an 8.3 path such as `RUNNER~1` while Windows canonicalization returns the long name; assert resolved identity or preserved path semantics instead.
 - When a validation rule is scoped to included build components, apply path exclusions before duplicate-name validation; when one component has multiple related source paths, record every matching exclusion pattern before emitting unmatched-pattern warnings.
 - Flat UserForm sidecar/spec artifacts are keyed by component name, not source subdirectory. Resolve them only after primary `.frm` exclusions select the remaining same-named candidate; do not invent a directory-scoped sidecar layout that conflicts with the source contract.
+- Windows coordination wait tests need a generous gap between scheduled owner release and the waiter deadline; a one-second budget can expire before timer delivery or owner metadata publication on hosted runners.
 
 # DialogWatcher
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -64,6 +64,7 @@
 - Once destructive VBIDE replacement begins, route every removal/import exception through the discard-poison path, preserve the attachment owner (`external` versus managed), and never emit `save_required` for state explicitly marked for discard.
 - Windows path tests must not assume the lexical path returned by `t.TempDir()` survives final-path resolution. Hosted runners may return an 8.3 path such as `RUNNER~1` while Windows canonicalization returns the long name; assert resolved identity or preserved path semantics instead.
 - When a validation rule is scoped to included build components, apply path exclusions before duplicate-name validation; when one component has multiple related source paths, record every matching exclusion pattern before emitting unmatched-pattern warnings.
+- Flat UserForm sidecar/spec artifacts are keyed by component name, not source subdirectory. Resolve them only after primary `.frm` exclusions select the remaining same-named candidate; do not invent a directory-scoped sidecar layout that conflicts with the source contract.
 
 # DialogWatcher
 


### PR DESCRIPTION
## Summary
- Add read-only build planning for VBA components and UserForm artifacts
- Support normalized doublestar exclusion patterns with stable unmatched warnings
- Validate source layouts, component names, duplicate names, and base/output paths
- Document `[build].exclude` configuration and add parsing/planner tests
- Ignore the repository-root `/build/` directory

## Testing
- Added configuration parsing and build planner unit tests covering filtering, determinism, validation errors, and input immutability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `[build].exclude` to exclude matching source components using project-root-relative glob patterns.
  * Build planning now derives base/output artifacts, validates source layouts and UserForm artifacts, enforces duplicate VBA name rules, and issues warnings when exclude patterns match no components.
* **Documentation**
  * Updated the CLI contract to specify glob normalization, matching behavior, and validation/error conditions.
* **Tests**
  * Added an expanded test suite covering deterministic include/exclude resolution and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->