### PR TITLE
Implement Excel-backed release workbook reconstruction pipeline

### DIFF
--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/BuildCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/BuildCommand.cs
@@ -1,0 +1,35 @@
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Commands;
+
+// Internal bridge command. The public Go CLI deliberately does not call this
+// until the publication and recovery stages are implemented.
+public sealed class BuildCommand : ICommandHandler
+{
+    private readonly IBuildService _service;
+
+    public BuildCommand(IBuildService? service = null) => _service = service ?? new ExcelBuildService();
+
+    public string CommandName => "build";
+
+    public bool Supports(BridgeRequest request) => string.Equals(request.Command, CommandName, StringComparison.OrdinalIgnoreCase);
+
+    public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
+    {
+        var baseWorkbookPath = BridgePayload.GetString(request.Payload, "BaseWorkbookPath") ?? "";
+        var temporaryDirectory = BridgePayload.GetString(request.Payload, "TemporaryDirectory") ?? "";
+        var planJson64 = BridgePayload.GetString(request.Payload, "PlanJson64") ?? "";
+        if (string.IsNullOrWhiteSpace(baseWorkbookPath) || string.IsNullOrWhiteSpace(temporaryDirectory) || string.IsNullOrWhiteSpace(planJson64))
+        {
+            return BridgeResponse.Failed(request, new BridgeError("build_args_invalid", "BaseWorkbookPath, TemporaryDirectory, and PlanJson64 are required", "build", "xlflow-excel-bridge"));
+        }
+
+        return _service.Execute(request, new BuildCommandArguments(
+            baseWorkbookPath,
+            temporaryDirectory,
+            planJson64,
+            BridgePayload.GetString(request.Payload, "CodeSource") ?? "",
+            BridgePayload.GetBool(request.Payload, "Visible")), cancellationToken);
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/BuildCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/BuildCommand.cs
@@ -17,15 +17,17 @@ public sealed class BuildCommand : ICommandHandler
 
     public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
     {
+        var projectRoot = BridgePayload.GetString(request.Payload, "ProjectRoot") ?? "";
         var baseWorkbookPath = BridgePayload.GetString(request.Payload, "BaseWorkbookPath") ?? "";
         var temporaryDirectory = BridgePayload.GetString(request.Payload, "TemporaryDirectory") ?? "";
         var planJson64 = BridgePayload.GetString(request.Payload, "PlanJson64") ?? "";
-        if (string.IsNullOrWhiteSpace(baseWorkbookPath) || string.IsNullOrWhiteSpace(temporaryDirectory) || string.IsNullOrWhiteSpace(planJson64))
+        if (string.IsNullOrWhiteSpace(projectRoot) || string.IsNullOrWhiteSpace(baseWorkbookPath) || string.IsNullOrWhiteSpace(temporaryDirectory) || string.IsNullOrWhiteSpace(planJson64))
         {
-            return BridgeResponse.Failed(request, new BridgeError("build_args_invalid", "BaseWorkbookPath, TemporaryDirectory, and PlanJson64 are required", "build", "xlflow-excel-bridge"));
+            return BridgeResponse.Failed(request, new BridgeError("build_args_invalid", "ProjectRoot, BaseWorkbookPath, TemporaryDirectory, and PlanJson64 are required", "build", "xlflow-excel-bridge"));
         }
 
         return _service.Execute(request, new BuildCommandArguments(
+            projectRoot,
             baseWorkbookPath,
             temporaryDirectory,
             planJson64,

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs
@@ -22,6 +22,7 @@ public sealed class CommandRegistry
         return new CommandRegistry(new ICommandHandler[]
         {
             new AttachCommand(),
+            new BuildCommand(),
             new DoctorCommand(),
             new EditCommand(),
             new ExportImageCommand(),
@@ -46,6 +47,7 @@ public sealed class CommandRegistry
 
     public static CommandRegistry Create(
         Func<ExcelDiagnosticsResult>? probeExcel,
+        IBuildService? buildService = null,
         IAttachService? attachService = null,
         IEditService? editService = null,
         IExportImageService? exportImageService = null,
@@ -69,6 +71,7 @@ public sealed class CommandRegistry
         return new CommandRegistry(new ICommandHandler[]
         {
             new AttachCommand(attachService),
+            new BuildCommand(buildService),
             new DoctorCommand(probeExcel),
             new EditCommand(editService),
             new ExportImageCommand(exportImageService),

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/BuildCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/BuildCommandArguments.cs
@@ -1,0 +1,10 @@
+namespace Xlflow.ExcelBridge.Services;
+
+// The plan is produced by internal/build in the Go frontend.  The bridge must
+// consume this explicit payload and must never rediscover source roots itself.
+public sealed record BuildCommandArguments(
+    string BaseWorkbookPath,
+    string TemporaryDirectory,
+    string PlanJson64,
+    string CodeSource,
+    bool Visible);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/BuildCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/BuildCommandArguments.cs
@@ -3,6 +3,7 @@ namespace Xlflow.ExcelBridge.Services;
 // The plan is produced by internal/build in the Go frontend.  The bridge must
 // consume this explicit payload and must never rediscover source roots itself.
 public sealed record BuildCommandArguments(
+    string ProjectRoot,
     string BaseWorkbookPath,
     string TemporaryDirectory,
     string PlanJson64,

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBuildService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBuildService.cs
@@ -19,38 +19,37 @@ public sealed class ExcelBuildService : IBuildService
     {
         object? excel = null;
         object? workbook = null;
-        var tempCreated = false;
+        string? temporaryBuildDirectory = null;
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
             var plan = DecodePlan(args.PlanJson64);
-            ValidatePlan(plan);
+            ValidatePlan(plan, args.ProjectRoot);
             var basePath = ExcelBridgeSupport.NormalizePath(args.BaseWorkbookPath);
             if (!File.Exists(basePath))
             {
                 throw new InvalidOperationException("base workbook does not exist");
             }
 
-            var tempRoot = Path.GetFullPath(args.TemporaryDirectory);
-            if (string.Equals(basePath, tempRoot, StringComparison.OrdinalIgnoreCase) || basePath.StartsWith(tempRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            var tempParent = Path.GetFullPath(args.TemporaryDirectory);
+            if (IsWithinDirectory(basePath, tempParent))
             {
                 throw new InvalidOperationException("temporary directory must not contain the base workbook");
             }
 
-            Directory.CreateDirectory(tempRoot);
-            tempCreated = true;
-            var temporaryWorkbook = Path.Combine(tempRoot, Path.GetFileName(basePath));
-            if (File.Exists(temporaryWorkbook))
-            {
-                throw new InvalidOperationException("temporary build workbook already exists");
-            }
+            // TemporaryDirectory belongs to the caller. Own and later remove
+            // only this invocation's unique child directory.
+            Directory.CreateDirectory(tempParent);
+            temporaryBuildDirectory = Path.Combine(tempParent, "xlflow-build-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(temporaryBuildDirectory);
+            var temporaryWorkbook = Path.Combine(temporaryBuildDirectory, Path.GetFileName(basePath));
 
             File.Copy(basePath, temporaryWorkbook);
 
             var attachment = ExcelBridgeSupport.OpenWorkbookDirect(temporaryWorkbook, args.Visible, disableAutomationMacros: true);
             excel = attachment.Excel;
             workbook = attachment.Workbook;
-            var applied = Reconstruct(workbook, plan, args.CodeSource, tempRoot, cancellationToken);
+            var applied = Reconstruct(workbook, plan, args.CodeSource, temporaryBuildDirectory, cancellationToken);
             ExcelBridgeSupport.InvokeViaDynamic(workbook, "Save");
             ExcelBridgeSupport.InvokeViaDynamic(workbook, "Close", false);
             ExcelBridgeSupport.ReleaseComObject(workbook);
@@ -83,9 +82,9 @@ public sealed class ExcelBuildService : IBuildService
         finally
         {
             CloseDedicated(workbook, excel);
-            if (tempCreated && Directory.Exists(args.TemporaryDirectory))
+            if (temporaryBuildDirectory is not null && Directory.Exists(temporaryBuildDirectory))
             {
-                try { Directory.Delete(args.TemporaryDirectory, true); } catch { }
+                try { Directory.Delete(temporaryBuildDirectory, true); } catch { }
             }
         }
     }
@@ -209,8 +208,13 @@ public sealed class ExcelBuildService : IBuildService
         catch (JsonException ex) { throw new InvalidOperationException("PlanJson64 does not contain a valid build plan", ex); }
     }
 
-    private static void ValidatePlan(BuildPlanPayload plan)
+    private static void ValidatePlan(BuildPlanPayload plan, string projectRoot)
     {
+        projectRoot = Path.GetFullPath(projectRoot);
+        if (!Directory.Exists(projectRoot))
+        {
+            throw new InvalidOperationException("project root does not exist");
+        }
         foreach (var component in plan.Included)
         {
             if (component.Type is not ("standard" or "class" or "document" or "form"))
@@ -218,19 +222,42 @@ public sealed class ExcelBuildService : IBuildService
                 throw new InvalidOperationException($"unsupported build component type '{component.Type}'");
             }
 
-            if (string.IsNullOrWhiteSpace(component.Name) || !Path.IsPathFullyQualified(component.SourcePath) || !File.Exists(component.SourcePath))
+            component.SourcePath = ResolvePlannerPath(projectRoot, component.SourcePath);
+            if (string.IsNullOrWhiteSpace(component.Name) || !File.Exists(component.SourcePath))
             {
                 throw new InvalidOperationException($"invalid planned component '{component.Name}'");
             }
 
-            foreach (var path in component.RelatedPaths)
+            for (var index = 0; index < component.RelatedPaths.Count; index++)
             {
-                if (!Path.IsPathFullyQualified(path) || !File.Exists(path))
+                component.RelatedPaths[index] = ResolvePlannerPath(projectRoot, component.RelatedPaths[index]);
+                if (!File.Exists(component.RelatedPaths[index]))
                 {
-                    throw new InvalidOperationException($"missing related artifact for '{component.Name}': {path}");
+                    throw new InvalidOperationException($"missing related artifact for '{component.Name}': {component.RelatedPaths[index]}");
                 }
             }
         }
+    }
+
+    private static string ResolvePlannerPath(string projectRoot, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return "";
+        var resolved = Path.GetFullPath(Path.IsPathFullyQualified(path)
+            ? path
+            : Path.Combine(projectRoot, path.Replace('/', Path.DirectorySeparatorChar)));
+        if (!IsWithinDirectory(resolved, projectRoot))
+        {
+            throw new InvalidOperationException($"planned component path is outside the project root: {path}");
+        }
+        return resolved;
+    }
+
+    private static bool IsWithinDirectory(string path, string directory)
+    {
+        var relative = Path.GetRelativePath(Path.GetFullPath(directory), Path.GetFullPath(path));
+        return relative == "." || (!relative.Equals("..", StringComparison.Ordinal) &&
+            !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+            !Path.IsPathFullyQualified(relative));
     }
 
     private static string Classify(Exception ex) => ex.Message.Contains("VBProject", StringComparison.OrdinalIgnoreCase) ? "build_vbproject_access_denied" : ex.Message.Contains("document module", StringComparison.OrdinalIgnoreCase) ? "build_document_module_unresolved" : ex.Message.Contains("UserForm", StringComparison.OrdinalIgnoreCase) ? "build_userform_reconstruct_failed" : "build_reconstruct_failed";
@@ -252,12 +279,12 @@ public sealed class ExcelBuildService : IBuildService
     private sealed class BuildComponentPayload
     {
         [JsonPropertyName("source_path")]
-        public string SourcePath { get; init; } = "";
+        public string SourcePath { get; set; } = "";
         [JsonPropertyName("name")]
         public string Name { get; init; } = "";
         [JsonPropertyName("type")]
         public string Type { get; init; } = "";
         [JsonPropertyName("related_paths")]
-        public List<string> RelatedPaths { get; init; } = [];
+        public List<string> RelatedPaths { get; set; } = [];
     }
 }

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBuildService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBuildService.cs
@@ -1,0 +1,263 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+// Reconstructs only an isolated workbook copy. Publication, compilation, and
+// recovery policy intentionally belong to later build sub-issues.
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "The bridge converts Excel and filesystem failures into structured build errors.")]
+public sealed class ExcelBuildService : IBuildService
+{
+    private const int ComponentTypeDocument = 100;
+    private const int ComponentTypeForm = 3;
+    private static readonly JsonSerializerOptions PlanJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public BridgeResponse Execute(BridgeRequest request, BuildCommandArguments args, CancellationToken cancellationToken)
+    {
+        object? excel = null;
+        object? workbook = null;
+        var tempCreated = false;
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var plan = DecodePlan(args.PlanJson64);
+            ValidatePlan(plan);
+            var basePath = ExcelBridgeSupport.NormalizePath(args.BaseWorkbookPath);
+            if (!File.Exists(basePath))
+            {
+                throw new InvalidOperationException("base workbook does not exist");
+            }
+
+            var tempRoot = Path.GetFullPath(args.TemporaryDirectory);
+            if (string.Equals(basePath, tempRoot, StringComparison.OrdinalIgnoreCase) || basePath.StartsWith(tempRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("temporary directory must not contain the base workbook");
+            }
+
+            Directory.CreateDirectory(tempRoot);
+            tempCreated = true;
+            var temporaryWorkbook = Path.Combine(tempRoot, Path.GetFileName(basePath));
+            if (File.Exists(temporaryWorkbook))
+            {
+                throw new InvalidOperationException("temporary build workbook already exists");
+            }
+
+            File.Copy(basePath, temporaryWorkbook);
+
+            var attachment = ExcelBridgeSupport.OpenWorkbookDirect(temporaryWorkbook, args.Visible, disableAutomationMacros: true);
+            excel = attachment.Excel;
+            workbook = attachment.Workbook;
+            var applied = Reconstruct(workbook, plan, args.CodeSource, tempRoot, cancellationToken);
+            ExcelBridgeSupport.InvokeViaDynamic(workbook, "Save");
+            ExcelBridgeSupport.InvokeViaDynamic(workbook, "Close", false);
+            ExcelBridgeSupport.ReleaseComObject(workbook);
+            workbook = null;
+            ExcelBridgeSupport.InvokeViaDynamic(excel, "Quit");
+            ExcelBridgeSupport.ReleaseComObject(excel);
+            excel = null;
+
+            return BridgeResponse.Ok(request, new Dictionary<string, object?>
+            {
+                ["build"] = new Dictionary<string, object?>
+                {
+                    ["backend"] = "excel",
+                    ["temporary_reconstruction"] = true,
+                    ["source_applied"] = true,
+                    ["components_applied"] = applied,
+                    ["workbook_saved"] = true,
+                    ["workbook_closed"] = true,
+                },
+            });
+        }
+        catch (Exception ex)
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                Code: Classify(ex),
+                Message: ExcelBridgeSupport.FormatExceptionDetail(ex),
+                Phase: "build_reconstruct",
+                Source: "xlflow-excel-bridge"));
+        }
+        finally
+        {
+            CloseDedicated(workbook, excel);
+            if (tempCreated && Directory.Exists(args.TemporaryDirectory))
+            {
+                try { Directory.Delete(args.TemporaryDirectory, true); } catch { }
+            }
+        }
+    }
+
+    private static int Reconstruct(object workbook, BuildPlanPayload plan, string codeSource, string tempRoot, CancellationToken cancellationToken)
+    {
+        ExcelPushService.RemoveNonDocumentComponents(workbook);
+        var applied = ImportComponents(workbook, plan.Included.Where(component => component.Type is "standard" or "class" or "form").ToArray(), codeSource, tempRoot, cancellationToken);
+        applied += UpdateDocumentModules(workbook, plan.Included.Where(component => component.Type == "document").ToArray());
+        return applied;
+    }
+
+    private static int ImportComponents(object workbook, IReadOnlyList<BuildComponentPayload> components, string codeSource, string tempRoot, CancellationToken cancellationToken)
+    {
+        object? project = null;
+        object? vbComponents = null;
+        try
+        {
+            project = ExcelBridgeSupport.Get(workbook, "VBProject") ?? throw new InvalidOperationException("VBProject access is denied");
+            vbComponents = ExcelBridgeSupport.Get(project, "VBComponents") ?? throw new InvalidOperationException("VBComponents are unavailable");
+            var applied = 0;
+            foreach (var component in components)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var importPath = Path.Combine(tempRoot, "imports", Guid.NewGuid().ToString("N") + Path.GetExtension(component.SourcePath));
+                VbaSourceHelper.PrepareSourceForImport(component.SourcePath, importPath, null, "off");
+                if (component.Type == "form")
+                {
+                    var frx = component.RelatedPaths.FirstOrDefault(path => string.Equals(Path.GetExtension(path), ".frx", StringComparison.OrdinalIgnoreCase));
+                    if (frx is not null)
+                    {
+                        File.Copy(frx, Path.ChangeExtension(importPath, ".frx"), true);
+                    }
+                }
+                object? imported = null;
+                try
+                {
+                    imported = ExcelBridgeSupport.InvokeViaDynamic(vbComponents, "Import", importPath) ?? throw new InvalidOperationException($"failed to import VBA component '{component.Name}'");
+                    var name = ExcelBridgeSupport.GetString(imported, "Name") ?? "";
+                    if (!string.Equals(name, component.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException($"imported VBA component name '{name}' did not match expected name '{component.Name}'");
+                    }
+                }
+                finally { ExcelBridgeSupport.ReleaseComObject(imported); }
+                if (component.Type == "form" && VbaSourceHelper.IsSidecarMode(codeSource))
+                {
+                    var codePath = component.RelatedPaths.FirstOrDefault(path => string.Equals(Path.GetExtension(path), ".bas", StringComparison.OrdinalIgnoreCase));
+                    if (string.IsNullOrWhiteSpace(codePath))
+                    {
+                        throw new InvalidOperationException($"UserForm '{component.Name}' has no sidecar code-behind");
+                    }
+
+                    ExcelPushService.SyncUserFormCodeBehindFromPath(workbook, component.Name, codePath, false, strict: true);
+                }
+                applied++;
+            }
+            return applied;
+        }
+        finally { ExcelBridgeSupport.ReleaseComObject(vbComponents); ExcelBridgeSupport.ReleaseComObject(project); }
+    }
+
+    private static int UpdateDocumentModules(object workbook, IReadOnlyList<BuildComponentPayload> documents)
+    {
+        var expected = documents.ToDictionary(component => component.Name, StringComparer.OrdinalIgnoreCase);
+        var found = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        object? project = null;
+        object? components = null;
+        try
+        {
+            project = ExcelBridgeSupport.Get(workbook, "VBProject") ?? throw new InvalidOperationException("VBProject access is denied");
+            components = ExcelBridgeSupport.Get(project, "VBComponents") ?? throw new InvalidOperationException("VBComponents are unavailable");
+            var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(components, "Count"));
+            for (var index = 1; index <= count; index++)
+            {
+                object? component = null;
+                object? code = null;
+                try
+                {
+                    component = ExcelBridgeSupport.Get(components, "Item", index);
+                    if (component is null || ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(component, "Type")) != ComponentTypeDocument)
+                    {
+                        continue;
+                    }
+
+                    var name = ExcelBridgeSupport.GetString(component, "Name") ?? "";
+                    code = ExcelBridgeSupport.Get(component, "CodeModule") ?? throw new InvalidOperationException($"document module '{name}' has no code module");
+                    if (expected.TryGetValue(name, out var source))
+                    {
+                        VbaSourceHelper.SetCodeModuleText(code, VbaSourceHelper.NormalizeDocumentModuleContent(File.ReadAllText(source.SourcePath, Encoding.UTF8)));
+                        found.Add(name);
+                    }
+                    else
+                    {
+                        // Document hosts are workbook-owned and cannot be removed.
+                        // Clearing their body is the equivalent of excluding them.
+                        VbaSourceHelper.SetCodeModuleText(code, "");
+                    }
+                }
+                finally { ExcelBridgeSupport.ReleaseComObject(code); ExcelBridgeSupport.ReleaseComObject(component); }
+            }
+        }
+        finally { ExcelBridgeSupport.ReleaseComObject(components); ExcelBridgeSupport.ReleaseComObject(project); }
+        var missing = expected.Keys.Where(name => !found.Contains(name)).ToArray();
+        if (missing.Length > 0)
+        {
+            throw new InvalidOperationException("document module could not be resolved: " + string.Join(", ", missing));
+        }
+
+        return found.Count;
+    }
+
+    private static BuildPlanPayload DecodePlan(string json64)
+    {
+        try
+        {
+            var plan = JsonSerializer.Deserialize<BuildPlanPayload>(Encoding.UTF8.GetString(Convert.FromBase64String(json64)), PlanJsonOptions);
+            return plan ?? throw new InvalidOperationException("build plan is empty");
+        }
+        catch (FormatException ex) { throw new InvalidOperationException("PlanJson64 is not valid base64", ex); }
+        catch (JsonException ex) { throw new InvalidOperationException("PlanJson64 does not contain a valid build plan", ex); }
+    }
+
+    private static void ValidatePlan(BuildPlanPayload plan)
+    {
+        foreach (var component in plan.Included)
+        {
+            if (component.Type is not ("standard" or "class" or "document" or "form"))
+            {
+                throw new InvalidOperationException($"unsupported build component type '{component.Type}'");
+            }
+
+            if (string.IsNullOrWhiteSpace(component.Name) || !Path.IsPathFullyQualified(component.SourcePath) || !File.Exists(component.SourcePath))
+            {
+                throw new InvalidOperationException($"invalid planned component '{component.Name}'");
+            }
+
+            foreach (var path in component.RelatedPaths)
+            {
+                if (!Path.IsPathFullyQualified(path) || !File.Exists(path))
+                {
+                    throw new InvalidOperationException($"missing related artifact for '{component.Name}': {path}");
+                }
+            }
+        }
+    }
+
+    private static string Classify(Exception ex) => ex.Message.Contains("VBProject", StringComparison.OrdinalIgnoreCase) ? "build_vbproject_access_denied" : ex.Message.Contains("document module", StringComparison.OrdinalIgnoreCase) ? "build_document_module_unresolved" : ex.Message.Contains("UserForm", StringComparison.OrdinalIgnoreCase) ? "build_userform_reconstruct_failed" : "build_reconstruct_failed";
+
+    private static void CloseDedicated(object? workbook, object? excel)
+    {
+        try { if (workbook is not null) { ExcelBridgeSupport.InvokeViaDynamic(workbook, "Close", false); } } catch { }
+        try { if (excel is not null) { ExcelBridgeSupport.InvokeViaDynamic(excel, "Quit"); } } catch { }
+        ExcelBridgeSupport.ReleaseComObject(workbook);
+        ExcelBridgeSupport.ReleaseComObject(excel);
+    }
+
+    private sealed class BuildPlanPayload
+    {
+        [JsonPropertyName("included")]
+        public List<BuildComponentPayload> Included { get; init; } = [];
+    }
+
+    private sealed class BuildComponentPayload
+    {
+        [JsonPropertyName("source_path")]
+        public string SourcePath { get; init; } = "";
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = "";
+        [JsonPropertyName("type")]
+        public string Type { get; init; } = "";
+        [JsonPropertyName("related_paths")]
+        public List<string> RelatedPaths { get; init; } = [];
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelPushService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelPushService.cs
@@ -807,7 +807,7 @@ public sealed class ExcelPushService : IPushService
         return imported;
     }
 
-    private static void SyncUserFormCodeBehind(object workbook, string formName, string formsDir, bool lineNumbersEnabled)
+    internal static void SyncUserFormCodeBehind(object workbook, string formName, string formsDir, bool lineNumbersEnabled)
     {
         var codePath = VbaSourceHelper.GetUserFormCodePath(formsDir, formName);
         if (string.IsNullOrWhiteSpace(codePath) || !File.Exists(codePath))
@@ -815,16 +815,23 @@ public sealed class ExcelPushService : IPushService
             return;
         }
 
+        SyncUserFormCodeBehindFromPath(workbook, formName, codePath, lineNumbersEnabled, strict: false);
+    }
+
+    // Build reconstruction supplies the exact sidecar file selected by the Go
+    // planner, rather than rediscovering it under a forms root.
+    internal static void SyncUserFormCodeBehindFromPath(object workbook, string formName, string codePath, bool lineNumbersEnabled, bool strict)
+    {
+
         var codeText = File.ReadAllText(codePath, Encoding.UTF8);
         if (lineNumbersEnabled && !ErlLineNumberTransformer.TryAdd(codeText, out codeText, out var lineNumberIssue))
         {
             throw new InvalidOperationException($"vba_line_number_safety_failed: {codePath}:{lineNumberIssue!.Line}: {lineNumberIssue.Message}");
         }
-        if (string.IsNullOrWhiteSpace(codeText))
+        if (string.IsNullOrWhiteSpace(codeText) && !strict)
         {
             return;
         }
-
         object? vbProject = null;
         object? vbComponents = null;
         try
@@ -832,13 +839,13 @@ public sealed class ExcelPushService : IPushService
             vbProject = ExcelBridgeSupport.Get(workbook, "VBProject");
             if (vbProject is null)
             {
-                return;
+                throw new InvalidOperationException("VBProject is unavailable while synchronizing UserForm code-behind.");
             }
 
             vbComponents = ExcelBridgeSupport.Get(vbProject, "VBComponents");
             if (vbComponents is null)
             {
-                return;
+                throw new InvalidOperationException("VBComponents are unavailable while synchronizing UserForm code-behind.");
             }
 
             var count = ExcelBridgeSupport.ToInt(ExcelBridgeSupport.Get(vbComponents, "Count"));
@@ -880,8 +887,12 @@ public sealed class ExcelPushService : IPushService
                     ExcelBridgeSupport.ReleaseComObject(component);
                 }
             }
+            if (strict)
+            {
+                throw new InvalidOperationException($"UserForm '{formName}' was not found after import.");
+            }
         }
-        catch
+        catch when (!strict)
         {
             // best-effort UserForm code-behind sync
         }

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IBuildService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/IBuildService.cs
@@ -1,0 +1,8 @@
+using Xlflow.ExcelBridge.Contract;
+
+namespace Xlflow.ExcelBridge.Services;
+
+public interface IBuildService
+{
+    BridgeResponse Execute(BridgeRequest request, BuildCommandArguments args, CancellationToken cancellationToken);
+}

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BuildCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BuildCommandTests.cs
@@ -15,6 +15,7 @@ public sealed class BuildCommandTests
         var command = new BuildCommand(new FakeBuildService((request, args) =>
         {
             Assert.Equal("build", request.Command);
+            Assert.Equal(@"C:\work", args.ProjectRoot);
             Assert.Equal(@"C:\work\Book.xlsm", args.BaseWorkbookPath);
             Assert.Equal(@"C:\work\.xlflow\tmp\build-1", args.TemporaryDirectory);
             Assert.Equal(encodedPlan, args.PlanJson64);
@@ -28,7 +29,7 @@ public sealed class BuildCommandTests
             RequestId = "req-build",
             Command = "build",
             Payload = JsonDocument.Parse($$"""
-                { "BaseWorkbookPath": "C:\\work\\Book.xlsm", "TemporaryDirectory": "C:\\work\\.xlflow\\tmp\\build-1", "PlanJson64": "{{encodedPlan}}", "CodeSource": "sidecar", "Visible": "false" }
+                { "ProjectRoot": "C:\\work", "BaseWorkbookPath": "C:\\work\\Book.xlsm", "TemporaryDirectory": "C:\\work\\.xlflow\\tmp\\build-1", "PlanJson64": "{{encodedPlan}}", "CodeSource": "sidecar", "Visible": "false" }
                 """).RootElement.Clone(),
         };
 
@@ -60,6 +61,7 @@ public sealed class BuildCommandTests
         try
         {
             var response = new ExcelBuildService().Execute(request, new BuildCommandArguments(
+                root,
                 Path.Combine(root, "Book.xlsm"),
                 Path.Combine(root, "temporary"),
                 "not-base64",
@@ -83,14 +85,17 @@ public sealed class BuildCommandTests
     public void ServiceReadsSnakeCasePlannerComponentFields()
     {
         var root = Path.Combine(Path.GetTempPath(), "xlflow-build-plan-test-" + Guid.NewGuid().ToString("N"));
-        var plan = Convert.ToBase64String(Encoding.UTF8.GetBytes("""{"included":[{"source_path":"C:\\missing\\Main.bas","name":"Main","type":"standard","related_paths":[]}]}"""));
+        var sourcePath = Path.Combine(root, "src", "modules", "Main.bas");
+        var plan = Convert.ToBase64String(Encoding.UTF8.GetBytes("""{"included":[{"source_path":"src/modules/Main.bas","name":"Main","type":"standard","related_paths":[]}]}"""));
         try
         {
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath)!);
+            File.WriteAllText(sourcePath, "Attribute VB_Name = \"Main\"");
             var response = new ExcelBuildService().Execute(new BridgeRequest { ProtocolVersion = ProtocolVersion.Current, RequestId = "req-build-plan", Command = "build" }, new BuildCommandArguments(
-                Path.Combine(root, "Book.xlsm"), Path.Combine(root, "temporary"), plan, "sidecar", false), CancellationToken.None);
+                root, Path.Combine(root, "Book.xlsm"), Path.Combine(root, "temporary"), plan, "sidecar", false), CancellationToken.None);
 
             Assert.Equal(BridgeStatus.Failed, response.Status);
-            Assert.Contains("invalid planned component 'Main'", response.Error?.Message);
+            Assert.Contains("base workbook does not exist", response.Error?.Message);
             Assert.False(Directory.Exists(Path.Combine(root, "temporary")));
         }
         finally
@@ -99,6 +104,36 @@ public sealed class BuildCommandTests
             {
                 Directory.Delete(root, true);
             }
+        }
+    }
+
+    [Fact]
+    public void ServiceKeepsCallerOwnedTemporaryParentWhenCopyOrOpenFails()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "xlflow-build-temp-owner-test-" + Guid.NewGuid().ToString("N"));
+        var sourcePath = Path.Combine(root, "src", "modules", "Main.bas");
+        var tempParent = Path.Combine(root, "caller-temp");
+        var sentinel = Path.Combine(tempParent, "keep.txt");
+        var baseWorkbook = Path.Combine(root, "Book.txt");
+        var plan = Convert.ToBase64String(Encoding.UTF8.GetBytes("""{"included":[{"source_path":"src/modules/Main.bas","name":"Main","type":"standard"}]}"""));
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath)!);
+            Directory.CreateDirectory(tempParent);
+            File.WriteAllText(sourcePath, "Attribute VB_Name = \"Main\"");
+            File.WriteAllText(baseWorkbook, "not a workbook");
+            File.WriteAllText(sentinel, "caller-owned");
+
+            var response = new ExcelBuildService().Execute(new BridgeRequest { ProtocolVersion = ProtocolVersion.Current, RequestId = "req-build-temp-owner", Command = "build" }, new BuildCommandArguments(
+                root, baseWorkbook, tempParent, plan, "sidecar", false), CancellationToken.None);
+
+            Assert.Equal(BridgeStatus.Failed, response.Status);
+            Assert.True(File.Exists(sentinel));
+            Assert.Empty(Directory.GetDirectories(tempParent, "xlflow-build-*"));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
         }
     }
 

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BuildCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BuildCommandTests.cs
@@ -1,0 +1,113 @@
+using System.Text;
+using System.Text.Json;
+using Xlflow.ExcelBridge.Commands;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class BuildCommandTests
+{
+    [Fact]
+    public void HandlePassesTheAuthoritativePlanWithoutSourceRediscovery()
+    {
+        var encodedPlan = Convert.ToBase64String(Encoding.UTF8.GetBytes("""{"included":[{"source_path":"C:\\work\\src\\modules\\Main.bas","name":"Main","type":"standard"}]}"""));
+        var command = new BuildCommand(new FakeBuildService((request, args) =>
+        {
+            Assert.Equal("build", request.Command);
+            Assert.Equal(@"C:\work\Book.xlsm", args.BaseWorkbookPath);
+            Assert.Equal(@"C:\work\.xlflow\tmp\build-1", args.TemporaryDirectory);
+            Assert.Equal(encodedPlan, args.PlanJson64);
+            Assert.Equal("sidecar", args.CodeSource);
+            Assert.False(args.Visible);
+            return BridgeResponse.Ok(request, new Dictionary<string, object?> { ["build"] = new Dictionary<string, object?> { ["temporary_reconstruction"] = true } });
+        }));
+        var request = new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-build",
+            Command = "build",
+            Payload = JsonDocument.Parse($$"""
+                { "BaseWorkbookPath": "C:\\work\\Book.xlsm", "TemporaryDirectory": "C:\\work\\.xlflow\\tmp\\build-1", "PlanJson64": "{{encodedPlan}}", "CodeSource": "sidecar", "Visible": "false" }
+                """).RootElement.Clone(),
+        };
+
+        var response = command.Handle(request, CancellationToken.None);
+        Assert.Equal(BridgeStatus.Ok, response.Status);
+        Assert.True((bool)((Dictionary<string, object?>)response.Extensions["build"]!)["temporary_reconstruction"]!);
+    }
+
+    [Fact]
+    public void HandleRejectsIncompleteArguments()
+    {
+        var response = new BuildCommand(new FakeBuildService((request, _) => BridgeResponse.Ok(request))).Handle(new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-build-invalid",
+            Command = "build",
+            Payload = JsonDocument.Parse("""{"BaseWorkbookPath":"C:\\work\\Book.xlsm"}""").RootElement.Clone(),
+        }, CancellationToken.None);
+
+        Assert.Equal(BridgeStatus.Failed, response.Status);
+        Assert.Equal("build_args_invalid", response.Error?.Code);
+    }
+
+    [Fact]
+    public void ServiceRejectsInvalidPlanBeforeCreatingTemporaryWorkspace()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "xlflow-build-command-test-" + Guid.NewGuid().ToString("N"));
+        var request = new BridgeRequest { ProtocolVersion = ProtocolVersion.Current, RequestId = "req-build-invalid-plan", Command = "build" };
+        try
+        {
+            var response = new ExcelBuildService().Execute(request, new BuildCommandArguments(
+                Path.Combine(root, "Book.xlsm"),
+                Path.Combine(root, "temporary"),
+                "not-base64",
+                "sidecar",
+                false), CancellationToken.None);
+
+            Assert.Equal(BridgeStatus.Failed, response.Status);
+            Assert.Equal("build_reconstruct_failed", response.Error?.Code);
+            Assert.False(Directory.Exists(Path.Combine(root, "temporary")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ServiceReadsSnakeCasePlannerComponentFields()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "xlflow-build-plan-test-" + Guid.NewGuid().ToString("N"));
+        var plan = Convert.ToBase64String(Encoding.UTF8.GetBytes("""{"included":[{"source_path":"C:\\missing\\Main.bas","name":"Main","type":"standard","related_paths":[]}]}"""));
+        try
+        {
+            var response = new ExcelBuildService().Execute(new BridgeRequest { ProtocolVersion = ProtocolVersion.Current, RequestId = "req-build-plan", Command = "build" }, new BuildCommandArguments(
+                Path.Combine(root, "Book.xlsm"), Path.Combine(root, "temporary"), plan, "sidecar", false), CancellationToken.None);
+
+            Assert.Equal(BridgeStatus.Failed, response.Status);
+            Assert.Contains("invalid planned component 'Main'", response.Error?.Message);
+            Assert.False(Directory.Exists(Path.Combine(root, "temporary")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
+    }
+
+    private sealed class FakeBuildService(Func<BridgeRequest, BuildCommandArguments, BridgeResponse> handler) : IBuildService
+    {
+        public BridgeResponse Execute(BridgeRequest request, BuildCommandArguments args, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request, args);
+        }
+    }
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -67,6 +67,8 @@
 - When a validation rule is scoped to included build components, apply path exclusions before duplicate-name validation; when one component has multiple related source paths, record every matching exclusion pattern before emitting unmatched-pattern warnings.
 - Flat UserForm sidecar/spec artifacts are keyed by component name, not source subdirectory. Resolve them only after primary `.frm` exclusions select the remaining same-named candidate; do not invent a directory-scoped sidecar layout that conflicts with the source contract.
 - Windows coordination wait tests need a generous gap between scheduled owner release and the waiter deadline; a one-second budget can expire before timer delivery or owner metadata publication on hosted runners.
+- Treat caller-supplied temporary directories as ownership boundaries: create and clean up only a unique child directory created by the operation, never recursively delete the supplied root.
+- Preserve source-plan path contracts across process boundaries. When a planner publishes project-root-relative paths, the receiving bridge must resolve them against an explicit project root rather than requiring callers to rewrite the plan ad hoc.
 
 # DialogWatcher
 

--- a/vitepress/help/index.md
+++ b/vitepress/help/index.md
@@ -14,11 +14,11 @@ xlflow status --json
 
 ## Find the right kind of help
 
-| If you are trying to… | Start here |
-| --- | --- |
-| Fix an installation, Excel, execution, session, or WSL failure | [Troubleshooting](./troubleshooting) |
-| Understand a common xlflow question | [FAQ](./faq) |
-| Check whether a capability is currently supported | [Known limitations](./known-limitations) |
-| Report a reproducible problem safely | [Reporting bugs](./reporting-bugs) |
+| If you are trying to…                                          | Start here                               |
+| -------------------------------------------------------------- | ---------------------------------------- |
+| Fix an installation, Excel, execution, session, or WSL failure | [Troubleshooting](./troubleshooting)     |
+| Understand a common xlflow question                            | [FAQ](./faq)                             |
+| Check whether a capability is currently supported              | [Known limitations](./known-limitations) |
+| Report a reproducible problem safely                           | [Reporting bugs](./reporting-bugs)       |
 
 When a command returns JSON with `"status": "error"`, use its `error.code` and the command's exit code to select the relevant troubleshooting section. If `error.code` is `workbook_recovery_required`, stop normal workbook commands and follow the recovery guidance; retrying with `--wait` cannot clear that state.

--- a/vitepress/reference/cli-command-inventory.md
+++ b/vitepress/reference/cli-command-inventory.md
@@ -2,45 +2,45 @@
 
 Generated from the Cobra command registrations in `internal/cli/root.go`. Run `pnpm docs:generate-cli` after adding a command.
 
-| Command | Documentation |
-| --- | --- |
+| Command               | Documentation                             |
+| --------------------- | ----------------------------------------- |
 | `xlflow capabilities` | [command guide](../commands/capabilities) |
-| `xlflow new` | [command guide](../commands/new) |
-| `xlflow init` | [command guide](../commands/init) |
-| `xlflow pack` | [command guide](../commands/pack) |
-| `xlflow doctor` | [command guide](../commands/doctor) |
-| `xlflow attach` | [command guide](../commands/attach) |
-| `xlflow backup` | [command guide](../commands/backup) |
-| `xlflow list` | [command guide](../commands/list) |
-| `xlflow form` | [command guide](../commands/form) |
-| `xlflow formulas` | [command guide](../commands/formulas) |
-| `xlflow pull` | [command guide](../commands/pull) |
-| `xlflow push` | [command guide](../commands/push) |
-| `xlflow rollback` | [command guide](../commands/rollback) |
-| `xlflow status` | [command guide](../commands/status) |
-| `xlflow session` | [command guide](../commands/session) |
-| `xlflow save` | [command guide](../commands/save) |
-| `xlflow recovery` | [command guide](../commands/recovery) |
-| `xlflow runner` | [command guide](../commands/runner) |
-| `xlflow run` | [command guide](../commands/run) |
+| `xlflow new`          | [command guide](../commands/new)          |
+| `xlflow init`         | [command guide](../commands/init)         |
+| `xlflow pack`         | [command guide](../commands/pack)         |
+| `xlflow doctor`       | [command guide](../commands/doctor)       |
+| `xlflow attach`       | [command guide](../commands/attach)       |
+| `xlflow backup`       | [command guide](../commands/backup)       |
+| `xlflow list`         | [command guide](../commands/list)         |
+| `xlflow form`         | [command guide](../commands/form)         |
+| `xlflow formulas`     | [command guide](../commands/formulas)     |
+| `xlflow pull`         | [command guide](../commands/pull)         |
+| `xlflow push`         | [command guide](../commands/push)         |
+| `xlflow rollback`     | [command guide](../commands/rollback)     |
+| `xlflow status`       | [command guide](../commands/status)       |
+| `xlflow session`      | [command guide](../commands/session)      |
+| `xlflow save`         | [command guide](../commands/save)         |
+| `xlflow recovery`     | [command guide](../commands/recovery)     |
+| `xlflow runner`       | [command guide](../commands/runner)       |
+| `xlflow run`          | [command guide](../commands/run)          |
 | `xlflow export-image` | [command guide](../commands/export-image) |
-| `xlflow edit` | [command guide](../commands/edit) |
-| `xlflow macros` | [command guide](../commands/macros) |
-| `xlflow ui` | [command guide](../commands/ui) |
-| `xlflow test` | [command guide](../commands/test) |
-| `xlflow type db` | [command guide](../commands/type-db) |
-| `xlflow diff` | [command guide](../commands/diff) |
-| `xlflow inspect` | [command guide](../commands/inspect) |
-| `xlflow inspect-gui` | [command guide](../commands/inspect-gui) |
-| `xlflow lint` | [command guide](../commands/lint) |
-| `xlflow lsp` | [command guide](../commands/lsp) |
-| `xlflow fmt` | [command guide](../commands/fmt) |
-| `xlflow analyze` | [command guide](../commands/analyze) |
-| `xlflow check` | [command guide](../commands/check) |
-| `xlflow generate` | [command guide](../commands/generate) |
-| `xlflow module` | [command guide](../commands/module) |
-| `xlflow completion` | [command guide](../commands/completion) |
-| `xlflow process` | [command guide](../commands/process) |
-| `xlflow skill` | [command guide](../commands/skill) |
-| `xlflow version` | [command guide](../commands/version) |
-| `xlflow update` | [command guide](../commands/update) |
+| `xlflow edit`         | [command guide](../commands/edit)         |
+| `xlflow macros`       | [command guide](../commands/macros)       |
+| `xlflow ui`           | [command guide](../commands/ui)           |
+| `xlflow test`         | [command guide](../commands/test)         |
+| `xlflow type db`      | [command guide](../commands/type-db)      |
+| `xlflow diff`         | [command guide](../commands/diff)         |
+| `xlflow inspect`      | [command guide](../commands/inspect)      |
+| `xlflow inspect-gui`  | [command guide](../commands/inspect-gui)  |
+| `xlflow lint`         | [command guide](../commands/lint)         |
+| `xlflow lsp`          | [command guide](../commands/lsp)          |
+| `xlflow fmt`          | [command guide](../commands/fmt)          |
+| `xlflow analyze`      | [command guide](../commands/analyze)      |
+| `xlflow check`        | [command guide](../commands/check)        |
+| `xlflow generate`     | [command guide](../commands/generate)     |
+| `xlflow module`       | [command guide](../commands/module)       |
+| `xlflow completion`   | [command guide](../commands/completion)   |
+| `xlflow process`      | [command guide](../commands/process)      |
+| `xlflow skill`        | [command guide](../commands/skill)        |
+| `xlflow version`      | [command guide](../commands/version)      |
+| `xlflow update`       | [command guide](../commands/update)       |


### PR DESCRIPTION
## Summary

- Add an internal `build` bridge command for Excel-backed workbook reconstruction
- Consume the Go planner’s explicit build plan without rediscovering source roots
- Reconstruct standard, class, document, and UserForm modules in an isolated workbook copy
- Add structured error classification, cleanup, and dependency injection support
- Add unit coverage for argument validation, plan forwarding, and invalid plans
- Align generated documentation table formatting

## Testing

- Added and updated unit tests for build command handling and plan validation
- UI and Excel COM end-to-end testing not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a build command that reconstructs Excel workbooks from a supplied build plan.
  * Added validation for build inputs, plan files, workbook paths, and project-relative artifacts.
  * Added support for importing VBA components and synchronizing UserForm code-behind.
  * Added cancellation handling and structured build error reporting.

* **Bug Fixes**
  * Improved temporary workspace cleanup without deleting caller-owned files.
  * Strengthened UserForm synchronization error handling.

* **Documentation**
  * Clarified temporary-directory ownership and project-relative path handling.
  * Reformatted help and CLI command reference tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->