### PR TITLE
Document build source exclusions and refresh generated reference tables

### DIFF
--- a/vitepress/reference/cli-command-inventory.md
+++ b/vitepress/reference/cli-command-inventory.md
@@ -2,45 +2,45 @@
 
 Generated from the Cobra command registrations in `internal/cli/root.go`. Run `pnpm docs:generate-cli` after adding a command.
 
-| Command               | Documentation                             |
-| --------------------- | ----------------------------------------- |
+| Command | Documentation |
+| --- | --- |
 | `xlflow capabilities` | [command guide](../commands/capabilities) |
-| `xlflow new`          | [command guide](../commands/new)          |
-| `xlflow init`         | [command guide](../commands/init)         |
-| `xlflow pack`         | [command guide](../commands/pack)         |
-| `xlflow doctor`       | [command guide](../commands/doctor)       |
-| `xlflow attach`       | [command guide](../commands/attach)       |
-| `xlflow backup`       | [command guide](../commands/backup)       |
-| `xlflow list`         | [command guide](../commands/list)         |
-| `xlflow form`         | [command guide](../commands/form)         |
-| `xlflow formulas`     | [command guide](../commands/formulas)     |
-| `xlflow pull`         | [command guide](../commands/pull)         |
-| `xlflow push`         | [command guide](../commands/push)         |
-| `xlflow rollback`     | [command guide](../commands/rollback)     |
-| `xlflow status`       | [command guide](../commands/status)       |
-| `xlflow session`      | [command guide](../commands/session)      |
-| `xlflow save`         | [command guide](../commands/save)         |
-| `xlflow recovery`     | [command guide](../commands/recovery)     |
-| `xlflow runner`       | [command guide](../commands/runner)       |
-| `xlflow run`          | [command guide](../commands/run)          |
+| `xlflow new` | [command guide](../commands/new) |
+| `xlflow init` | [command guide](../commands/init) |
+| `xlflow pack` | [command guide](../commands/pack) |
+| `xlflow doctor` | [command guide](../commands/doctor) |
+| `xlflow attach` | [command guide](../commands/attach) |
+| `xlflow backup` | [command guide](../commands/backup) |
+| `xlflow list` | [command guide](../commands/list) |
+| `xlflow form` | [command guide](../commands/form) |
+| `xlflow formulas` | [command guide](../commands/formulas) |
+| `xlflow pull` | [command guide](../commands/pull) |
+| `xlflow push` | [command guide](../commands/push) |
+| `xlflow rollback` | [command guide](../commands/rollback) |
+| `xlflow status` | [command guide](../commands/status) |
+| `xlflow session` | [command guide](../commands/session) |
+| `xlflow save` | [command guide](../commands/save) |
+| `xlflow recovery` | [command guide](../commands/recovery) |
+| `xlflow runner` | [command guide](../commands/runner) |
+| `xlflow run` | [command guide](../commands/run) |
 | `xlflow export-image` | [command guide](../commands/export-image) |
-| `xlflow edit`         | [command guide](../commands/edit)         |
-| `xlflow macros`       | [command guide](../commands/macros)       |
-| `xlflow ui`           | [command guide](../commands/ui)           |
-| `xlflow test`         | [command guide](../commands/test)         |
-| `xlflow type db`      | [command guide](../commands/type-db)      |
-| `xlflow diff`         | [command guide](../commands/diff)         |
-| `xlflow inspect`      | [command guide](../commands/inspect)      |
-| `xlflow inspect-gui`  | [command guide](../commands/inspect-gui)  |
-| `xlflow lint`         | [command guide](../commands/lint)         |
-| `xlflow lsp`          | [command guide](../commands/lsp)          |
-| `xlflow fmt`          | [command guide](../commands/fmt)          |
-| `xlflow analyze`      | [command guide](../commands/analyze)      |
-| `xlflow check`        | [command guide](../commands/check)        |
-| `xlflow generate`     | [command guide](../commands/generate)     |
-| `xlflow module`       | [command guide](../commands/module)       |
-| `xlflow completion`   | [command guide](../commands/completion)   |
-| `xlflow process`      | [command guide](../commands/process)      |
-| `xlflow skill`        | [command guide](../commands/skill)        |
-| `xlflow version`      | [command guide](../commands/version)      |
-| `xlflow update`       | [command guide](../commands/update)       |
+| `xlflow edit` | [command guide](../commands/edit) |
+| `xlflow macros` | [command guide](../commands/macros) |
+| `xlflow ui` | [command guide](../commands/ui) |
+| `xlflow test` | [command guide](../commands/test) |
+| `xlflow type db` | [command guide](../commands/type-db) |
+| `xlflow diff` | [command guide](../commands/diff) |
+| `xlflow inspect` | [command guide](../commands/inspect) |
+| `xlflow inspect-gui` | [command guide](../commands/inspect-gui) |
+| `xlflow lint` | [command guide](../commands/lint) |
+| `xlflow lsp` | [command guide](../commands/lsp) |
+| `xlflow fmt` | [command guide](../commands/fmt) |
+| `xlflow analyze` | [command guide](../commands/analyze) |
+| `xlflow check` | [command guide](../commands/check) |
+| `xlflow generate` | [command guide](../commands/generate) |
+| `xlflow module` | [command guide](../commands/module) |
+| `xlflow completion` | [command guide](../commands/completion) |
+| `xlflow process` | [command guide](../commands/process) |
+| `xlflow skill` | [command guide](../commands/skill) |
+| `xlflow version` | [command guide](../commands/version) |
+| `xlflow update` | [command guide](../commands/update) |

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -81,6 +81,12 @@ code_source = "sidecar"
 # min_keep = 5
 # max_total_size_mb = 2048
 
+# Release build source filtering. This affects `build` only; `push` and `pack`
+# always use the complete source tree.
+# [build]
+# Exclude project-root-relative doublestar glob patterns from `xlflow build`.
+# exclude = ["src/modules/Tests/**"]
+
 # Static analysis rules.
 [lint]
 # Disable specific lint rules by diagnostic ID.
@@ -173,6 +179,14 @@ Set `enabled = true` only when runtime diagnostics need meaningful `Erl` values.
 Automatic retention is disabled by default and only affects backups for the configured `[excel].path`. Manual `xlflow backup prune` does not require `enabled = true`.
 
 Negative numeric values are configuration errors. `min_keep > max_count` is also invalid when `max_count` is greater than zero. If all limits are disabled, automatic pruning performs no deletion. Invalid entries and legacy directories without metadata are skipped, not deleted.
+
+### `[build]`
+
+| Key       | Type     | Required | Default | Description                                                                                             |
+| --------- | -------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `exclude` | string[] | no       | `[]`    | Project-root-relative `doublestar` glob patterns excluded from `xlflow build` source selection only. |
+
+Each pattern is normalized to `/`; Windows and WSL separators match identically. Absolute paths and patterns that traverse outside the project root are invalid. `xlflow build` reports unmatched patterns as `build_exclude_unmatched` warnings. A matching UserForm artifact excludes the whole form component, including its related `.frx`, sidecar code, and persisted spec files. This setting does not change source selection for `push` or `pack`.
 
 ### `[lint]`
 

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -36,6 +36,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `backup_scan_failed`
 - `bad_arg_count`
 - `bad_prog`
+- `base_workbook`
 - `before_dialog_action`
 - `binary_expression`
 - `bridge_file_not_openable`
@@ -45,6 +46,10 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `bridge_protocol_mismatch`
 - `bridge_response_indeterminate`
 - `bridge_terminated_during_excel_operation`
+- `build_args_invalid`
+- `build_exclude_unmatched`
+- `build_not_implemented`
+- `build_plan_invalid`
 - `build_settings`
 - `builtin_casing`
 - `builtin_like`


### PR DESCRIPTION
## Summary

- Document the new `[build].exclude` configuration for `xlflow build`.
- Clarify path normalization, unmatched-pattern warnings, UserForm handling, and `push`/`pack` behavior.
- Normalize the CLI command inventory table formatting.
- Add newly introduced build-related error codes to the generated inventory.

## Testing

- Not run (not requested).