### PR TITLE
Update tree-sitter-vba to v0.9.0

### DIFF
--- a/THIRD_PARTY_LICENCES.md
+++ b/THIRD_PARTY_LICENCES.md
@@ -14,7 +14,7 @@ This file is provided for attribution and licence review. It is not a substitute
 | `github.com/bmatcuk/doublestar/v4`      | `v4.10.0` | MIT               | `https://github.com/bmatcuk/doublestar/blob/v4.10.0/LICENSE`         |
 | `github.com/charmbracelet/bubbletea`    | `v1.3.10` | MIT               | `https://github.com/charmbracelet/bubbletea/blob/v1.3.10/LICENSE`    |
 | `github.com/charmbracelet/lipgloss`     |  `v1.1.0` | MIT               | `https://github.com/charmbracelet/lipgloss/blob/v1.1.0/LICENSE`      |
-| `github.com/harumiWeb/tree-sitter-vba`  |  `v0.8.1` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.8.1/LICENSE`   |
+| `github.com/harumiWeb/tree-sitter-vba`  |  `v0.9.0` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.9.0/LICENSE`   |
 | `github.com/sourcegraph/jsonrpc2`       |  `v0.2.0` | MIT               | `https://github.com/sourcegraph/jsonrpc2/blob/v0.2.0/LICENSE`        |
 | `github.com/spf13/cobra`                | `v1.10.2` | Apache-2.0        | `https://github.com/spf13/cobra/blob/v1.10.2/LICENSE.txt`            |
 | `github.com/tliron/glsp`                |  `v0.2.2` | Apache-2.0        | `https://github.com/tliron/glsp/blob/v0.2.2/LICENSE`                 |

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/harumiWeb/tree-sitter-vba v0.8.1
+	github.com/harumiWeb/tree-sitter-vba v0.9.0
 	github.com/richardlehane/mscfb v1.0.7
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-github.com/harumiWeb/tree-sitter-vba v0.8.1 h1:8VO2gAo2D1y7pYigpLP7pXn0RObajhXNqbzClCqAUvI=
-github.com/harumiWeb/tree-sitter-vba v0.8.1/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
+github.com/harumiWeb/tree-sitter-vba v0.9.0 h1:+bB2W2orAU+o3AOp0zFE45unUTht/YMA3R/zwPLmxmk=
+github.com/harumiWeb/tree-sitter-vba v0.9.0/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -88,3 +88,4 @@
 - When replacing repeated scans with a lazy index, treat index construction as fallible at every caller. Check both the returned status and pointer before lookup, and retain a safe declared-type fallback where one already exists.
 - When adding procedure-name filters or staged execution errors, preserve VBA modifier/casing variants and scope filters to the component kinds where they are semantic. Keep timeout and dialog outcomes ahead of inferred runner-stage classifications.
 - For user documentation, do not treat accurate command syntax as sufficient onboarding. Explain the user's goal, the state that each step reads or changes, a visible success condition, and the next safe action before relying on command references for detail.
+- When updating a Go module version, update `THIRD_PARTY_LICENCES.md` (including version-pinned licence URLs) in the same change and run `scripts/dev/check-third-party-licences.ps1` before finalizing.


### PR DESCRIPTION
## Summary

- Upgrade `github.com/harumiWeb/tree-sitter-vba` from v0.8.1 to v0.9.0
- Refresh `go.sum` checksums

## Testing

- Not run (not requested)