### PR TITLE
Handle Option Explicit when injecting VBA source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed .NET bridge temporary VBA module injection for `run`, `test`, and related form/UI helpers when VBE's **Require Variable Declaration** option pre-populates a new module with `Option Explicit`. Generated code now replaces the initial module content, avoiding duplicate declarations and compile failures.
 - Added `xlflow impact <Module.Procedure>` for deterministic, AI-friendly VBA call impact analysis. It reports confirmed direct/transitive callers and callees, cycles, affected modules, source locations, and explicit conservative-resolution uncertainty without opening Excel.
 - Added standard LSP Call Hierarchy for confidently resolved project-local VBA procedures. Incoming and outgoing calls reuse the incremental workspace index and current unsaved editor overlays; ambiguous, unresolved, external, built-in-like, dynamic-member, and module-level calls remain excluded, and private procedures stay module-scoped.
 - Extended LSP `VB030` argument diagnostics to flag known project-local arrays passed to non-array `Object` parameters, including both `ByVal` and `ByRef` calls, before Excel can surface a runtime type mismatch.

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormExportImageService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormExportImageService.cs
@@ -335,7 +335,7 @@ public sealed class ExcelFormExportImageService : IFormExportImageService
             ExcelBridgeSupport.Set(component, "Name", "XlflowCap_" + Guid.NewGuid().ToString("N")[..20]);
             codeModule = ExcelBridgeSupport.Get(component, "CodeModule")
                 ?? throw new InvalidOperationException("vba_compile_failed: helper CodeModule is unavailable.");
-            ExcelBridgeSupport.InvokeMethod(codeModule, "AddFromString", BuildHelperCode());
+            VbaSourceHelper.SetCodeModuleText(codeModule, BuildHelperCode());
             return component;
         }
         finally

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormInspectionService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelFormInspectionService.cs
@@ -410,7 +410,7 @@ public sealed class ExcelFormInspectionService : IInspectFormService
             SetProperty(component, "Name", "XlflowForm_" + Guid.NewGuid().ToString("N")[..20]);
             codeModule = ExcelBridgeSupport.Get(component, "CodeModule")
                 ?? throw new InvalidOperationException("inspect helper CodeModule is unavailable.");
-            ExcelBridgeSupport.InvokeMethod(codeModule, "AddFromString", BuildInspectHelperCode());
+            VbaSourceHelper.SetCodeModuleText(codeModule, BuildInspectHelperCode());
             return component;
         }
         finally

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunService.cs
@@ -142,7 +142,7 @@ public sealed class ExcelRunService : IRunService
                 RuntimeInjectionHelper.SetDefinedName(workbook, "__XLFLOW_RUN_HELPER__", runnerName);
                 runnerCodeModule = ExcelBridgeSupport.Get(runnerComponent, "CodeModule")
                     ?? throw new InvalidOperationException("inject_harness failed: CodeModule is unavailable.");
-                ExcelBridgeSupport.InvokeMethod(runnerCodeModule, "AddFromString", BuildRunHarnessCode(macroName, macroArgs));
+                VbaSourceHelper.SetCodeModuleText(runnerCodeModule, BuildRunHarnessCode(macroName, macroArgs));
                 ExcelBridgeSupport.ReleaseComObject(runnerCodeModule);
                 runnerCodeModule = null;
                 ExcelBridgeSupport.ReleaseComObject(runnerComponents);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunnerService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelRunnerService.cs
@@ -196,7 +196,7 @@ public sealed class ExcelRunnerService : IRunnerService
             component = ExcelBridgeSupport.InvokeMethod(components, "Add", 1);
             ExcelBridgeSupport.Set(component!, "Name", "XlflowRunner");
             codeModule = ExcelBridgeSupport.Get(component!, "CodeModule");
-            ExcelBridgeSupport.InvokeMethod(codeModule!, "AddFromString", BuildRunnerModuleCode());
+            VbaSourceHelper.SetCodeModuleText(codeModule!, BuildRunnerModuleCode());
         }
         finally
         {

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelTestService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelTestService.cs
@@ -629,7 +629,7 @@ public sealed class ExcelTestService : ITestService
             SetProperty(runnerComponent, "Name", runnerName);
             var runnerCodeModule = ExcelBridgeSupport.Get(runnerComponent, "CodeModule")
                 ?? throw new InvalidOperationException("CodeModule is unavailable.");
-            ExcelBridgeSupport.InvokeMethod(runnerCodeModule, "AddFromString",
+            VbaSourceHelper.SetCodeModuleText(runnerCodeModule,
                 BuildTestRunnerCode(executableSelected, hooksByModule));
             ExcelBridgeSupport.ReleaseComObject(runnerCodeModule);
             ExcelBridgeSupport.ReleaseComObject(components);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/RuntimeInjectionHelper.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/RuntimeInjectionHelper.cs
@@ -563,7 +563,7 @@ internal static class RuntimeInjectionHelper
         SetProperty(component, "Name", moduleName);
         var codeModule = ExcelBridgeSupport.Get(component, "CodeModule")
             ?? throw new InvalidOperationException("CodeModule is unavailable.");
-        ExcelBridgeSupport.InvokeMethod(codeModule, "AddFromString", BuildUIStreamModuleCode(pipeName));
+        VbaSourceHelper.SetCodeModuleText(codeModule, BuildUIStreamModuleCode(pipeName));
         ExcelBridgeSupport.ReleaseComObject(codeModule);
         ExcelBridgeSupport.ReleaseComObject(component);
         ExcelBridgeSupport.ReleaseComObject(components);

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/VbaSourceHelperTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/VbaSourceHelperTests.cs
@@ -78,6 +78,17 @@ public sealed class VbaSourceHelperTests
     }
 
     [Fact]
+    public void SetCodeModuleText_ReplacesVbeInsertedOptionExplicit()
+    {
+        var module = new FakeCodeModule("Option Explicit\r\n");
+
+        VbaSourceHelper.SetCodeModuleText(module, "Option Explicit\r\nPublic Sub Run()\r\nEnd Sub\r\n");
+
+        Assert.Equal("Option Explicit\r\nPublic Sub Run()\r\nEnd Sub\r\n", module.Text);
+        Assert.Equal(1, module.DeleteLinesCalls);
+    }
+
+    [Fact]
     public void FindDuplicateModuleNames_IgnoresUserFormCodeSidecars()
     {
         var files = new List<DiscoveredSourceFile>
@@ -219,6 +230,28 @@ public sealed class VbaSourceHelperTests
             {
                 Directory.Delete(root, true);
             }
+        }
+    }
+    public sealed class FakeCodeModule(string text)
+    {
+        public string Text { get; private set; } = text;
+        public int CountOfLines => Text.Split(["\r\n", "\n", "\r"], StringSplitOptions.None).Length - 1;
+        public int DeleteLinesCalls { get; private set; }
+
+        public object? DeleteLines(object startLine, object count)
+        {
+            Assert.Equal(1, Convert.ToInt32(startLine));
+            Assert.Equal(CountOfLines, Convert.ToInt32(count));
+            Text = "";
+            DeleteLinesCalls++;
+            return null;
+        }
+
+        public object? InsertLines(object startLine, object text)
+        {
+            Assert.Equal(1, Convert.ToInt32(startLine));
+            Text = Convert.ToString(text) ?? "";
+            return null;
         }
     }
 }

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/VbaSourceHelperTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/VbaSourceHelperTests.cs
@@ -89,6 +89,17 @@ public sealed class VbaSourceHelperTests
     }
 
     [Fact]
+    public void SetCodeModuleText_ReplacesUnterminatedInitialLine()
+    {
+        var module = new FakeCodeModule("Option Explicit");
+
+        VbaSourceHelper.SetCodeModuleText(module, "Public Sub Run()\r\nEnd Sub\r\n");
+
+        Assert.Equal("Public Sub Run()\r\nEnd Sub\r\n", module.Text);
+        Assert.Equal(1, module.DeleteLinesCalls);
+    }
+
+    [Fact]
     public void FindDuplicateModuleNames_IgnoresUserFormCodeSidecars()
     {
         var files = new List<DiscoveredSourceFile>
@@ -235,7 +246,19 @@ public sealed class VbaSourceHelperTests
     public sealed class FakeCodeModule(string text)
     {
         public string Text { get; private set; } = text;
-        public int CountOfLines => Text.Split(["\r\n", "\n", "\r"], StringSplitOptions.None).Length - 1;
+        public int CountOfLines
+        {
+            get
+            {
+                if (Text.Length == 0)
+                {
+                    return 0;
+                }
+
+                var lines = Text.Split(["\r\n", "\n", "\r"], StringSplitOptions.None);
+                return lines.Length - (Text[^1] is '\r' or '\n' ? 1 : 0);
+            }
+        }
         public int DeleteLinesCalls { get; private set; }
 
         public object? DeleteLines(object startLine, object count)

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -513,11 +513,12 @@ func TestWorkbookCoordinationUsesOneTimeoutBudgetAcrossMultipleTargets(t *testin
 	defer func() { _ = firstOwner.Release() }()
 	defer func() { _ = secondOwner.Release() }()
 
-	// Keep a wide enough gap between one shared deadline (about 1.5s) and a
-	// mistakenly restarted second deadline (about 2.4s) for Windows CI
-	// scheduling delays. The former 220ms budget was too narrow and flaky.
-	const waitBudget = 1500 * time.Millisecond
-	time.AfterFunc(900*time.Millisecond, func() { _ = firstOwner.Release() })
+	// Release the first lock close to the shared deadline. A correct shared
+	// deadline expires after about 4s, while a mistakenly restarted deadline
+	// needs about 7s. The 1.5s upper-bound allowance absorbs hosted Windows
+	// scheduler pauses without masking the restarted-timeout regression.
+	const waitBudget = 4 * time.Second
+	time.AfterFunc(3*time.Second, func() { _ = firstOwner.Release() })
 	var stdout bytes.Buffer
 	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: waitBudget, stdout: &stdout, stderr: &bytes.Buffer{}, coordination: manager}
 	started := time.Now()
@@ -527,10 +528,10 @@ func TestWorkbookCoordinationUsesOneTimeoutBudgetAcrossMultipleTargets(t *testin
 	})
 	elapsed := time.Since(started)
 	assertCoordinationWaitFailure(t, err, stdout.Bytes(), coordination.WorkbookBusyTimeoutCode, waitBudget.String())
-	if elapsed < 1200*time.Millisecond {
+	if elapsed < 3500*time.Millisecond {
 		t.Fatalf("multi-target acquisition timed out too early after %s", elapsed)
 	}
-	if elapsed >= 2100*time.Millisecond {
+	if elapsed >= 5500*time.Millisecond {
 		t.Fatalf("multi-target acquisition took %s; timeout budget appears to have restarted per target", elapsed)
 	}
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -69,6 +69,7 @@
 - Flat UserForm sidecar/spec artifacts are keyed by component name, not source subdirectory. Resolve them only after primary `.frm` exclusions select the remaining same-named candidate; do not invent a directory-scoped sidecar layout that conflicts with the source contract.
 - Windows coordination wait tests need a generous gap between scheduled owner release and the waiter deadline; a one-second budget can expire before timer delivery or owner metadata publication on hosted runners.
 - Treat caller-supplied temporary directories as ownership boundaries: create and clean up only a unique child directory created by the operation, never recursively delete the supplied root.
+- User-visible compatibility fixes must add a concise `CHANGELOG.md` entry under `Unreleased`, including fixes to generated .NET bridge runtime behavior.
 - Preserve source-plan path contracts across process boundaries. When a planner publishes project-root-relative paths, the receiving bridge must resolve them against an explicit project root rather than requiring callers to rewrite the plan ad hoc.
 - For destructive output paths, lexical project-root containment is insufficient: resolve the nearest existing ancestor and reject paths whose canonical identity escapes through a symlink or junction.
 - Treat matching xlflow session metadata as a liveness hint, not proof of ownership: verify the recorded Excel process and workbook before blocking an output path, and ensure human command renderers include top-level operational warnings returned by the bridge.


### PR DESCRIPTION
Related Issues #369 

## Summary

- Route generated VBA injection through `VbaSourceHelper.SetCodeModuleText`.
- Prevent VBE-inserted `Option Explicit` from duplicating or conflicting with generated source.
- Add regression coverage for replacing existing module text.

## Testing

- Added and ran the `VbaSourceHelper` unit test covering existing `Option Explicit` handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed runtime VBA module injection for `run`/`test` and form/UI automation when Excel pre-populates modules with **Require Variable Declaration** (`Option Explicit`), preventing duplicate declarations and compile errors.
  - Improved consistency by replacing existing initial module content before inserting generated helper/runner code.
  - Preserved workbook execution behavior while enhancing compatibility with Excel’s VBA environment.

- **Tests**
  - Added unit tests covering `Option Explicit` replacement, including the unterminated case.

- **Documentation**
  - Updated `CHANGELOG.md` guidance and entry for this user-visible compatibility fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->