### PR TITLE
Fix false VBA209 warnings for function array returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed `xlflow analyze` `VBA209` false positives for bundled `XlflowUI` functions that return array values.
 - Fixed .NET bridge temporary VBA module injection for `run`, `test`, and related form/UI helpers when VBE's **Require Variable Declaration** option pre-populates a new module with `Option Explicit`. Generated code now replaces the initial module content, avoiding duplicate declarations and compile failures.
 - Added `xlflow impact <Module.Procedure>` for deterministic, AI-friendly VBA call impact analysis. It reports confirmed direct/transitive callers and callees, cycles, affected modules, source locations, and explicit conservative-resolution uncertainty without opening Excel.
 - Added standard LSP Call Hierarchy for confidently resolved project-local VBA procedures. Incoming and outgoing calls reuse the incremental workspace index and current unsaved editor overlays; ambiguous, unresolved, external, built-in-like, dynamic-member, and module-level calls remain excluded, and private procedures stay module-scoped.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -1112,7 +1112,7 @@ func identifierComparedAsOperand(stmt, name string, proc sourceProcedure) bool {
 		}
 		left := stmt[:i]
 		right := stmt[i+opLen:]
-		if opLen == 1 && stmt[i] == '=' && isFunctionReturnAssignment(left, proc) {
+		if opLen == 1 && stmt[i] == '=' && isFunctionReturnAssignment(stmt, i, proc) {
 			i += opLen - 1
 			continue
 		}
@@ -1124,8 +1124,12 @@ func identifierComparedAsOperand(stmt, name string, proc sourceProcedure) bool {
 	return false
 }
 
-func isFunctionReturnAssignment(left string, proc sourceProcedure) bool {
-	return proc.Kind == "Function" && proc.Name != "" && strings.EqualFold(cleanIdentifier(strings.TrimSpace(left)), proc.Name)
+func isFunctionReturnAssignment(stmt string, operatorIndex int, proc sourceProcedure) bool {
+	match := assignRe.FindStringSubmatchIndex(stmt)
+	if len(match) < 4 || match[1]-1 != operatorIndex || proc.Kind != "Function" || proc.Name == "" {
+		return false
+	}
+	return strings.EqualFold(stmt[match[2]:match[3]], proc.Name)
 }
 
 func comparisonOperatorLength(stmt string, index int) int {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -1093,14 +1093,14 @@ func (a Analyzer) objectArrayComparisonFindings(file parsedFile, proc sourceProc
 		if decl.Object && strings.Contains(lower, key+" = nothing") {
 			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", decl.Name+" is compared to Nothing with =.", "Object references must be compared with Is Nothing, not the scalar equality operator.", "Use `If "+decl.Name+" Is Nothing Then` or `If Not "+decl.Name+" Is Nothing Then`."))
 		}
-		if decl.Array && identifierComparedAsOperand(lower, key) {
+		if decl.Array && identifierComparedAsOperand(lower, key, proc) {
 			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", decl.Name+" appears to be compared as a scalar value.", "VBA arrays cannot be compared directly to scalar values.", "Compare explicit elements or bounds instead of the array variable itself."))
 		}
 	}
 	return findings
 }
 
-func identifierComparedAsOperand(stmt, name string) bool {
+func identifierComparedAsOperand(stmt, name string, proc sourceProcedure) bool {
 	name = strings.ToLower(cleanIdentifier(name))
 	if name == "" {
 		return false
@@ -1112,12 +1112,20 @@ func identifierComparedAsOperand(stmt, name string) bool {
 		}
 		left := stmt[:i]
 		right := stmt[i+opLen:]
+		if opLen == 1 && stmt[i] == '=' && isFunctionReturnAssignment(left, proc) {
+			i += opLen - 1
+			continue
+		}
 		if operandEndsWithBareIdentifier(left, name) || operandStartsWithBareIdentifier(right, name) {
 			return true
 		}
 		i += opLen - 1
 	}
 	return false
+}
+
+func isFunctionReturnAssignment(left string, proc sourceProcedure) bool {
+	return proc.Kind == "Function" && proc.Name != "" && strings.EqualFold(cleanIdentifier(strings.TrimSpace(left)), proc.Name)
 }
 
 func comparisonOperatorLength(stmt string, index int) int {

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -703,7 +703,7 @@ Private Function CopyValues() As Variant
   Dim values() As String
   ReDim values(0 To 0)
   values(0) = "value"
-  CopyValues = values
+	Let CopyValues = values
 End Function
 
 Public Sub Run()

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -696,6 +696,32 @@ End Sub
 	}
 }
 
+func TestAnalyzerArrayComparisonIgnoresFunctionReturnAssignment(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Function CopyValues() As Variant
+  Dim values() As String
+  ReDim values(0 To 0)
+  values(0) = "value"
+  CopyValues = values
+End Function
+
+Public Sub Run()
+  Dim values() As String
+  If values = "unexpected" Then Debug.Print "bad"
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA209")
+	if len(got) != 1 || got[0].Line != 11 {
+		t.Fatalf("expected only the array comparison on line 11, got %+v", got)
+	}
+}
+
 func TestAnalyzerArrayComparisonIgnoresElementsAndProcedureHeaders(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/project/scaffold_test.go
+++ b/internal/project/scaffold_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/harumiWeb/xlflow/internal/analyze"
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/excel/forms"
 	"github.com/harumiWeb/xlflow/internal/lint"
@@ -824,6 +825,27 @@ func TestNewScaffoldUIHelperLintsCleanly(t *testing.T) {
 	}
 	if len(issues) != 0 {
 		t.Fatalf("UI helper should lint cleanly: %+v", issues)
+	}
+}
+
+func TestNewScaffoldUIHelperAnalyzesCleanly(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := New(dir, "Book", fakeWorkbookCreator); err != nil {
+		t.Fatal(err)
+	}
+	uiPath := filepath.Join(dir, "src", "modules", "Xlflow", "XlflowUI.bas")
+	findings, err := analyze.Analyzer{
+		RootDir: dir,
+		Config:  config.Default(),
+		PathFilter: func(path string) bool {
+			return filepath.Clean(path) == filepath.Clean(uiPath)
+		},
+	}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("UI helper should analyze cleanly: %+v", findings)
 	}
 }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -94,3 +94,4 @@
 - When updating a Go module version, update `THIRD_PARTY_LICENCES.md` (including version-pinned licence URLs) in the same change and run `scripts/dev/check-third-party-licences.ps1` before finalizing.
 - LSP ranges derived from tree-sitter positions must translate UTF-8 byte columns to UTF-16 code units using the effective source buffer; preserve that buffer in incremental analysis when range-bearing results are served from the index.
 - Do not turn a disk-backed `getOrRead` document into an editor overlay. Only `didOpen` / `didChange` lifecycle documents may override watcher-managed disk index entries.
+- When extending VBA assignment analysis, reuse the existing assignment grammar so valid optional modifiers such as `Let` receive the same treatment; add a regression test for each supported form.


### PR DESCRIPTION
## Summary

- Prevents `xlflow analyze` from treating function return assignments as scalar array comparisons.
- Adds regression coverage for array-returning functions and scaffolded `XlflowUI` helpers.
- Updates the changelog.

## Testing

- Added and updated unit tests for analyzer findings and scaffold analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a false-positive `VBA209` warning when analyzing bundled `XlflowUI` functions that return arrays.
  * Array-returning functions are now analyzed correctly without generating unnecessary comparison warnings.

* **Tests**
  * Added regression coverage to verify accurate array-comparison findings.
  * Added validation that generated UI helper code analyzes cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->