### PR TITLE
Update tree-sitter-vba to v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed `--wait-timeout` so uncontended workbook coordination metadata work no longer consumes the lock-wait budget.
 - Updated `tree-sitter-vba` to v0.10.1, adding support for nested colon-separated single-line control flow, shared `Next` counter lists, and complete single-line `If` statement sequences.
 
 ## v0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Updated `tree-sitter-vba` to v0.10.1, adding support for nested colon-separated single-line control flow, shared `Next` counter lists, and complete single-line `If` statement sequences.
+
 ## v0.27.0
 
 - Added `xlflow test --visible` to run GUI-bound VBA integration tests, such as `Application.OnKey` registration, with a visible Excel window without changing the project's `[excel].visible` configuration.

--- a/THIRD_PARTY_LICENCES.md
+++ b/THIRD_PARTY_LICENCES.md
@@ -14,7 +14,7 @@ This file is provided for attribution and licence review. It is not a substitute
 | `github.com/bmatcuk/doublestar/v4`      | `v4.10.0` | MIT               | `https://github.com/bmatcuk/doublestar/blob/v4.10.0/LICENSE`         |
 | `github.com/charmbracelet/bubbletea`    | `v1.3.10` | MIT               | `https://github.com/charmbracelet/bubbletea/blob/v1.3.10/LICENSE`    |
 | `github.com/charmbracelet/lipgloss`     |  `v1.1.0` | MIT               | `https://github.com/charmbracelet/lipgloss/blob/v1.1.0/LICENSE`      |
-| `github.com/harumiWeb/tree-sitter-vba`  |  `v0.9.0` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.9.0/LICENSE`   |
+| `github.com/harumiWeb/tree-sitter-vba`  | `v0.10.1` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.10.1/LICENSE`  |
 | `github.com/sourcegraph/jsonrpc2`       |  `v0.2.0` | MIT               | `https://github.com/sourcegraph/jsonrpc2/blob/v0.2.0/LICENSE`        |
 | `github.com/spf13/cobra`                | `v1.10.2` | Apache-2.0        | `https://github.com/spf13/cobra/blob/v1.10.2/LICENSE.txt`            |
 | `github.com/tliron/glsp`                |  `v0.2.2` | Apache-2.0        | `https://github.com/tliron/glsp/blob/v0.2.2/LICENSE`                 |

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/harumiWeb/tree-sitter-vba v0.9.0
+	github.com/harumiWeb/tree-sitter-vba v0.10.1
 	github.com/richardlehane/mscfb v1.0.7
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/harumiWeb/tree-sitter-vba v0.9.0 h1:+bB2W2orAU+o3AOp0zFE45unUTht/YMA3R/zwPLmxmk=
 github.com/harumiWeb/tree-sitter-vba v0.9.0/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
+github.com/harumiWeb/tree-sitter-vba v0.10.1 h1:bIUVSf8/AizFzG+al52kQ8o0n35tNoE6vsdkK338gd4=
+github.com/harumiWeb/tree-sitter-vba v0.10.1/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/internal/cli/coordination.go
+++ b/internal/cli/coordination.go
@@ -291,12 +291,19 @@ func (a *app) acquireWorkbookCoordination(ctx context.Context, commandID coordin
 	acquireCtx := ctx
 	stopSignal := func() {}
 	cancelTimeout := func() {}
-	if a.wait {
+	waitStarted := false
+	startWait := func() {
+		if waitStarted {
+			return
+		}
 		acquireCtx, stopSignal = signal.NotifyContext(ctx, os.Interrupt)
 		acquireCtx, cancelTimeout = context.WithTimeout(acquireCtx, a.waitTimeout)
+		waitStarted = true
 	}
-	defer stopSignal()
-	defer cancelTimeout()
+	defer func() {
+		stopSignal()
+		cancelTimeout()
+	}()
 
 	leases := make([]*coordination.Lease, 0, len(lockIDs))
 	waitingAnnounced := false
@@ -320,10 +327,14 @@ func (a *app) acquireWorkbookCoordination(ctx context.Context, commandID coordin
 				_, _ = fmt.Fprintf(a.stderrWriter(), "Waiting up to %s for the workbook to become available: %s\n", a.waitTimeout, busy.Identity.CanonicalPath)
 				waitingAnnounced = true
 			}
+			// Start the deadline only after the initial non-waiting probe found
+			// contention. Metadata publication on an uncontended acquisition must
+			// not consume the user's wait budget or affect the command body.
+			startWait()
 			request.Wait = true
 			lease, acquireErr = manager.Acquire(acquireCtx, request)
 		}
-		if acquireErr == nil && a.wait && acquireCtx.Err() != nil {
+		if acquireErr == nil && waitStarted && acquireCtx.Err() != nil {
 			_ = lease.Release()
 			acquireErr = acquireCtx.Err()
 		}

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -410,9 +410,9 @@ func TestWorkbookCoordinationWithoutContentionEmitsNoWaitMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stderr bytes.Buffer
-	// The wait deadline also covers lock metadata publication, which can be slow
-	// on loaded Windows CI runners even without workbook contention.
-	a := &app{cwd: rootDir, wait: true, waitTimeout: 5 * time.Second, stdout: &bytes.Buffer{}, stderr: &stderr, coordination: manager}
+	// An uncontended acquisition must not start the wait timer. This keeps
+	// metadata publication independent from the user-visible wait budget.
+	a := &app{cwd: rootDir, wait: true, waitTimeout: 50 * time.Millisecond, stdout: &bytes.Buffer{}, stderr: &stderr, coordination: manager}
 	if err := a.withWorkbookCoordination(context.Background(), "push", []string{filepath.Join(rootDir, "book.xlsm")}, func() error { return nil }); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vba/ast/ast_test.go
+++ b/internal/vba/ast/ast_test.go
@@ -48,6 +48,21 @@ func TestParserReportsErrorAndMissingRecovery(t *testing.T) {
 	}
 }
 
+func TestParserParsesNestedInlineLoopsWithSharedNextVariables(t *testing.T) {
+	parser, err := NewParser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parser.Close()
+
+	result := parser.Parse("Main.bas", []byte("Public Sub Run()\nFor outer = 1 To 2: For inner = 1 To 2: Next inner, outer\nEnd Sub\n"))
+	defer result.Close()
+
+	if result.HasError || result.HasMissing {
+		t.Fatalf("unexpected recovery state: error=%t missing=%t tree=%s", result.HasError, result.HasMissing, result.Root.ToSexp())
+	}
+}
+
 func TestParsedDocumentOwnsRecoveryStateAndClosesAfterReaders(t *testing.T) {
 	doc, err := ParseDocument("Broken.bas", []byte("Public Function Foo(ByVal x As String\nEnd Function\n"))
 	if err != nil {


### PR DESCRIPTION
## Summary

- Update `tree-sitter-vba` from v0.9.0 to v0.10.1
- Add parser coverage for nested inline loops with shared `Next` variables
- Document support for additional single-line VBA control-flow syntax

## Testing

- Added a unit test verifying nested inline loops parse without errors or missing nodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nested colon-separated single-line control flow in VBA.
  * Added support for shared `Next` counter lists.
  * Added support for complete single-line `If` statement sequences.

* **Bug Fixes**
  * Improved parsing reliability for nested inline VBA loops and related control-flow syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->