### PR TITLE
Introduce reusable procedure-level analysis IR

### DIFF
--- a/docs/adr/ADR-0021-procedure-analysis-ir.md
+++ b/docs/adr/ADR-0021-procedure-analysis-ir.md
@@ -1,0 +1,143 @@
+# ADR-0021: Shared Procedure-Level VBA Analysis IR
+
+## Status
+
+Accepted
+
+## Context
+
+xlflow's VBA consumers already share the owned tree-sitter parser, but they do
+not share one normalized representation of a procedure. `internal/analyze`,
+`internal/vba/calls`, `internal/vba/symbols`, and `internal/vba/intel` each
+derive overlapping procedure, declaration, call, range, and event facts for
+their own use. Adding control-flow and interprocedural reliability analysis
+under issue #425 would multiply those traversals and make CLI and LSP behavior
+more likely to drift.
+
+Raw tree-sitter nodes are unsuitable as the shared contract. They are valid
+only during `ast.ParsedDocument.Read`, their tree is serialized and owned by the
+parsed document, and an LSP snapshot can retire that document while older
+analysis values remain in use. LSP protocol types are also unsuitable because
+the same analysis must remain reusable by source-only CLI commands.
+
+The foundation in issue #426 needs exact existing diagnostic locations,
+recoverable partial analysis, deterministic output, and project resolution
+that can be refreshed without rewalking unchanged syntax. It does not yet need
+control-flow graphs or effect propagation.
+
+## Decision
+
+Add a protocol-neutral, procedure-level intermediate representation under
+`internal/vba/procedureir`.
+
+The IR builder performs one traversal inside `ast.ParsedDocument.Read` and
+copies only Go-owned values: strings, enums, stable IDs, slices, and
+`ast.Range`. It never retains tree-sitter nodes, trees, or source slices from
+the read callback. `BuildSource` owns parsing and closing for one-shot callers;
+`BuildParsed` uses a caller-owned parsed document without closing it.
+
+Separate syntax extraction from project resolution. A syntax-local
+`DocumentIR` records procedures, declarations, statements, expressions, calls,
+and variable accesses. `Resolve` applies a replaceable project symbol/call
+resolver to a copy of that IR without reparsing or rescanning source. Resolution
+must explicitly represent matched, ambiguous, unresolved, external,
+built-in-like, and member-call outcomes.
+
+Use `ast.Range` as the canonical source coordinate contract. LSP UTF-16
+conversion remains in the LSP adapter; the IR does not import LSP protocol
+types.
+
+Make the immutable `AnalysisSnapshot` the LSP ownership and cache boundary.
+Each snapshot lazily constructs at most one syntax IR from its owned parsed
+document, supports concurrent readers, and returns defensive copies. A new
+incrementally parsed snapshot gets its own IR; issue #426 does not splice
+procedure IR fragments across revisions.
+
+Centralize procedure-kind and event-handler classification in the IR. `Sub`,
+`Function`, and `Property Get/Let/Set` bodies are procedures. A module-level
+`Event Foo(...)` declaration is a declaration, not a procedure body.
+Document-module `Workbook_*` and `Worksheet_*` procedures, `Auto_Open` and
+`Auto_Close`, and non-test UserForm procedures with a non-empty
+`<source>_<event>` shape carry event metadata compatible with the existing
+`internal/vba/intel` behavior.
+
+Malformed but parseable source produces partial IR with document recovery flags
+and recovered or unknown statements where useful facts remain available.
+Consumers retain authority over whether recovery is acceptable; in particular,
+batch `analyze` may continue to reject parser recovery even though the builder
+does not discard the partial IR.
+
+Issue #426 models syntactic statement nesting only. Basic blocks, control-flow
+edges, reachability, and path queries belong to issue #427. Direct/transitive
+effect summaries and fixed-point propagation belong to issue #428.
+
+Migrate `VBA204` error-handler fallthrough detection as the validation consumer.
+Its diagnostic fields, ordering, cleanup-label exception, inline suppression,
+CLI JSON, and LSP ranges remain unchanged. Existing `inspect calls` output is
+also a compatibility contract; projecting call facts from the IR must not
+change its JSON shape or resolution meaning.
+
+## Consequences
+
+- Positive: lint, analyze, inspect, LSP, and later project-wide analyses can
+  reuse one procedure and source-location model.
+- Positive: syntax extraction is independent of changing project symbols, so
+  call resolution can be refreshed without another CST walk.
+- Positive: cached analysis values are safe after the parsed document closes
+  because the IR contains no borrowed parser state.
+- Positive: partial syntax facts remain available for editor scenarios while
+  strict batch consumers can continue to fail closed.
+- Positive: CFG and effect work get an explicit, narrow input boundary instead
+  of expanding rule-specific CST walkers.
+- Negative: the normalized model must evolve when tree-sitter-vba adds syntax
+  that cannot be represented by current statement or expression kinds.
+- Negative: defensive copies and normalization allocate more Go values than a
+  consumer-specific walk.
+- Negative: compatibility projections remain necessary while existing calls,
+  symbols, analyzer, and LSP result types continue to serve their public
+  contracts.
+- Limitation: issue #426 provides syntactic structure, not executable-path
+  truth, type-complete member binding, COM type-library resolution, or
+  interprocedural effects.
+
+## Alternatives Considered
+
+1. **Continue traversing raw CST nodes in every rule** - Rejected because
+   procedure discovery, ranges, calls, and recovery handling would continue to
+   diverge, and later CFG/effect work would duplicate parser-lifetime logic.
+2. **Retain tree-sitter nodes in a shared model** - Rejected because nodes are
+   borrowed from a serialized, closeable `ParsedDocument` and cannot safely
+   outlive its `Read` callback or owning snapshot.
+3. **Create a separate model per analyzer rule** - Rejected because it preserves
+   duplicated extraction and gives later analyses no common deterministic
+   input.
+4. **Make the shared model LSP-specific** - Rejected because CLI analysis and
+   inspection must not depend on protocol coordinates or lifecycle types, and
+   ADR-0014 already confines LSP conversion to the adapter boundary.
+5. **Build CFG and effects into the first IR** - Rejected because those layers
+   require separate graph and propagation decisions covered by issues #427 and
+   #428. Keeping the foundation syntactic makes #426 independently testable.
+6. **Rebuild syntax whenever the project symbol snapshot changes** - Rejected
+   because local syntax is unchanged; a separate resolution overlay is cheaper
+   and makes unresolved or ambiguous states explicit.
+
+## Evidence
+
+- Requirements: xlflow issues #425 and #426.
+- Existing parser lifetime and range contract:
+  `internal/vba/ast/ast.go`, `internal/vba/ast/ast_test.go`.
+- Existing call extraction and resolution contract:
+  `internal/vba/calls/calls.go`, `internal/vba/calls/calls_test.go`.
+- Existing snapshot ownership and incremental parsing:
+  `internal/vba/intel/analysis_snapshot.go`,
+  `internal/vba/intel/analysis_snapshot_test.go`.
+- Validation consumer: `internal/analyze/analyzer.go`,
+  `internal/analyze/analyzer_test.go`.
+- Public compatibility contract: `docs/specs/cli-contract.md`.
+
+## Related
+
+- `docs/adr/ADR-0013-analyze-runtime-risk-ownership.md`
+- `docs/adr/ADR-0014-reusable-vba-lsp-server.md`
+- `docs/specs/vba-analysis-ir.md`
+- xlflow issues #425, #426, #427, and #428

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -1,0 +1,236 @@
+# VBA Procedure Analysis IR
+
+This specification defines xlflow's protocol-neutral, procedure-level
+intermediate representation (IR). ADR-0021 records the rationale. The IR is an
+internal analysis contract: it does not change the public CLI JSON or LSP
+diagnostic contracts.
+
+## Construction and Ownership
+
+`internal/vba/procedureir` exposes two construction paths:
+
+```go
+func BuildSource(BuildOptions, []byte) (DocumentIR, error)
+func BuildParsed(BuildOptions, *ast.ParsedDocument) (DocumentIR, error)
+func Resolve(DocumentIR, Resolver) DocumentIR
+```
+
+`BuildSource` parses the supplied immutable source and closes the parsed
+document before returning. `BuildParsed` reads an existing caller-owned parsed
+document and never closes it. This is the incremental construction path for
+LSP: if the document was produced by `ast.ParseDocumentIncremental`, the builder
+uses that already-incremental tree and does not parse the source again.
+
+All tree and source access occurs inside `ast.ParsedDocument.Read`. Returned IR
+values own every string and slice they expose and contain no tree-sitter node,
+tree, or borrowed `ParsedView.Source` slice. They remain safe to read after the
+parsed document is closed.
+
+`BuildOptions` supplies document context that syntax alone cannot reliably
+provide, including path and module kind. A missing module name is derived using
+the same source attribute/path fallback as existing source inspectors.
+
+## Document and Procedure Meaning
+
+`DocumentIR` records:
+
+- path, module name/identity, and module kind;
+- parse recovery flags corresponding to tree-sitter `HasError` and
+  `HasMissing`;
+- module-level declarations; and
+- procedures in source order.
+
+`ProcedureIR` records a `ProcedureSymbol`, declarations, normalized statements
+and expressions, call sites, and variable reads and writes. Its block
+information is syntactic parent/child nesting only.
+
+`ProcedureSymbol` distinguishes `Sub`, `Function`, `Property Get`,
+`Property Let`, and `Property Set`. It records visibility, parameters, return
+type where applicable, declaration and body ranges, and event-handler metadata.
+Property accessor kinds stay distinct even when they share the same VBA name.
+For a procedure with no body block, the body range is a zero-width range at
+the start of its `End Sub`, `End Function`, or `End Property` statement.
+
+A module-level `Event Foo(...)` declaration is a declaration and must not create
+a `ProcedureIR`. `Declare Sub` and `Declare Function` are declarations without
+VBA bodies; they may participate in symbol or call resolution but are not
+procedure bodies.
+
+Event metadata uses module context as well as the procedure name:
+
+- `Auto_Open` and `Auto_Close` are recognized host entry points.
+- In `document` modules, `Workbook_*` and `Worksheet_*` procedures are
+  recognized document event handlers.
+- In `form` modules, a non-test procedure whose name has non-empty text on both
+  sides of its last underscore is recognized as a UserForm/control event
+  handler.
+- Test-shaped names remain tests rather than UserForm event handlers.
+- Similar names in ordinary standard modules are not reclassified as document
+  or UserForm events.
+
+This classification is syntactic host metadata, not proof that a COM event
+source exists or that a handler signature matches a type library.
+
+## Statements, Expressions, and Accesses
+
+Statements have a stable source-order ID, an optional parent ID, a canonical
+`ast.Range`, and recovery state. Normalized statement kinds cover:
+
+- declarations and `Let`/implicit or `Set` assignments;
+- explicit and implicit calls;
+- `If`, `ElseIf`, `Else`, `Select Case`, and `Case`;
+- `For`, `For Each`, `Do`, `While`, and `With`;
+- `Exit`, labels, `GoTo`, `On Error`, and `Resume`; and
+- unknown or recovered syntax.
+
+Nested constructs preserve their source parent/child relationship. Colon-
+separated statements are separate statements ordered by byte position.
+Multiline logical statements remain one normalized statement whose range spans
+the complete source form.
+
+Expressions normalize identifiers, literals, member access, calls, `New`,
+unary and binary operators, parentheses, and unknown syntax. Their relationship
+to a statement identifies roles such as assignment target, assigned value,
+condition, or argument.
+
+Variable accesses identify their source range, name, access mode
+(`read`, `write`, or `read_write`), and resolved scope. A simple value reference
+is a read. An assignment target is a write; `Set` remains distinguishable as
+object assignment. An operation that both consumes and updates a value uses
+`read_write` and must not be reduced to write-only.
+
+The IR is conservative. Unsupported or ambiguous syntax is represented as
+unknown/recovered instead of being assigned an invented meaning.
+
+## Scope and Resolution
+
+Symbol scope values are:
+
+- `parameter`
+- `local`
+- `module`
+- `project`
+- `unresolved`
+
+VBA name matching is case-insensitive. Within a procedure, parameters and local
+declarations shadow module declarations; module declarations shadow project
+symbols. Same-scope ambiguity remains explicit rather than depending on map or
+filesystem iteration order.
+
+A reference bound to a declaration in the current module has `module` scope
+even when that declaration is publicly visible to other modules. Public or
+Friend visibility makes the declaration a project candidate for other modules;
+it does not allow a project overlay to replace the current-module binding.
+
+Syntax construction does not require a project snapshot. Calls initially carry
+`not_attempted` resolution, and variable accesses that cannot be decided from
+procedure/module declarations remain unresolved until a resolver is supplied.
+
+`Resolve` returns an independently owned IR with a resolution overlay derived
+from the supplied project snapshot. It does not mutate the input IR or rescan
+source. Replacing the resolver can therefore re-resolve the same syntax after a
+workspace symbol change.
+
+Call resolution statuses are:
+
+- `not_attempted`: no project resolver has been applied;
+- `matched`: exactly one visible project candidate was selected;
+- `ambiguous`: multiple visible candidates remain;
+- `unresolved`: no known candidate or special category applies;
+- `external`: a known external receiver owns the call;
+- `builtin_like`: the call text matches a recognized VBA-like built-in; and
+- `member_call`: a receiver/member call cannot be bound conservatively.
+
+Candidates use deterministic order and preserve qualified name, kind, file, and
+declaration line needed by the existing `inspect calls` projection. Private
+procedures are visible only from the same module. Resolution does not claim
+full VBA type inference, COM type-library binding, or Excel object-model
+dispatch.
+
+## Ranges and Determinism
+
+Every externally useful syntax fact uses `ast.Range`:
+
+- lines and columns are 1-based;
+- columns count UTF-8 bytes, matching tree-sitter positions;
+- `StartByte` and `EndByte` are absolute zero-based source byte offsets; and
+- ranges use tree-sitter's half-open end position.
+
+LSP adapters convert these byte-based ranges to UTF-16 positions. The IR never
+stores LSP positions, and introducing the IR must not change existing CLI or
+LSP locations, including CRLF, non-ASCII, and supplementary-plane input.
+
+All slices are deterministic:
+
+- procedures, declarations, statements, expressions, calls, and accesses use
+  ascending source byte order;
+- ties use stable kind/name keys defined by the builder, never Go map order;
+- statement IDs are assigned from the final source order and are stable for the
+  same source and build options; and
+- resolver candidates use stable qualified-name, kind, file, and location
+  ordering.
+
+Determinism is per document revision. IDs are not persistent identities across
+edits and must not be stored as workspace-global references.
+
+## Recovery
+
+Tree-sitter recovery does not make construction fail by itself. `DocumentIR`
+preserves `HasError` and `HasMissing`, emits every complete fact that can be
+normalized safely, and represents meaningful unclassified regions with
+unknown/recovered statements. Recovered facts retain exact ranges and are
+marked so consumers can avoid treating them as certain.
+
+An operational parse/read error still returns an error. A malformed but
+successfully parsed document returns partial IR plus recovery flags.
+
+Recovery acceptance belongs to the consumer:
+
+- interactive/editor consumers may use partial IR for best-effort features;
+- existing batch `analyze` behavior may reject a document with parser recovery;
+  and
+- a rule must not turn unknown syntax into a positive control-flow or semantic
+  claim.
+
+## Snapshot Cache
+
+An `internal/vba/intel.AnalysisSnapshot` owns the syntax IR for one immutable
+document revision. The cache:
+
+- builds lazily from the snapshot-owned `ParsedDocument`;
+- is safe for concurrent readers and performs at most one IR build per
+  snapshot;
+- shares the same parsed document already used by snapshot symbols,
+  diagnostics, and calls;
+- returns defensive copies so callers cannot mutate cached slices or nested
+  candidate data; and
+- is retired with the snapshot and never closes the parsed document itself.
+
+An incremental edit creates a new parsed-document snapshot and therefore a new
+IR cache. Reusing unchanged procedure objects across revisions is not part of
+this contract. A project-symbol change may reuse syntax IR and replace only its
+resolution overlay.
+
+## Compatibility and Layer Boundaries
+
+Existing adapters may project IR facts into `calls.CallSite`, analyzer findings,
+symbol results, or LSP-owned values. Those projections preserve:
+
+- `inspect calls` JSON fields, caller/property metadata, resolution statuses,
+  candidate meaning, and sort order;
+- analyzer finding fields and ordering;
+- `VBA204` cleanup-label handling, message, reason, suggestion, nearby code,
+  severity, and inline suppression; and
+- CLI byte-based and LSP UTF-16 diagnostic ranges.
+
+Issue #426 intentionally stops at procedure syntax and conservative name/call
+resolution:
+
+- issue #427 adds basic blocks, CFG edges, reachability, and path queries; and
+- issue #428 adds direct and transitive effect summaries plus fixed-point
+  propagation.
+
+Until those layers exist, `Blocks` means syntax nesting only and the IR must not
+expose reachability or effect claims. No new public CLI flag, configuration key,
+JSON field, diagnostic ID, or LSP capability is introduced by this
+specification.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/gui"
 	"github.com/harumiWeb/xlflow/internal/suppression"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -152,7 +153,8 @@ type parsedFile struct {
 	Module string
 	Source []byte
 	Root   *tree_sitter.Node
-	Result *vbaast.ParseResult
+	IR     procedureir.DocumentIR
+	Parsed *vbaast.ParsedDocument
 }
 
 type sourceProcedure struct {
@@ -162,6 +164,7 @@ type sourceProcedure struct {
 	StartLine  int
 	EndLine    int
 	Params     []parameterInfo
+	Statements []procedureir.Statement
 }
 
 type sourceDeclaration struct {
@@ -197,30 +200,39 @@ func (a Analyzer) RunResult() (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	parser, err := vbaast.NewParser()
-	if err != nil {
-		return Result{}, err
-	}
-	defer parser.Close()
 	parsedFiles := make([]parsedFile, 0, len(files))
 	for _, file := range files {
-		parsed, err := parser.ParseFile(file)
+		source, err := os.ReadFile(file)
 		if err != nil {
 			closeParsedFiles(parsedFiles)
 			return Result{}, err
 		}
-		if parsed.HasError || parsed.HasMissing {
+		parsed, err := vbaast.ParseDocument(file, source)
+		if err != nil {
+			closeParsedFiles(parsedFiles)
+			return Result{}, err
+		}
+		ir, err := procedureir.BuildParsed(procedureir.BuildOptions{
+			RootDir: a.RootDir,
+			Path:    file,
+		}, parsed)
+		if err != nil {
+			parsed.Close()
+			closeParsedFiles(parsedFiles)
+			return Result{}, err
+		}
+		if ir.Parse.HasError || ir.Parse.HasMissing {
 			parsed.Close()
 			closeParsedFiles(parsedFiles)
 			return Result{}, fmt.Errorf("parse %s: VBA parser reported errors or missing nodes", file)
 		}
 		parsedFiles = append(parsedFiles, parsedFile{
 			Path:   file,
-			Lines:  normalizedSourceLines(string(parsed.Source)),
+			Lines:  normalizedSourceLines(string(source)),
 			Module: strings.TrimSuffix(filepath.Base(file), filepath.Ext(file)),
-			Source: parsed.Source,
-			Root:   parsed.Root,
-			Result: parsed,
+			Source: source,
+			IR:     ir,
+			Parsed: parsed,
 		})
 	}
 	defer closeParsedFiles(parsedFiles)
@@ -228,7 +240,13 @@ func (a Analyzer) RunResult() (Result, error) {
 	ctx := a.buildContext(parsedFiles)
 	var findings []Finding
 	for _, file := range parsedFiles {
-		findings = append(findings, a.analyzeParsedFile(file, ctx)...)
+		if err := file.Parsed.Read(func(view vbaast.ParsedView) error {
+			file.Root = view.Root
+			findings = append(findings, a.analyzeParsedFile(file, ctx)...)
+			return nil
+		}); err != nil {
+			return Result{}, err
+		}
 	}
 	sortFindings(findings)
 	directives, warnings, err := suppression.DirectivesForFiles(a.RootDir, files)
@@ -242,8 +260,8 @@ func (a Analyzer) RunResult() (Result, error) {
 
 func closeParsedFiles(files []parsedFile) {
 	for _, file := range files {
-		if file.Result != nil {
-			file.Result.Close()
+		if file.Parsed != nil {
+			file.Parsed.Close()
 		}
 	}
 }
@@ -263,17 +281,22 @@ func SourceNonShortCircuitObjectGuardFindings(rootDir, path string, cfg config.C
 // SourceNonShortCircuitObjectGuardFindingsParsed analyzes a caller-owned
 // parsed VBA document without closing it or retaining tree-sitter nodes.
 func SourceNonShortCircuitObjectGuardFindingsParsed(rootDir string, cfg config.Config, doc *vbaast.ParsedDocument) ([]Finding, error) {
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{RootDir: rootDir}, doc)
+	if err != nil {
+		return nil, err
+	}
 	var findings []Finding
-	err := doc.Read(func(view vbaast.ParsedView) error {
+	err = doc.Read(func(view vbaast.ParsedView) error {
 		file := parsedFile{
 			Path:   view.Path,
 			Lines:  normalizedSourceLines(string(view.Source)),
 			Module: strings.TrimSuffix(filepath.Base(view.Path), filepath.Ext(view.Path)),
 			Source: view.Source,
 			Root:   view.Root,
+			IR:     ir,
 		}
 		analyzer := Analyzer{RootDir: rootDir, Config: cfg}
-		procedures := sourceProceduresFromAST(file.Root, file.Source)
+		procedures := sourceProceduresFromIR(ir)
 		for _, proc := range procedures {
 			findings = append(findings, analyzer.nonShortCircuitObjectGuardFindings(file, proc)...)
 		}
@@ -308,6 +331,17 @@ func SourceRealtimeFindings(rootDir, path string, cfg config.Config, source []by
 // SourceRealtimeFindingsParsed runs real-time source analysis against a
 // caller-owned parsed VBA document. It does not close doc or retain nodes.
 func SourceRealtimeFindingsParsed(rootDir string, cfg config.Config, doc *vbaast.ParsedDocument) ([]Finding, error) {
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{RootDir: rootDir}, doc)
+	if err != nil {
+		return nil, err
+	}
+	return SourceRealtimeFindingsParsedIR(rootDir, cfg, doc, ir)
+}
+
+// SourceRealtimeFindingsParsedIR runs real-time source analysis with a
+// caller-supplied procedure IR built from doc. It lets immutable LSP snapshots
+// reuse their cached IR without reparsing or rewalking procedure syntax.
+func SourceRealtimeFindingsParsedIR(rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR) ([]Finding, error) {
 	if !cfg.Analyze.DetectRangeFindNothingCheck &&
 		!cfg.Analyze.DetectErrorHandlerFallthrough &&
 		!cfg.Analyze.DetectRedimPreserveDimension &&
@@ -324,9 +358,10 @@ func SourceRealtimeFindingsParsed(rootDir string, cfg config.Config, doc *vbaast
 			Module: strings.TrimSuffix(filepath.Base(view.Path), filepath.Ext(view.Path)),
 			Source: view.Source,
 			Root:   view.Root,
+			IR:     ir,
 		}
 		analyzer := Analyzer{RootDir: rootDir, Config: cfg}
-		procedures := sourceProceduresFromAST(file.Root, file.Source)
+		procedures := sourceProceduresFromIR(ir)
 		moduleDecls := moduleDeclarations(file.Lines, procedures)
 		if len(procedures) == 0 {
 			procedures = []sourceProcedure{{StartLine: 1, EndLine: len(file.Lines)}}
@@ -382,7 +417,7 @@ func (a Analyzer) sourceRealtimeProcedureFindings(file parsedFile, proc sourcePr
 		}
 	}
 	if a.Config.Analyze.DetectErrorHandlerFallthrough {
-		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc, onErrorHandlerLabels(file.Lines, proc))...)
+		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc)...)
 	}
 	return findings
 }
@@ -447,7 +482,7 @@ func (a Analyzer) shouldIncludeFile(path string) bool {
 func (a Analyzer) buildContext(files []parsedFile) analysisContext {
 	ctx := analysisContext{functionReturns: map[string]string{}, procedures: map[string]procedureSignature{}}
 	for _, file := range files {
-		for _, proc := range sourceProceduresFromAST(file.Root, file.Source) {
+		for _, proc := range sourceProceduresFromIR(file.IR) {
 			if isObjectType(proc.ReturnType) {
 				ctx.functionReturns[strings.ToLower(proc.Name)] = proc.ReturnType
 			}
@@ -465,7 +500,7 @@ func (a Analyzer) buildContext(files []parsedFile) analysisContext {
 func (a Analyzer) analyzeParsedFile(file parsedFile, ctx analysisContext) []Finding {
 	reportedMissingHelpers := map[string]bool{}
 	var findings []Finding
-	procedures := sourceProceduresFromAST(file.Root, file.Source)
+	procedures := sourceProceduresFromIR(file.IR)
 	moduleDecls := moduleDeclarations(file.Lines, procedures)
 	appStateProcedures := applicationStateProcedureSummaries(file.Lines, procedures)
 	for _, proc := range procedures {
@@ -486,7 +521,6 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 	for _, param := range proc.Params {
 		decls[strings.ToLower(param.Name)] = sourceDeclaration{Name: param.Name, Type: param.Type, Line: proc.StartLine, Object: isObjectType(param.Type), Parameter: true}
 	}
-	handlerLabels := onErrorHandlerLabels(file.Lines, proc)
 	withStack := make([]withInfo, 0)
 	initialized := initialObjectState(decls)
 	maybeInitializedByCall := map[string]bool{}
@@ -600,7 +634,7 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 		findings = append(findings, a.applicationStateFindings(file, proc, appStateProcedures)...)
 	}
 	if a.Config.Analyze.DetectErrorHandlerFallthrough {
-		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc, handlerLabels)...)
+		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc)...)
 	}
 	if a.Config.Analyze.DetectFunctionReturnPath && proc.Kind == "Function" && proc.Name != "" && !functionAssigned {
 		findings = append(findings, a.simpleFinding(file, proc, proc.StartLine, "VBA210", "warning", proc.Name+" may exit without assigning its return value.", "Functions return the default value when no assignment to the function name is reached.", "Assign "+proc.Name+" on every successful return path, or make the default return explicit."))
@@ -608,76 +642,34 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 	return findings
 }
 
-func sourceProceduresFromAST(root *tree_sitter.Node, source []byte) []sourceProcedure {
-	var procedures []sourceProcedure
-	collectSourceProcedures(root, source, &procedures)
-	sort.SliceStable(procedures, func(i, j int) bool {
-		return procedures[i].StartLine < procedures[j].StartLine
-	})
-	return procedures
-}
-
-func collectSourceProcedures(node *tree_sitter.Node, source []byte, procedures *[]sourceProcedure) {
-	if node == nil {
-		return
-	}
-	switch node.Kind() {
-	case "sub_declaration", "function_declaration", "property_declaration", "property_get_declaration", "property_let_declaration", "property_set_declaration":
-		r := vbaast.NodeRange(node)
+func sourceProceduresFromIR(document procedureir.DocumentIR) []sourceProcedure {
+	procedures := make([]sourceProcedure, 0, len(document.Procedures))
+	for _, procedure := range document.Procedures {
 		kind := "Sub"
-		if strings.Contains(node.Kind(), "function") {
+		switch procedure.Symbol.Kind {
+		case procedureir.ProcedureFunction:
 			kind = "Function"
-		} else if strings.Contains(node.Kind(), "property") {
+		case procedureir.ProcedureProperty, procedureir.ProcedurePropertyGet,
+			procedureir.ProcedurePropertyLet, procedureir.ProcedurePropertySet:
 			kind = "Property"
 		}
-		*procedures = append(*procedures, sourceProcedure{
+		params := make([]parameterInfo, len(procedure.Symbol.Parameters))
+		for i, parameter := range procedure.Symbol.Parameters {
+			params[i] = parameterInfo{
+				Name: parameter.Name, Type: parameter.Type, Passing: parameter.Passing,
+			}
+		}
+		procedures = append(procedures, sourceProcedure{
 			Kind:       kind,
-			Name:       nodeProcedureName(node, source),
-			ReturnType: typeText(node, source),
-			StartLine:  r.StartLine,
-			EndLine:    r.EndLine,
-			Params:     parameters(node, source),
+			Name:       procedure.Symbol.Name,
+			ReturnType: procedure.Symbol.ReturnType,
+			StartLine:  procedure.Symbol.DeclarationRange.StartLine,
+			EndLine:    procedure.Symbol.DeclarationRange.EndLine,
+			Params:     params,
+			Statements: append([]procedureir.Statement(nil), procedure.Statements...),
 		})
-		return
 	}
-	for i := uint(0); i < node.NamedChildCount(); i++ {
-		collectSourceProcedures(node.NamedChild(i), source, procedures)
-	}
-}
-
-func nodeProcedureName(node *tree_sitter.Node, source []byte) string {
-	if name := node.ChildByFieldName("name"); name != nil {
-		return cleanIdentifier(name.Utf8Text(source))
-	}
-	if name := firstNamedChildKind(node, "identifier"); name != nil {
-		return cleanIdentifier(name.Utf8Text(source))
-	}
-	return ""
-}
-
-func parameters(node *tree_sitter.Node, source []byte) []parameterInfo {
-	list := node.ChildByFieldName("parameters")
-	if list == nil {
-		list = firstNamedChildKind(node, "parameter_list")
-	}
-	if list == nil {
-		return nil
-	}
-	var params []parameterInfo
-	for i := uint(0); i < list.NamedChildCount(); i++ {
-		child := list.NamedChild(i)
-		if child == nil || child.Kind() != "parameter" {
-			continue
-		}
-		param := parameterInfo{Name: nodeName(child, source), Type: typeText(child, source)}
-		if hasWord(child.Utf8Text(source), "ByVal") {
-			param.Passing = "ByVal"
-		} else {
-			param.Passing = "ByRef"
-		}
-		params = append(params, param)
-	}
-	return params
+	return procedures
 }
 
 func procedureDeclarations(lines []string, proc sourceProcedure) map[string]sourceDeclaration {
@@ -1324,41 +1316,34 @@ func hasLaterApplicationRestore(lines []string, proc sourceProcedure, start int,
 	return false
 }
 
-func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourceProcedure, handlerLabels map[string]bool) []Finding {
+func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourceProcedure) []Finding {
+	handlerLabels := map[string]bool{}
+	for _, statement := range proc.Statements {
+		if statement.Kind != procedureir.StatementOnError {
+			continue
+		}
+		label := cleanIdentifier(statement.Label)
+		if label != "" && !strings.EqualFold(label, "0") {
+			handlerLabels[strings.ToLower(label)] = true
+		}
+	}
 	if len(handlerLabels) == 0 {
 		return nil
 	}
 	var findings []Finding
-	lastCode := ""
-	for i := proc.StartLine - 1; i < proc.EndLine-1 && i < len(file.Lines); i++ {
-		lineNo := i + 1
-		stmt := normalizedCodeLine(file.Lines[i])
-		if stmt == "" {
-			continue
-		}
-		if label, ok := labelName(stmt); ok && handlerLabels[strings.ToLower(label)] {
-			if !isCleanupFallthroughLabel(label) && !terminatesNormalFlow(lastCode) {
+	lastCodeByParent := map[int]string{}
+	for _, statement := range proc.Statements {
+		if statement.Kind == procedureir.StatementLabel {
+			label := cleanIdentifier(statement.Label)
+			if handlerLabels[strings.ToLower(label)] &&
+				!isCleanupFallthroughLabel(label) && !terminatesNormalFlow(lastCodeByParent[statement.ParentID]) {
+				lineNo := statement.Range.StartLine
 				findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA204", "warning", "Normal execution can fall through into error handler "+label+".", "Without Exit Sub, Exit Function, or Exit Property before the handler label, successful execution can run error handling code.", errorHandlerFallthroughSuggestion(proc, label)))
 			}
 		}
-		lastCode = stmt
+		lastCodeByParent[statement.ParentID] = statement.Text
 	}
 	return findings
-}
-
-func onErrorHandlerLabels(lines []string, proc sourceProcedure) map[string]bool {
-	labels := map[string]bool{}
-	for i := proc.StartLine - 1; i < proc.EndLine && i < len(lines); i++ {
-		stmt := normalizedCodeLine(lines[i])
-		lower := strings.ToLower(stmt)
-		if strings.HasPrefix(lower, "on error goto ") && lower != "on error goto 0" {
-			label := cleanIdentifier(strings.TrimSpace(stmt[len("on error goto "):]))
-			if label != "" {
-				labels[strings.ToLower(label)] = true
-			}
-		}
-	}
-	return labels
 }
 
 func BlockingFindings(findings []Finding) []Finding {
@@ -1684,15 +1669,6 @@ func rangeFindAssignment(stmt string) (string, bool) {
 	return cleanIdentifier(fields[len(fields)-1]), true
 }
 
-func labelName(stmt string) (string, bool) {
-	stmt = strings.TrimSpace(stmt)
-	if !strings.HasSuffix(stmt, ":") || strings.Contains(stmt, " ") {
-		return "", false
-	}
-	name := cleanIdentifier(strings.TrimSuffix(stmt, ":"))
-	return name, name != ""
-}
-
 func isCleanupFallthroughLabel(label string) bool {
 	switch strings.ToLower(label) {
 	case "cleanup", "clean_up", "finally", "done":
@@ -1823,47 +1799,6 @@ func obviousArgumentMismatch(arg, typ string) bool {
 		return lowerType == "string" || isObjectType(typ)
 	}
 	return false
-}
-
-func typeText(node *tree_sitter.Node, source []byte) string {
-	asType := node.ChildByFieldName("type")
-	if asType == nil {
-		asType = firstNamedChildKind(node, "as_type_clause")
-	}
-	if asType == nil {
-		return ""
-	}
-	if typeExpr := asType.ChildByFieldName("type"); typeExpr != nil {
-		return strings.TrimSpace(typeExpr.Utf8Text(source))
-	}
-	if asType.Kind() == "type_expression" {
-		return strings.TrimSpace(asType.Utf8Text(source))
-	}
-	text := strings.TrimSpace(asType.Utf8Text(source))
-	if strings.HasPrefix(strings.ToLower(text), "as ") {
-		return strings.TrimSpace(text[3:])
-	}
-	return text
-}
-
-func nodeName(node *tree_sitter.Node, source []byte) string {
-	if name := node.ChildByFieldName("name"); name != nil {
-		return cleanIdentifier(name.Utf8Text(source))
-	}
-	if name := firstNamedChildKind(node, "identifier"); name != nil {
-		return cleanIdentifier(name.Utf8Text(source))
-	}
-	return ""
-}
-
-func firstNamedChildKind(node *tree_sitter.Node, kind string) *tree_sitter.Node {
-	for i := uint(0); i < node.NamedChildCount(); i++ {
-		child := node.NamedChild(i)
-		if child != nil && child.Kind() == kind {
-			return child
-		}
-	}
-	return nil
 }
 
 func cleanIdentifier(text string) string {

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -571,6 +571,103 @@ End Sub
 	}
 }
 
+func TestAnalyzerIRVBA204PreservesPropertyExitAndCleanupSemantics(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Property Get SafeValue() As Long
+  On Error GoTo Handler
+  SafeValue = 1
+  Exit Property
+Handler:
+  SafeValue = 0
+End Property
+
+Public Property Get UnsafeValue() As Long
+  On Error GoTo Handler
+  UnsafeValue = 1
+Handler:
+  UnsafeValue = 0
+End Property
+
+Public Sub CleanupAllowed()
+  On Error GoTo Cleanup
+  Debug.Print "work"
+Cleanup:
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA204")
+	if len(got) != 1 || got[0].Procedure != "UnsafeValue" || got[0].Line != 13 {
+		t.Fatalf("VBA204 findings = %+v, want only UnsafeValue handler", got)
+	}
+	if !containsAll(got[0].Suggestion, "`Exit Property`", "`Handler:`") {
+		t.Fatalf("unexpected property suggestion: %+v", got[0])
+	}
+}
+
+func TestAnalyzerIRVBA204PreservesInlineSuppression(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  On Error GoTo Handler
+  Debug.Print "work"
+  ' xlflow:disable-next-line VBA204
+Handler:
+End Sub
+`)
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA204"); len(got) != 0 {
+		t.Fatalf("VBA204 should remain suppressible: %+v", got)
+	}
+}
+
+func TestAnalyzerIRVBA204DoesNotTreatNestedExitAsUnconditional(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run(ByVal stopEarly As Boolean)
+  On Error GoTo Handler
+  If stopEarly Then
+    Exit Sub
+  End If
+Handler:
+End Sub
+`)
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA204")
+	if len(got) != 1 || got[0].Procedure != "Run" || got[0].Line != 7 {
+		t.Fatalf("VBA204 findings = %+v, want conditional Exit Sub fallthrough", got)
+	}
+}
+
+func TestAnalyzerIRVBA204DoesNotNestHandlerAfterSingleLineIf(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run(ByVal stopEarly As Boolean)
+  On Error GoTo Handler
+  If stopEarly Then Exit Sub
+Handler:
+End Sub
+`)
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA204")
+	if len(got) != 1 || got[0].Procedure != "Run" || got[0].Line != 5 {
+		t.Fatalf("VBA204 findings = %+v, want single-line If fallthrough", got)
+	}
+}
+
 func TestAnalyzerChecksObjectUseOnSetAssignmentRHS(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/lspserver/analysis_snapshot_test.go
+++ b/internal/lspserver/analysis_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,6 +14,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/config"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 func TestDocumentsReuseReplaceCloseAndReopenSnapshots(t *testing.T) {
@@ -175,6 +177,25 @@ func TestDocumentsApplyChangesIncrementalMultilineMatchesFullParse(t *testing.T)
 	}
 	if incrementalSexp != completeSexp || incrementalRecovery != completeRecovery {
 		t.Fatalf("incremental = (%s, %v), complete = (%s, %v)", incrementalSexp, incrementalRecovery, completeSexp, completeRecovery)
+	}
+	incrementalIR, _, err := result.document.Snapshot.ProcedureIR(func() (procedureir.DocumentIR, error) {
+		return procedureir.BuildParsed(procedureir.BuildOptions{
+			Path: result.document.Path, ModuleKind: result.document.ModuleKind,
+		}, incrementalParsed)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completeIR, _, err := complete.ProcedureIR(func() (procedureir.DocumentIR, error) {
+		return procedureir.BuildParsed(procedureir.BuildOptions{
+			Path: result.document.Path, ModuleKind: result.document.ModuleKind,
+		}, completeParsed)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(incrementalIR, completeIR) {
+		t.Fatalf("incremental procedure IR differs from complete parse:\nincremental=%+v\ncomplete=%+v", incrementalIR, completeIR)
 	}
 }
 

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/typedb"
 	"github.com/harumiWeb/xlflow/internal/vba/calls"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 	"github.com/harumiWeb/xlflow/internal/vbadb"
 	"github.com/harumiWeb/xlflow/internal/vbafmt"
@@ -1277,16 +1278,22 @@ func (s *Server) analyzeIndexedDocument(doc intel.Document) (indexedFileAnalysis
 	if err != nil {
 		return indexedFileAnalysis{}, err
 	}
-	rawCalls, _, err := snapshot.RawCallSites(func() (calls.FileResult, error) {
+	procedureIR, _, err := snapshot.ProcedureIR(func() (procedureir.DocumentIR, error) {
 		parsed, err := snapshot.ParsedDocument()
 		if err != nil {
-			return calls.FileResult{}, err
+			return procedureir.DocumentIR{}, err
 		}
-		return calls.ExtractParsed(calls.SourceOptions{
+		return procedureir.BuildParsed(procedureir.BuildOptions{
 			RootDir:    s.opts.RootDir,
 			Path:       doc.Path,
 			ModuleKind: doc.ModuleKind,
 		}, parsed)
+	})
+	if err != nil {
+		return indexedFileAnalysis{}, err
+	}
+	rawCalls, _, err := snapshot.RawCallSites(func() (calls.FileResult, error) {
+		return calls.ExtractIR(procedureIR), nil
 	})
 	if err != nil {
 		return indexedFileAnalysis{}, err

--- a/internal/vba/calls/calls.go
+++ b/internal/vba/calls/calls.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
@@ -163,7 +164,8 @@ type extractor struct {
 // Resolver resolves raw call sites against a snapshot of project procedure
 // symbols. A Resolver can be replaced without re-extracting unchanged sites.
 type Resolver struct {
-	byName map[string][]Candidate
+	byName  map[string][]Candidate
+	symbols procedureir.SymbolResolver
 }
 
 var procedureKinds = map[string]bool{
@@ -316,6 +318,103 @@ func ExtractSource(opts SourceOptions, source []byte) (FileResult, error) {
 // returns.
 func ExtractParsed(opts SourceOptions, doc *vbaast.ParsedDocument) (FileResult, error) {
 	rootDir := opts.RootDir
+	if strings.TrimSpace(rootDir) == "" {
+		rootDir = "."
+	}
+	rootDir, err := filepath.Abs(rootDir)
+	if err != nil {
+		return FileResult{}, err
+	}
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{
+		RootDir:    rootDir,
+		Path:       opts.Path,
+		ModuleKind: opts.ModuleKind,
+	}, doc)
+	if err != nil {
+		return FileResult{}, err
+	}
+	return ExtractIR(ir), nil
+}
+
+// ExtractIR projects syntax-local calls and type references from the shared
+// procedure IR without reparsing or rescanning source.
+func ExtractIR(ir procedureir.DocumentIR) FileResult {
+	result := FileResult{
+		Path:       ir.Path,
+		ModuleName: ir.ModuleName,
+		ModuleKind: ir.ModuleKind,
+		Parse: symbols.ParseSummary{
+			HasError: ir.Parse.HasError, HasMissing: ir.Parse.HasMissing,
+		},
+		CallSites:      []CallSite{},
+		TypeReferences: []TypeReference{},
+	}
+	for _, procedure := range ir.Procedures {
+		for _, site := range procedure.Calls {
+			result.CallSites = append(result.CallSites, callSiteFromIR(site, result.Parse))
+		}
+	}
+	for _, reference := range ir.TypeReferences {
+		result.TypeReferences = append(result.TypeReferences, typeReferenceFromIR(reference, result.Parse))
+	}
+	sort.SliceStable(result.CallSites, func(i, j int) bool {
+		return result.CallSites[i].Range.StartByte < result.CallSites[j].Range.StartByte
+	})
+	sort.SliceStable(result.TypeReferences, func(i, j int) bool {
+		return result.TypeReferences[i].Range.StartByte < result.TypeReferences[j].Range.StartByte
+	})
+	return result
+}
+
+func callSiteFromIR(site procedureir.CallSite, parse symbols.ParseSummary) CallSite {
+	var caller *Caller
+	if site.Caller.Name != "" || site.Caller.QualifiedName != "" {
+		caller = &Caller{
+			Name: site.Caller.Name, Kind: string(site.Caller.Kind),
+			QualifiedName: site.Caller.QualifiedName,
+		}
+	}
+	named := make([]NamedArgument, len(site.Arguments.Named))
+	for i, argument := range site.Arguments.Named {
+		named[i] = NamedArgument{Name: argument.Name, ValueText: argument.ValueText}
+	}
+	return CallSite{
+		File: site.File, Module: site.Module, Caller: caller,
+		Callee: Callee{
+			Text: site.Callee.Text, BaseName: site.Callee.BaseName,
+			Receiver: cloneStringPointer(site.Callee.Receiver), Member: site.Callee.Member,
+		},
+		Arguments: Arguments{Count: site.Arguments.Count, Named: named},
+		Range:     site.Range, Parse: parse,
+	}
+}
+
+func typeReferenceFromIR(reference procedureir.TypeReference, parse symbols.ParseSummary) TypeReference {
+	var caller *Caller
+	if reference.Caller != nil {
+		caller = &Caller{
+			Name: reference.Caller.Name, Kind: string(reference.Caller.Kind),
+			QualifiedName: reference.Caller.QualifiedName,
+		}
+	}
+	return TypeReference{
+		Kind: reference.Kind, File: reference.File, Module: reference.Module,
+		Caller: caller, Target: reference.Target, Range: reference.Range, Parse: parse,
+	}
+}
+
+func cloneStringPointer(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+// extractParsedLegacy is retained temporarily as an independent compatibility
+// oracle for tests while call extraction migrates to procedureir.
+func extractParsedLegacy(opts SourceOptions, doc *vbaast.ParsedDocument) (FileResult, error) {
+	rootDir := opts.RootDir
 	if rootDir == "" {
 		rootDir = "."
 	}
@@ -390,7 +489,21 @@ func NewResolver(projectSymbols []symbols.Symbol) Resolver {
 // NewResolverFromSymbols creates a deterministic resolver from the
 // protocol-neutral symbol shape.
 func NewResolverFromSymbols(projectSymbols []ResolverSymbol) Resolver {
-	res := Resolver{byName: map[string][]Candidate{}}
+	irSymbols := make([]procedureir.ResolverSymbol, 0, len(projectSymbols))
+	for _, sym := range projectSymbols {
+		irSymbols = append(irSymbols, procedureir.ResolverSymbol{
+			Name:       sym.Name,
+			Module:     sym.Module,
+			Kind:       sym.Kind,
+			Visibility: sym.Visibility,
+			File:       sym.File,
+			Line:       sym.Line,
+		})
+	}
+	res := Resolver{
+		byName:  map[string][]Candidate{},
+		symbols: procedureir.NewResolver(irSymbols),
+	}
 	for _, sym := range projectSymbols {
 		if !procedureKinds[sym.Kind] || sym.Name == "" {
 			continue
@@ -423,6 +536,31 @@ func (r Resolver) Resolve(site CallSite) Call {
 		CallSite:   CloneCallSite(site),
 		Resolution: r.resolveCallee(site),
 	}
+}
+
+// ResolveCall adapts the existing project call resolver to procedureir without
+// coupling the IR package to inspect-call result types.
+func (r Resolver) ResolveCall(site procedureir.CallSite) procedureir.CallResolution {
+	resolved := r.Resolve(callSiteFromIR(site, symbols.ParseSummary{})).Resolution
+	candidates := make([]procedureir.Candidate, len(resolved.Candidates))
+	for i, candidate := range resolved.Candidates {
+		candidates[i] = procedureir.Candidate{
+			QualifiedName: candidate.QualifiedName,
+			Kind:          candidate.Kind,
+			File:          candidate.File,
+			Line:          candidate.Line,
+		}
+	}
+	return procedureir.CallResolution{
+		Status:     procedureir.ResolutionStatus(resolved.Status),
+		Candidates: candidates,
+	}
+}
+
+// ResolveSymbol provides the symbol half of procedureir.Resolver using the
+// complete project symbol snapshot, including non-procedure declarations.
+func (r Resolver) ResolveSymbol(reference procedureir.SymbolReference) procedureir.SymbolResolution {
+	return r.symbols.ResolveSymbol(reference)
 }
 
 func (e *extractor) visit(node *tree_sitter.Node) {

--- a/internal/vba/calls/calls_test.go
+++ b/internal/vba/calls/calls_test.go
@@ -144,6 +144,32 @@ End Function
 	}
 }
 
+func TestExtractParsedPreservesParenthesizedComparisonCallCompatibility(t *testing.T) {
+	source := []byte(`Public Sub Run()
+    Dim actual As Long
+    Dim expected As Long
+    Check (actual) = expected
+End Sub
+`)
+	doc, err := vbaast.ParseDocument("Module1.bas", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+
+	got, err := ExtractParsed(SourceOptions{Path: "Module1.bas"}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := extractParsedLegacy(SourceOptions{Path: "Module1.bas"}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parenthesized comparison call compatibility changed:\nIR=%+v\nlegacy=%+v", got, want)
+	}
+}
+
 func TestResolverCanReResolveUnchangedCallSite(t *testing.T) {
 	site := CallSite{
 		File:      "src/modules/Main.bas",

--- a/internal/vba/calls/calls_test.go
+++ b/internal/vba/calls/calls_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 )
 
@@ -38,6 +39,17 @@ End Sub
 	}, doc)
 	if err != nil {
 		t.Fatal(err)
+	}
+	legacyResult, err := extractParsedLegacy(SourceOptions{
+		RootDir:    dir,
+		Path:       path,
+		ModuleKind: "standard",
+	}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(parsedResult, legacyResult) {
+		t.Fatalf("procedure IR projection changed call extraction:\nIR=%+v\nlegacy=%+v", parsedResult, legacyResult)
 	}
 	if parsedResult.Path != "Main.bas" || parsedResult.ModuleName != "Main" || parsedResult.ModuleKind != "standard" {
 		t.Fatalf("unexpected file metadata: %+v", parsedResult)
@@ -84,6 +96,54 @@ End Sub
 	}
 }
 
+func TestExtractParsedPreservesDefaultRootPathCompatibility(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Main.bas")
+	source := []byte("Public Sub Run()\n    Call Target\nEnd Sub\n")
+	doc, err := vbaast.ParseDocument(path, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+
+	got, err := ExtractParsed(SourceOptions{Path: path}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := extractParsedLegacy(SourceOptions{Path: path}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("empty RootDir path compatibility changed:\nIR=%+v\nlegacy=%+v", got, want)
+	}
+}
+
+func TestExtractParsedPreservesConditionalProcedureCompatibility(t *testing.T) {
+	source := []byte(`#If VBA7 Then
+Public Function ConditionalRun() As Long
+    ConditionalRun = TargetCall(1)
+End Function
+#End If
+`)
+	doc, err := vbaast.ParseDocument("Module1.bas", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+
+	got, err := ExtractParsed(SourceOptions{Path: "Module1.bas"}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := extractParsedLegacy(SourceOptions{Path: "Module1.bas"}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("conditional procedure compatibility changed:\nIR=%+v\nlegacy=%+v", got, want)
+	}
+}
+
 func TestResolverCanReResolveUnchangedCallSite(t *testing.T) {
 	site := CallSite{
 		File:      "src/modules/Main.bas",
@@ -125,6 +185,37 @@ func TestResolverCanReResolveUnchangedCallSite(t *testing.T) {
 	}
 	if site.Callee.Text != "Target" {
 		t.Fatalf("resolver mutated raw site: %+v", site)
+	}
+}
+
+func TestResolverAdaptsToProcedureIR(t *testing.T) {
+	var _ procedureir.Resolver = Resolver{}
+	document := procedureir.DocumentIR{
+		Procedures: []procedureir.ProcedureIR{{
+			Calls: []procedureir.CallSite{{
+				Caller: procedureir.ProcedureRef{
+					Name: "Run", Kind: procedureir.ProcedureSub, QualifiedName: "Main.Run",
+				},
+				Callee: procedureir.Callee{
+					Text: "Target", BaseName: "Target", Member: "Target",
+				},
+				Resolution: procedureir.CallResolution{Status: procedureir.ResolutionNotAttempted},
+			}},
+		}},
+	}
+	resolver := NewResolver([]symbols.Symbol{{
+		Name: "Target", Module: "Helpers", Kind: "sub",
+		File: "src/modules/Helpers.bas", StartLine: 4,
+	}})
+	resolved := procedureir.Resolve(document, resolver)
+	call := resolved.Procedures[0].Calls[0]
+	if call.Resolution.Status != procedureir.ResolutionMatched ||
+		len(call.Resolution.Candidates) != 1 ||
+		call.Resolution.Candidates[0].QualifiedName != "Helpers.Target" {
+		t.Fatalf("procedure IR call resolution = %+v", call.Resolution)
+	}
+	if document.Procedures[0].Calls[0].Resolution.Status != procedureir.ResolutionNotAttempted {
+		t.Fatalf("procedure IR resolver mutated input: %+v", document)
 	}
 }
 
@@ -221,6 +312,30 @@ func TestNewResolverFromSymbolsNormalizesAndDeterministicallyOrdersCandidates(t 
 	}
 	if !reflect.DeepEqual(call.Resolution.Candidates, want) {
 		t.Fatalf("candidates = %+v, want %+v", call.Resolution.Candidates, want)
+	}
+}
+
+func TestResolverAdapterResolvesNonProcedureProjectSymbols(t *testing.T) {
+	resolver := NewResolverFromSymbols([]ResolverSymbol{{
+		Name: "SharedValue", Module: "Globals", Kind: "variable",
+		Visibility: "Public", File: "src/modules/Globals.bas", Line: 3,
+	}})
+
+	resolution := resolver.ResolveSymbol(procedureir.SymbolReference{
+		Name: "SharedValue",
+		Caller: procedureir.ProcedureRef{
+			Name: "Run", Kind: procedureir.ProcedureSub, QualifiedName: "Main.Run",
+		},
+	})
+	if resolution.Scope != procedureir.ScopeProject {
+		t.Fatalf("scope = %q, want project: %+v", resolution.Scope, resolution)
+	}
+	want := []procedureir.Candidate{{
+		QualifiedName: "Globals.SharedValue", Kind: "variable",
+		File: "src/modules/Globals.bas", Line: 3,
+	}}
+	if !reflect.DeepEqual(resolution.Candidates, want) {
+		t.Fatalf("candidates = %+v, want %+v", resolution.Candidates, want)
 	}
 }
 

--- a/internal/vba/intel/analysis_snapshot.go
+++ b/internal/vba/intel/analysis_snapshot.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/calls"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -50,6 +51,10 @@ type AnalysisSnapshot struct {
 	callSitesOnce sync.Once
 	callSites     calls.FileResult
 	callSitesErr  error
+
+	procedureIROnce sync.Once
+	procedureIR     procedureir.DocumentIR
+	procedureIRErr  error
 
 	indexOnce sync.Once
 	index     *documentIndex
@@ -266,6 +271,25 @@ func (s *AnalysisSnapshot) RawCallSites(load func() (calls.FileResult, error)) (
 	return calls.CloneFileResult(s.callSites), initialized, s.callSitesErr
 }
 
+// ProcedureIR returns the snapshot-scoped procedure analysis IR and whether
+// the lazy value was already initialized. Both successful results and build
+// errors are cached for this immutable revision. The returned IR is a deep
+// copy and can be modified by the caller.
+func (s *AnalysisSnapshot) ProcedureIR(load func() (procedureir.DocumentIR, error)) (procedureir.DocumentIR, bool, error) {
+	if s == nil {
+		result, err := load()
+		return procedureir.Clone(result), false, err
+	}
+	initialized := true
+	s.procedureIROnce.Do(func() {
+		initialized = false
+		result, err := load()
+		s.procedureIR = procedureir.Clone(result)
+		s.procedureIRErr = err
+	})
+	return procedureir.Clone(s.procedureIR), initialized, s.procedureIRErr
+}
+
 // documentIndex returns the immutable lookup index for this snapshot. The
 // caller supplies the same symbol loader used by document analysis so custom
 // analyzers and the normal source-symbol cache retain identical semantics.
@@ -370,6 +394,21 @@ func parsedDocumentForDocument(doc Document) (*ast.ParsedDocument, func(), error
 		return nil, func() {}, err
 	}
 	return parsed, parsed.Close, nil
+}
+
+func procedureIRForDocument(doc Document, rootDir string, parsed *ast.ParsedDocument) (procedureir.DocumentIR, error) {
+	load := func() (procedureir.DocumentIR, error) {
+		return procedureir.BuildParsed(procedureir.BuildOptions{
+			RootDir:    rootDir,
+			Path:       doc.Path,
+			ModuleKind: doc.ModuleKind,
+		}, parsed)
+	}
+	if snapshot := analysisSnapshotForDocument(doc); snapshot != nil {
+		result, _, err := snapshot.ProcedureIR(load)
+		return result, err
+	}
+	return load()
 }
 
 func documentLines(doc Document) []string {

--- a/internal/vba/intel/analysis_snapshot_test.go
+++ b/internal/vba/intel/analysis_snapshot_test.go
@@ -10,6 +10,7 @@ import (
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/calls"
 	"github.com/harumiWeb/xlflow/internal/vba/doccomments"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
@@ -235,6 +236,87 @@ func TestAnalysisSnapshotCachesDeterministicRawCallSiteError(t *testing.T) {
 	}
 }
 
+func TestAnalysisSnapshotProcedureIRIsLazyConcurrentAndDefensive(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{
+		URI: "file:///Main.bas", Path: "Main.bas", Source: "Sub Main()\nEnd Sub\n", Version: 1,
+	})
+	var loads atomic.Int32
+	load := func() (procedureir.DocumentIR, error) {
+		loads.Add(1)
+		return procedureir.DocumentIR{
+			Path: "Main.bas",
+			Procedures: []procedureir.ProcedureIR{{
+				Symbol: procedureir.ProcedureSymbol{
+					Name: "Main", Parameters: []procedureir.Parameter{{Name: "value"}},
+				},
+				Statements: []procedureir.Statement{{
+					ID: 1, Kind: procedureir.StatementCall, Text: "Target",
+				}},
+			}},
+		}, nil
+	}
+	const readers = 24
+	start := make(chan struct{})
+	results := make(chan procedureir.DocumentIR, readers)
+	var wg sync.WaitGroup
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result, _, err := snapshot.ProcedureIR(load)
+			if err != nil {
+				t.Error(err)
+			}
+			results <- result
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		if len(result.Procedures) != 1 || result.Procedures[0].Symbol.Name != "Main" {
+			t.Fatalf("procedure IR = %+v", result)
+		}
+	}
+	if loads.Load() != 1 {
+		t.Fatalf("loads = %d, want 1", loads.Load())
+	}
+
+	result, hit, err := snapshot.ProcedureIR(load)
+	if err != nil || !hit {
+		t.Fatalf("cached procedure IR = (hit=%v, err=%v)", hit, err)
+	}
+	result.Procedures[0].Symbol.Name = "mutated"
+	result.Procedures[0].Symbol.Parameters[0].Name = "mutated"
+	result.Procedures[0].Statements[0].Text = "mutated"
+	again, _, _ := snapshot.ProcedureIR(load)
+	if again.Procedures[0].Symbol.Name != "Main" ||
+		again.Procedures[0].Symbol.Parameters[0].Name != "value" ||
+		again.Procedures[0].Statements[0].Text != "Target" {
+		t.Fatalf("cached procedure IR was mutated: %+v", again)
+	}
+}
+
+func TestAnalysisSnapshotCachesDeterministicProcedureIRError(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{Source: "broken", Version: 1})
+	want := errors.New("procedure IR build failed")
+	var loads atomic.Int32
+	load := func() (procedureir.DocumentIR, error) {
+		loads.Add(1)
+		return procedureir.DocumentIR{Path: "Main.bas"}, want
+	}
+	for i := 0; i < 2; i++ {
+		result, hit, err := snapshot.ProcedureIR(load)
+		if !errors.Is(err, want) || hit != (i > 0) || result.Path != "Main.bas" {
+			t.Fatalf("call %d = (result=%+v, hit=%v, err=%v)", i, result, hit, err)
+		}
+	}
+	if loads.Load() != 1 {
+		t.Fatalf("loads = %d, want 1", loads.Load())
+	}
+}
+
 func TestAnalysisSnapshotSharesOneParsedDocumentAcrossDiagnosticsSymbolsAndSemanticTokens(t *testing.T) {
 	snapshot := NewAnalysisSnapshot(Document{
 		URI:        "file:///Main.bas",
@@ -251,6 +333,13 @@ func TestAnalysisSnapshotSharesOneParsedDocumentAcrossDiagnosticsSymbolsAndSeman
 	doc := snapshot.Document()
 	analyzer := newTestAnalyzer(t)
 	_ = analyzer.Diagnostics(doc)
+	procedureIR, hit, err := snapshot.ProcedureIR(func() (procedureir.DocumentIR, error) {
+		t.Fatal("diagnostics did not initialize the snapshot procedure IR")
+		return procedureir.DocumentIR{}, nil
+	})
+	if err != nil || !hit || len(procedureIR.Procedures) != 1 {
+		t.Fatalf("procedure IR = (result=%+v, hit=%v, err=%v)", procedureIR, hit, err)
+	}
 	if _, err := analyzer.DocumentSymbols(doc); err != nil {
 		t.Fatal(err)
 	}
@@ -258,15 +347,7 @@ func TestAnalysisSnapshotSharesOneParsedDocumentAcrossDiagnosticsSymbolsAndSeman
 		t.Fatal(err)
 	}
 	callResult, hit, err := snapshot.RawCallSites(func() (calls.FileResult, error) {
-		parsed, err := snapshot.ParsedDocument()
-		if err != nil {
-			return calls.FileResult{}, err
-		}
-		return calls.ExtractParsed(calls.SourceOptions{
-			RootDir:    ".",
-			Path:       snapshot.Path(),
-			ModuleKind: snapshot.ModuleKind(),
-		}, parsed)
+		return calls.ExtractIR(procedureIR), nil
 	})
 	if err != nil || hit {
 		t.Fatalf("raw call sites = (result=%+v, hit=%v, err=%v)", callResult, hit, err)

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -216,7 +216,7 @@ func (a Analyzer) DiagnosticsContext(ctx context.Context, doc Document) []Diagno
 	}
 	procedureIR, err := procedureIRForDocument(doc, a.RootDir, parsed)
 	if err != nil {
-		return []Diagnostic{lineDiagnostic("VBA000", "error", 0, err.Error())}
+		return append(out, lineDiagnostic("VBA000", "error", 0, err.Error()))
 	}
 	findings, err := analyze.SourceRealtimeFindingsParsedIR(a.RootDir, a.Config, parsed, procedureIR)
 	if ctx.Err() != nil {

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/lint"
 	"github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/doccomments"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 	"github.com/harumiWeb/xlflow/internal/vba/userforms"
 	"github.com/harumiWeb/xlflow/internal/vbadb"
@@ -213,7 +214,11 @@ func (a Analyzer) DiagnosticsContext(ctx context.Context, doc Document) []Diagno
 	if ctx.Err() != nil {
 		return nil
 	}
-	findings, err := analyze.SourceRealtimeFindingsParsed(a.RootDir, a.Config, parsed)
+	procedureIR, err := procedureIRForDocument(doc, a.RootDir, parsed)
+	if err != nil {
+		return []Diagnostic{lineDiagnostic("VBA000", "error", 0, err.Error())}
+	}
+	findings, err := analyze.SourceRealtimeFindingsParsedIR(a.RootDir, a.Config, parsed, procedureIR)
 	if ctx.Err() != nil {
 		return nil
 	}
@@ -5670,29 +5675,13 @@ func isTestProcedureName(name string) bool {
 }
 
 func isUserFormEventProcedure(sym Symbol) bool {
-	if !strings.EqualFold(sym.ModuleKind, "form") {
-		return false
-	}
-	name := strings.TrimSpace(sym.Name)
-	if name == "" || !strings.Contains(name, "_") {
-		return false
-	}
-	if isTestProcedureName(name) {
-		return false
-	}
-	idx := strings.LastIndex(name, "_")
-	return idx > 0 && idx < len(name)-1
+	event, kind := procedureir.ClassifyEvent(sym.ModuleKind, sym.Name)
+	return event && kind == "userform"
 }
 
 func isWorkbookEventProcedure(sym Symbol) bool {
-	name := strings.ToLower(strings.TrimSpace(sym.Name))
-	if name == "auto_open" || name == "auto_close" {
-		return true
-	}
-	if !strings.EqualFold(sym.ModuleKind, "document") {
-		return false
-	}
-	return strings.HasPrefix(name, "workbook_") || strings.HasPrefix(name, "worksheet_")
+	event, kind := procedureir.ClassifyEvent(sym.ModuleKind, sym.Name)
+	return event && (kind == "auto" || kind == "workbook" || kind == "worksheet")
 }
 
 func moduleNameForDocument(doc Document) string {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/lint"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vbadb"
 )
 
@@ -154,6 +155,34 @@ End Sub
 `
 	if diagnostics := analyzer.Diagnostics(doc); len(diagnostics) != 0 {
 		t.Fatalf("expected diagnostics to clear, got %+v", diagnostics)
+	}
+}
+
+func TestDiagnosticsPreserveLintResultsWhenProcedureIRBuildFails(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	snapshot := NewAnalysisSnapshot(Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Public Sub Run()
+    Range("A1").Select
+End Sub
+`,
+		Version: 1,
+	})
+	wantErr := errors.New("procedure IR unavailable")
+	if _, _, err := snapshot.ProcedureIR(func() (procedureir.DocumentIR, error) {
+		return procedureir.DocumentIR{}, wantErr
+	}); !errors.Is(err, wantErr) {
+		t.Fatalf("seed procedure IR error = %v, want %v", err, wantErr)
+	}
+
+	diagnostics := analyzer.Diagnostics(snapshot.Document())
+	if !hasDiagnostic(diagnostics, "VB002") {
+		t.Fatalf("lint diagnostic was discarded: %+v", diagnostics)
+	}
+	vba000 := diagnosticsByCode(diagnostics, "VBA000")
+	if len(vba000) != 1 || !strings.Contains(vba000[0].Message, wantErr.Error()) {
+		t.Fatalf("procedure IR error diagnostic = %+v, want %q", vba000, wantErr)
 	}
 }
 

--- a/internal/vba/procedureir/builder.go
+++ b/internal/vba/procedureir/builder.go
@@ -587,11 +587,19 @@ func statementOperand(text string, kind StatementKind) string {
 		}
 	case StatementOnError:
 		if len(fields) >= 4 {
-			return cleanIdentifier(fields[len(fields)-1])
+			rawTarget := strings.TrimSpace(fields[len(fields)-1])
+			if strings.EqualFold(rawTarget, "Next") || rawTarget == "0" {
+				return ""
+			}
+			return cleanIdentifier(rawTarget)
 		}
 	case StatementResume:
 		if len(fields) >= 2 {
-			return cleanIdentifier(fields[1])
+			rawTarget := strings.TrimSpace(fields[1])
+			if strings.EqualFold(rawTarget, "Next") {
+				return ""
+			}
+			return cleanIdentifier(rawTarget)
 		}
 	case StatementExit:
 		if len(fields) >= 2 {

--- a/internal/vba/procedureir/builder.go
+++ b/internal/vba/procedureir/builder.go
@@ -1,0 +1,690 @@
+package procedureir
+
+import (
+	"path/filepath"
+	"strings"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func BuildSource(opts BuildOptions, source []byte) (DocumentIR, error) {
+	path := opts.Path
+	if strings.TrimSpace(path) == "" {
+		path = "Untitled.bas"
+	}
+	doc, err := vbaast.ParseDocument(path, source)
+	if err != nil {
+		return DocumentIR{}, err
+	}
+	defer doc.Close()
+	return BuildParsed(opts, doc)
+}
+
+func BuildParsed(opts BuildOptions, doc *vbaast.ParsedDocument) (DocumentIR, error) {
+	var result DocumentIR
+	err := doc.Read(func(view vbaast.ParsedView) error {
+		path := firstNonEmpty(opts.Path, view.Path, "Untitled.bas")
+		moduleName := firstNonEmpty(opts.ModuleName, moduleNameFromSource(path, view.Source))
+		moduleKind := firstNonEmpty(opts.ModuleKind, moduleKindFromPath(path))
+		display := displayPath(opts.RootDir, path)
+		builder := documentBuilder{
+			source:     view.Source,
+			file:       display,
+			moduleName: moduleName,
+			moduleKind: moduleKind,
+			parse: ParseSummary{
+				HasError: view.HasError, HasMissing: view.HasMissing,
+			},
+			nextDeclarationID: 1,
+		}
+		result = builder.build(view.Root)
+		return nil
+	})
+	return result, err
+}
+
+type documentBuilder struct {
+	source            []byte
+	file              string
+	moduleName        string
+	moduleKind        string
+	parse             ParseSummary
+	nextDeclarationID int
+}
+
+func (b *documentBuilder) build(root *tree_sitter.Node) DocumentIR {
+	return b.buildSinglePass(root)
+}
+
+func (b *documentBuilder) procedureSymbol(node *tree_sitter.Node) ProcedureSymbol {
+	name := nodeText(childByFieldOrKind(node, "name", "identifier"), b.source)
+	kind := procedureKind(node, b.source)
+	qualified := name
+	if b.moduleName != "" && name != "" {
+		qualified = b.moduleName + "." + name
+	}
+	bodyRange := vbaast.NodeRange(node)
+	if body := childByKind(node, "block"); body != nil {
+		bodyRange = vbaast.NodeRange(body)
+	} else if end := procedureEndNode(node); end != nil {
+		bodyRange = zeroRangeAtStart(vbaast.NodeRange(end))
+	}
+	event, eventKind := ClassifyEvent(b.moduleKind, name)
+	return ProcedureSymbol{
+		Name: name, QualifiedName: qualified, Kind: kind,
+		Visibility: visibilityOfNode(node, b.source),
+		Parameters: b.parameters(node), ReturnType: typeText(node, b.source),
+		DeclarationRange: vbaast.NodeRange(node), BodyRange: bodyRange,
+		IsEventHandler: event, EventKind: eventKind, Recovered: recovered(node),
+	}
+}
+
+func (b *documentBuilder) parameters(node *tree_sitter.Node) []Parameter {
+	list := node.ChildByFieldName("parameters")
+	if list == nil {
+		list = childByKind(node, "parameter_list")
+	}
+	if list == nil {
+		return []Parameter{}
+	}
+	out := make([]Parameter, 0, list.NamedChildCount())
+	for i := uint(0); i < list.NamedChildCount(); i++ {
+		child := list.NamedChild(i)
+		if child == nil || child.Kind() != "parameter" {
+			continue
+		}
+		passing := "ByRef"
+		if mode := child.ChildByFieldName("passing_mode"); mode != nil && mode.Kind() == "byval_modifier" {
+			passing = "ByVal"
+		}
+		param := Parameter{
+			Name: nodeText(childByFieldOrKind(child, "name", "identifier"), b.source),
+			Type: typeText(child, b.source), Passing: passing, Range: vbaast.NodeRange(child),
+			Optional:   child.ChildByFieldName("optional_modifier") != nil,
+			ParamArray: child.ChildByFieldName("paramarray_modifier") != nil,
+		}
+		if value := child.ChildByFieldName("default_value"); value != nil {
+			param.Default = nodeText(value, b.source)
+		}
+		out = append(out, param)
+	}
+	return out
+}
+
+func (b *documentBuilder) declarations(node *tree_sitter.Node, scope SymbolScope) []Declaration {
+	declaratorKind := "variable_declarator"
+	kind := "variable"
+	if node.Kind() == "const_declaration" {
+		declaratorKind, kind = "const_declarator", "const"
+	}
+	out := []Declaration{}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil || child.Kind() != declaratorKind {
+			continue
+		}
+		text := nodeText(child, b.source)
+		declVisibility := visibilityOfNode(node, b.source)
+		decl := Declaration{
+			ID:   b.takeDeclarationID(),
+			Name: nodeText(childByFieldOrKind(child, "name", "identifier"), b.source),
+			Type: typeText(child, b.source), Scope: declarationScope(scope, declVisibility), Visibility: declVisibility,
+			Kind: kind, IsArray: strings.Contains(text, "("), Range: vbaast.NodeRange(child),
+			Recovered: recovered(child),
+		}
+		decl.IsObject = looksObjectType(decl.Type) || hasWord(text, "New")
+		out = append(out, decl)
+	}
+	return out
+}
+
+func (b *documentBuilder) simpleDeclaration(node *tree_sitter.Node, scope SymbolScope) (Declaration, bool) {
+	name := nodeText(childByFieldOrKind(node, "name", "identifier"), b.source)
+	if name == "" {
+		return Declaration{}, false
+	}
+	declVisibility := visibilityOfNode(node, b.source)
+	return Declaration{
+		ID: b.takeDeclarationID(), Name: name, Type: typeText(node, b.source),
+		Scope: declarationScope(scope, declVisibility), Visibility: declVisibility,
+		Kind: strings.TrimSuffix(node.Kind(), "_statement"), Range: vbaast.NodeRange(node),
+		Recovered: recovered(node),
+	}, true
+}
+
+func (b *documentBuilder) takeDeclarationID() int {
+	id := b.nextDeclarationID
+	b.nextDeclarationID++
+	return id
+}
+
+func declarationScope(scope SymbolScope, visibility string) SymbolScope {
+	if scope == ScopeModule && (strings.EqualFold(visibility, "Public") || strings.EqualFold(visibility, "Friend")) {
+		return ScopeProject
+	}
+	return scope
+}
+
+func isProcedureNode(kind string) bool {
+	switch kind {
+	case "sub_declaration", "function_declaration", "property_declaration",
+		"property_get_declaration", "property_let_declaration", "property_set_declaration",
+		"conditional_sub_declaration", "conditional_function_declaration", "conditional_property_declaration":
+		return true
+	default:
+		return false
+	}
+}
+
+func procedureKind(node *tree_sitter.Node, source []byte) ProcedureKind {
+	switch node.Kind() {
+	case "sub_declaration":
+		return ProcedureSub
+	case "function_declaration":
+		return ProcedureFunction
+	case "conditional_sub_declaration":
+		return ProcedureSub
+	case "conditional_function_declaration":
+		return ProcedureFunction
+	case "conditional_property_declaration":
+		text := strings.ToLower(nodeText(node, source))
+		switch {
+		case strings.Contains(text, "property get"):
+			return ProcedurePropertyGet
+		case strings.Contains(text, "property let"):
+			return ProcedurePropertyLet
+		case strings.Contains(text, "property set"):
+			return ProcedurePropertySet
+		default:
+			return ProcedureProperty
+		}
+	case "property_get_declaration":
+		return ProcedurePropertyGet
+	case "property_let_declaration":
+		return ProcedurePropertyLet
+	case "property_set_declaration":
+		return ProcedurePropertySet
+	}
+	text := strings.ToLower(nodeText(node, source))
+	switch {
+	case strings.Contains(text, "property get"):
+		return ProcedurePropertyGet
+	case strings.Contains(text, "property let"):
+		return ProcedurePropertyLet
+	case strings.Contains(text, "property set"):
+		return ProcedurePropertySet
+	default:
+		return ProcedureProperty
+	}
+}
+
+func statementKind(node *tree_sitter.Node) (StatementKind, bool) {
+	kind := strings.ToLower(node.Kind())
+	switch kind {
+	case "variable_declaration", "const_declaration":
+		return StatementDeclaration, true
+	case "assignment_statement", "let_statement":
+		return StatementAssignment, true
+	case "set_statement":
+		return StatementSet, true
+	case "redim_statement":
+		return StatementReDim, true
+	case "call_statement":
+		return StatementCall, true
+	case "label_statement", "line_number_statement":
+		return StatementLabel, true
+	case "goto_statement":
+		return StatementGoTo, true
+	case "on_error_statement":
+		return StatementOnError, true
+	case "resume_statement":
+		return StatementResume, true
+	case "exit_statement":
+		return StatementExit, true
+	}
+	switch {
+	case strings.Contains(kind, "else_if") || strings.Contains(kind, "elseif"):
+		return StatementElseIf, true
+	case kind == "else_fragment":
+		return StatementElse, true
+	case strings.Contains(kind, "else") && strings.Contains(kind, "clause"):
+		return StatementElse, true
+	case strings.Contains(kind, "if") && (strings.Contains(kind, "statement") || strings.Contains(kind, "block")):
+		return StatementIf, true
+	case strings.Contains(kind, "select") && !strings.Contains(kind, "case"):
+		return StatementSelect, true
+	case strings.Contains(kind, "case"):
+		return StatementCase, true
+	case strings.Contains(kind, "for_each"):
+		return StatementForEach, true
+	case strings.HasPrefix(kind, "for_"):
+		return StatementFor, true
+	case strings.HasPrefix(kind, "do_"):
+		return StatementDo, true
+	case strings.HasPrefix(kind, "while_"):
+		return StatementWhile, true
+	case strings.HasPrefix(kind, "with_"):
+		return StatementWith, true
+	case kind == "error":
+		return StatementRecovered, true
+	case strings.HasSuffix(kind, "_statement") && !isNonExecutableStatement(kind):
+		return StatementUnknown, true
+	default:
+		return "", false
+	}
+}
+
+func isNonExecutableStatement(kind string) bool {
+	switch kind {
+	case "option_statement", "attribute_statement", "implements_statement", "declare_statement",
+		"declare_sub_statement", "declare_function_statement", "event_statement":
+		return true
+	default:
+		return false
+	}
+}
+
+func expressionKind(kind string) ExpressionKind {
+	lower := strings.ToLower(kind)
+	switch {
+	case lower == "identifier":
+		return ExpressionIdentifier
+	case strings.HasSuffix(lower, "_literal"):
+		return ExpressionLiteral
+	case lower == "qualified_member_expression" || lower == "implicit_member_expression" || lower == "member_expression":
+		return ExpressionMember
+	case lower == "call_expression":
+		return ExpressionCall
+	case lower == "new_expression":
+		return ExpressionNew
+	case strings.Contains(lower, "unary_expression"):
+		return ExpressionUnary
+	case strings.Contains(lower, "binary_expression") || lower == "comparison_expression":
+		return ExpressionBinary
+	case lower == "parenthesized_expression":
+		return ExpressionParentheses
+	default:
+		return ExpressionUnknown
+	}
+}
+
+func isExpressionNode(kind string) bool {
+	lower := strings.ToLower(kind)
+	return lower == "identifier" || strings.HasSuffix(lower, "_literal") ||
+		strings.HasSuffix(lower, "_expression")
+}
+
+func typeText(node *tree_sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	typ := node.ChildByFieldName("type")
+	if typ == nil {
+		if clause := childByKind(node, "as_type_clause"); clause != nil {
+			typ = clause.ChildByFieldName("type")
+			if typ == nil {
+				typ = clause
+			}
+		}
+	}
+	text := nodeText(typ, source)
+	if strings.HasPrefix(strings.ToLower(text), "as ") {
+		text = strings.TrimSpace(text[3:])
+	}
+	return text
+}
+
+// ClassifyEvent centralizes the event-procedure naming contract used by IR
+// consumers. Event declarations are not passed to this helper as procedures.
+func ClassifyEvent(moduleKind, name string) (bool, string) {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "auto_open" || lower == "auto_close" {
+		return true, "auto"
+	}
+	switch strings.ToLower(moduleKind) {
+	case "document":
+		if strings.HasPrefix(lower, "workbook_") {
+			return true, "workbook"
+		}
+		if strings.HasPrefix(lower, "worksheet_") {
+			return true, "worksheet"
+		}
+	case "form":
+		if index := strings.LastIndex(lower, "_"); index > 0 && index < len(lower)-1 &&
+			!strings.HasPrefix(lower, "test") && !strings.HasSuffix(lower, "_test") {
+			return true, "userform"
+		}
+	}
+	return false, ""
+}
+
+func procedureEndNode(node *tree_sitter.Node) *tree_sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child != nil && strings.HasPrefix(child.Kind(), "end_") && strings.HasSuffix(child.Kind(), "_statement") {
+			return child
+		}
+	}
+	return nil
+}
+
+func zeroRangeAtStart(rng vbaast.Range) vbaast.Range {
+	return vbaast.Range{
+		StartLine: rng.StartLine, StartColumn: rng.StartColumn,
+		EndLine: rng.StartLine, EndColumn: rng.StartColumn,
+		StartByte: rng.StartByte, EndByte: rng.StartByte,
+	}
+}
+
+func visibilityOfNode(node *tree_sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	if modifier := node.ChildByFieldName("visibility"); modifier != nil {
+		return normalizedVisibility(nodeText(modifier, source))
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		if child.Kind() == "visibility" {
+			return normalizedVisibility(nodeText(child, source))
+		}
+		if child.Kind() != "procedure_modifier" {
+			continue
+		}
+		for j := uint(0); j < child.NamedChildCount(); j++ {
+			modifier := child.NamedChild(j)
+			if modifier != nil && modifier.Kind() == "visibility" {
+				return normalizedVisibility(nodeText(modifier, source))
+			}
+		}
+	}
+	header := nodeText(node, source)
+	if line, _, ok := strings.Cut(header, "\n"); ok {
+		header = strings.TrimSuffix(line, "\r")
+	}
+	fields := strings.Fields(header)
+	if len(fields) == 0 {
+		return ""
+	}
+	return normalizedVisibility(fields[0])
+}
+
+func normalizedVisibility(text string) string {
+	for _, value := range []string{"Private", "Public", "Friend"} {
+		if hasWord(text, value) {
+			return value
+		}
+	}
+	return ""
+}
+
+func recovered(node *tree_sitter.Node) bool {
+	return node != nil && (node.IsError() || node.IsMissing() || node.HasError())
+}
+
+func childByFieldNameAny(node *tree_sitter.Node, names ...string) *tree_sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for _, name := range names {
+		if child := node.ChildByFieldName(name); child != nil {
+			return child
+		}
+	}
+	return nil
+}
+
+func childByFieldOrKind(node *tree_sitter.Node, field, kind string) *tree_sitter.Node {
+	if node == nil {
+		return nil
+	}
+	if child := node.ChildByFieldName(field); child != nil {
+		return child
+	}
+	return childByKind(node, kind)
+}
+
+func childByKind(node *tree_sitter.Node, kind string) *tree_sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child != nil && child.Kind() == kind {
+			return child
+		}
+	}
+	return nil
+}
+
+func firstNamedChild(node *tree_sitter.Node) *tree_sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		if child := node.NamedChild(i); child != nil {
+			return child
+		}
+	}
+	return nil
+}
+
+func sameNode(a, b *tree_sitter.Node) bool {
+	return a != nil && b != nil && a.Kind() == b.Kind() && a.StartByte() == b.StartByte() && a.EndByte() == b.EndByte()
+}
+
+func nodeText(node *tree_sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	return strings.TrimSpace(node.Utf8Text(source))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func moduleNameFromSource(path string, source []byte) string {
+	for _, line := range strings.Split(string(source), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(strings.ToLower(trimmed), "attribute vb_name") {
+			continue
+		}
+		if _, value, ok := strings.Cut(trimmed, "="); ok {
+			if value = strings.Trim(strings.TrimSpace(value), `"`); value != "" {
+				return value
+			}
+		}
+	}
+	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+}
+
+func moduleKindFromPath(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".cls":
+		return "class"
+	case ".frm":
+		return "form"
+	default:
+		return "standard"
+	}
+}
+
+func displayPath(root, path string) string {
+	if strings.TrimSpace(root) == "" || !filepath.IsAbs(path) {
+		return filepath.ToSlash(path)
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func hasWord(text, word string) bool {
+	for _, part := range strings.FieldsFunc(text, func(r rune) bool {
+		return r != '_' && (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z')
+	}) {
+		if strings.EqualFold(part, word) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanIdentifier(text string) string {
+	text = strings.TrimSpace(strings.Trim(text, "[]"))
+	return strings.TrimRight(text, "$%&#@^!")
+}
+
+func looksObjectType(typ string) bool {
+	lower := strings.ToLower(cleanIdentifier(typ))
+	switch lower {
+	case "object", "application", "workbook", "worksheet", "range", "collection", "dictionary":
+		return true
+	default:
+		return strings.Contains(lower, ".")
+	}
+}
+
+func containsRange(outer, inner vbaast.Range) bool {
+	return inner.StartByte >= outer.StartByte && inner.EndByte <= outer.EndByte
+}
+
+func containingExpressionID(expressions []Expression, rng vbaast.Range) int {
+	id, width := 0, int(^uint(0)>>1)
+	for _, expr := range expressions {
+		if !containsRange(expr.Range, rng) {
+			continue
+		}
+		if candidate := expr.Range.EndByte - expr.Range.StartByte; candidate < width {
+			id, width = expr.ID, candidate
+		}
+	}
+	return id
+}
+
+func statementOperand(text string, kind StatementKind) string {
+	fields := strings.Fields(strings.TrimSpace(text))
+	switch kind {
+	case StatementLabel:
+		return cleanIdentifier(strings.TrimSuffix(strings.TrimSpace(text), ":"))
+	case StatementGoTo:
+		if len(fields) >= 2 {
+			return cleanIdentifier(fields[1])
+		}
+	case StatementOnError:
+		if len(fields) >= 4 {
+			return cleanIdentifier(fields[len(fields)-1])
+		}
+	case StatementResume:
+		if len(fields) >= 2 {
+			return cleanIdentifier(fields[1])
+		}
+	case StatementExit:
+		if len(fields) >= 2 {
+			return strings.ToLower(fields[1])
+		}
+	}
+	return ""
+}
+
+func calleeFromNode(node *tree_sitter.Node, source []byte) Callee {
+	text := nodeText(node, source)
+	callee := Callee{Text: text}
+	switch node.Kind() {
+	case "qualified_member_expression":
+		if receiver := childByFieldNameAny(node, "receiver", "object"); receiver != nil {
+			value := nodeText(receiver, source)
+			callee.Receiver = &value
+		}
+		callee.Member = nodeText(childByFieldNameAny(node, "member", "property"), source)
+	case "implicit_member_expression":
+		callee.Member = nodeText(childByFieldNameAny(node, "member", "property"), source)
+	default:
+		callee.Member = lastNamePart(text)
+	}
+	callee.Member = cleanIdentifier(callee.Member)
+	callee.BaseName = callee.Member
+	if callee.BaseName == "" {
+		callee.BaseName = cleanIdentifier(lastNamePart(text))
+		callee.Member = callee.BaseName
+	}
+	return callee
+}
+
+func argumentsFromCallNode(callNode, target *tree_sitter.Node, source []byte) Arguments {
+	if callNode.Kind() == "call_expression" {
+		return argumentsFromCallExpression(callNode, source)
+	}
+	if target != nil && target.Kind() == "call_expression" {
+		return argumentsFromCallExpression(target, source)
+	}
+	if list := callNode.ChildByFieldName("arguments"); list != nil {
+		return argumentsFromArgumentList(list, source)
+	}
+	return Arguments{Named: []NamedArgument{}}
+}
+
+func argumentsFromCallExpression(node *tree_sitter.Node, source []byte) Arguments {
+	if list := node.ChildByFieldName("arguments"); list != nil {
+		return argumentsFromArgumentList(list, source)
+	}
+	out := Arguments{Named: []NamedArgument{}}
+	fn := node.ChildByFieldName("function")
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil || sameNode(child, fn) {
+			continue
+		}
+		out.Count++
+		if child.Kind() == "named_argument" {
+			out.Named = append(out.Named, namedArgument(child, source))
+		}
+	}
+	return out
+}
+
+func argumentsFromArgumentList(node *tree_sitter.Node, source []byte) Arguments {
+	out := Arguments{Named: []NamedArgument{}}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		out.Count++
+		if child.Kind() == "named_argument" {
+			out.Named = append(out.Named, namedArgument(child, source))
+		}
+	}
+	return out
+}
+
+func namedArgument(node *tree_sitter.Node, source []byte) NamedArgument {
+	return NamedArgument{
+		Name:      cleanIdentifier(nodeText(node.ChildByFieldName("name"), source)),
+		ValueText: nodeText(node.ChildByFieldName("value"), source),
+	}
+}
+
+func lastNamePart(text string) string {
+	text = strings.TrimSpace(strings.TrimPrefix(text, "New "))
+	for _, separator := range []string{".", "!"} {
+		if index := strings.LastIndex(text, separator); index >= 0 {
+			text = text[index+1:]
+		}
+	}
+	return text
+}

--- a/internal/vba/procedureir/builder_test.go
+++ b/internal/vba/procedureir/builder_test.go
@@ -204,6 +204,39 @@ End Sub
 	}
 }
 
+func TestNonLabelErrorHandlingFormsHaveNoLabel(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+    On Error Resume Next
+    On Error GoTo 0
+    On Error GoTo [Next]
+    Resume
+    Resume Next
+    Resume [Next]
+    Resume Handler
+Handler:
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var onErrorLabels, resumeLabels []string
+	for _, statement := range doc.Procedures[0].Statements {
+		switch statement.Kind {
+		case StatementOnError:
+			onErrorLabels = append(onErrorLabels, statement.Label)
+		case StatementResume:
+			resumeLabels = append(resumeLabels, statement.Label)
+		}
+	}
+	if !reflect.DeepEqual(onErrorLabels, []string{"", "", "Next"}) {
+		t.Fatalf("On Error labels = %#v, want non-label forms empty", onErrorLabels)
+	}
+	if !reflect.DeepEqual(resumeLabels, []string{"", "", "Next", "Handler"}) {
+		t.Fatalf("Resume labels = %#v, want only explicit handler label", resumeLabels)
+	}
+}
+
 func TestSetAssignmentRecordsObjectWriteAndRead(t *testing.T) {
 	t.Parallel()
 	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
@@ -219,6 +252,75 @@ End Sub
 	requireStatementKind(t, procedure.Statements, StatementSet)
 	assertAccess(t, procedure.Accesses, "target", ScopeLocal, AccessWrite)
 	assertAccess(t, procedure.Accesses, "source", ScopeLocal, AccessRead)
+}
+
+func TestCompositeAssignmentTargetsKeepReceiverAndIndexesAsReads(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+    Dim obj As Object
+    Dim values() As Long
+    Dim index As Long
+    Dim source As Long
+    obj.Value = source
+    values(index) = source
+    Let values(index) = source
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	modes := map[string][]AccessMode{}
+	for _, access := range doc.Procedures[0].Accesses {
+		key := strings.ToLower(access.Name)
+		modes[key] = append(modes[key], access.Mode)
+	}
+	if !reflect.DeepEqual(modes["obj"], []AccessMode{AccessRead}) {
+		t.Fatalf("object receiver modes = %v, want read", modes["obj"])
+	}
+	if !reflect.DeepEqual(modes["values"], []AccessMode{AccessWrite, AccessWrite}) {
+		t.Fatalf("indexed assignment base modes = %v, want writes; accesses=%+v",
+			modes["values"], doc.Procedures[0].Accesses)
+	}
+	if !reflect.DeepEqual(modes["index"], []AccessMode{AccessRead, AccessRead}) {
+		t.Fatalf("index modes = %v, want reads", modes["index"])
+	}
+	if !reflect.DeepEqual(modes["source"], []AccessMode{AccessRead, AccessRead, AccessRead}) {
+		t.Fatalf("assignment value modes = %v, want reads", modes["source"])
+	}
+}
+
+func TestParenthesizedComparisonArgumentRemainsCallAndReads(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+    Dim actual As Long
+    Dim expected As Long
+    Check (actual) = expected
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	procedure := doc.Procedures[0]
+	var statement *Statement
+	for i := range procedure.Statements {
+		if procedure.Statements[i].Range.StartLine == 4 {
+			statement = &procedure.Statements[i]
+			break
+		}
+	}
+	if statement == nil || statement.Kind != StatementCall {
+		t.Fatalf("comparison argument statement = %+v, want call", statement)
+	}
+	if len(procedure.Calls) != 1 || !strings.EqualFold(procedure.Calls[0].Callee.BaseName, "Check") {
+		t.Fatalf("comparison argument call was lost: %+v", procedure.Calls)
+	}
+	assertAccess(t, procedure.Accesses, "actual", ScopeLocal, AccessRead)
+	assertAccess(t, procedure.Accesses, "expected", ScopeLocal, AccessRead)
+	for _, access := range procedure.Accesses {
+		if strings.EqualFold(access.Name, "Check") {
+			t.Fatalf("callee became a variable access: %+v", access)
+		}
+	}
 }
 
 func TestCallAccessesExcludeOnlyCalleeAndNamedArgumentLabels(t *testing.T) {
@@ -459,8 +561,8 @@ End Sub
 
 func TestFunctionAndPropertyGetNamesResolveAsLocalReturnSlots(t *testing.T) {
 	t.Parallel()
-	doc, err := BuildSource(BuildOptions{Path: "Thing.cls", ModuleKind: "class"}, []byte(`Public Function Compute() As Long
-    Compute = 1
+	doc, err := BuildSource(BuildOptions{Path: "Thing.cls", ModuleKind: "class"}, []byte(`Public Function Compute(ByVal input As Long) As Long
+    Compute = input
 End Function
 
 Public Property Get Value() As Long
@@ -469,6 +571,11 @@ End Property
 `))
 	if err != nil {
 		t.Fatal(err)
+	}
+	declarations := doc.Procedures[0].Declarations
+	if len(declarations) < 2 || declarations[0].Kind != "return_slot" || declarations[1].Kind != "parameter" ||
+		declarations[0].Range.StartByte >= declarations[1].Range.StartByte {
+		t.Fatalf("function declarations are not in source order: %+v", declarations)
 	}
 	resolved := Resolve(doc, NewResolver([]ResolverSymbol{
 		{Name: "Compute", Module: "Other", Kind: "module_variable", Visibility: "Public"},

--- a/internal/vba/procedureir/builder_test.go
+++ b/internal/vba/procedureir/builder_test.go
@@ -1,0 +1,624 @@
+package procedureir
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestBuildSourceNormalizesProceduresStatementsCallsAndScopes(t *testing.T) {
+	t.Parallel()
+	source := []byte(`Attribute VB_Name = "Module1"
+Option Explicit
+Private moduleValue As Long
+
+Public Function Compute(ByVal inputValue As Long, Optional label As String = "x") As Long
+    Dim localValue As Long
+    localValue = inputValue + moduleValue
+    Call Helper(localValue)
+    Compute = localValue
+    Exit Function
+Handler:
+    Resume Next
+End Function
+`)
+	doc, err := BuildSource(BuildOptions{Path: "src/modules/Module1.bas"}, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.ModuleName != "Module1" || doc.ModuleKind != "standard" {
+		t.Fatalf("unexpected module: %#v", doc)
+	}
+	if len(doc.Procedures) != 1 {
+		t.Fatalf("procedures = %d, want 1", len(doc.Procedures))
+	}
+	procedure := doc.Procedures[0]
+	if procedure.Symbol.Name != "Compute" || procedure.Symbol.Kind != ProcedureFunction {
+		t.Fatalf("unexpected procedure symbol: %#v", procedure.Symbol)
+	}
+	if procedure.Symbol.Visibility != "Public" || procedure.Symbol.ReturnType != "Long" {
+		t.Fatalf("unexpected procedure signature: %#v", procedure.Symbol)
+	}
+	if got := len(procedure.Symbol.Parameters); got != 2 {
+		t.Fatalf("parameters = %d, want 2", got)
+	}
+	if procedure.Symbol.Parameters[0].Passing != "ByVal" || !procedure.Symbol.Parameters[1].Optional {
+		t.Fatalf("unexpected parameters: %#v", procedure.Symbol.Parameters)
+	}
+	requireStatementKind(t, procedure.Statements, StatementDeclaration)
+	requireStatementKind(t, procedure.Statements, StatementAssignment)
+	requireStatementKind(t, procedure.Statements, StatementCall)
+	requireStatementKind(t, procedure.Statements, StatementExit)
+	requireStatementKind(t, procedure.Statements, StatementLabel)
+	requireStatementKind(t, procedure.Statements, StatementResume)
+	if len(procedure.Calls) != 1 || procedure.Calls[0].Callee.BaseName != "Helper" {
+		t.Fatalf("unexpected calls: %#v", procedure.Calls)
+	}
+	assertAccess(t, procedure.Accesses, "inputValue", ScopeParameter, AccessRead)
+	assertAccess(t, procedure.Accesses, "moduleValue", ScopeModule, AccessRead)
+	assertAccess(t, procedure.Accesses, "localValue", ScopeLocal, AccessWrite)
+	if procedure.Symbol.DeclarationRange.StartLine != 5 || procedure.Symbol.BodyRange.StartLine < 5 {
+		t.Fatalf("unexpected ranges: %#v", procedure.Symbol)
+	}
+}
+
+func TestBuildSourceClassifiesPropertiesAndEvents(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		opts      BuildOptions
+		source    string
+		kind      ProcedureKind
+		event     bool
+		eventKind string
+	}{
+		{"property get", BuildOptions{Path: "Thing.cls", ModuleKind: "class"}, "Public Property Get Value() As Long\nValue = 1\nEnd Property\n", ProcedurePropertyGet, false, ""},
+		{"property let", BuildOptions{Path: "Thing.cls", ModuleKind: "class"}, "Public Property Let Value(ByVal rhs As Long)\nEnd Property\n", ProcedurePropertyLet, false, ""},
+		{"property set", BuildOptions{Path: "Thing.cls", ModuleKind: "class"}, "Public Property Set Value(ByVal rhs As Object)\nEnd Property\n", ProcedurePropertySet, false, ""},
+		{"workbook", BuildOptions{Path: "ThisWorkbook.cls", ModuleKind: "document"}, "Private Sub Workbook_Open()\nEnd Sub\n", ProcedureSub, true, "workbook"},
+		{"worksheet", BuildOptions{Path: "Sheet1.cls", ModuleKind: "document"}, "Private Sub Worksheet_Change(ByVal Target As Range)\nEnd Sub\n", ProcedureSub, true, "worksheet"},
+		{"form", BuildOptions{Path: "Dialog.frm", ModuleKind: "form"}, "Private Sub Submit_Click()\nEnd Sub\n", ProcedureSub, true, "userform"},
+		{"form test", BuildOptions{Path: "Dialog.frm", ModuleKind: "form"}, "Private Sub Test_Click()\nEnd Sub\n", ProcedureSub, false, ""},
+		{"auto", BuildOptions{Path: "Module1.bas"}, "Public Sub Auto_Open()\nEnd Sub\n", ProcedureSub, true, "auto"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			doc, err := BuildSource(test.opts, []byte(test.source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(doc.Procedures) != 1 {
+				t.Fatalf("procedures = %d", len(doc.Procedures))
+			}
+			symbol := doc.Procedures[0].Symbol
+			if symbol.Kind != test.kind || symbol.IsEventHandler != test.event || symbol.EventKind != test.eventKind {
+				t.Fatalf("unexpected symbol: %#v", symbol)
+			}
+		})
+	}
+}
+
+func TestBuildParsedDoesNotCloseDocumentAndIRSurvivesClose(t *testing.T) {
+	t.Parallel()
+	doc, err := vbaast.ParseDocument("Module1.bas", []byte("Public Sub Run()\nMsgBox \"ok\"\nEnd Sub\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir, err := BuildParsed(BuildOptions{}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := doc.Read(func(vbaast.ParsedView) error { return nil }); err != nil {
+		t.Fatalf("BuildParsed closed caller document: %v", err)
+	}
+	doc.Close()
+	if len(ir.Procedures) != 1 || len(ir.Procedures[0].Calls) != 1 {
+		t.Fatalf("IR unusable after close: %#v", ir)
+	}
+	if containsTreeSitterType(reflect.TypeOf(ir), map[reflect.Type]bool{}) {
+		t.Fatal("DocumentIR retains a tree-sitter type")
+	}
+}
+
+func TestBuildSourceReturnsPartialIRForRecoveredSource(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Broken.bas"}, []byte("Public Sub Broken(\nDim value As Long\nvalue =\nEnd Sub\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !doc.Parse.HasError && !doc.Parse.HasMissing {
+		t.Fatalf("expected parser recovery metadata: %#v", doc.Parse)
+	}
+	if len(doc.Procedures) == 0 {
+		t.Fatal("expected recoverable procedure facts")
+	}
+	if !doc.Procedures[0].Symbol.Recovered && !hasRecoveredStatement(doc.Procedures[0].Statements) {
+		t.Fatal("expected recovered IR facts")
+	}
+}
+
+func TestTypeReferencesAndEventDeclaration(t *testing.T) {
+	t.Parallel()
+	source := []byte(`Public Event Changed(ByVal value As Long)
+Implements IFoo
+Private service As IService
+Public Sub Run()
+    Dim item As New Widget
+    Set item = New Widget
+End Sub
+`)
+	doc, err := BuildSource(BuildOptions{Path: "Thing.cls", ModuleKind: "class"}, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Procedures) != 1 || doc.Procedures[0].Symbol.Name != "Run" {
+		t.Fatalf("Event declaration was treated as a procedure: %#v", doc.Procedures)
+	}
+	assertTypeReference(t, doc.TypeReferences, "implements", "IFoo")
+	assertTypeReference(t, doc.TypeReferences, "uses_type", "IService")
+	assertTypeReference(t, doc.TypeReferences, "uses_type", "Widget")
+	assertTypeReference(t, doc.TypeReferences, "constructs", "Widget")
+}
+
+func TestStatementHierarchyAndErrorHandlingKinds(t *testing.T) {
+	t.Parallel()
+	source := []byte(`Public Sub Run()
+    On Error GoTo Handler
+    If Ready Then
+        For Each item In items
+            Call Work(item)
+        Next
+    Else
+        GoTo Done
+    End If
+    Exit Sub
+Handler:
+    Resume Next
+Done:
+End Sub
+`)
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statements := doc.Procedures[0].Statements
+	for _, kind := range []StatementKind{
+		StatementOnError, StatementIf, StatementForEach, StatementCall,
+		StatementElse, StatementGoTo, StatementExit, StatementLabel, StatementResume,
+	} {
+		requireStatementKind(t, statements, kind)
+	}
+	for _, statement := range statements {
+		if statement.Kind == StatementCall && statement.ParentID == 0 {
+			t.Fatalf("nested call has no parent: %#v", statement)
+		}
+		if statement.Kind == StatementOnError && !strings.EqualFold(statement.Label, "Handler") {
+			t.Fatalf("On Error target = %q", statement.Label)
+		}
+	}
+}
+
+func TestSetAssignmentRecordsObjectWriteAndRead(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+    Dim target As Object
+    Dim source As Object
+    Set target = source
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	procedure := doc.Procedures[0]
+	requireStatementKind(t, procedure.Statements, StatementSet)
+	assertAccess(t, procedure.Accesses, "target", ScopeLocal, AccessWrite)
+	assertAccess(t, procedure.Accesses, "source", ScopeLocal, AccessRead)
+}
+
+func TestCallAccessesExcludeOnlyCalleeAndNamedArgumentLabels(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+    Dim Foo As Long
+    Dim value As Long
+    Call Foo(Foo)
+    Call Target(Bar:=value)
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := map[string]int{}
+	for _, access := range doc.Procedures[0].Accesses {
+		counts[strings.ToLower(access.Name)]++
+	}
+	if counts["foo"] != 1 {
+		t.Fatalf("Foo accesses = %d, want only the argument read: %+v", counts["foo"], doc.Procedures[0].Accesses)
+	}
+	if counts["bar"] != 0 {
+		t.Fatalf("named argument label became a variable read: %+v", doc.Procedures[0].Accesses)
+	}
+	if counts["value"] != 1 {
+		t.Fatalf("value accesses = %d, want argument read: %+v", counts["value"], doc.Procedures[0].Accesses)
+	}
+}
+
+func TestRangesPreserveUTF8ByteColumnsAndCRLFOffsets(t *testing.T) {
+	t.Parallel()
+	source := []byte("Public Sub Run()\r\n    MsgBox \"😀\", Title:=\"日本語\"\r\nEnd Sub\r\n")
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call := doc.Procedures[0].Calls[0]
+	if call.Range.StartLine != 2 || call.Range.StartColumn != 5 {
+		t.Fatalf("unexpected call range: %#v", call.Range)
+	}
+	if got := string(source[call.Range.StartByte:call.Range.EndByte]); !strings.Contains(got, "😀") {
+		t.Fatalf("byte offsets do not address original UTF-8 source: %q", got)
+	}
+	if call.Arguments.Count != 2 || len(call.Arguments.Named) != 1 || call.Arguments.Named[0].Name != "Title" {
+		t.Fatalf("unexpected arguments: %#v", call.Arguments)
+	}
+}
+
+func TestResolveIsRepeatableAndDoesNotMutateSyntaxIR(t *testing.T) {
+	t.Parallel()
+	source, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Private projectValue As Long
+Public Sub Run()
+    MissingCall projectValue
+    MsgBox "ok"
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewSymbolResolver([]ResolverSymbol{
+		{Name: "MissingCall", Module: "Module2", Kind: "sub", Visibility: "Public", File: "Module2.bas", Line: 4},
+		{Name: "projectName", Module: "Module2", Kind: "module_variable", Visibility: "Public", File: "Module2.bas", Line: 1},
+	})
+	resolved := Resolve(source, resolver)
+	if source.Procedures[0].Calls[0].Resolution.Status != ResolutionNotAttempted {
+		t.Fatal("Resolve mutated source")
+	}
+	if got := resolved.Procedures[0].Calls[0].Resolution.Status; got != ResolutionMatched {
+		t.Fatalf("call status = %q", got)
+	}
+	if got := resolved.Procedures[0].Calls[1].Resolution.Status; got != ResolutionBuiltinLike {
+		t.Fatalf("builtin status = %q", got)
+	}
+	again := Resolve(resolved, NewSymbolResolver(nil))
+	if got := again.Procedures[0].Calls[0].Resolution.Status; got != ResolutionUnresolved {
+		t.Fatalf("re-resolution status = %q", got)
+	}
+}
+
+func TestResolveSymbolOverlayAndPrivateVisibility(t *testing.T) {
+	t.Parallel()
+	source, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+    projectName = externalValue + implicitHidden + implicitField + implicitWithEvents
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewResolver([]ResolverSymbol{
+		{Name: "projectName", Module: "Module2", Kind: "module_variable", Visibility: "Public", File: "Module2.bas", Line: 1},
+		{Name: "externalValue", Module: "Module2", Kind: "module_variable", Visibility: "Private", File: "Module2.bas", Line: 2},
+		{Name: "implicitHidden", Module: "Module2", Kind: "module_variable", File: "Module2.bas", Line: 3},
+		{Name: "implicitField", Module: "Class1", Kind: "field", File: "Class1.cls", Line: 1},
+		{Name: "implicitWithEvents", Module: "Class1", Kind: "withevents_field", File: "Class1.cls", Line: 2},
+	})
+	resolved := Resolve(source, resolver)
+	assertAccess(t, resolved.Procedures[0].Accesses, "projectName", ScopeProject, AccessWrite)
+	assertAccess(t, resolved.Procedures[0].Accesses, "externalValue", ScopeUnresolved, AccessRead)
+	assertAccess(t, resolved.Procedures[0].Accesses, "implicitHidden", ScopeUnresolved, AccessRead)
+	assertAccess(t, resolved.Procedures[0].Accesses, "implicitField", ScopeUnresolved, AccessRead)
+	assertAccess(t, resolved.Procedures[0].Accesses, "implicitWithEvents", ScopeUnresolved, AccessRead)
+	sameModule := resolver.ResolveSymbol(SymbolReference{
+		Name:   "implicitHidden",
+		Caller: ProcedureRef{Name: "Run", Kind: ProcedureSub, QualifiedName: "Module2.Run"},
+	})
+	if sameModule.Scope != ScopeProject || len(sameModule.Candidates) != 1 {
+		t.Fatalf("same-module implicit private resolution = %+v", sameModule)
+	}
+}
+
+func TestModuleDeclarationsAfterProcedureParticipateInScopeResolution(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+    privateAfter = publicAfter
+End Sub
+
+Private privateAfter As Long
+Public publicAfter As Long
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Declarations) != 2 {
+		t.Fatalf("module declarations = %d, want 2: %#v", len(doc.Declarations), doc.Declarations)
+	}
+	var privateDecl, publicDecl Declaration
+	for _, declaration := range doc.Declarations {
+		switch declaration.Name {
+		case "privateAfter":
+			privateDecl = declaration
+		case "publicAfter":
+			publicDecl = declaration
+		}
+	}
+	if privateDecl.Scope != ScopeModule || publicDecl.Scope != ScopeProject {
+		t.Fatalf("unexpected declaration scopes: private=%q public=%q", privateDecl.Scope, publicDecl.Scope)
+	}
+	assertAccess(t, doc.Procedures[0].Accesses, "privateAfter", ScopeModule, AccessWrite)
+	assertAccess(t, doc.Procedures[0].Accesses, "publicAfter", ScopeModule, AccessRead)
+}
+
+func TestVisibilityOnlyUsesDeclarationHeader(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Const AccessLabel As String = "Public"
+
+Sub Run(Optional value As String = "Private")
+    Debug.Print "Friend"
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := doc.Declarations[0]; got.Visibility != "" || got.Scope != ScopeModule {
+		t.Fatalf("module declaration visibility leaked from initializer: %+v", got)
+	}
+	if got := doc.Procedures[0].Symbol.Visibility; got != "" {
+		t.Fatalf("procedure visibility leaked from signature/body text: %q", got)
+	}
+	parameter := doc.Procedures[0].Symbol.Parameters[0]
+	if parameter.Passing != "ByRef" || !parameter.Optional {
+		t.Fatalf("parameter modifiers leaked from default text: %+v", parameter)
+	}
+}
+
+func TestEmptyProcedureHasNoBodyFacts(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte("Public Sub Empty()\nEnd Sub\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	procedure := doc.Procedures[0]
+	if len(procedure.Statements) != 0 || len(procedure.Expressions) != 0 ||
+		len(procedure.Calls) != 0 || len(procedure.Accesses) != 0 {
+		t.Fatalf("empty procedure contains body facts: %+v", procedure)
+	}
+	if procedure.Symbol.BodyRange.StartByte != procedure.Symbol.BodyRange.EndByte ||
+		procedure.Symbol.BodyRange.StartLine != 2 {
+		t.Fatalf("empty body range = %+v, want zero-width range at End Sub", procedure.Symbol.BodyRange)
+	}
+}
+
+func TestCurrentModulePublicDeclarationShadowsProjectSymbols(t *testing.T) {
+	t.Parallel()
+	source, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public sharedValue As Long
+Public Sub Run()
+    sharedValue = sharedValue + 1
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(source, NewResolver([]ResolverSymbol{{
+		Name: "sharedValue", Module: "Other", Kind: "module_variable",
+		Visibility: "Public", File: "Other.bas", Line: 1,
+	}}))
+	for _, access := range resolved.Procedures[0].Accesses {
+		if strings.EqualFold(access.Name, "sharedValue") &&
+			(access.Scope != ScopeModule || len(access.Resolution.Candidates) != 0) {
+			t.Fatalf("current-module binding was replaced by project resolution: %+v", access)
+		}
+	}
+}
+
+func TestCanonicalExpressionLinksIncludeWrappedCallArguments(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run(ByVal a As Long, ByVal b As Long)
+    Dim result As Long
+    result = Foo(a + 1, named:=Bar(b))
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	procedure := doc.Procedures[0]
+	var assignment *Statement
+	for i := range procedure.Statements {
+		if procedure.Statements[i].Kind == StatementAssignment {
+			assignment = &procedure.Statements[i]
+			break
+		}
+	}
+	if assignment == nil || assignment.TargetID == 0 || assignment.ValueID == 0 {
+		t.Fatalf("assignment lacks canonical target/value links: %+v", assignment)
+	}
+	if assignment.Target == nil || assignment.Target.ID != assignment.TargetID ||
+		assignment.Value == nil || assignment.Value.ID != assignment.ValueID {
+		t.Fatalf("statement pointers are detached from canonical expressions: %+v", assignment)
+	}
+	foo := procedure.Calls[0]
+	if foo.Arguments.Count != 2 || len(foo.Arguments.ExpressionIDs) != 2 ||
+		foo.Arguments.ExpressionIDs[0] == 0 || foo.Arguments.ExpressionIDs[1] == 0 {
+		t.Fatalf("wrapped argument expressions are not linked: %+v", foo.Arguments)
+	}
+	if len(foo.Arguments.Named) != 1 || foo.Arguments.Named[0].ExpressionID == 0 {
+		t.Fatalf("named argument value lacks expression link: %+v", foo.Arguments.Named)
+	}
+}
+
+func TestFunctionAndPropertyGetNamesResolveAsLocalReturnSlots(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Thing.cls", ModuleKind: "class"}, []byte(`Public Function Compute() As Long
+    Compute = 1
+End Function
+
+Public Property Get Value() As Long
+    Value = 2
+End Property
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(doc, NewResolver([]ResolverSymbol{
+		{Name: "Compute", Module: "Other", Kind: "module_variable", Visibility: "Public"},
+		{Name: "Value", Module: "Other", Kind: "module_variable", Visibility: "Public"},
+	}))
+	for _, procedure := range resolved.Procedures {
+		assertAccess(t, procedure.Accesses, procedure.Symbol.Name, ScopeLocal, AccessWrite)
+		for _, access := range procedure.Accesses {
+			if strings.EqualFold(access.Name, procedure.Symbol.Name) && len(access.Resolution.Candidates) != 0 {
+				t.Fatalf("return slot flowed to project resolver: %+v", access)
+			}
+		}
+	}
+}
+
+func TestReDimAccessModes(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Resize()
+    Dim values() As Long
+    ReDim values(10)
+    ReDim Preserve values(20)
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var modes []AccessMode
+	for _, access := range doc.Procedures[0].Accesses {
+		if strings.EqualFold(access.Name, "values") {
+			modes = append(modes, access.Mode)
+		}
+	}
+	if len(modes) != 2 || modes[0] != AccessWrite || modes[1] != AccessReadWrite {
+		t.Fatalf("ReDim access modes = %v, want [write read_write]", modes)
+	}
+}
+
+func TestConditionalProcedureRetainsCallerAndBodyCalls(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`#If VBA7 Then
+Public Function ConditionalRun() As Long
+    ConditionalRun = TargetCall(1)
+End Function
+#End If
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Procedures) != 1 {
+		t.Fatalf("conditional procedures = %d: %+v", len(doc.Procedures), doc.Procedures)
+	}
+	procedure := doc.Procedures[0]
+	if procedure.Symbol.Name != "ConditionalRun" || len(procedure.Calls) != 1 {
+		t.Fatalf("conditional procedure facts lost: %+v", procedure)
+	}
+	if procedure.Calls[0].Caller.Name != "ConditionalRun" ||
+		procedure.Calls[0].Caller.QualifiedName != "Module1.ConditionalRun" {
+		t.Fatalf("conditional caller metadata = %+v", procedure.Calls[0].Caller)
+	}
+}
+
+func TestCloneIsDeep(t *testing.T) {
+	t.Parallel()
+	source, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte("Public Sub Run(ByVal x As Long)\nCall Foo(x)\nEnd Sub\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	clone := Clone(source)
+	clone.Procedures[0].Symbol.Parameters[0].Name = "changed"
+	clone.Procedures[0].Statements[0].ExpressionIDs = append(clone.Procedures[0].Statements[0].ExpressionIDs, 999)
+	clone.Procedures[0].Calls[0].Callee.Text = "changed"
+	if source.Procedures[0].Symbol.Parameters[0].Name == "changed" ||
+		source.Procedures[0].Calls[0].Callee.Text == "changed" {
+		t.Fatal("Clone shares mutable storage")
+	}
+}
+
+func TestBuildParsedClosedDocument(t *testing.T) {
+	t.Parallel()
+	doc, err := vbaast.ParseDocument("Module1.bas", []byte("Sub Run()\nEnd Sub\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc.Close()
+	_, err = BuildParsed(BuildOptions{}, doc)
+	if !errors.Is(err, vbaast.ErrParsedDocumentClosed) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func requireStatementKind(t *testing.T, statements []Statement, want StatementKind) {
+	t.Helper()
+	for _, statement := range statements {
+		if statement.Kind == want {
+			return
+		}
+	}
+	t.Fatalf("missing statement kind %q in %#v", want, statements)
+}
+
+func assertAccess(t *testing.T, accesses []VariableAccess, name string, scope SymbolScope, mode AccessMode) {
+	t.Helper()
+	for _, access := range accesses {
+		if strings.EqualFold(access.Name, name) && access.Scope == scope && access.Mode == mode {
+			return
+		}
+	}
+	t.Fatalf("missing access %s/%s/%s in %#v", name, scope, mode, accesses)
+}
+
+func assertTypeReference(t *testing.T, refs []TypeReference, kind, target string) {
+	t.Helper()
+	for _, ref := range refs {
+		if ref.Kind == kind && strings.EqualFold(ref.Target, target) {
+			return
+		}
+	}
+	t.Fatalf("missing type reference %s/%s in %#v", kind, target, refs)
+}
+
+func hasRecoveredStatement(statements []Statement) bool {
+	for _, statement := range statements {
+		if statement.Recovered {
+			return true
+		}
+	}
+	return false
+}
+
+func containsTreeSitterType(typ reflect.Type, visited map[reflect.Type]bool) bool {
+	if typ == nil || visited[typ] {
+		return false
+	}
+	visited[typ] = true
+	treeSitterNode := reflect.TypeOf(tree_sitter.Node{})
+	treeSitterTree := reflect.TypeOf(tree_sitter.Tree{})
+	if typ == treeSitterNode || typ == treeSitterTree {
+		return true
+	}
+	switch typ.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Array:
+		return containsTreeSitterType(typ.Elem(), visited)
+	case reflect.Map:
+		return containsTreeSitterType(typ.Key(), visited) || containsTreeSitterType(typ.Elem(), visited)
+	case reflect.Struct:
+		for i := 0; i < typ.NumField(); i++ {
+			if containsTreeSitterType(typ.Field(i).Type, visited) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/vba/procedureir/clone.go
+++ b/internal/vba/procedureir/clone.go
@@ -1,0 +1,84 @@
+package procedureir
+
+func Clone(in DocumentIR) DocumentIR {
+	out := in
+	out.Declarations = append([]Declaration(nil), in.Declarations...)
+	out.TypeReferences = make([]TypeReference, len(in.TypeReferences))
+	for i := range in.TypeReferences {
+		out.TypeReferences[i] = in.TypeReferences[i]
+		if in.TypeReferences[i].Caller != nil {
+			caller := *in.TypeReferences[i].Caller
+			out.TypeReferences[i].Caller = &caller
+		}
+	}
+	out.Procedures = make([]ProcedureIR, len(in.Procedures))
+	for i := range in.Procedures {
+		out.Procedures[i] = cloneProcedure(in.Procedures[i])
+	}
+	return out
+}
+
+// CloneDocumentIR is the explicit-name form of Clone.
+func CloneDocumentIR(in DocumentIR) DocumentIR {
+	return Clone(in)
+}
+
+// CloneProcedureIR returns a deep copy of one procedure.
+func CloneProcedureIR(in ProcedureIR) ProcedureIR {
+	return cloneProcedure(in)
+}
+
+// CloneCallSite returns a deep copy of one call site.
+func CloneCallSite(in CallSite) CallSite {
+	return cloneCall(in)
+}
+
+func cloneProcedure(in ProcedureIR) ProcedureIR {
+	out := in
+	out.Symbol.Parameters = append([]Parameter(nil), in.Symbol.Parameters...)
+	out.Declarations = append([]Declaration(nil), in.Declarations...)
+	out.Statements = make([]Statement, len(in.Statements))
+	for i := range in.Statements {
+		out.Statements[i] = in.Statements[i]
+		out.Statements[i].ExpressionIDs = append([]int(nil), in.Statements[i].ExpressionIDs...)
+		out.Statements[i].Target = cloneExpressionPointer(in.Statements[i].Target)
+		out.Statements[i].Value = cloneExpressionPointer(in.Statements[i].Value)
+		out.Statements[i].Condition = cloneExpressionPointer(in.Statements[i].Condition)
+	}
+	out.Expressions = make([]Expression, len(in.Expressions))
+	for i := range in.Expressions {
+		out.Expressions[i] = in.Expressions[i]
+		out.Expressions[i].Children = append([]int(nil), in.Expressions[i].Children...)
+	}
+	out.Calls = make([]CallSite, len(in.Calls))
+	for i := range in.Calls {
+		out.Calls[i] = cloneCall(in.Calls[i])
+	}
+	out.Accesses = make([]VariableAccess, len(in.Accesses))
+	for i := range in.Accesses {
+		out.Accesses[i] = in.Accesses[i]
+		out.Accesses[i].Resolution.Candidates = append([]Candidate(nil), in.Accesses[i].Resolution.Candidates...)
+	}
+	return out
+}
+
+func cloneExpressionPointer(in *Expression) *Expression {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.Children = append([]int(nil), in.Children...)
+	return &out
+}
+
+func cloneCall(in CallSite) CallSite {
+	out := in
+	if in.Callee.Receiver != nil {
+		receiver := *in.Callee.Receiver
+		out.Callee.Receiver = &receiver
+	}
+	out.Arguments.Named = append([]NamedArgument(nil), in.Arguments.Named...)
+	out.Arguments.ExpressionIDs = append([]int(nil), in.Arguments.ExpressionIDs...)
+	out.Resolution.Candidates = append([]Candidate(nil), in.Resolution.Candidates...)
+	return out
+}

--- a/internal/vba/procedureir/resolver.go
+++ b/internal/vba/procedureir/resolver.go
@@ -1,0 +1,269 @@
+package procedureir
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Resolve returns a deep copy with project-dependent call and symbol
+// resolutions applied. Syntax-local parameter/local/module scopes are kept.
+func Resolve(in DocumentIR, resolver Resolver) DocumentIR {
+	out := Clone(in)
+	if resolver == nil {
+		return out
+	}
+	for procedureIndex := range out.Procedures {
+		procedure := &out.Procedures[procedureIndex]
+		for callIndex := range procedure.Calls {
+			call := &procedure.Calls[callIndex]
+			call.Resolution = cloneCallResolution(resolver.ResolveCall(cloneCall(*call)))
+		}
+		for accessIndex := range procedure.Accesses {
+			access := &procedure.Accesses[accessIndex]
+			if access.Scope != ScopeUnresolved && access.Scope != ScopeProject {
+				access.Resolution = SymbolResolution{Scope: access.Scope}
+				continue
+			}
+			resolution := resolver.ResolveSymbol(SymbolReference{
+				Name: access.Name, Module: out.ModuleName,
+				Caller: ProcedureRef{
+					Name: procedure.Symbol.Name, Kind: procedure.Symbol.Kind,
+					QualifiedName: procedure.Symbol.QualifiedName,
+				},
+				Range: access.Range,
+			})
+			access.Resolution = cloneSymbolResolution(resolution)
+			access.Scope = resolution.Scope
+			if access.Scope == "" {
+				access.Scope = ScopeUnresolved
+				access.Resolution.Scope = ScopeUnresolved
+			}
+		}
+	}
+	return out
+}
+
+func cloneCallResolution(in CallResolution) CallResolution {
+	in.Candidates = append([]Candidate(nil), in.Candidates...)
+	return in
+}
+
+func cloneSymbolResolution(in SymbolResolution) SymbolResolution {
+	in.Candidates = append([]Candidate(nil), in.Candidates...)
+	return in
+}
+
+type resolverEntry struct {
+	Candidate
+	module     string
+	visibility string
+}
+
+// SymbolResolver is a deterministic protocol-neutral project resolver.
+type SymbolResolver struct {
+	byName map[string][]resolverEntry
+}
+
+func NewSymbolResolver(symbols []ResolverSymbol) SymbolResolver {
+	out := SymbolResolver{byName: map[string][]resolverEntry{}}
+	for _, symbol := range symbols {
+		if strings.TrimSpace(symbol.Name) == "" {
+			continue
+		}
+		qualified := symbol.Name
+		if symbol.Module != "" {
+			qualified = symbol.Module + "." + symbol.Name
+		}
+		entry := resolverEntry{
+			Candidate: Candidate{
+				QualifiedName: qualified, Kind: symbol.Kind,
+				File: normalizeCandidateFile(symbol.File), Line: symbol.Line,
+			},
+			module: symbol.Module, visibility: symbol.Visibility,
+		}
+		key := strings.ToLower(cleanIdentifier(symbol.Name))
+		out.byName[key] = append(out.byName[key], entry)
+	}
+	for key := range out.byName {
+		sort.Slice(out.byName[key], func(i, j int) bool {
+			a, b := out.byName[key][i], out.byName[key][j]
+			if a.QualifiedName != b.QualifiedName {
+				return a.QualifiedName < b.QualifiedName
+			}
+			if a.Kind != b.Kind {
+				return a.Kind < b.Kind
+			}
+			if a.File != b.File {
+				return a.File < b.File
+			}
+			return a.Line < b.Line
+		})
+	}
+	return out
+}
+
+// NewResolver creates the default resolver backed by project symbols.
+func NewResolver(symbols []ResolverSymbol) SymbolResolver {
+	return NewSymbolResolver(symbols)
+}
+
+func (r SymbolResolver) ResolveCall(site CallSite) CallResolution {
+	base := cleanIdentifier(strings.TrimPrefix(site.Callee.BaseName, "New "))
+	entries := r.visible(r.byName[strings.ToLower(base)], callerModule(site.Caller))
+	procedures := make([]resolverEntry, 0, len(entries))
+	for _, entry := range entries {
+		if isProcedureSymbolKind(entry.Kind) {
+			procedures = append(procedures, entry)
+		}
+	}
+	if site.Callee.Receiver != nil {
+		receiver := cleanQualifiedName(*site.Callee.Receiver)
+		if isExternalLikeReceiver(receiver) {
+			return CallResolution{Status: ResolutionExternal}
+		}
+		matches := receiverMatches(procedures, receiver, base)
+		switch len(matches) {
+		case 1:
+			return CallResolution{Status: ResolutionMatched, Candidates: entriesToCandidates(matches)}
+		case 0:
+			return CallResolution{Status: ResolutionMemberCall}
+		default:
+			return CallResolution{Status: ResolutionAmbiguous, Candidates: entriesToCandidates(matches)}
+		}
+	}
+	switch len(procedures) {
+	case 1:
+		return CallResolution{Status: ResolutionMatched, Candidates: entriesToCandidates(procedures)}
+	default:
+		if len(procedures) > 1 {
+			return CallResolution{Status: ResolutionAmbiguous, Candidates: entriesToCandidates(procedures)}
+		}
+	}
+	textKey := strings.ToLower(strings.TrimPrefix(site.Callee.Text, "New "))
+	if builtinLikeNames[textKey] || builtinLikeNames[strings.ToLower(base)] {
+		return CallResolution{Status: ResolutionBuiltinLike}
+	}
+	return CallResolution{Status: ResolutionUnresolved}
+}
+
+func (r SymbolResolver) ResolveSymbol(ref SymbolReference) SymbolResolution {
+	entries := r.visible(r.byName[strings.ToLower(cleanIdentifier(ref.Name))], callerModule(ref.Caller))
+	var candidates []Candidate
+	for _, entry := range entries {
+		if isProcedureSymbolKind(entry.Kind) || strings.EqualFold(entry.Kind, "module") {
+			continue
+		}
+		candidates = append(candidates, entry.Candidate)
+	}
+	if len(candidates) == 0 {
+		return SymbolResolution{Scope: ScopeUnresolved}
+	}
+	return SymbolResolution{Scope: ScopeProject, Candidates: candidates}
+}
+
+func (r SymbolResolver) visible(entries []resolverEntry, callerModule string) []resolverEntry {
+	out := make([]resolverEntry, 0, len(entries))
+	for _, entry := range entries {
+		if symbolIsPrivate(entry) && !strings.EqualFold(entry.module, callerModule) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func symbolIsPrivate(entry resolverEntry) bool {
+	if strings.EqualFold(entry.visibility, "private") {
+		return true
+	}
+	if strings.TrimSpace(entry.visibility) != "" {
+		return false
+	}
+	switch strings.ToLower(entry.Kind) {
+	case "variable", "module_variable", "field", "withevents_field", "const", "constant":
+		return true
+	default:
+		return false
+	}
+}
+
+func callerModule(caller ProcedureRef) string {
+	if index := strings.LastIndex(strings.TrimSpace(caller.QualifiedName), "."); index > 0 {
+		return caller.QualifiedName[:index]
+	}
+	return ""
+}
+
+func receiverMatches(entries []resolverEntry, receiver, base string) []resolverEntry {
+	qualified := strings.ToLower(receiver + "." + base)
+	shortQualified := strings.ToLower(cleanIdentifier(lastNamePart(receiver)) + "." + base)
+	out := make([]resolverEntry, 0, len(entries))
+	for _, entry := range entries {
+		name := strings.ToLower(entry.QualifiedName)
+		if name == qualified || name == shortQualified {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func entriesToCandidates(entries []resolverEntry) []Candidate {
+	out := make([]Candidate, len(entries))
+	for i := range entries {
+		out[i] = entries[i].Candidate
+	}
+	return out
+}
+
+func isProcedureSymbolKind(kind string) bool {
+	switch strings.ToLower(kind) {
+	case "sub", "function", "property", "property_get", "property_let", "property_set",
+		"declare", "declare_sub", "declare_function", "event":
+		return true
+	default:
+		return false
+	}
+}
+
+func cleanQualifiedName(text string) string {
+	parts := strings.FieldsFunc(strings.TrimSpace(text), func(r rune) bool { return r == '.' || r == '!' })
+	cleaned := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = cleanIdentifier(part); part != "" {
+			cleaned = append(cleaned, part)
+		}
+	}
+	return strings.Join(cleaned, ".")
+}
+
+func isExternalLikeReceiver(receiver string) bool {
+	for _, part := range strings.Split(receiver, ".") {
+		switch strings.ToLower(cleanIdentifier(part)) {
+		case "application", "debug", "excel", "worksheetfunction":
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeCandidateFile(file string) string {
+	if strings.TrimSpace(file) == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(file))
+}
+
+var builtinLikeNames = map[string]bool{
+	"array": true, "asc": true, "cbool": true, "cbyte": true, "ccur": true,
+	"cdate": true, "cdbl": true, "cdec": true, "choose": true, "chr": true,
+	"cint": true, "clng": true, "clnglng": true, "clngptr": true, "cos": true,
+	"createobject": true, "cstr": true, "date": true, "dateadd": true,
+	"debug.print": true, "dir": true, "doevents": true, "environ": true,
+	"format": true, "getobject": true, "inputbox": true, "instr": true,
+	"isarray": true, "isdate": true, "isempty": true, "iserror": true,
+	"isnull": true, "isnumeric": true, "join": true, "lbound": true,
+	"lcase": true, "left": true, "len": true, "mid": true, "msgbox": true,
+	"replace": true, "right": true, "rnd": true, "split": true, "str": true,
+	"trim": true, "typename": true, "ubound": true, "ucase": true, "val": true,
+}

--- a/internal/vba/procedureir/types.go
+++ b/internal/vba/procedureir/types.go
@@ -1,0 +1,284 @@
+// Package procedureir normalizes VBA procedure syntax into protocol-neutral
+// Go values. Values returned by this package never retain tree-sitter nodes or
+// source byte slices.
+package procedureir
+
+import vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+
+type BuildOptions struct {
+	RootDir    string
+	Path       string
+	ModuleName string
+	ModuleKind string
+}
+
+type ParseSummary struct {
+	HasError   bool `json:"hasError"`
+	HasMissing bool `json:"hasMissing"`
+}
+
+type DocumentIR struct {
+	Path           string          `json:"path"`
+	ModuleName     string          `json:"moduleName"`
+	ModuleKind     string          `json:"moduleKind"`
+	Parse          ParseSummary    `json:"parse"`
+	Declarations   []Declaration   `json:"declarations"`
+	Procedures     []ProcedureIR   `json:"procedures"`
+	TypeReferences []TypeReference `json:"-"`
+}
+
+type ProcedureIR struct {
+	Symbol       ProcedureSymbol  `json:"symbol"`
+	Declarations []Declaration    `json:"declarations"`
+	Statements   []Statement      `json:"statements"`
+	Expressions  []Expression     `json:"expressions"`
+	Calls        []CallSite       `json:"calls"`
+	Accesses     []VariableAccess `json:"accesses"`
+}
+
+type ProcedureKind string
+
+const (
+	ProcedureSub         ProcedureKind = "sub"
+	ProcedureFunction    ProcedureKind = "function"
+	ProcedureProperty    ProcedureKind = "property"
+	ProcedurePropertyGet ProcedureKind = "property_get"
+	ProcedurePropertyLet ProcedureKind = "property_let"
+	ProcedurePropertySet ProcedureKind = "property_set"
+)
+
+type ProcedureSymbol struct {
+	Name             string        `json:"name"`
+	QualifiedName    string        `json:"qualifiedName"`
+	Kind             ProcedureKind `json:"kind"`
+	Visibility       string        `json:"visibility,omitempty"`
+	Parameters       []Parameter   `json:"parameters"`
+	ReturnType       string        `json:"returnType,omitempty"`
+	DeclarationRange vbaast.Range  `json:"declarationRange"`
+	BodyRange        vbaast.Range  `json:"bodyRange"`
+	IsEventHandler   bool          `json:"isEventHandler"`
+	EventKind        string        `json:"eventKind,omitempty"`
+	Recovered        bool          `json:"recovered,omitempty"`
+}
+
+type Parameter struct {
+	Name       string       `json:"name"`
+	Type       string       `json:"type,omitempty"`
+	Passing    string       `json:"passing,omitempty"`
+	Optional   bool         `json:"optional,omitempty"`
+	ParamArray bool         `json:"paramArray,omitempty"`
+	Default    string       `json:"default,omitempty"`
+	Range      vbaast.Range `json:"range"`
+}
+
+type Declaration struct {
+	ID         int          `json:"id"`
+	Name       string       `json:"name"`
+	Type       string       `json:"type,omitempty"`
+	Scope      SymbolScope  `json:"scope"`
+	Visibility string       `json:"visibility,omitempty"`
+	Kind       string       `json:"kind"`
+	IsArray    bool         `json:"isArray,omitempty"`
+	IsObject   bool         `json:"isObject,omitempty"`
+	Range      vbaast.Range `json:"range"`
+	Recovered  bool         `json:"recovered,omitempty"`
+}
+
+type StatementKind string
+
+const (
+	StatementDeclaration StatementKind = "declaration"
+	StatementAssignment  StatementKind = "assignment"
+	StatementSet         StatementKind = "set_assignment"
+	StatementCall        StatementKind = "call"
+	StatementIf          StatementKind = "if"
+	StatementElseIf      StatementKind = "elseif"
+	StatementElse        StatementKind = "else"
+	StatementSelect      StatementKind = "select"
+	StatementCase        StatementKind = "case"
+	StatementFor         StatementKind = "for"
+	StatementForEach     StatementKind = "for_each"
+	StatementDo          StatementKind = "do"
+	StatementWhile       StatementKind = "while"
+	StatementWith        StatementKind = "with"
+	StatementReDim       StatementKind = "redim"
+	StatementExit        StatementKind = "exit"
+	StatementLabel       StatementKind = "label"
+	StatementGoTo        StatementKind = "goto"
+	StatementOnError     StatementKind = "on_error"
+	StatementResume      StatementKind = "resume"
+	StatementUnknown     StatementKind = "unknown"
+	StatementRecovered   StatementKind = "recovered"
+)
+
+type Statement struct {
+	ID            int           `json:"id"`
+	ParentID      int           `json:"parentId,omitempty"`
+	Kind          StatementKind `json:"kind"`
+	SyntaxKind    string        `json:"syntaxKind"`
+	Text          string        `json:"text"`
+	Range         vbaast.Range  `json:"range"`
+	Recovered     bool          `json:"recovered,omitempty"`
+	Label         string        `json:"label,omitempty"`
+	Target        *Expression   `json:"target,omitempty"`
+	Value         *Expression   `json:"value,omitempty"`
+	Condition     *Expression   `json:"condition,omitempty"`
+	TargetID      int           `json:"targetId,omitempty"`
+	ValueID       int           `json:"valueId,omitempty"`
+	ConditionID   int           `json:"conditionId,omitempty"`
+	ExpressionIDs []int         `json:"expressionIds,omitempty"`
+}
+
+type ExpressionKind string
+
+const (
+	ExpressionIdentifier  ExpressionKind = "identifier"
+	ExpressionLiteral     ExpressionKind = "literal"
+	ExpressionMember      ExpressionKind = "member_access"
+	ExpressionCall        ExpressionKind = "call"
+	ExpressionNew         ExpressionKind = "new"
+	ExpressionUnary       ExpressionKind = "unary"
+	ExpressionBinary      ExpressionKind = "binary"
+	ExpressionParentheses ExpressionKind = "parenthesized"
+	ExpressionUnknown     ExpressionKind = "unknown"
+)
+
+type Expression struct {
+	ID          int            `json:"id"`
+	ParentID    int            `json:"parentId,omitempty"`
+	StatementID int            `json:"statementId,omitempty"`
+	Kind        ExpressionKind `json:"kind"`
+	SyntaxKind  string         `json:"syntaxKind"`
+	Text        string         `json:"text"`
+	Range       vbaast.Range   `json:"range"`
+	Children    []int          `json:"children,omitempty"`
+	Recovered   bool           `json:"recovered,omitempty"`
+}
+
+type AccessMode string
+
+const (
+	AccessRead      AccessMode = "read"
+	AccessWrite     AccessMode = "write"
+	AccessReadWrite AccessMode = "read_write"
+)
+
+type SymbolScope string
+
+const (
+	ScopeParameter  SymbolScope = "parameter"
+	ScopeLocal      SymbolScope = "local"
+	ScopeModule     SymbolScope = "module"
+	ScopeProject    SymbolScope = "project"
+	ScopeUnresolved SymbolScope = "unresolved"
+)
+
+type VariableAccess struct {
+	Name         string           `json:"name"`
+	Mode         AccessMode       `json:"mode"`
+	Scope        SymbolScope      `json:"scope"`
+	Range        vbaast.Range     `json:"range"`
+	StatementID  int              `json:"statementId,omitempty"`
+	ExpressionID int              `json:"expressionId,omitempty"`
+	Resolution   SymbolResolution `json:"resolution"`
+}
+
+type Callee struct {
+	Text     string  `json:"text"`
+	BaseName string  `json:"baseName"`
+	Receiver *string `json:"receiver,omitempty"`
+	Member   string  `json:"member"`
+}
+
+type Arguments struct {
+	Count         int             `json:"count"`
+	Named         []NamedArgument `json:"named"`
+	ExpressionIDs []int           `json:"-"`
+}
+
+type NamedArgument struct {
+	Name         string `json:"name"`
+	ValueText    string `json:"valueText"`
+	ExpressionID int    `json:"-"`
+}
+
+type CallSite struct {
+	ID           int            `json:"id"`
+	File         string         `json:"file"`
+	Module       string         `json:"module"`
+	Caller       ProcedureRef   `json:"caller"`
+	Callee       Callee         `json:"callee"`
+	Arguments    Arguments      `json:"arguments"`
+	Range        vbaast.Range   `json:"range"`
+	StatementID  int            `json:"statementId,omitempty"`
+	ExpressionID int            `json:"expressionId,omitempty"`
+	Resolution   CallResolution `json:"resolution"`
+}
+
+type ProcedureRef struct {
+	Name          string        `json:"name"`
+	Kind          ProcedureKind `json:"kind"`
+	QualifiedName string        `json:"qualifiedName"`
+}
+
+type ResolutionStatus string
+
+const (
+	ResolutionNotAttempted ResolutionStatus = "not_attempted"
+	ResolutionMatched      ResolutionStatus = "matched"
+	ResolutionAmbiguous    ResolutionStatus = "ambiguous"
+	ResolutionUnresolved   ResolutionStatus = "unresolved"
+	ResolutionExternal     ResolutionStatus = "external"
+	ResolutionBuiltinLike  ResolutionStatus = "builtin_like"
+	ResolutionMemberCall   ResolutionStatus = "member_call"
+)
+
+type Candidate struct {
+	QualifiedName string `json:"qualifiedName"`
+	Kind          string `json:"kind"`
+	File          string `json:"file"`
+	Line          int    `json:"line"`
+}
+
+type CallResolution struct {
+	Status     ResolutionStatus `json:"status"`
+	Candidates []Candidate      `json:"candidates,omitempty"`
+}
+
+type SymbolReference struct {
+	Name   string
+	Module string
+	Caller ProcedureRef
+	Range  vbaast.Range
+}
+
+type SymbolResolution struct {
+	Scope      SymbolScope `json:"scope"`
+	Candidates []Candidate `json:"candidates,omitempty"`
+}
+
+// Resolver provides project-dependent overlays. Implementations must be safe
+// to call repeatedly; Resolve never mutates either its input or the resolver.
+type Resolver interface {
+	ResolveCall(CallSite) CallResolution
+	ResolveSymbol(SymbolReference) SymbolResolution
+}
+
+type ResolverSymbol struct {
+	Name       string
+	Module     string
+	Kind       string
+	Visibility string
+	File       string
+	Line       int
+}
+
+type TypeReference struct {
+	Kind   string        `json:"kind"`
+	File   string        `json:"file"`
+	Module string        `json:"module"`
+	Caller *ProcedureRef `json:"caller,omitempty"`
+	Target string        `json:"target"`
+	Range  vbaast.Range  `json:"range"`
+	Parse  ParseSummary  `json:"parse"`
+}

--- a/internal/vba/procedureir/visitor.go
+++ b/internal/vba/procedureir/visitor.go
@@ -1,0 +1,634 @@
+package procedureir
+
+import (
+	"sort"
+	"strings"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type visitContext struct {
+	procedure    int
+	statementID  int
+	parentExprID int
+	metadata     bool
+	accessMode   AccessMode
+	callIndex    int
+	suppressCall bool
+	inBody       bool
+}
+
+type argumentFact struct {
+	rng        vbaast.Range
+	name       string
+	valueText  string
+	valueRange vbaast.Range
+}
+
+type callFact struct {
+	arguments []argumentFact
+}
+
+type singleVisitor struct {
+	builder     *documentBuilder
+	document    DocumentIR
+	callFacts   [][]callFact
+	moduleScope map[string]SymbolScope
+}
+
+func (b *documentBuilder) buildSinglePass(root *tree_sitter.Node) DocumentIR {
+	v := singleVisitor{
+		builder: b,
+		document: DocumentIR{
+			Path: b.file, ModuleName: b.moduleName, ModuleKind: b.moduleKind, Parse: b.parse,
+			Declarations: []Declaration{}, Procedures: []ProcedureIR{}, TypeReferences: []TypeReference{},
+		},
+		moduleScope: map[string]SymbolScope{},
+	}
+	if root != nil {
+		v.visit(root, visitContext{procedure: -1, callIndex: -1})
+	}
+	v.finalize()
+	return v.document
+}
+
+func (v *singleVisitor) visit(node *tree_sitter.Node, ctx visitContext) {
+	if node == nil {
+		return
+	}
+
+	if isProcedureNode(node.Kind()) {
+		ctx = v.enterProcedure(node)
+	}
+	procedure := v.procedure(ctx.procedure)
+
+	if node.Kind() == "variable_declaration" || node.Kind() == "const_declaration" {
+		scope := ScopeModule
+		if procedure != nil && ctx.inBody {
+			scope = ScopeLocal
+		}
+		declarations := v.builder.declarations(node, scope)
+		if procedure == nil {
+			v.document.Declarations = append(v.document.Declarations, declarations...)
+		} else if ctx.inBody {
+			procedure.Declarations = append(procedure.Declarations, declarations...)
+		}
+	}
+	if procedure == nil {
+		switch node.Kind() {
+		case "declare_statement", "declare_sub_statement", "declare_function_statement", "event_statement", "event_declaration":
+			if declaration, ok := v.builder.simpleDeclaration(node, ScopeModule); ok {
+				v.document.Declarations = append(v.document.Declarations, declaration)
+			}
+		}
+	}
+
+	v.addTypeReference(node, ctx)
+	if procedure != nil && ctx.inBody {
+		if kind, ok := statementKind(node); ok {
+			ctx.statementID = v.addStatement(procedure, node, ctx.statementID, kind)
+		}
+		if isExpressionNode(node.Kind()) {
+			ctx.parentExprID = v.addExpression(procedure, node, ctx)
+		}
+		ctx.callIndex = v.addCall(procedure, node, ctx)
+		if node.Kind() == "identifier" && !ctx.metadata {
+			v.addAccess(procedure, node, ctx)
+		}
+	}
+
+	if node.Kind() == "block" && procedure != nil {
+		v.visitBlock(node, ctx)
+		return
+	}
+	if node.Kind() == "argument_list" && procedure != nil && ctx.callIndex >= 0 {
+		v.visitArgumentList(node, ctx)
+		return
+	}
+	if node.Kind() == "named_argument" && procedure != nil && ctx.callIndex >= 0 {
+		v.visitNamedArgument(node, ctx)
+		return
+	}
+
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		childCtx := v.childContext(node, child, ctx)
+		v.visit(child, childCtx)
+	}
+}
+
+func (v *singleVisitor) enterProcedure(node *tree_sitter.Node) visitContext {
+	symbol := v.builder.procedureSymbol(node)
+	procedure := ProcedureIR{
+		Symbol: symbol, Declarations: []Declaration{}, Statements: []Statement{},
+		Expressions: []Expression{}, Calls: []CallSite{}, Accesses: []VariableAccess{},
+	}
+	for _, parameter := range symbol.Parameters {
+		procedure.Declarations = append(procedure.Declarations, Declaration{
+			ID: v.builder.takeDeclarationID(), Name: parameter.Name, Type: parameter.Type,
+			Scope: ScopeParameter, Kind: "parameter", Range: parameter.Range,
+		})
+	}
+	if symbol.Kind == ProcedureFunction || symbol.Kind == ProcedurePropertyGet || symbol.Kind == ProcedureProperty {
+		nameRange := symbol.DeclarationRange
+		if name := node.ChildByFieldName("name"); name != nil {
+			nameRange = vbaast.NodeRange(name)
+		}
+		procedure.Declarations = append(procedure.Declarations, Declaration{
+			ID: v.builder.takeDeclarationID(), Name: symbol.Name, Type: symbol.ReturnType,
+			Scope: ScopeLocal, Kind: "return_slot", Range: nameRange,
+		})
+	}
+	v.document.Procedures = append(v.document.Procedures, procedure)
+	v.callFacts = append(v.callFacts, []callFact{})
+	return visitContext{procedure: len(v.document.Procedures) - 1, callIndex: -1}
+}
+
+func (v *singleVisitor) procedure(index int) *ProcedureIR {
+	if index < 0 || index >= len(v.document.Procedures) {
+		return nil
+	}
+	return &v.document.Procedures[index]
+}
+
+func (v *singleVisitor) addStatement(procedure *ProcedureIR, node *tree_sitter.Node, parentID int, kind StatementKind) int {
+	id := len(procedure.Statements) + 1
+	statement := Statement{
+		ID: id, ParentID: parentID, Kind: kind, SyntaxKind: node.Kind(),
+		Text: nodeText(node, v.builder.source), Range: vbaast.NodeRange(node), Recovered: recovered(node),
+	}
+	if statement.Recovered && kind == StatementUnknown {
+		statement.Kind = StatementRecovered
+	}
+	switch statement.Kind {
+	case StatementLabel, StatementGoTo, StatementOnError, StatementResume, StatementExit:
+		statement.Label = statementOperand(statement.Text, statement.Kind)
+	}
+	procedure.Statements = append(procedure.Statements, statement)
+	return id
+}
+
+func (v *singleVisitor) addExpression(procedure *ProcedureIR, node *tree_sitter.Node, ctx visitContext) int {
+	id := len(procedure.Expressions) + 1
+	expression := Expression{
+		ID: id, ParentID: ctx.parentExprID, StatementID: ctx.statementID,
+		Kind: expressionKind(node.Kind()), SyntaxKind: node.Kind(), Text: nodeText(node, v.builder.source),
+		Range: vbaast.NodeRange(node), Recovered: recovered(node),
+	}
+	procedure.Expressions = append(procedure.Expressions, expression)
+	if ctx.parentExprID > 0 {
+		if parent := expressionByID(procedure, ctx.parentExprID); parent != nil {
+			parent.Children = append(parent.Children, id)
+		}
+	} else if statement := statementByID(procedure, ctx.statementID); statement != nil {
+		statement.ExpressionIDs = append(statement.ExpressionIDs, id)
+	}
+	if statement := statementByID(procedure, ctx.statementID); statement != nil {
+		v.linkStatementExpression(statement, node, expression)
+	}
+	return id
+}
+
+func (v *singleVisitor) linkStatementExpression(statement *Statement, node *tree_sitter.Node, expression Expression) {
+	rng := vbaast.NodeRange(node)
+	if statement.Target != nil && sameRange(statement.Target.Range, rng) {
+		statement.TargetID = expression.ID
+	}
+	if statement.Value != nil && sameRange(statement.Value.Range, rng) {
+		statement.ValueID = expression.ID
+	}
+	if statement.Condition != nil && sameRange(statement.Condition.Range, rng) {
+		statement.ConditionID = expression.ID
+	}
+}
+
+func (v *singleVisitor) addCall(procedure *ProcedureIR, node *tree_sitter.Node, ctx visitContext) int {
+	if ctx.suppressCall {
+		return ctx.callIndex
+	}
+	field := ""
+	switch node.Kind() {
+	case "call_statement":
+		field = "callee"
+	case "call_expression":
+		field = "function"
+	case "new_expression":
+		target := node.ChildByFieldName("type")
+		if target == nil {
+			return ctx.callIndex
+		}
+		callee := calleeFromNode(target, v.builder.source)
+		callee.Text = "New " + callee.Text
+		return v.appendCall(procedure, node, callee, ctx)
+	default:
+		return ctx.callIndex
+	}
+	target := node.ChildByFieldName(field)
+	if target == nil && node.Kind() == "call_statement" {
+		target = firstNamedChild(node)
+	}
+	if target == nil {
+		return ctx.callIndex
+	}
+	if target.Kind() == "call_expression" {
+		if function := target.ChildByFieldName("function"); function != nil {
+			target = function
+		}
+	}
+	callee := calleeFromNode(target, v.builder.source)
+	if callee.Text == "" {
+		return ctx.callIndex
+	}
+	return v.appendCall(procedure, node, callee, ctx)
+}
+
+func (v *singleVisitor) appendCall(procedure *ProcedureIR, node *tree_sitter.Node, callee Callee, ctx visitContext) int {
+	expressionID := 0
+	if node.Kind() == "call_expression" || node.Kind() == "new_expression" {
+		expressionID = ctx.parentExprID
+	}
+	arguments, facts := v.argumentsForCall(node)
+	procedure.Calls = append(procedure.Calls, CallSite{
+		ID: len(procedure.Calls) + 1, File: v.builder.file, Module: v.builder.moduleName,
+		Caller: ProcedureRef{Name: procedure.Symbol.Name, Kind: procedure.Symbol.Kind, QualifiedName: procedure.Symbol.QualifiedName},
+		Callee: callee, Arguments: arguments,
+		Range: vbaast.NodeRange(node), StatementID: ctx.statementID, ExpressionID: expressionID,
+		Resolution: CallResolution{Status: ResolutionNotAttempted},
+	})
+	procedureIndex := len(v.document.Procedures) - 1
+	v.callFacts[procedureIndex] = append(v.callFacts[procedureIndex], callFact{arguments: facts})
+	return len(procedure.Calls) - 1
+}
+
+func (v *singleVisitor) argumentsForCall(node *tree_sitter.Node) (Arguments, []argumentFact) {
+	target := node.ChildByFieldName("function")
+	if node.Kind() == "call_statement" {
+		target = node.ChildByFieldName("callee")
+	}
+	arguments := argumentsFromCallNode(node, target, v.builder.source)
+	arguments.ExpressionIDs = []int{}
+	list := node.ChildByFieldName("arguments")
+	if list == nil && target != nil && target.Kind() == "call_expression" {
+		list = target.ChildByFieldName("arguments")
+	}
+	if list == nil {
+		return arguments, nil
+	}
+	facts := make([]argumentFact, 0, list.NamedChildCount())
+	for i := uint(0); i < list.NamedChildCount(); i++ {
+		child := list.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		fact := argumentFact{rng: vbaast.NodeRange(child)}
+		if child.Kind() == "named_argument" {
+			fact.name = cleanIdentifier(nodeText(child.ChildByFieldName("name"), v.builder.source))
+			if value := child.ChildByFieldName("value"); value != nil {
+				fact.valueText = nodeText(value, v.builder.source)
+				fact.valueRange = vbaast.NodeRange(value)
+			}
+		}
+		facts = append(facts, fact)
+	}
+	return arguments, facts
+}
+
+func (v *singleVisitor) addAccess(procedure *ProcedureIR, node *tree_sitter.Node, ctx visitContext) {
+	name := cleanIdentifier(nodeText(node, v.builder.source))
+	if name == "" {
+		return
+	}
+	procedure.Accesses = append(procedure.Accesses, VariableAccess{
+		Name: name, Mode: firstAccessMode(ctx.accessMode), Scope: ScopeUnresolved,
+		Range: vbaast.NodeRange(node), StatementID: ctx.statementID, ExpressionID: ctx.parentExprID,
+		Resolution: SymbolResolution{Scope: ScopeUnresolved},
+	})
+}
+
+func (v *singleVisitor) addTypeReference(node *tree_sitter.Node, ctx visitContext) {
+	kind, field := "", ""
+	switch node.Kind() {
+	case "as_type_clause":
+		kind, field = "uses_type", "type"
+	case "new_expression":
+		kind, field = "constructs", "type"
+	case "implements_statement":
+		kind, field = "implements", "name"
+	}
+	if kind == "" {
+		return
+	}
+	target := node.ChildByFieldName(field)
+	if target == nil {
+		return
+	}
+	ref := TypeReference{
+		Kind: kind, File: v.builder.file, Module: v.builder.moduleName,
+		Target: nodeText(target, v.builder.source), Range: vbaast.NodeRange(target), Parse: v.builder.parse,
+	}
+	if procedure := v.procedure(ctx.procedure); procedure != nil {
+		caller := ProcedureRef{
+			Name: procedure.Symbol.Name, Kind: procedure.Symbol.Kind, QualifiedName: procedure.Symbol.QualifiedName,
+		}
+		ref.Caller = &caller
+	}
+	v.document.TypeReferences = append(v.document.TypeReferences, ref)
+	if node.Kind() == "as_type_clause" && hasWord(nodeText(node, v.builder.source), "New") {
+		ref.Kind = "constructs"
+		v.document.TypeReferences = append(v.document.TypeReferences, ref)
+	}
+}
+
+func (v *singleVisitor) visitBlock(node *tree_sitter.Node, ctx visitContext) {
+	type ifFrame struct{ outer, ifID int }
+	activeParent := ctx.statementID
+	stack := []ifFrame{}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case "else_fragment":
+			if len(stack) == 0 {
+				continue
+			}
+			procedure := v.procedure(ctx.procedure)
+			activeParent = v.addStatement(procedure, child, stack[len(stack)-1].ifID, StatementElse)
+			continue
+		case "end_if_fragment":
+			if len(stack) > 0 {
+				activeParent = stack[len(stack)-1].outer
+				stack = stack[:len(stack)-1]
+			}
+			continue
+		}
+		childCtx := v.childContext(node, child, ctx)
+		childCtx.statementID = activeParent
+		before := len(v.procedure(ctx.procedure).Statements)
+		kind, isStatement := statementKind(child)
+		v.visit(child, childCtx)
+		if !isStatement || len(v.procedure(ctx.procedure).Statements) == before {
+			continue
+		}
+		id := before + 1
+		switch kind {
+		case StatementIf:
+			if child.Kind() != "single_line_if_statement" {
+				stack = append(stack, ifFrame{outer: activeParent, ifID: id})
+				activeParent = id
+			}
+		case StatementElseIf:
+			if len(stack) > 0 {
+				activeParent = id
+			}
+		}
+	}
+}
+
+func (v *singleVisitor) visitArgumentList(node *tree_sitter.Node, ctx visitContext) {
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		v.visit(child, v.childContext(node, child, ctx))
+	}
+}
+
+func (v *singleVisitor) visitNamedArgument(node *tree_sitter.Node, ctx visitContext) {
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		childCtx := v.childContext(node, child, ctx)
+		if sameNode(child, node.ChildByFieldName("name")) {
+			childCtx.metadata = true
+		}
+		v.visit(child, childCtx)
+	}
+}
+
+func (v *singleVisitor) childContext(parent, child *tree_sitter.Node, ctx visitContext) visitContext {
+	childCtx := ctx
+	if isExpressionNode(parent.Kind()) {
+		childCtx.parentExprID = ctx.parentExprID
+	}
+	if isDeclarationNode(parent.Kind()) || parent.Kind() == "as_type_clause" || parent.Kind() == "implements_statement" {
+		childCtx.metadata = true
+	}
+	if isProcedureNode(parent.Kind()) && child.Kind() != "block" {
+		childCtx.metadata = true
+	}
+	if isProcedureNode(parent.Kind()) && child.Kind() == "block" {
+		childCtx.inBody = true
+	}
+	switch parent.Kind() {
+	case "qualified_member_expression", "implicit_member_expression", "member_expression":
+		if sameNode(child, childByFieldNameAny(parent, "member", "property")) {
+			childCtx.metadata = true
+		}
+	case "new_expression":
+		if sameNode(child, parent.ChildByFieldName("type")) {
+			childCtx.metadata = true
+		}
+	case "named_argument":
+		if sameNode(child, parent.ChildByFieldName("name")) {
+			childCtx.metadata = true
+		}
+	case "call_expression":
+		if sameNode(child, parent.ChildByFieldName("function")) {
+			childCtx.suppressCall = true
+			if child.Kind() == "identifier" {
+				childCtx.metadata = true
+			}
+		}
+		if sameNode(child, parent.ChildByFieldName("arguments")) {
+			childCtx.suppressCall = false
+		}
+	case "call_statement":
+		if sameNode(child, parent.ChildByFieldName("callee")) {
+			childCtx.callIndex = ctx.callIndex
+			childCtx.suppressCall = child.Kind() == "call_expression"
+			if child.Kind() == "identifier" {
+				childCtx.metadata = true
+			}
+		}
+	case "redim_statement":
+		if child.Kind() == "redim_declarator" {
+			if statement := statementByID(v.procedure(ctx.procedure), ctx.statementID); statement != nil {
+				childCtx.accessMode = targetAccessMode(*statement)
+				if target := childByKind(child, "identifier"); target != nil {
+					statement.Target = expressionStub(target, ctx.statementID, v.builder.source)
+				}
+			}
+		}
+	case "redim_declarator":
+		if child.Kind() == "array_bounds" {
+			childCtx.accessMode = AccessRead
+		}
+	}
+	if statement := statementByID(v.procedure(ctx.procedure), ctx.statementID); statement != nil {
+		target := childByFieldNameAny(parent, "target", "left", "variable")
+		value := childByFieldNameAny(parent, "value", "right")
+		condition := childByFieldNameAny(parent, "condition", "test")
+		switch {
+		case sameNode(child, target):
+			childCtx.accessMode = targetAccessMode(*statement)
+			statement.Target = expressionStub(child, ctx.statementID, v.builder.source)
+		case sameNode(child, value):
+			childCtx.accessMode = AccessRead
+			statement.Value = expressionStub(child, ctx.statementID, v.builder.source)
+		case sameNode(child, condition):
+			childCtx.accessMode = AccessRead
+			statement.Condition = expressionStub(child, ctx.statementID, v.builder.source)
+		}
+	}
+	return childCtx
+}
+
+func (v *singleVisitor) finalize() {
+	sort.SliceStable(v.document.Declarations, func(i, j int) bool {
+		return v.document.Declarations[i].Range.StartByte < v.document.Declarations[j].Range.StartByte
+	})
+	for _, declaration := range v.document.Declarations {
+		v.moduleScope[strings.ToLower(declaration.Name)] = declaration.Scope
+	}
+	for procedureIndex := range v.document.Procedures {
+		procedure := &v.document.Procedures[procedureIndex]
+		scopes := map[string]SymbolScope{}
+		for name := range v.moduleScope {
+			scopes[name] = ScopeModule
+		}
+		for _, declaration := range procedure.Declarations {
+			scopes[strings.ToLower(declaration.Name)] = declaration.Scope
+		}
+		for accessIndex := range procedure.Accesses {
+			access := &procedure.Accesses[accessIndex]
+			if scope := scopes[strings.ToLower(access.Name)]; scope != "" {
+				access.Scope = scope
+				access.Resolution.Scope = scope
+			}
+		}
+		for callIndex := range procedure.Calls {
+			call := &procedure.Calls[callIndex]
+			fact := &v.callFacts[procedureIndex][callIndex]
+			if len(fact.arguments) > 0 {
+				call.Arguments.Count = len(fact.arguments)
+				call.Arguments.Named = nil
+			}
+			for _, argument := range fact.arguments {
+				expressionID := expressionIDWithin(procedure.Expressions, argument.rng)
+				call.Arguments.ExpressionIDs = append(call.Arguments.ExpressionIDs, expressionID)
+				if argument.name != "" {
+					valueID := expressionIDWithin(procedure.Expressions, argument.valueRange)
+					call.Arguments.Named = append(call.Arguments.Named, NamedArgument{
+						Name: argument.name, ValueText: argument.valueText, ExpressionID: valueID,
+					})
+				}
+			}
+			if call.ExpressionID == 0 {
+				call.ExpressionID = containingExpressionID(procedure.Expressions, call.Range)
+			}
+		}
+		for statementIndex := range procedure.Statements {
+			statement := &procedure.Statements[statementIndex]
+			statement.Target = canonicalExpression(procedure.Expressions, statement.TargetID, statement.Target)
+			statement.Value = canonicalExpression(procedure.Expressions, statement.ValueID, statement.Value)
+			statement.Condition = canonicalExpression(procedure.Expressions, statement.ConditionID, statement.Condition)
+		}
+	}
+	sort.SliceStable(v.document.Procedures, func(i, j int) bool {
+		return v.document.Procedures[i].Symbol.DeclarationRange.StartByte < v.document.Procedures[j].Symbol.DeclarationRange.StartByte
+	})
+}
+
+func statementByID(procedure *ProcedureIR, id int) *Statement {
+	if procedure == nil || id <= 0 || id > len(procedure.Statements) {
+		return nil
+	}
+	return &procedure.Statements[id-1]
+}
+
+func expressionByID(procedure *ProcedureIR, id int) *Expression {
+	if procedure == nil || id <= 0 || id > len(procedure.Expressions) {
+		return nil
+	}
+	return &procedure.Expressions[id-1]
+}
+
+func expressionStub(node *tree_sitter.Node, statementID int, source []byte) *Expression {
+	if node == nil {
+		return nil
+	}
+	return &Expression{
+		StatementID: statementID, Kind: expressionKind(node.Kind()), SyntaxKind: node.Kind(),
+		Text: nodeText(node, source), Range: vbaast.NodeRange(node), Recovered: recovered(node),
+	}
+}
+
+func canonicalExpression(expressions []Expression, id int, fallback *Expression) *Expression {
+	if id > 0 && id <= len(expressions) {
+		expression := expressions[id-1]
+		expression.Children = append([]int(nil), expression.Children...)
+		return &expression
+	}
+	return fallback
+}
+
+func expressionIDWithin(expressions []Expression, rng vbaast.Range) int {
+	if rng.EndByte <= rng.StartByte {
+		return 0
+	}
+	best, width := 0, -1
+	for _, expression := range expressions {
+		if !containsRange(rng, expression.Range) {
+			continue
+		}
+		candidate := expression.Range.EndByte - expression.Range.StartByte
+		if candidate > width {
+			best, width = expression.ID, candidate
+		}
+	}
+	return best
+}
+
+func sameRange(a, b vbaast.Range) bool {
+	return a.StartByte == b.StartByte && a.EndByte == b.EndByte
+}
+
+func firstAccessMode(mode AccessMode) AccessMode {
+	if mode == "" {
+		return AccessRead
+	}
+	return mode
+}
+
+func targetAccessMode(statement Statement) AccessMode {
+	switch statement.Kind {
+	case StatementAssignment, StatementSet, StatementForEach, StatementReDim:
+		if statement.Kind == StatementReDim && hasWord(statement.Text, "Preserve") {
+			return AccessReadWrite
+		}
+		return AccessWrite
+	case StatementFor:
+		return AccessReadWrite
+	default:
+		return AccessRead
+	}
+}
+
+func isDeclarationNode(kind string) bool {
+	switch kind {
+	case "variable_declaration", "const_declaration", "parameter", "declare_statement",
+		"declare_sub_statement", "declare_function_statement", "event_statement", "event_declaration":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/vba/procedureir/visitor.go
+++ b/internal/vba/procedureir/visitor.go
@@ -87,6 +87,9 @@ func (v *singleVisitor) visit(node *tree_sitter.Node, ctx visitContext) {
 	v.addTypeReference(node, ctx)
 	if procedure != nil && ctx.inBody {
 		if kind, ok := statementKind(node); ok {
+			if kind == StatementCall && isIndexedAssignmentNode(node, v.builder.source) {
+				kind = StatementAssignment
+			}
 			ctx.statementID = v.addStatement(procedure, node, ctx.statementID, kind)
 		}
 		if isExpressionNode(node.Kind()) {
@@ -127,12 +130,6 @@ func (v *singleVisitor) enterProcedure(node *tree_sitter.Node) visitContext {
 		Symbol: symbol, Declarations: []Declaration{}, Statements: []Statement{},
 		Expressions: []Expression{}, Calls: []CallSite{}, Accesses: []VariableAccess{},
 	}
-	for _, parameter := range symbol.Parameters {
-		procedure.Declarations = append(procedure.Declarations, Declaration{
-			ID: v.builder.takeDeclarationID(), Name: parameter.Name, Type: parameter.Type,
-			Scope: ScopeParameter, Kind: "parameter", Range: parameter.Range,
-		})
-	}
 	if symbol.Kind == ProcedureFunction || symbol.Kind == ProcedurePropertyGet || symbol.Kind == ProcedureProperty {
 		nameRange := symbol.DeclarationRange
 		if name := node.ChildByFieldName("name"); name != nil {
@@ -141,6 +138,12 @@ func (v *singleVisitor) enterProcedure(node *tree_sitter.Node) visitContext {
 		procedure.Declarations = append(procedure.Declarations, Declaration{
 			ID: v.builder.takeDeclarationID(), Name: symbol.Name, Type: symbol.ReturnType,
 			Scope: ScopeLocal, Kind: "return_slot", Range: nameRange,
+		})
+	}
+	for _, parameter := range symbol.Parameters {
+		procedure.Declarations = append(procedure.Declarations, Declaration{
+			ID: v.builder.takeDeclarationID(), Name: parameter.Name, Type: parameter.Type,
+			Scope: ScopeParameter, Kind: "parameter", Range: parameter.Range,
 		})
 	}
 	v.document.Procedures = append(v.document.Procedures, procedure)
@@ -432,6 +435,8 @@ func (v *singleVisitor) childContext(parent, child *tree_sitter.Node, ctx visitC
 	case "qualified_member_expression", "implicit_member_expression", "member_expression":
 		if sameNode(child, childByFieldNameAny(parent, "member", "property")) {
 			childCtx.metadata = true
+		} else if isTargetAccessMode(ctx.accessMode) {
+			childCtx.accessMode = AccessRead
 		}
 	case "new_expression":
 		if sameNode(child, parent.ChildByFieldName("type")) {
@@ -445,18 +450,47 @@ func (v *singleVisitor) childContext(parent, child *tree_sitter.Node, ctx visitC
 		if sameNode(child, parent.ChildByFieldName("function")) {
 			childCtx.suppressCall = true
 			if child.Kind() == "identifier" {
-				childCtx.metadata = true
+				if isTargetAccessMode(ctx.accessMode) {
+					childCtx.metadata = false
+					childCtx.accessMode = ctx.accessMode
+					if statement := statementByID(v.procedure(ctx.procedure), ctx.statementID); statement != nil {
+						statement.Target = expressionStub(child, ctx.statementID, v.builder.source)
+					}
+				} else {
+					childCtx.metadata = true
+				}
 			}
 		}
 		if sameNode(child, parent.ChildByFieldName("arguments")) {
 			childCtx.suppressCall = false
+			if isTargetAccessMode(ctx.accessMode) {
+				childCtx.accessMode = AccessRead
+			}
 		}
 	case "call_statement":
 		if sameNode(child, parent.ChildByFieldName("callee")) {
 			childCtx.callIndex = ctx.callIndex
 			childCtx.suppressCall = child.Kind() == "call_expression"
-			if child.Kind() == "identifier" {
+			if isIndexedAssignmentNode(parent, v.builder.source) && !isLetIndexedAssignmentNode(parent, v.builder.source) {
+				childCtx.metadata = false
+				childCtx.accessMode = AccessWrite
+				if statement := statementByID(v.procedure(ctx.procedure), ctx.statementID); statement != nil {
+					statement.Target = expressionStub(child, ctx.statementID, v.builder.source)
+				}
+			} else if child.Kind() == "identifier" {
 				childCtx.metadata = true
+			}
+		}
+		if sameNode(child, parent.ChildByFieldName("arguments")) &&
+			isLetIndexedAssignmentNode(parent, v.builder.source) {
+			childCtx.accessMode = AccessWrite
+		}
+	case "comparison_expression":
+		if statement := statementByID(v.procedure(ctx.procedure), ctx.statementID); statement != nil &&
+			statement.SyntaxKind == "call_statement" && statement.Kind == StatementAssignment {
+			childCtx.accessMode = AccessRead
+			if sameNode(child, childByFieldNameAny(parent, "right", "value")) {
+				statement.Value = expressionStub(child, ctx.statementID, v.builder.source)
 			}
 		}
 	case "redim_statement":
@@ -477,8 +511,10 @@ func (v *singleVisitor) childContext(parent, child *tree_sitter.Node, ctx visitC
 		target := childByFieldNameAny(parent, "target", "left", "variable")
 		value := childByFieldNameAny(parent, "value", "right")
 		condition := childByFieldNameAny(parent, "condition", "test")
+		indexedAssignmentComparison := parent.Kind() == "comparison_expression" &&
+			statement.SyntaxKind == "call_statement" && statement.Kind == StatementAssignment
 		switch {
-		case sameNode(child, target):
+		case sameNode(child, target) && !indexedAssignmentComparison:
 			childCtx.accessMode = targetAccessMode(*statement)
 			statement.Target = expressionStub(child, ctx.statementID, v.builder.source)
 		case sameNode(child, value):
@@ -507,6 +543,9 @@ func (v *singleVisitor) finalize() {
 		}
 		for _, declaration := range procedure.Declarations {
 			scopes[strings.ToLower(declaration.Name)] = declaration.Scope
+		}
+		for statementIndex := range procedure.Statements {
+			ensureIndexedAssignmentAccess(procedure, &procedure.Statements[statementIndex])
 		}
 		for accessIndex := range procedure.Accesses {
 			access := &procedure.Accesses[accessIndex]
@@ -542,6 +581,9 @@ func (v *singleVisitor) finalize() {
 			statement.Value = canonicalExpression(procedure.Expressions, statement.ValueID, statement.Value)
 			statement.Condition = canonicalExpression(procedure.Expressions, statement.ConditionID, statement.Condition)
 		}
+		sort.SliceStable(procedure.Accesses, func(i, j int) bool {
+			return procedure.Accesses[i].Range.StartByte < procedure.Accesses[j].Range.StartByte
+		})
 	}
 	sort.SliceStable(v.document.Procedures, func(i, j int) bool {
 		return v.document.Procedures[i].Symbol.DeclarationRange.StartByte < v.document.Procedures[j].Symbol.DeclarationRange.StartByte
@@ -607,6 +649,114 @@ func firstAccessMode(mode AccessMode) AccessMode {
 		return AccessRead
 	}
 	return mode
+}
+
+func isTargetAccessMode(mode AccessMode) bool {
+	return mode == AccessWrite || mode == AccessReadWrite
+}
+
+func isIndexedAssignmentNode(node *tree_sitter.Node, source []byte) bool {
+	if node == nil || node.Kind() != "call_statement" || node.ChildByFieldName("callee") == nil {
+		return false
+	}
+	if isLetIndexedAssignmentNode(node, source) {
+		return true
+	}
+	callee := node.ChildByFieldName("callee")
+	if callee.EndByte() >= node.EndByte() || int(node.EndByte()) > len(source) {
+		return false
+	}
+	tail := string(source[callee.EndByte():node.EndByte()])
+	return hasIndexedAssignmentTail(tail)
+}
+
+func isLetIndexedAssignmentNode(node *tree_sitter.Node, source []byte) bool {
+	if node == nil || node.Kind() != "call_statement" {
+		return false
+	}
+	text := nodeText(node, source)
+	if len(text) < len("Let ") || !strings.EqualFold(text[:len("Let ")], "Let ") {
+		return false
+	}
+	tail := strings.TrimSpace(text[len("Let "):])
+	open := strings.IndexByte(tail, '(')
+	return open > 0 && hasIndexedAssignmentTail(tail[open:])
+}
+
+func hasIndexedAssignmentTail(tail string) bool {
+	if !strings.HasPrefix(tail, "(") {
+		return false
+	}
+	depth := 0
+	inString := false
+	for i := 0; i < len(tail); i++ {
+		switch tail[i] {
+		case '"':
+			if inString && i+1 < len(tail) && tail[i+1] == '"' {
+				i++
+				continue
+			}
+			inString = !inString
+		case '(':
+			if !inString {
+				depth++
+			}
+		case ')':
+			if !inString && depth > 0 {
+				depth--
+			}
+		case '=':
+			if !inString && depth == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ensureIndexedAssignmentAccess(procedure *ProcedureIR, statement *Statement) {
+	if procedure == nil || statement == nil || statement.Kind != StatementAssignment ||
+		statement.SyntaxKind != "call_statement" {
+		return
+	}
+	name := indexedAssignmentTargetName(statement.Text)
+	if name == "" {
+		return
+	}
+	for accessIndex := range procedure.Accesses {
+		access := &procedure.Accesses[accessIndex]
+		if access.StatementID == statement.ID && strings.EqualFold(access.Name, name) {
+			access.Mode = AccessWrite
+			return
+		}
+	}
+	for expressionIndex := range procedure.Expressions {
+		expression := &procedure.Expressions[expressionIndex]
+		if expression.StatementID != statement.ID || expression.Kind != ExpressionIdentifier ||
+			!strings.EqualFold(cleanIdentifier(expression.Text), name) {
+			continue
+		}
+		statement.TargetID = expression.ID
+		statement.Target = canonicalExpression(procedure.Expressions, expression.ID, nil)
+		procedure.Accesses = append(procedure.Accesses, VariableAccess{
+			Name: name, Mode: AccessWrite, Scope: ScopeUnresolved, Range: expression.Range,
+			StatementID: statement.ID, ExpressionID: expression.ID,
+			Resolution: SymbolResolution{Scope: ScopeUnresolved},
+		})
+		return
+	}
+}
+
+func indexedAssignmentTargetName(text string) string {
+	text = strings.TrimSpace(text)
+	if len(text) >= len("Let ") && strings.EqualFold(text[:len("Let ")], "Let ") {
+		text = strings.TrimSpace(text[len("Let "):])
+	}
+	open := strings.IndexByte(text, '(')
+	if open <= 0 {
+		return ""
+	}
+	return cleanIdentifier(text[:open])
 }
 
 func targetAccessMode(statement Statement) AccessMode {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -95,5 +95,7 @@
 - When adapting structured recovery metadata for a secondary surface such as LSP, do not make one optional field a prerequisite for all metadata. Preserve every available field independently and test the empty-context fallback.
 - When updating a Go module version, update `THIRD_PARTY_LICENCES.md` (including version-pinned licence URLs) in the same change and run `scripts/dev/check-third-party-licences.ps1` before finalizing.
 - LSP ranges derived from tree-sitter positions must translate UTF-8 byte columns to UTF-16 code units using the effective source buffer; preserve that buffer in incremental analysis when range-bearing results are served from the index.
+- When a diagnostic pipeline has already accumulated valid findings, a later optional-stage failure must append its error diagnostic instead of replacing earlier results.
+- Assignment access modes belong to the actual lvalue binding only. Receivers and index expressions inside composite targets remain reads even when the enclosing target is a write.
 - Do not turn a disk-backed `getOrRead` document into an editor overlay. Only `didOpen` / `didChange` lifecycle documents may override watcher-managed disk index entries.
 - When extending VBA assignment analysis, reuse the existing assignment grammar so valid optional modifiers such as `Let` receive the same treatment; add a regression test for each supported form.

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -11,6 +11,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `analyze_failed`
 - `argument_count`
 - `argument_list`
+- `array_bounds`
 - `as_type_clause`
 - `assignable_to`
 - `assignment_statement`
@@ -19,6 +20,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `attach_active_deprecated`
 - `attach_args_invalid`
 - `attempted_operation`
+- `attribute_statement`
 - `auto_close`
 - `auto_open`
 - `auto_session`
@@ -198,6 +200,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `edit_coordinates_unreconciled`
 - `else_clause`
 - `else_fragment`
+- `else_if`
 - `elseif_clause`
 - `elseif_fragment`
 - `empty_parentheses`
@@ -229,6 +232,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `executable_path`
 - `existing_warning`
 - `exit_code`
+- `exit_statement`
 - `expanded_formula`
 - `expected_closer`
 - `expected_error`
@@ -252,6 +256,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `fmt_stdin_write_failed`
 - `fmt_write_hint`
 - `folder_annotation`
+- `for_each`
 - `for_each_statement`
 - `for_statement`
 - `forbid_activate`
@@ -306,6 +311,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `generator_version`
 - `generator_version_changed`
 - `global_values`
+- `goto_statement`
 - `graph_dependencies_failed`
 - `gui_boundaries`
 - `gui_boundary_detected`
@@ -363,6 +369,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `leading_underscore`
 - `legacy_backup_entry`
 - `legacy_entry`
+- `let_statement`
 - `likely_cause`
 - `line_number_label`
 - `line_number_literal`
@@ -404,7 +411,9 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `max_count`
 - `max_rows`
 - `max_total_size_mb`
+- `member_access`
 - `member_call`
+- `member_expression`
 - `merge_range`
 - `merged_ranges`
 - `message_pump`
@@ -442,6 +451,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `non_numeric`
 - `non_test`
 - `not_applicable`
+- `not_attempted`
 - `not_performed`
 - `not_run`
 - `not_vba_document`
@@ -449,6 +459,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `number_format`
 - `old_name`
 - `older_than`
+- `on_error`
 - `on_error_statement`
 - `open_workbook`
 - `opening_column`
@@ -483,7 +494,9 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `pack_write_failed`
 - `parallel_safe`
 - `param_array`
+- `paramarray_modifier`
 - `parameter_list`
+- `parenthesized_expression`
 - `parse_status`
 - `parse_status_summary`
 - `parser_node`
@@ -533,6 +546,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `qualified_name`
 - `quoted_name`
 - `read_only`
+- `read_write`
 - `reason_not_runnable`
 - `recorded_at`
 - `recover_workbook`
@@ -542,6 +556,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `recovery_force_cleared`
 - `recovery_metadata_invalid`
 - `recovery_required`
+- `redim_declarator`
+- `redim_statement`
 - `refers_to`
 - `replaced_existing`
 - `request_id`
@@ -557,7 +573,9 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `response_source`
 - `restored_from`
 - `result_file`
+- `resume_statement`
 - `retryable_when_busy`
+- `return_slot`
 - `return_type`
 - `returned_range`
 - `rollback_args_invalid`
@@ -598,6 +616,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `session_requested`
 - `session_required`
 - `session_rerun_failed`
+- `set_assignment`
 - `set_statement`
 - `shared_formula_malformed_ref`
 - `shared_formula_missing_anchor`
@@ -607,6 +626,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `sheet_exists`
 - `sheet_id`
 - `sheet_not_found`
+- `single_line_if_statement`
 - `single_space`
 - `size_bytes`
 - `skill_agent_required`
@@ -687,6 +707,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `ui_button_args_invalid`
 - `ui_dialog`
 - `ui_stream_init_failed`
+- `unary_expression`
 - `uncertain_edges`
 - `undeclared_variable`
 - `unexpected_helper_mode`


### PR DESCRIPTION
## Summary

- Add a reusable procedure-level intermediate representation for VBA analysis.
- Implement IR building, cloning, resolution, and visitor support.
- Integrate procedure analysis into the analyzer, LSP server, IntelliSense snapshots, and call analysis.
- Document the design and specification in ADR-0021 and the VBA analysis IR spec.
- Update the error-code inventory.

## Testing

- Added and updated analyzer, procedure IR, call analysis, LSP, and IntelliSense snapshot tests.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent procedure-level analysis foundation for VBA code, including procedures, statements, expressions, calls, scopes, and event handlers.
  * Improved call and symbol resolution with clearer handling for matched, ambiguous, external, built-in-like, and unresolved references.
  * Analysis snapshots now reuse cached results for more consistent and efficient editor features.

* **Bug Fixes**
  * Preserved VBA204 error-handler diagnostics, suppression behavior, cleanup exceptions, output formats, and source locations.
  * Improved recovery for partially malformed VBA while retaining accurate ranges and analysis results.

* **Documentation**
  * Added architectural and specification documentation for the new VBA analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->