### PR TITLE
Add a conservative VBA control-flow graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to xlflow will be documented in this file.
 ## Unreleased
 
 - Updated `tree-sitter-vba` to v0.11.0 and preserved lint and formatter behavior across its flat multiline-`If` CST: VB014 now runs structural block validation even when the parser accepts fragment nodes, and formatting pairs `if_statement`, `elseif_fragment`, `else_fragment`, and `end_if_fragment` ranges.
+- Added a conservative procedure-level VBA control-flow graph shared by batch analysis and LSP snapshots, and moved `VBA204` error-handler fallthrough detection from preceding-text heuristics to normal-flow reachability without changing its public diagnostic contract.
 
 ## v0.27.1
 

--- a/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
+++ b/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
@@ -1,0 +1,131 @@
+# ADR-0022: Conservative VBA Control-Flow Graph
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0021 establishes a protocol-neutral, procedure-level VBA analysis IR. Its
+statement nesting is syntactic: it cannot answer whether a statement is
+reachable, whether an assignment holds on every path, or whether cleanup runs
+before every exit. Issue #427 needs those answers as a shared foundation for
+the reliability analysis proposed by issue #425.
+
+VBA control flow includes structured branches and loops, unstructured labels
+and `GoTo`, procedure and loop exits, process-terminating `End`, and path-local
+`On Error` modes. Malformed source, duplicate or missing labels, and dynamic
+`Resume` targets also prevent a graph builder from always identifying one exact
+successor. Treating those cases as impossible would let guarantee-oriented
+rules report unsafe conclusions.
+
+The graph must serve both batch analysis and immutable LSP snapshots without
+depending on CLI or LSP protocol types. Issue #428 will later refine which
+statements can fail and propagate interprocedural effects, but issue #427 must
+remain conservative without that information.
+
+## Decision
+
+Add `internal/vba/cfg` as a separate layer built from
+`procedureir.DocumentIR`. Do not embed graph state in `ProcedureIR` or retain
+tree-sitter values. Each procedure graph uses deterministic, source-ordered
+block and edge IDs and supports defensive cloning.
+
+Represent normal versus exceptional flow independently from certainty. An edge
+is classified by its control-flow meaning and as normal or exceptional, and it
+may separately be marked uncertain. This allows, for example, both a known
+normal successor and an uncertain exceptional successor from one statement
+without conflating their semantics.
+
+Each graph has synthetic entry, normal-exit, exceptional-exit,
+termination-exit, and unknown-exit blocks. Structured branches, selection,
+loops, nearest-loop exits, procedure exits, labels, `GoTo`, `On Error`,
+`Resume`, and standalone `End` map to explicit transitions. Missing, duplicate,
+or recovered targets must not be resolved to an arbitrary statement.
+
+Model the active VBA error mode with forward, path-sensitive dataflow.
+`On Error GoTo <label>`, `On Error Resume Next`, and `On Error GoTo 0` update
+that mode along their paths and are merged conservatively. Until issue #428
+provides effect information, every executable statement is a possible fault
+site. The builder therefore adds uncertain exceptional transitions to the
+active handler, the resume-next successor, or the exceptional exit as
+appropriate. Dynamic or recovered `Resume` behavior and other unresolved
+control flow pass through conservative unknown flow rather than disappearing.
+
+Guarantee-oriented queries include uncertain edges. Reachability,
+unreachability, dominance, definite assignment, exit transitions, and
+all-paths-cleanup queries must therefore avoid proving a property by omitting an
+unresolved path. Consumers may request an explicit view, such as normal flow
+without exceptional edges, when the rule's contract calls for it; uncertainty
+within that selected view still participates.
+
+Cache the document CFG lazily on the immutable `AnalysisSnapshot`, using the
+same revision ownership, concurrency, error caching, and defensive-copy
+contract as the procedure IR cache. An incremental edit creates a new cache and
+does not reuse graph fragments or IDs across revisions.
+
+Migrate `VBA204` as the first CFG consumer. It detects handler fallthrough by
+normal-flow reachability of the handler label rather than by scanning preceding
+text. Its diagnostic ID, fields, ordering, cleanup-label exception, inline
+suppression, CLI JSON, and LSP ranges remain unchanged. No public CLI option,
+configuration key, JSON shape, diagnostic ID, or LSP capability is added.
+
+## Consequences
+
+- Positive: batch and LSP reliability checks share one deterministic
+  control-flow model instead of implementing rule-specific walkers.
+- Positive: normal, exceptional, termination, and unresolved outcomes remain
+  distinguishable for later analyses.
+- Positive: conservative uncertainty prevents guarantee queries from producing
+  false confidence on malformed or dynamically targeted control flow.
+- Positive: the graph remains protocol-neutral and safe after parser retirement
+  because it contains only Go-owned IR values and ranges.
+- Negative: treating every executable statement as a potential fault site adds
+  edges and can reduce precision until issue #428 supplies effect summaries.
+- Negative: path-sensitive error modes and conservative unknown flow make graph
+  construction and query testing more complex than a structured-only CFG.
+- Negative: callers must choose a flow view deliberately; using a normal-only
+  view for a general guarantee would be unsound.
+- Limitation: graph IDs are stable only for the same document revision and are
+  not persistent workspace identities.
+
+## Alternatives Considered
+
+1. **Build CFG data into `ProcedureIR`** - Rejected because syntax ownership and
+   executable-path analysis evolve independently, and consumers that need only
+   normalized syntax should not pay for or depend on graph construction.
+2. **Construct a separate CFG inside each rule** - Rejected because label
+   resolution, error modes, recovery, and exit semantics would drift between
+   batch and LSP consumers.
+3. **Ignore exceptional flow until effect analysis exists** - Rejected because
+   guarantee queries would incorrectly treat faulting paths as impossible.
+4. **Treat unresolved targets as unreachable** - Rejected because missing,
+   duplicate, recovered, and dynamic targets are uncertainty, not proof that no
+   execution path exists.
+5. **Mix exceptional flow and uncertainty into one edge kind** - Rejected
+   because a transition can be exceptional but precisely known, or normal but
+   uncertain; consumers need both dimensions.
+6. **Reuse graph fragments across incremental revisions** - Rejected because
+   statement and graph IDs are revision-local, and reuse would complicate
+   snapshot lifetime and stale-publication guarantees.
+
+## Evidence
+
+- Requirements: xlflow issues #425 and #427.
+- Procedure IR boundary and recovery contract:
+  `docs/adr/ADR-0021-procedure-analysis-ir.md`,
+  `docs/specs/vba-analysis-ir.md`.
+- Analyzer ownership: `docs/adr/ADR-0013-analyze-runtime-risk-ownership.md`,
+  `internal/analyze/analyzer.go`.
+- Snapshot and LSP boundary:
+  `docs/adr/ADR-0014-reusable-vba-lsp-server.md`,
+  `internal/vba/intel/analysis_snapshot.go`.
+- Existing validation behavior: `internal/analyze/analyzer_test.go`.
+
+## Related
+
+- `docs/adr/ADR-0013-analyze-runtime-risk-ownership.md`
+- `docs/adr/ADR-0014-reusable-vba-lsp-server.md`
+- `docs/adr/ADR-0021-procedure-analysis-ir.md`
+- `docs/specs/vba-control-flow-graph.md`
+- xlflow issues #425, #426, #427, and #428

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -224,13 +224,12 @@ symbol results, or LSP-owned values. Those projections preserve:
 - CLI byte-based and LSP UTF-16 diagnostic ranges.
 
 Issue #426 intentionally stops at procedure syntax and conservative name/call
-resolution:
+resolution. The separate CFG layer defined by
+`docs/specs/vba-control-flow-graph.md` consumes this IR to provide basic blocks,
+edges, reachability, and path queries without changing the meaning of the IR's
+syntactic `Blocks`. Issue #428 adds direct and transitive effect summaries plus
+fixed-point propagation.
 
-- issue #427 adds basic blocks, CFG edges, reachability, and path queries; and
-- issue #428 adds direct and transitive effect summaries plus fixed-point
-  propagation.
-
-Until those layers exist, `Blocks` means syntax nesting only and the IR must not
-expose reachability or effect claims. No new public CLI flag, configuration key,
-JSON field, diagnostic ID, or LSP capability is introduced by this
-specification.
+The IR itself does not expose reachability or effect claims. No new public CLI
+flag, configuration key, JSON field, diagnostic ID, or LSP capability is
+introduced by this specification.

--- a/docs/specs/vba-control-flow-graph.md
+++ b/docs/specs/vba-control-flow-graph.md
@@ -89,7 +89,12 @@ A missing, duplicate, or recovered target is not resolved to an arbitrary
 candidate. Its transition enters conservative unknown flow, preserving the
 possibility of reaching relevant known successors and `UnknownExit`. Unknown or
 recovered control syntax follows the same rule whenever omitting it could make
-a guarantee appear true.
+a guarantee appear true. The graph records these sources once instead of
+materializing an edge from every unknown source to every statement. Queries
+interpret a reachable unknown-flow source conservatively. Valid executable
+statements whose control behavior is known to be ordinary fallthrough do not
+become unknown flow merely because their statement kind is otherwise
+unclassified.
 
 Colon-separated executable statements remain individually ordered statements.
 Control transitions use their exact normalized ranges so CRLF, UTF-8 source,
@@ -120,7 +125,9 @@ statement. Labels and purely structural markers are not fault sites.
 `Resume Next` have dynamic destinations determined by the active error and
 fault site; when one exact destination cannot be proven, they use conservative
 unknown flow. Missing, duplicate, or recovered resume labels are handled like
-unresolved `GoTo` targets.
+unresolved `GoTo` targets. A uniquely resolved `Resume <label>` carries the
+enabled handler mode to the continuation, where the handler is inactive and may
+be entered again by a later fault.
 
 ## Query Semantics
 
@@ -148,8 +155,9 @@ class does not remove uncertain edges of the retained class.
 
 `VBA204` error-handler fallthrough detection uses an explicit normal-flow view
 that excludes exceptional edges. A handler is a fallthrough risk when its label
-block is normally reachable from the procedure entry. A transfer caused only
-by an error does not make the handler normally reachable.
+block has a reachable implicit normal-flow predecessor. An explicit
+`GoTo <handler>` does not count as fallthrough, and a transfer caused only by an
+error does not make the handler normally reachable.
 
 This replaces the previous preceding-text heuristic and correctly accounts for
 structured branches and jumps. The existing cleanup-label exception, inline

--- a/docs/specs/vba-control-flow-graph.md
+++ b/docs/specs/vba-control-flow-graph.md
@@ -1,0 +1,184 @@
+# VBA Control-Flow Graph
+
+This specification defines xlflow's conservative, protocol-neutral VBA
+control-flow graph (CFG). ADR-0022 records the rationale. The graph is an
+internal analysis contract built on the procedure IR from ADR-0021; it does not
+change public CLI, configuration, JSON, diagnostic, or LSP contracts.
+
+## Construction and Ownership
+
+`internal/vba/cfg.BuildDocument` builds procedure graphs from a
+`procedureir.DocumentIR`. It consumes only Go-owned normalized values and never
+reads or retains tree-sitter nodes, parser trees, source buffers, or LSP
+protocol values.
+
+Each procedure is built independently. A graph and the document-level result
+support defensive cloning: callers may mutate returned slices without changing
+the builder result or a snapshot's cached copy. Graph construction is
+deterministic for the same IR.
+
+Graph and block IDs belong to one document revision. They are assigned in
+stable source order, but are not persistent identities and must not be reused
+as workspace-global references after an edit.
+
+## Graph Model
+
+A procedure graph contains source blocks and these synthetic blocks:
+
+- `Entry`, the only procedure entry;
+- `NormalExit`, for ordinary fallthrough and `Exit Sub`, `Exit Function`, or
+  `Exit Property`;
+- `ExceptionalExit`, for errors that leave the procedure;
+- `TerminationExit`, for standalone VBA `End`; and
+- `UnknownExit`, for unresolved control flow that may leave the known graph.
+
+Every source statement belongs to a block or is represented by the transition
+whose control marker it defines. Blocks retain source-order statement
+references and canonical `ast.Range` values from the procedure IR. Reachable
+and unreachable blocks remain in the graph; construction does not discard dead
+source.
+
+Edges record:
+
+- a source and destination block;
+- the control transition kind, such as sequential, branch, loop, jump, exit,
+  resume, or fault;
+- a flow class of normal or exceptional;
+- an independent `uncertain` flag;
+- the originating statement ID, when a source statement caused the edge; and
+- the originating `ast.Range`.
+
+Flow class and certainty are orthogonal. An exceptional edge is not inherently
+uncertain, and an unresolved normal jump is both normal and uncertain.
+
+## Structured Control Flow
+
+Sequential executable statements flow in source order unless a terminating
+transition replaces that successor.
+
+Multiline and single-line `If` constructs create true and false paths.
+Single-line `then` and `else` statements use their normalized branch membership,
+not physical-line heuristics. `ElseIf` contributes another conditional branch,
+and every branch rejoins at the statement following the complete construct.
+
+`Select Case` branches from the selector to each case. `Case Else` is the
+default alternative. When no `Case Else` exists, a no-match path reaches the
+statement after `End Select`. Case bodies rejoin after the selection unless
+they terminate elsewhere.
+
+`For`, `For Each`, `While`, and all pre-test and post-test `Do While` /
+`Do Until` forms include loop-entry, loop-back, and loop-exit transitions.
+Pre-test loops include a zero-iteration path. Post-test loops execute their body
+before the condition. `Exit For` and `Exit Do` target the successor of the
+nearest enclosing loop of the matching kind; an unresolved enclosing loop is
+represented conservatively.
+
+`Exit Sub`, `Exit Function`, and `Exit Property` target `NormalExit` when they
+match the current procedure kind. Ordinary procedure fallthrough also targets
+`NormalExit`. Standalone `End` targets `TerminationExit` and has no sequential
+successor.
+
+## Labels, Jumps, and Recovery
+
+Named and numeric line labels are distinct statements from executable source on
+the same physical line. Label matching is case-insensitive. A uniquely resolved
+`GoTo` targets the corresponding label block, whether the target is forward or
+backward.
+
+A missing, duplicate, or recovered target is not resolved to an arbitrary
+candidate. Its transition enters conservative unknown flow, preserving the
+possibility of reaching relevant known successors and `UnknownExit`. Unknown or
+recovered control syntax follows the same rule whenever omitting it could make
+a guarantee appear true.
+
+Colon-separated executable statements remain individually ordered statements.
+Control transitions use their exact normalized ranges so CRLF, UTF-8 source,
+and multiple statements on one line do not change graph meaning or diagnostic
+locations.
+
+## Error Modes and Exceptional Flow
+
+The builder propagates the active error mode forward and separately along each
+path:
+
+- default or `On Error GoTo 0`: an error leaves through `ExceptionalExit`;
+- `On Error GoTo <label>`: an error transfers to the uniquely resolved handler,
+  or to conservative unknown flow when the label cannot be resolved safely;
+  and
+- `On Error Resume Next`: an error continues at the successor of the faulting
+  statement.
+
+Merging paths preserves every possible active mode rather than selecting one.
+`On Error` statements change the mode only on paths that execute them.
+
+Until issue #428 provides direct and propagated effect summaries, every
+executable statement is a possible fault site. The graph adds an uncertain
+exceptional transition according to every error mode that can reach that
+statement. Labels and purely structural markers are not fault sites.
+
+`Resume <label>` targets a uniquely resolved label. Bare `Resume` and
+`Resume Next` have dynamic destinations determined by the active error and
+fault site; when one exact destination cannot be proven, they use conservative
+unknown flow. Missing, duplicate, or recovered resume labels are handled like
+unresolved `GoTo` targets.
+
+## Query Semantics
+
+The CFG provides procedure-level queries for:
+
+- reachable and unreachable blocks;
+- transitions to each synthetic exit;
+- block dominance;
+- definite assignment at block boundaries; and
+- whether one of a supplied set of cleanup statements occurs on every path to
+  the selected exits.
+
+Guarantee-oriented queries always include uncertain edges in the selected flow
+view. Definite assignment uses intersection at path joins, and an assignment is
+definite only when it occurs on every included path. Dominance and all-paths
+cleanup use the same conservative reachability. A path through unknown flow or
+`UnknownExit` prevents a guarantee unless the queried property is already
+established before that path diverges.
+
+The default guarantee view includes normal and exceptional flow. A consumer may
+explicitly request a narrower view when its rule defines one. Narrowing by flow
+class does not remove uncertain edges of the retained class.
+
+## `VBA204` Integration
+
+`VBA204` error-handler fallthrough detection uses an explicit normal-flow view
+that excludes exceptional edges. A handler is a fallthrough risk when its label
+block is normally reachable from the procedure entry. A transfer caused only
+by an error does not make the handler normally reachable.
+
+This replaces the previous preceding-text heuristic and correctly accounts for
+structured branches and jumps. The existing cleanup-label exception, inline
+suppression, diagnostic position, message, reason, suggestion, severity,
+ordering, CLI JSON, and LSP UTF-16 range remain compatibility requirements.
+
+Generic lint and `VBA210` are not CFG consumers under issue #427.
+
+## Snapshot Cache
+
+An `internal/vba/intel.AnalysisSnapshot` owns one lazy document CFG cache for
+its immutable revision. The cache:
+
+- builds from the snapshot's cached procedure IR;
+- performs at most one build and caches either its result or error;
+- is safe for concurrent readers;
+- returns defensive copies; and
+- retires with the snapshot without retaining parser state.
+
+An incremental edit creates a new snapshot and a new CFG cache. Procedure graph
+fragments, blocks, edges, and IDs are not reused across revisions.
+
+## Compatibility and Layer Boundaries
+
+The procedure IR owns normalized syntax, statement identity, ranges, and
+recovery metadata. The CFG owns executable-path structure and procedure-local
+path queries. Issue #428 owns direct and transitive effects and may refine
+potential fault sites without changing this graph's conservative fallback.
+
+The CFG does not define interprocedural call propagation, public visualization,
+new CLI output, configuration, or LSP capabilities. Adapters remain responsible
+for converting `ast.Range` byte columns to LSP UTF-16 positions.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/gui"
 	"github.com/harumiWeb/xlflow/internal/suppression"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
@@ -154,6 +155,7 @@ type parsedFile struct {
 	Source []byte
 	Root   *tree_sitter.Node
 	IR     procedureir.DocumentIR
+	CFG    vbacfg.Document
 	Parsed *vbaast.ParsedDocument
 }
 
@@ -165,6 +167,7 @@ type sourceProcedure struct {
 	EndLine    int
 	Params     []parameterInfo
 	Statements []procedureir.Statement
+	Graph      *vbacfg.Graph
 }
 
 type sourceDeclaration struct {
@@ -226,12 +229,14 @@ func (a Analyzer) RunResult() (Result, error) {
 			closeParsedFiles(parsedFiles)
 			return Result{}, fmt.Errorf("parse %s: VBA parser reported errors or missing nodes", file)
 		}
+		controlFlow := vbacfg.BuildDocument(ir)
 		parsedFiles = append(parsedFiles, parsedFile{
 			Path:   file,
 			Lines:  normalizedSourceLines(string(source)),
 			Module: strings.TrimSuffix(filepath.Base(file), filepath.Ext(file)),
 			Source: source,
 			IR:     ir,
+			CFG:    controlFlow,
 			Parsed: parsed,
 		})
 	}
@@ -342,6 +347,13 @@ func SourceRealtimeFindingsParsed(rootDir string, cfg config.Config, doc *vbaast
 // caller-supplied procedure IR built from doc. It lets immutable LSP snapshots
 // reuse their cached IR without reparsing or rewalking procedure syntax.
 func SourceRealtimeFindingsParsedIR(rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR) ([]Finding, error) {
+	return SourceRealtimeFindingsParsedIRCFG(rootDir, cfg, doc, ir, vbacfg.BuildDocument(ir))
+}
+
+// SourceRealtimeFindingsParsedIRCFG runs real-time source analysis with
+// caller-supplied procedure IR and control-flow graphs. Immutable LSP
+// snapshots use this entry point to reuse both cached analysis layers.
+func SourceRealtimeFindingsParsedIRCFG(rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document) ([]Finding, error) {
 	if !cfg.Analyze.DetectRangeFindNothingCheck &&
 		!cfg.Analyze.DetectErrorHandlerFallthrough &&
 		!cfg.Analyze.DetectRedimPreserveDimension &&
@@ -359,9 +371,10 @@ func SourceRealtimeFindingsParsedIR(rootDir string, cfg config.Config, doc *vbaa
 			Source: view.Source,
 			Root:   view.Root,
 			IR:     ir,
+			CFG:    controlFlow,
 		}
 		analyzer := Analyzer{RootDir: rootDir, Config: cfg}
-		procedures := sourceProceduresFromIR(ir)
+		procedures := sourceProceduresFromIR(ir, controlFlow)
 		moduleDecls := moduleDeclarations(file.Lines, procedures)
 		if len(procedures) == 0 {
 			procedures = []sourceProcedure{{StartLine: 1, EndLine: len(file.Lines)}}
@@ -500,7 +513,7 @@ func (a Analyzer) buildContext(files []parsedFile) analysisContext {
 func (a Analyzer) analyzeParsedFile(file parsedFile, ctx analysisContext) []Finding {
 	reportedMissingHelpers := map[string]bool{}
 	var findings []Finding
-	procedures := sourceProceduresFromIR(file.IR)
+	procedures := sourceProceduresFromIR(file.IR, file.CFG)
 	moduleDecls := moduleDeclarations(file.Lines, procedures)
 	appStateProcedures := applicationStateProcedureSummaries(file.Lines, procedures)
 	for _, proc := range procedures {
@@ -642,9 +655,9 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 	return findings
 }
 
-func sourceProceduresFromIR(document procedureir.DocumentIR) []sourceProcedure {
+func sourceProceduresFromIR(document procedureir.DocumentIR, controlFlow ...vbacfg.Document) []sourceProcedure {
 	procedures := make([]sourceProcedure, 0, len(document.Procedures))
-	for _, procedure := range document.Procedures {
+	for procedureIndex, procedure := range document.Procedures {
 		kind := "Sub"
 		switch procedure.Symbol.Kind {
 		case procedureir.ProcedureFunction:
@@ -659,7 +672,7 @@ func sourceProceduresFromIR(document procedureir.DocumentIR) []sourceProcedure {
 				Name: parameter.Name, Type: parameter.Type, Passing: parameter.Passing,
 			}
 		}
-		procedures = append(procedures, sourceProcedure{
+		source := sourceProcedure{
 			Kind:       kind,
 			Name:       procedure.Symbol.Name,
 			ReturnType: procedure.Symbol.ReturnType,
@@ -667,7 +680,12 @@ func sourceProceduresFromIR(document procedureir.DocumentIR) []sourceProcedure {
 			EndLine:    procedure.Symbol.DeclarationRange.EndLine,
 			Params:     params,
 			Statements: append([]procedureir.Statement(nil), procedure.Statements...),
-		})
+		}
+		if len(controlFlow) > 0 && procedureIndex < len(controlFlow[0].Graphs) {
+			graph := controlFlow[0].Graphs[procedureIndex]
+			source.Graph = &graph
+		}
+		procedures = append(procedures, source)
 	}
 	return procedures
 }
@@ -1331,6 +1349,29 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 		return nil
 	}
 	var findings []Finding
+	if proc.Graph != nil {
+		reachable := map[vbacfg.BlockID]bool{}
+		for _, blockID := range proc.Graph.Reachable(vbacfg.EdgeFilter{NormalOnly: true}) {
+			reachable[blockID] = true
+		}
+		for _, statement := range proc.Statements {
+			if statement.Kind != procedureir.StatementLabel {
+				continue
+			}
+			label := cleanIdentifier(statement.Label)
+			if !handlerLabels[strings.ToLower(label)] || isCleanupFallthroughLabel(label) {
+				continue
+			}
+			block, ok := proc.Graph.BlockForStatement(statement.ID)
+			if !ok || !reachable[block.ID] {
+				continue
+			}
+			lineNo := statement.Range.StartLine
+			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA204", "warning", "Normal execution can fall through into error handler "+label+".", "Without Exit Sub, Exit Function, or Exit Property before the handler label, successful execution can run error handling code.", errorHandlerFallthroughSuggestion(proc, label)))
+		}
+		return findings
+	}
+
 	lastCodeByParent := map[int]string{}
 	for _, statement := range proc.Statements {
 		if statement.Kind == procedureir.StatementLabel {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -1366,6 +1366,17 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 			if !ok || !reachable[block.ID] {
 				continue
 			}
+			implicitEntry := false
+			for _, edge := range proc.Graph.Edges {
+				if edge.To == block.ID && edge.Class == vbacfg.EdgeNormal && reachable[edge.From] &&
+					edge.Kind != vbacfg.EdgeGoto && edge.Kind != vbacfg.EdgeUnknown {
+					implicitEntry = true
+					break
+				}
+			}
+			if !implicitEntry {
+				continue
+			}
 			lineNo := statement.Range.StartLine
 			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA204", "warning", "Normal execution can fall through into error handler "+label+".", "Without Exit Sub, Exit Function, or Exit Property before the handler label, successful execution can run error handling code.", errorHandlerFallthroughSuggestion(proc, label)))
 		}

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -668,6 +668,28 @@ End Sub
 	}
 }
 
+func TestAnalyzerCFGVBA204DoesNotReportHandlerSkippedByGoto(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  On Error GoTo Handler
+  Debug.Print "work"
+  GoTo Done
+Handler:
+  Debug.Print "failed"
+Done:
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA204"); len(got) != 0 {
+		t.Fatalf("VBA204 should not report a handler skipped by normal GoTo: %+v", got)
+	}
+}
+
 func TestAnalyzerChecksObjectUseOnSetAssignmentRHS(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -690,6 +690,27 @@ End Sub
 	}
 }
 
+func TestAnalyzerCFGVBA204DoesNotTreatGotoHandlerAsFallthrough(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  On Error GoTo Handler
+  GoTo Handler
+  Exit Sub
+Handler:
+  Debug.Print "handled"
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA204"); len(got) != 0 {
+		t.Fatalf("VBA204 should not treat explicit GoTo Handler as fallthrough: %+v", got)
+	}
+}
+
 func TestAnalyzerChecksObjectUseOnSetAssignmentRHS(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit

--- a/internal/lspserver/analysis_snapshot_test.go
+++ b/internal/lspserver/analysis_snapshot_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
@@ -196,6 +197,21 @@ func TestDocumentsApplyChangesIncrementalMultilineMatchesFullParse(t *testing.T)
 	}
 	if !reflect.DeepEqual(incrementalIR, completeIR) {
 		t.Fatalf("incremental procedure IR differs from complete parse:\nincremental=%+v\ncomplete=%+v", incrementalIR, completeIR)
+	}
+	incrementalCFG, _, err := result.document.Snapshot.ControlFlowGraphs(func() (vbacfg.Document, error) {
+		return vbacfg.BuildDocument(incrementalIR), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completeCFG, _, err := complete.ControlFlowGraphs(func() (vbacfg.Document, error) {
+		return vbacfg.BuildDocument(completeIR), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(incrementalCFG, completeCFG) {
+		t.Fatalf("incremental CFG differs from complete parse:\nincremental=%+v\ncomplete=%+v", incrementalCFG, completeCFG)
 	}
 }
 

--- a/internal/vba/cfg/build.go
+++ b/internal/vba/cfg/build.go
@@ -48,7 +48,7 @@ func Build(in procedureir.ProcedureIR) Graph {
 		entry = b.buildSequence(top, b.graph.NormalExit, nil)
 	}
 	b.add(b.graph.Entry, entry, EdgeFallthrough, EdgeNormal, false, nil)
-	b.addUnknownRecoveryEdges()
+	b.addUnknownRecoveryFlow()
 	b.addExceptionalEdges()
 	b.finish()
 	return b.graph
@@ -204,7 +204,7 @@ func transferMatchesProcedure(transfer procedureir.TransferKind, kind procedurei
 func (b *builder) buildIf(statement procedureir.Statement, next BlockID, loops []loopFrame) {
 	block := b.blockByID[statement.ID]
 	children := b.children[statement.ID]
-	var thenIDs, alternatives []int
+	var thenIDs, alternatives, unclassified []int
 	hasRoles := false
 	for _, id := range children {
 		child := b.stmtByID[id]
@@ -215,9 +215,12 @@ func (b *builder) buildIf(statement procedureir.Statement, next BlockID, loops [
 			} else {
 				thenIDs = append(thenIDs, id)
 			}
+		} else {
+			unclassified = append(unclassified, id)
 		}
 	}
 	if !hasRoles {
+		unclassified = nil
 		for _, id := range children {
 			child := b.stmtByID[id]
 			if child.Kind == procedureir.StatementElseIf || child.Kind == procedureir.StatementElse {
@@ -241,6 +244,10 @@ func (b *builder) buildIf(statement procedureir.Statement, next BlockID, loops [
 	}
 	b.add(block, thenEntry, EdgeBranchTrue, EdgeNormal, false, &statement)
 	b.add(block, elseEntry, EdgeBranchFalse, EdgeNormal, false, &statement)
+	if len(unclassified) > 0 {
+		entry := b.buildSequence(unclassified, next, loops)
+		b.add(block, entry, EdgeUnknown, EdgeNormal, true, &statement)
+	}
 }
 
 func (b *builder) buildAlternativeChain(ids []int, falseFallback, join BlockID, loops []loopFrame) BlockID {
@@ -289,9 +296,11 @@ func (b *builder) buildSelect(statement procedureir.Statement, next BlockID, loo
 	block := b.blockByID[statement.ID]
 	cases := b.children[statement.ID]
 	hasElse := false
+	var unclassified []int
 	for _, id := range cases {
 		candidate := b.stmtByID[id]
 		if candidate.Kind != procedureir.StatementCase {
+			unclassified = append(unclassified, id)
 			continue
 		}
 		caseEntry := b.buildStatement(id, next, loops)
@@ -300,6 +309,10 @@ func (b *builder) buildSelect(statement procedureir.Statement, next BlockID, loo
 	}
 	if !hasElse {
 		b.add(block, next, EdgeBranchFalse, EdgeNormal, false, &statement)
+	}
+	if len(unclassified) > 0 {
+		entry := b.buildSequence(unclassified, next, loops)
+		b.add(block, entry, EdgeUnknown, EdgeNormal, true, &statement)
 	}
 }
 
@@ -437,19 +450,29 @@ func (b *builder) add(from, to BlockID, kind EdgeKind, class EdgeClass, uncertai
 	b.edges = append(b.edges, edge)
 }
 
-func (b *builder) addUnknownRecoveryEdges() {
+func (b *builder) addUnknownRecoveryFlow() {
 	for _, statement := range b.procedure.Statements {
-		if statement.Kind != procedureir.StatementUnknown && statement.Kind != procedureir.StatementRecovered &&
-			!statement.Recovered {
+		if !requiresUnknownFlow(statement) {
 			continue
 		}
 		from := b.blockByID[statement.ID]
+		b.graph.UnknownFlowSources = append(b.graph.UnknownFlowSources, from)
 		b.add(from, b.graph.UnknownExit, EdgeUnknown, EdgeNormal, true, &statement)
-		for _, block := range b.graph.Blocks {
-			if block.Kind == BlockStatement && block.ID != from {
-				b.add(from, block.ID, EdgeUnknown, EdgeNormal, true, &statement)
-			}
-		}
+	}
+}
+
+func requiresUnknownFlow(statement procedureir.Statement) bool {
+	if statement.Kind == procedureir.StatementRecovered || statement.Recovered {
+		return true
+	}
+	if statement.Kind != procedureir.StatementUnknown {
+		return false
+	}
+	switch strings.ToLower(statement.SyntaxKind) {
+	case "on_goto_statement", "stop_statement":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -462,23 +485,7 @@ const (
 
 func (b *builder) addExceptionalEdges() {
 	modes := map[BlockID]map[errorMode]bool{b.graph.Entry: {errorDisabled: true}}
-	changed := true
-	for changed {
-		changed = false
-		for _, edge := range b.edges {
-			if edge.Class != EdgeNormal {
-				continue
-			}
-			in := modes[edge.From]
-			if len(in) == 0 {
-				continue
-			}
-			out := b.transferErrorMode(edge.From, in)
-			if mergeModes(modes, edge.To, out) {
-				changed = true
-			}
-		}
-	}
+	b.propagateErrorModes(modes)
 	baseEdges := append([]Edge(nil), b.edges...)
 	for _, block := range b.graph.Blocks {
 		if !b.isFaultSite(block) {
@@ -528,6 +535,40 @@ func (b *builder) addExceptionalEdges() {
 			if b.isFaultSite(block) {
 				b.add(blockID, b.graph.ExceptionalExit, EdgeError, EdgeExceptional, true, block.Statement)
 			}
+		}
+	}
+}
+
+func (b *builder) propagateErrorModes(modes map[BlockID]map[errorMode]bool) {
+	successors := map[BlockID][]BlockID{}
+	for _, edge := range b.edges {
+		if edge.Class == EdgeNormal ||
+			(edge.Class == EdgeExceptional && edge.Kind == EdgeResume && !edge.Uncertain) {
+			successors[edge.From] = append(successors[edge.From], edge.To)
+		}
+	}
+	queue := []BlockID{b.graph.Entry}
+	queued := map[BlockID]bool{b.graph.Entry: true}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		queued[current] = false
+		out := b.transferErrorMode(current, modes[current])
+		targets := successors[current]
+		block := b.graph.block(current)
+		if block.Statement != nil && block.Statement.Control != nil &&
+			block.Statement.Control.Transfer == procedureir.TransferOnErrorGoto {
+			candidates := b.labels[normalizedTarget(block.Statement.Control.Target)]
+			if len(candidates) == 1 {
+				targets = append(targets, candidates[0])
+			}
+		}
+		for _, target := range targets {
+			if !mergeModes(modes, target, out) || queued[target] {
+				continue
+			}
+			queue = append(queue, target)
+			queued[target] = true
 		}
 	}
 }

--- a/internal/vba/cfg/build.go
+++ b/internal/vba/cfg/build.go
@@ -1,0 +1,633 @@
+package cfg
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+// BuildDocument builds one independent graph per procedure in source order.
+func BuildDocument(in procedureir.DocumentIR) Document {
+	out := Document{Path: in.Path, Graphs: make([]Graph, len(in.Procedures))}
+	for i := range in.Procedures {
+		out.Graphs[i] = Build(in.Procedures[i])
+	}
+	return out
+}
+
+type loopFrame struct {
+	kind procedureir.StatementKind
+	exit BlockID
+}
+
+type builder struct {
+	procedure procedureir.ProcedureIR
+	graph     Graph
+	blockByID map[int]BlockID
+	stmtByID  map[int]procedureir.Statement
+	children  map[int][]int
+	labels    map[string][]BlockID
+	edges     []Edge
+}
+
+// Build constructs a deterministic conservative graph for one procedure.
+func Build(in procedureir.ProcedureIR) Graph {
+	in = procedureir.CloneProcedureIR(in)
+	b := &builder{
+		procedure: in,
+		blockByID: map[int]BlockID{},
+		stmtByID:  map[int]procedureir.Statement{},
+		children:  map[int][]int{},
+		labels:    map[string][]BlockID{},
+	}
+	b.initialize()
+	top := b.children[0]
+	entry := b.graph.NormalExit
+	if len(top) > 0 {
+		entry = b.buildSequence(top, b.graph.NormalExit, nil)
+	}
+	b.add(b.graph.Entry, entry, EdgeFallthrough, EdgeNormal, false, nil)
+	b.addUnknownRecoveryEdges()
+	b.addExceptionalEdges()
+	b.finish()
+	return b.graph
+}
+
+func (b *builder) initialize() {
+	symbol := b.procedure.Symbol
+	symbol.Parameters = append([]procedureir.Parameter(nil), b.procedure.Symbol.Parameters...)
+	b.graph = Graph{
+		Procedure: symbol,
+		Entry:     1, NormalExit: 2, ExceptionalExit: 3, TerminationExit: 4, UnknownExit: 5,
+		Blocks: []Block{
+			{ID: 1, Kind: BlockEntry},
+			{ID: 2, Kind: BlockNormalExit},
+			{ID: 3, Kind: BlockExceptionalExit},
+			{ID: 4, Kind: BlockTerminationExit},
+			{ID: 5, Kind: BlockUnknownExit},
+		},
+	}
+	statements := append([]procedureir.Statement(nil), b.procedure.Statements...)
+	sort.SliceStable(statements, func(i, j int) bool {
+		if statements[i].Range.StartByte != statements[j].Range.StartByte {
+			return statements[i].Range.StartByte < statements[j].Range.StartByte
+		}
+		return statements[i].ID < statements[j].ID
+	})
+	assignments := map[int][]Variable{}
+	for _, access := range b.procedure.Accesses {
+		if access.StatementID == 0 ||
+			(access.Mode != procedureir.AccessWrite && access.Mode != procedureir.AccessReadWrite) {
+			continue
+		}
+		assignments[access.StatementID] = appendVariable(assignments[access.StatementID],
+			Variable{Scope: access.Scope, Name: access.Name})
+	}
+	for i := range statements {
+		statement := statements[i]
+		id := BlockID(len(b.graph.Blocks) + 1)
+		copyStatement := statement
+		copyStatement.ExpressionIDs = append([]int(nil), statement.ExpressionIDs...)
+		copyStatement.Target = cloneExpression(statement.Target)
+		copyStatement.Value = cloneExpression(statement.Value)
+		copyStatement.Condition = cloneExpression(statement.Condition)
+		if statement.Control != nil {
+			control := *statement.Control
+			copyStatement.Control = &control
+		}
+		b.graph.Blocks = append(b.graph.Blocks, Block{
+			ID: id, Kind: BlockStatement, StatementID: statement.ID,
+			Statement: &copyStatement, Range: statement.Range,
+			Assignments: assignments[statement.ID],
+		})
+		b.blockByID[statement.ID] = id
+		b.stmtByID[statement.ID] = statement
+		b.children[statement.ParentID] = append(b.children[statement.ParentID], statement.ID)
+		if statement.Kind == procedureir.StatementLabel {
+			name := normalizedTarget(statement.Label)
+			if statement.Control != nil && statement.Control.Target != "" {
+				name = normalizedTarget(statement.Control.Target)
+			}
+			if name != "" {
+				b.labels[name] = append(b.labels[name], id)
+			}
+		}
+	}
+}
+
+func appendVariable(in []Variable, variable Variable) []Variable {
+	variable = variable.canonical()
+	for _, existing := range in {
+		if existing == variable {
+			return in
+		}
+	}
+	return append(in, variable)
+}
+
+func (b *builder) buildSequence(ids []int, continuation BlockID, loops []loopFrame) BlockID {
+	next := continuation
+	for i := len(ids) - 1; i >= 0; i-- {
+		next = b.buildStatement(ids[i], next, loops)
+	}
+	return next
+}
+
+func (b *builder) buildStatement(statementID int, next BlockID, loops []loopFrame) BlockID {
+	statement := b.stmtByID[statementID]
+	block := b.blockByID[statementID]
+	control := statement.Control
+	if control != nil {
+		switch control.Transfer {
+		case procedureir.TransferGoto:
+			b.addTarget(block, control.Target, EdgeGoto, EdgeNormal, false, statement)
+			return block
+		case procedureir.TransferExitSub, procedureir.TransferExitFunction, procedureir.TransferExitProperty:
+			if transferMatchesProcedure(control.Transfer, b.procedure.Symbol.Kind) {
+				b.add(block, b.graph.NormalExit, EdgeProcedureExit, EdgeNormal, false, &statement)
+			} else {
+				b.add(block, b.graph.UnknownExit, EdgeUnknown, EdgeNormal, true, &statement)
+			}
+			return block
+		case procedureir.TransferExitFor:
+			target := nearestLoopExit(loops, procedureir.StatementFor, procedureir.StatementForEach, b.graph.UnknownExit)
+			b.add(block, target, EdgeLoopExit, EdgeNormal, target == b.graph.UnknownExit, &statement)
+			return block
+		case procedureir.TransferExitDo:
+			target := nearestLoopExit(loops, procedureir.StatementDo, "", b.graph.UnknownExit)
+			b.add(block, target, EdgeLoopExit, EdgeNormal, target == b.graph.UnknownExit, &statement)
+			return block
+		case procedureir.TransferResumeRetry, procedureir.TransferResumeNext:
+			b.add(block, b.graph.UnknownExit, EdgeResume, EdgeExceptional, true, &statement)
+			return block
+		case procedureir.TransferResumeLabel:
+			b.addTarget(block, control.Target, EdgeResume, EdgeExceptional, false, statement)
+			return block
+		case procedureir.TransferTerminate:
+			b.add(block, b.graph.TerminationExit, EdgeTermination, EdgeNormal, false, &statement)
+			return block
+		}
+	}
+	switch statement.Kind {
+	case procedureir.StatementIf, procedureir.StatementElseIf:
+		b.buildIf(statement, next, loops)
+	case procedureir.StatementSelect:
+		b.buildSelect(statement, next, loops)
+	case procedureir.StatementFor, procedureir.StatementForEach, procedureir.StatementWhile, procedureir.StatementDo:
+		b.buildLoop(statement, next, loops)
+	default:
+		children := b.children[statement.ID]
+		dest := next
+		if len(children) > 0 {
+			dest = b.buildSequence(children, next, loops)
+		}
+		b.add(block, dest, EdgeFallthrough, EdgeNormal, false, &statement)
+	}
+	return block
+}
+
+func transferMatchesProcedure(transfer procedureir.TransferKind, kind procedureir.ProcedureKind) bool {
+	switch transfer {
+	case procedureir.TransferExitSub:
+		return kind == procedureir.ProcedureSub
+	case procedureir.TransferExitFunction:
+		return kind == procedureir.ProcedureFunction
+	case procedureir.TransferExitProperty:
+		return kind == procedureir.ProcedureProperty || kind == procedureir.ProcedurePropertyGet ||
+			kind == procedureir.ProcedurePropertyLet || kind == procedureir.ProcedurePropertySet
+	default:
+		return false
+	}
+}
+
+func (b *builder) buildIf(statement procedureir.Statement, next BlockID, loops []loopFrame) {
+	block := b.blockByID[statement.ID]
+	children := b.children[statement.ID]
+	var thenIDs, alternatives []int
+	hasRoles := false
+	for _, id := range children {
+		child := b.stmtByID[id]
+		if child.Control != nil && child.Control.Branch != "" {
+			hasRoles = true
+			if child.Control.Branch == procedureir.BranchElse {
+				alternatives = append(alternatives, id)
+			} else {
+				thenIDs = append(thenIDs, id)
+			}
+		}
+	}
+	if !hasRoles {
+		for _, id := range children {
+			child := b.stmtByID[id]
+			if child.Kind == procedureir.StatementElseIf || child.Kind == procedureir.StatementElse {
+				alternatives = append(alternatives, id)
+			} else if len(alternatives) == 0 {
+				thenIDs = append(thenIDs, id)
+			}
+		}
+	}
+	thenEntry := next
+	if len(thenIDs) > 0 {
+		thenEntry = b.buildSequence(thenIDs, next, loops)
+	}
+	elseEntry := next
+	if len(alternatives) > 0 {
+		if hasRoles {
+			elseEntry = b.buildSequence(alternatives, next, loops)
+		} else {
+			elseEntry = b.buildAlternativeChain(alternatives, next, next, loops)
+		}
+	}
+	b.add(block, thenEntry, EdgeBranchTrue, EdgeNormal, false, &statement)
+	b.add(block, elseEntry, EdgeBranchFalse, EdgeNormal, false, &statement)
+}
+
+func (b *builder) buildAlternativeChain(ids []int, falseFallback, join BlockID, loops []loopFrame) BlockID {
+	nextAlternative := falseFallback
+	for i := len(ids) - 1; i >= 0; i-- {
+		statement := b.stmtByID[ids[i]]
+		if statement.Kind == procedureir.StatementElse {
+			nextAlternative = b.buildStatement(statement.ID, join, loops)
+			continue
+		}
+		if statement.Kind != procedureir.StatementElseIf {
+			nextAlternative = b.buildStatement(statement.ID, nextAlternative, loops)
+			continue
+		}
+		nextAlternative = b.buildElseIf(statement, nextAlternative, join, loops)
+	}
+	return nextAlternative
+}
+
+func (b *builder) buildElseIf(statement procedureir.Statement, falseEntry, continuation BlockID, loops []loopFrame) BlockID {
+	var body, nestedAlternatives []int
+	for _, id := range b.children[statement.ID] {
+		child := b.stmtByID[id]
+		if child.Kind == procedureir.StatementElseIf || child.Kind == procedureir.StatementElse {
+			nestedAlternatives = append(nestedAlternatives, id)
+		} else if len(nestedAlternatives) == 0 {
+			body = append(body, id)
+		} else {
+			nestedAlternatives = append(nestedAlternatives, id)
+		}
+	}
+	if len(nestedAlternatives) > 0 {
+		falseEntry = b.buildAlternativeChain(nestedAlternatives, falseEntry, continuation, loops)
+	}
+	trueEntry := continuation
+	if len(body) > 0 {
+		trueEntry = b.buildSequence(body, continuation, loops)
+	}
+	block := b.blockByID[statement.ID]
+	b.add(block, trueEntry, EdgeBranchTrue, EdgeNormal, false, &statement)
+	b.add(block, falseEntry, EdgeBranchFalse, EdgeNormal, false, &statement)
+	return block
+}
+
+func (b *builder) buildSelect(statement procedureir.Statement, next BlockID, loops []loopFrame) {
+	block := b.blockByID[statement.ID]
+	cases := b.children[statement.ID]
+	hasElse := false
+	for _, id := range cases {
+		candidate := b.stmtByID[id]
+		if candidate.Kind != procedureir.StatementCase {
+			continue
+		}
+		caseEntry := b.buildStatement(id, next, loops)
+		b.add(block, caseEntry, EdgeCase, EdgeNormal, false, &statement)
+		hasElse = hasElse || candidate.Control != nil && candidate.Control.CaseElse
+	}
+	if !hasElse {
+		b.add(block, next, EdgeBranchFalse, EdgeNormal, false, &statement)
+	}
+}
+
+func (b *builder) buildLoop(statement procedureir.Statement, next BlockID, loops []loopFrame) {
+	block := b.blockByID[statement.ID]
+	frame := loopFrame{kind: statement.Kind, exit: next}
+	body := b.children[statement.ID]
+	if statement.Kind == procedureir.StatementDo {
+		var testID int
+		filtered := make([]int, 0, len(body))
+		for _, id := range body {
+			if b.stmtByID[id].SyntaxKind == "do_condition" {
+				testID = id
+			} else {
+				filtered = append(filtered, id)
+			}
+		}
+		body = filtered
+		if testID != 0 {
+			testBlock := b.blockByID[testID]
+			bodyEntry := testBlock
+			if len(body) > 0 {
+				bodyEntry = b.buildSequence(body, testBlock, append(loops, frame))
+			}
+			b.markLoopBackEdges(statement.ID, testBlock)
+			postTest := statement.Control != nil &&
+				(statement.Control.Loop == procedureir.LoopPostWhile || statement.Control.Loop == procedureir.LoopPostUntil)
+			if postTest {
+				b.add(block, bodyEntry, EdgeLoopBody, EdgeNormal, false, &statement)
+				b.add(testBlock, bodyEntry, EdgeLoopBack, EdgeNormal, false, b.statementPointer(testID))
+			} else {
+				b.add(block, testBlock, EdgeFallthrough, EdgeNormal, false, &statement)
+				b.add(testBlock, bodyEntry, EdgeLoopBody, EdgeNormal, false, b.statementPointer(testID))
+				if len(body) == 0 {
+					b.add(testBlock, testBlock, EdgeLoopBack, EdgeNormal, false, b.statementPointer(testID))
+				}
+			}
+			b.add(testBlock, next, EdgeLoopExit, EdgeNormal, false, b.statementPointer(testID))
+			return
+		}
+		bodyEntry := block
+		if len(body) > 0 {
+			bodyEntry = b.buildSequence(body, block, append(loops, frame))
+		}
+		b.add(block, bodyEntry, EdgeLoopBody, EdgeNormal, false, &statement)
+		if len(body) == 0 {
+			b.add(block, block, EdgeLoopBack, EdgeNormal, false, &statement)
+		}
+		return
+	}
+	bodyEntry := block
+	if len(body) > 0 {
+		bodyEntry = b.buildSequence(body, block, append(loops, frame))
+	}
+	b.markLoopBackEdges(statement.ID, block)
+	b.add(block, bodyEntry, EdgeLoopBody, EdgeNormal, false, &statement)
+	if len(body) == 0 {
+		b.add(block, block, EdgeLoopBack, EdgeNormal, false, &statement)
+	}
+	b.add(block, next, EdgeLoopExit, EdgeNormal, false, &statement)
+}
+
+func (b *builder) markLoopBackEdges(loopStatementID int, target BlockID) {
+	for i := range b.edges {
+		edge := &b.edges[i]
+		if edge.To == target && edge.Class == EdgeNormal &&
+			edge.Kind != EdgeGoto && b.isDescendantStatement(edge.StatementID, loopStatementID) {
+			edge.Kind = EdgeLoopBack
+		}
+	}
+}
+
+func (b *builder) isDescendantStatement(statementID, ancestorID int) bool {
+	for statementID != 0 {
+		statement := b.stmtByID[statementID]
+		if statement.ParentID == ancestorID {
+			return true
+		}
+		statementID = statement.ParentID
+	}
+	return false
+}
+
+func (b *builder) statementPointer(id int) *procedureir.Statement {
+	statement, ok := b.stmtByID[id]
+	if !ok {
+		return nil
+	}
+	return &statement
+}
+
+func nearestLoopExit(loops []loopFrame, first, second procedureir.StatementKind, fallback BlockID) BlockID {
+	for i := len(loops) - 1; i >= 0; i-- {
+		if loops[i].kind == first || second != "" && loops[i].kind == second {
+			return loops[i].exit
+		}
+	}
+	return fallback
+}
+
+func (b *builder) addTarget(from BlockID, target string, kind EdgeKind, class EdgeClass, uncertain bool, statement procedureir.Statement) {
+	candidates := b.labels[normalizedTarget(target)]
+	if len(candidates) == 1 {
+		targetBlock := b.graph.Blocks[int(candidates[0])-1]
+		targetRecovered := targetBlock.Statement != nil && targetBlock.Statement.Recovered
+		b.add(from, candidates[0], kind, class, uncertain || targetRecovered, &statement)
+		if targetRecovered {
+			b.add(from, b.graph.UnknownExit, EdgeUnknown, class, true, &statement)
+		}
+		return
+	}
+	if len(candidates) == 0 {
+		b.add(from, b.graph.UnknownExit, EdgeUnknown, class, true, &statement)
+		return
+	}
+	for _, candidate := range candidates {
+		b.add(from, candidate, kind, class, true, &statement)
+	}
+	b.add(from, b.graph.UnknownExit, EdgeUnknown, class, true, &statement)
+}
+
+func normalizedTarget(target string) string {
+	return strings.ToLower(strings.Trim(strings.TrimSpace(target), "[]:"))
+}
+
+func (b *builder) add(from, to BlockID, kind EdgeKind, class EdgeClass, uncertain bool, statement *procedureir.Statement) {
+	edge := Edge{From: from, To: to, Kind: kind, Class: class, Uncertain: uncertain}
+	if statement != nil {
+		edge.StatementID = statement.ID
+		edge.Range = statement.Range
+		if statement.Control != nil && statement.Control.Range.EndByte > statement.Control.Range.StartByte {
+			edge.Range = statement.Control.Range
+		}
+	}
+	b.edges = append(b.edges, edge)
+}
+
+func (b *builder) addUnknownRecoveryEdges() {
+	for _, statement := range b.procedure.Statements {
+		if statement.Kind != procedureir.StatementUnknown && statement.Kind != procedureir.StatementRecovered &&
+			!statement.Recovered {
+			continue
+		}
+		from := b.blockByID[statement.ID]
+		b.add(from, b.graph.UnknownExit, EdgeUnknown, EdgeNormal, true, &statement)
+		for _, block := range b.graph.Blocks {
+			if block.Kind == BlockStatement && block.ID != from {
+				b.add(from, block.ID, EdgeUnknown, EdgeNormal, true, &statement)
+			}
+		}
+	}
+}
+
+type errorMode string
+
+const (
+	errorDisabled errorMode = "disabled"
+	errorNext     errorMode = "next"
+)
+
+func (b *builder) addExceptionalEdges() {
+	modes := map[BlockID]map[errorMode]bool{b.graph.Entry: {errorDisabled: true}}
+	changed := true
+	for changed {
+		changed = false
+		for _, edge := range b.edges {
+			if edge.Class != EdgeNormal {
+				continue
+			}
+			in := modes[edge.From]
+			if len(in) == 0 {
+				continue
+			}
+			out := b.transferErrorMode(edge.From, in)
+			if mergeModes(modes, edge.To, out) {
+				changed = true
+			}
+		}
+	}
+	baseEdges := append([]Edge(nil), b.edges...)
+	for _, block := range b.graph.Blocks {
+		if !b.isFaultSite(block) {
+			continue
+		}
+		for mode := range modes[block.ID] {
+			statement := block.Statement
+			switch mode {
+			case errorDisabled:
+				b.add(block.ID, b.graph.ExceptionalExit, EdgeError, EdgeExceptional, true, statement)
+			case errorNext:
+				added := false
+				for _, edge := range baseEdges {
+					if edge.From == block.ID && edge.Class == EdgeNormal {
+						b.add(block.ID, edge.To, EdgeError, EdgeExceptional, true, statement)
+						added = true
+					}
+				}
+				if !added {
+					b.add(block.ID, b.graph.NormalExit, EdgeError, EdgeExceptional, true, statement)
+				}
+			default:
+				target := strings.TrimPrefix(string(mode), "handler:")
+				candidates := b.labels[target]
+				if len(candidates) == 1 {
+					b.add(block.ID, candidates[0], EdgeError, EdgeExceptional, true, statement)
+				} else {
+					b.add(block.ID, b.graph.UnknownExit, EdgeError, EdgeExceptional, true, statement)
+				}
+			}
+		}
+	}
+	// Once a handler is active, a second fault does not re-enter that handler.
+	// The CFG intentionally has no separate active-handler block state, so add
+	// the conservative outward failure transition to every normal-flow block
+	// reachable from a configured handler target.
+	for _, statement := range b.procedure.Statements {
+		if statement.Control == nil || statement.Control.Transfer != procedureir.TransferOnErrorGoto {
+			continue
+		}
+		candidates := b.labels[normalizedTarget(statement.Control.Target)]
+		if len(candidates) != 1 {
+			continue
+		}
+		for blockID := range reachableFromEdges(candidates[0], baseEdges) {
+			block := b.graph.Blocks[int(blockID)-1]
+			if b.isFaultSite(block) {
+				b.add(blockID, b.graph.ExceptionalExit, EdgeError, EdgeExceptional, true, block.Statement)
+			}
+		}
+	}
+}
+
+func reachableFromEdges(entry BlockID, edges []Edge) map[BlockID]bool {
+	seen := map[BlockID]bool{entry: true}
+	queue := []BlockID{entry}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, edge := range edges {
+			if edge.From != current || edge.Class != EdgeNormal || seen[edge.To] {
+				continue
+			}
+			seen[edge.To] = true
+			queue = append(queue, edge.To)
+		}
+	}
+	return seen
+}
+
+func (b *builder) transferErrorMode(blockID BlockID, in map[errorMode]bool) map[errorMode]bool {
+	block := b.graph.Blocks[int(blockID)-1]
+	if block.Statement == nil || block.Statement.Control == nil {
+		return in
+	}
+	switch block.Statement.Control.Transfer {
+	case procedureir.TransferOnErrorDisable:
+		return map[errorMode]bool{errorDisabled: true}
+	case procedureir.TransferOnErrorResumeNext:
+		return map[errorMode]bool{errorNext: true}
+	case procedureir.TransferOnErrorGoto:
+		target := normalizedTarget(block.Statement.Control.Target)
+		if target == "" {
+			return map[errorMode]bool{errorDisabled: true}
+		}
+		return map[errorMode]bool{errorMode("handler:" + target): true}
+	default:
+		return in
+	}
+}
+
+func mergeModes(all map[BlockID]map[errorMode]bool, id BlockID, incoming map[errorMode]bool) bool {
+	if all[id] == nil {
+		all[id] = map[errorMode]bool{}
+	}
+	changed := false
+	for mode := range incoming {
+		if !all[id][mode] {
+			all[id][mode] = true
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (b *builder) isFaultSite(block Block) bool {
+	if block.Statement == nil {
+		return false
+	}
+	switch block.Statement.Kind {
+	case procedureir.StatementLabel, procedureir.StatementOnError, procedureir.StatementResume,
+		procedureir.StatementGoTo, procedureir.StatementExit, procedureir.StatementEnd:
+		return false
+	default:
+		return true
+	}
+}
+
+func (b *builder) finish() {
+	sort.SliceStable(b.edges, func(i, j int) bool {
+		a, c := b.edges[i], b.edges[j]
+		if a.From != c.From {
+			return a.From < c.From
+		}
+		if a.To != c.To {
+			return a.To < c.To
+		}
+		if a.Class != c.Class {
+			return a.Class < c.Class
+		}
+		if a.Kind != c.Kind {
+			return a.Kind < c.Kind
+		}
+		if a.Uncertain != c.Uncertain {
+			return !a.Uncertain
+		}
+		return a.StatementID < c.StatementID
+	})
+	out := make([]Edge, 0, len(b.edges))
+	for _, edge := range b.edges {
+		if len(out) > 0 {
+			last := out[len(out)-1]
+			last.ID, edge.ID = 0, 0
+			if last == edge {
+				continue
+			}
+		}
+		edge.ID = EdgeID(len(out) + 1)
+		out = append(out, edge)
+	}
+	b.graph.Edges = out
+}

--- a/internal/vba/cfg/cfg_test.go
+++ b/internal/vba/cfg/cfg_test.go
@@ -441,6 +441,190 @@ func TestRecoveredLabelTargetAlsoRetainsUnknownFlow(t *testing.T) {
 	}
 }
 
+func TestValidUnclassifiedStatementKeepsOrdinaryFallthrough(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run(ByVal filePath As String)
+    Open filePath For Input As #1
+    GoTo Done
+Handler:
+    Call Failed
+Done:
+    Exit Sub
+End Sub
+`))
+	unknownID := statementIDContaining(t, graph, "Open filePath")
+	unknownBlock := graph.block(blockID(t, graph, unknownID))
+	if unknownBlock.Statement == nil || unknownBlock.Statement.Kind != procedureir.StatementUnknown {
+		t.Fatalf("Open statement kind = %+v, want valid unclassified statement", unknownBlock.Statement)
+	}
+	unknown := unknownBlock.ID
+	gotoBlock := blockID(t, graph, statementIDContaining(t, graph, "GoTo Done"))
+	handler := blockID(t, graph, statementIDContaining(t, graph, "Handler:"))
+	if !hasEdge(graph, unknown, gotoBlock, EdgeFallthrough) {
+		t.Fatalf("valid unclassified statement lost fallthrough: %+v", graph.Edges)
+	}
+	if len(graph.UnknownFlowSources) != 0 {
+		t.Fatalf("valid unclassified statement became unknown flow: %+v", graph.UnknownFlowSources)
+	}
+	if graph.IsReachable(handler, EdgeFilter{NormalOnly: true}) {
+		t.Fatal("valid unclassified statement made skipped handler reachable")
+	}
+}
+
+func TestUnclassifiedStructuredChildrenRemainConservativelyReachable(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		statements []procedureir.Statement
+		parentID   int
+		childID    int
+	}{
+		{
+			name: "if",
+			statements: []procedureir.Statement{
+				{ID: 1, Kind: procedureir.StatementIf},
+				{
+					ID: 2, ParentID: 1, Kind: procedureir.StatementCall,
+					Control: &procedureir.ControlFlowMetadata{Branch: procedureir.BranchThen},
+				},
+				{
+					ID: 3, ParentID: 1, Kind: procedureir.StatementCall,
+					Control: &procedureir.ControlFlowMetadata{Branch: procedureir.BranchElse},
+				},
+				{ID: 4, ParentID: 1, Kind: procedureir.StatementRecovered, Recovered: true},
+				{ID: 5, Kind: procedureir.StatementExit, Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferExitSub}},
+			},
+			parentID: 1,
+			childID:  4,
+		},
+		{
+			name: "select",
+			statements: []procedureir.Statement{
+				{ID: 1, Kind: procedureir.StatementSelect},
+				{ID: 2, ParentID: 1, Kind: procedureir.StatementCase},
+				{ID: 3, ParentID: 1, Kind: procedureir.StatementRecovered, Recovered: true},
+				{ID: 4, Kind: procedureir.StatementExit, Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferExitSub}},
+			},
+			parentID: 1,
+			childID:  3,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			graph := Build(procedureir.ProcedureIR{
+				Symbol:     procedureir.ProcedureSymbol{Name: "Run", Kind: procedureir.ProcedureSub},
+				Statements: test.statements,
+			})
+			parent := blockID(t, graph, test.parentID)
+			child := blockID(t, graph, test.childID)
+			if !hasUncertainEdge(graph, parent, child) {
+				t.Fatalf("unclassified child lacks local uncertain entry: %+v", graph.Edges)
+			}
+			if !graph.IsReachable(child, EdgeFilter{NormalOnly: true}) {
+				t.Fatal("unclassified structured child is spuriously unreachable")
+			}
+		})
+	}
+}
+
+func TestExactResumeTargetRetainsEnabledErrorMode(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run()
+    On Error GoTo Handler
+    Call First
+    Exit Sub
+Handler:
+    Resume ContinueHere
+ContinueHere:
+    Call Second
+    Exit Sub
+End Sub
+`))
+	handler := blockID(t, graph, statementIDContaining(t, graph, "Handler:"))
+	resume := blockID(t, graph, statementIDContaining(t, graph, "Resume ContinueHere"))
+	continuation := blockID(t, graph, statementIDContaining(t, graph, "ContinueHere:"))
+	second := blockID(t, graph, statementIDContaining(t, graph, "Call Second"))
+	if !hasEdge(graph, resume, continuation, EdgeResume) {
+		t.Fatalf("exact Resume target missing: %+v", graph.Edges)
+	}
+	found := false
+	for _, edge := range graph.Edges {
+		if edge.From == second && edge.To == handler && edge.Kind == EdgeError &&
+			edge.Class == EdgeExceptional && edge.Uncertain {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("post-Resume fault lost enabled handler mode: %+v", graph.Edges)
+	}
+}
+
+func TestRecoveredFlowUsesLinearMarkersAndPreWriteAssignmentState(t *testing.T) {
+	t.Parallel()
+	const statementCount = 100
+	statements := make([]procedureir.Statement, statementCount)
+	for i := range statements {
+		statements[i] = procedureir.Statement{
+			ID: i + 1, Kind: procedureir.StatementRecovered, Recovered: true,
+		}
+	}
+	procedure := procedureir.ProcedureIR{
+		Symbol:     procedureir.ProcedureSymbol{Name: "Recovered", Kind: procedureir.ProcedureSub},
+		Statements: statements,
+		Accesses: []procedureir.VariableAccess{{
+			Name: "value", Mode: procedureir.AccessWrite, Scope: procedureir.ScopeLocal, StatementID: 1,
+		}},
+	}
+	graph := Build(procedure)
+	if len(graph.UnknownFlowSources) != statementCount {
+		t.Fatalf("unknown-flow sources = %d, want %d", len(graph.UnknownFlowSources), statementCount)
+	}
+	if got := countEdges(graph, EdgeUnknown); got != statementCount {
+		t.Fatalf("unknown edges = %d, want linear count %d", got, statementCount)
+	}
+	if graph.IsDefinitelyAssigned(
+		blockID(t, graph, 2),
+		Variable{Scope: procedureir.ScopeLocal, Name: "value"},
+		EdgeFilter{NormalOnly: true},
+	) {
+		t.Fatal("recovered assignment write propagated after unknown divergence")
+	}
+}
+
+func TestUnknownFlowPreservesPreDivergenceFactsWithoutInventingSyntheticExits(t *testing.T) {
+	t.Parallel()
+	procedure := procedureir.ProcedureIR{
+		Symbol: procedureir.ProcedureSymbol{Name: "Recovered", Kind: procedureir.ProcedureSub},
+		Statements: []procedureir.Statement{
+			{ID: 1, Kind: procedureir.StatementAssignment},
+			{ID: 2, Kind: procedureir.StatementRecovered, Recovered: true},
+			{ID: 3, Kind: procedureir.StatementLabel, Label: "Cleanup"},
+		},
+		Accesses: []procedureir.VariableAccess{{
+			Name: "value", Mode: procedureir.AccessWrite, Scope: procedureir.ScopeLocal, StatementID: 1,
+		}},
+	}
+	graph := Build(procedure)
+	filter := EdgeFilter{NormalOnly: true}
+	assignment := blockID(t, graph, 1)
+	cleanup := blockID(t, graph, 3)
+	value := Variable{Scope: procedureir.ScopeLocal, Name: "value"}
+	if !graph.IsDefinitelyAssigned(cleanup, value, filter) {
+		t.Fatal("assignment completed before unknown divergence was discarded")
+	}
+	if !containsBlock(graph.Dominators(filter)[cleanup], assignment) {
+		t.Fatal("pre-divergence assignment should still dominate the cleanup label")
+	}
+	if graph.IsReachable(graph.TerminationExit, filter) {
+		t.Fatal("unknown flow invented a termination exit without an End statement")
+	}
+	if !graph.CleanupGuaranteed([]int{3}, ExitSelection{Normal: true}, filter) {
+		t.Fatal("unknown flow invented a normal path around the terminal cleanup label")
+	}
+}
+
 func TestReachabilityDominanceDefiniteAssignmentAndCleanup(t *testing.T) {
 	t.Parallel()
 	graph := Build(buildProcedure(t, `Public Sub Run(ByVal Ready As Boolean)

--- a/internal/vba/cfg/cfg_test.go
+++ b/internal/vba/cfg/cfg_test.go
@@ -1,0 +1,691 @@
+package cfg
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+func TestBuildDocumentIsDeterministicAndCloneIsDefensive(t *testing.T) {
+	t.Parallel()
+	doc := buildIR(t, `Public Sub First()
+    Call Work
+End Sub
+Public Sub Second()
+End Sub
+`)
+	first := BuildDocument(doc)
+	second := BuildDocument(doc)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("identical IR produced different graphs")
+	}
+	if len(first.Graphs) != 2 || first.Graphs[0].Procedure.Name != "First" ||
+		first.Graphs[1].Procedure.Name != "Second" {
+		t.Fatalf("unexpected document graphs: %+v", first.Graphs)
+	}
+	doc.Procedures[0].Statements[0].Text = "mutated input"
+	if first.Graphs[0].Blocks[5].Statement.Text == "mutated input" {
+		t.Fatal("BuildDocument retains mutable input storage")
+	}
+	clone := CloneDocument(first)
+	clone.Graphs[0].Blocks[5].Statement.Text = "changed"
+	clone.Graphs[0].Edges[0].Kind = EdgeUnknown
+	if first.Graphs[0].Blocks[5].Statement.Text == "changed" ||
+		first.Graphs[0].Edges[0].Kind == EdgeUnknown {
+		t.Fatal("CloneDocument shares graph storage")
+	}
+	doc.Procedures[0].Symbol.Parameters = append(doc.Procedures[0].Symbol.Parameters,
+		procedureir.Parameter{Name: "late"})
+	doc.Procedures[0].Statements[0].Text = "mutated input"
+	if len(first.Graphs[0].Procedure.Parameters) != 0 ||
+		first.Graphs[0].Blocks[5].Statement.Text == "mutated input" {
+		t.Fatal("BuildDocument retained mutable input storage")
+	}
+}
+
+func TestStructuredBranchesLoopsTransfersAndLabels(t *testing.T) {
+	t.Parallel()
+	procedure := buildProcedure(t, `Public Sub Run()
+    If Ready Then
+        For Each item In items
+            If Skip Then GoTo Done
+            If StopNow Then Exit For
+            Call ContinueWork
+        Next
+    Else
+        Call Other
+    End If
+    Do
+        Call Again
+    Loop While Ready
+    Exit Sub
+Done:
+    End
+End Sub
+`)
+	graph := Build(procedure)
+	ifEdge := requireEdgeFromKind(t, graph, procedureir.StatementIf, EdgeBranchTrue)
+	if ifEdge.Class != EdgeNormal || ifEdge.Uncertain {
+		t.Fatalf("if edge = %+v", ifEdge)
+	}
+	requireEdge(t, graph, EdgeBranchFalse)
+	requireEdge(t, graph, EdgeLoopBody)
+	requireEdge(t, graph, EdgeLoopBack)
+	requireEdge(t, graph, EdgeLoopExit)
+	gotoEdge := requireEdge(t, graph, EdgeGoto)
+	if graph.block(gotoEdge.To).Statement == nil ||
+		graph.block(gotoEdge.To).Statement.Kind != procedureir.StatementLabel {
+		t.Fatalf("goto did not resolve to label: %+v", gotoEdge)
+	}
+	requireTransitionTo(t, graph, EdgeProcedureExit, graph.NormalExit)
+	requireTransitionTo(t, graph, EdgeTermination, graph.TerminationExit)
+}
+
+func TestSelectAndLoopFormsExposeConservativeAlternatives(t *testing.T) {
+	t.Parallel()
+	document := buildIR(t, `Public Sub Selection(ByVal value As Long)
+    Select Case value
+    Case 1
+        Call One
+    Case Else
+        Call Other
+    End Select
+End Sub
+
+Public Sub NoDefault(ByVal value As Long)
+    Select Case value
+    Case 1
+        Call One
+    End Select
+End Sub
+
+Public Sub Loops(ByVal ready As Boolean)
+    Dim i As Long
+    For i = 1 To 2
+        Call Work
+    Next
+    While ready
+        Call Work
+    Wend
+    Do While ready
+        Call Work
+    Loop
+    Do Until ready
+        Call Work
+    Loop
+    Do
+        Call Work
+    Loop While ready
+    Do
+        Call Work
+    Loop Until ready
+End Sub
+`)
+	if len(document.Procedures) != 3 {
+		t.Fatalf("procedures = %d, want 3", len(document.Procedures))
+	}
+	selection := Build(document.Procedures[0])
+	if got := countEdges(selection, EdgeCase); got != 2 {
+		t.Fatalf("Select Case edges = %d, want 2; edges=%+v", got, selection.Edges)
+	}
+	if got := countEdges(selection, EdgeBranchFalse); got != 0 {
+		t.Fatalf("Select Case Else should cover the default path, false edges=%d", got)
+	}
+	noDefault := Build(document.Procedures[1])
+	if got := countEdges(noDefault, EdgeBranchFalse); got != 1 {
+		t.Fatalf("Select without Case Else false edges = %d, want 1", got)
+	}
+	loops := Build(document.Procedures[2])
+	if got := countEdges(loops, EdgeLoopBack); got < 6 {
+		t.Fatalf("loop-back edges = %d, want at least one per loop; edges=%+v", got, loops.Edges)
+	}
+	if got := countEdges(loops, EdgeLoopExit); got < 6 {
+		t.Fatalf("loop-exit edges = %d, want at least one per loop; edges=%+v", got, loops.Edges)
+	}
+	for _, block := range loops.Blocks {
+		if block.Statement == nil || block.Statement.Kind != procedureir.StatementDo ||
+			block.Statement.SyntaxKind == "do_condition" {
+			continue
+		}
+		if block.Statement.Control == nil || block.Statement.Control.Loop == "" {
+			t.Fatalf("Do block lacks normalized loop mode: %+v", block.Statement)
+		}
+	}
+}
+
+func TestElseIfTrueBranchSkipsFollowingElse(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run(ByVal value As Long)
+    If value = 1 Then
+        Call One
+    ElseIf value = 2 Then
+        Call Two
+    ElseIf value = 3 Then
+        Call Three
+    Else
+        Call Other
+    End If
+    Call Afterward
+End Sub
+`))
+	var firstElseIf, secondElseIf, elseBlock Block
+	for _, block := range graph.Blocks {
+		if block.Statement == nil {
+			continue
+		}
+		switch {
+		case block.Statement.Kind == procedureir.StatementElseIf &&
+			strings.Contains(block.Statement.Text, "value = 2"):
+			firstElseIf = block
+		case block.Statement.Kind == procedureir.StatementElseIf &&
+			strings.Contains(block.Statement.Text, "value = 3"):
+			secondElseIf = block
+		case block.Statement.Kind == procedureir.StatementElse:
+			elseBlock = block
+		}
+	}
+	if firstElseIf.ID == 0 || secondElseIf.ID == 0 || elseBlock.ID == 0 {
+		t.Fatalf("conditional chain blocks missing: first=%+v second=%+v else=%+v", firstElseIf, secondElseIf, elseBlock)
+	}
+	twoBlock := blockID(t, graph, statementIDContaining(t, graph, "Call Two"))
+	threeBlock := blockID(t, graph, statementIDContaining(t, graph, "Call Three"))
+	otherBlock := blockID(t, graph, statementIDContaining(t, graph, "Call Other"))
+	afterBlock := blockID(t, graph, statementIDContaining(t, graph, "Call Afterward"))
+	if !hasEdge(graph, firstElseIf.ID, twoBlock, EdgeBranchTrue) {
+		t.Fatalf("ElseIf true edge does not enter its body: %+v", graph.Edges)
+	}
+	if !hasEdge(graph, firstElseIf.ID, secondElseIf.ID, EdgeBranchFalse) {
+		t.Fatalf("first ElseIf false edge does not enter second ElseIf: %+v", graph.Edges)
+	}
+	if !hasEdge(graph, secondElseIf.ID, threeBlock, EdgeBranchTrue) {
+		t.Fatalf("second ElseIf true edge does not enter its body: %+v", graph.Edges)
+	}
+	if !hasEdge(graph, secondElseIf.ID, elseBlock.ID, EdgeBranchFalse) {
+		t.Fatalf("second ElseIf false edge does not enter Else: %+v", graph.Edges)
+	}
+	if !hasEdge(graph, twoBlock, afterBlock, EdgeFallthrough) {
+		t.Fatalf("ElseIf body does not rejoin after the If: %+v", graph.Edges)
+	}
+	if !hasEdge(graph, threeBlock, afterBlock, EdgeFallthrough) {
+		t.Fatalf("second ElseIf body does not rejoin after the If: %+v", graph.Edges)
+	}
+	if hasEdge(graph, twoBlock, otherBlock, EdgeFallthrough) {
+		t.Fatalf("ElseIf true body incorrectly falls through into Else: %+v", graph.Edges)
+	}
+}
+
+func TestEmptyLoopsRetainBackEdges(t *testing.T) {
+	t.Parallel()
+	document := buildIR(t, `Public Sub EmptyFor()
+    For i = 1 To 2
+    Next
+End Sub
+
+Public Sub EmptyWhile(ByVal ready As Boolean)
+    While ready
+    Wend
+End Sub
+
+Public Sub EmptyPreDo(ByVal ready As Boolean)
+    Do While ready
+    Loop
+End Sub
+
+Public Sub EmptyPostDo(ByVal ready As Boolean)
+    Do
+    Loop Until ready
+End Sub
+
+Public Sub EmptyInfiniteDo()
+    Do
+    Loop
+End Sub
+`)
+	if len(document.Procedures) != 5 {
+		t.Fatalf("procedures = %d, want 5", len(document.Procedures))
+	}
+	for _, procedure := range document.Procedures {
+		graph := Build(procedure)
+		if got := countEdges(graph, EdgeLoopBack); got == 0 {
+			t.Fatalf("%s has no loop-back edge: %+v", procedure.Symbol.Name, graph.Edges)
+		}
+	}
+}
+
+func TestDuplicateAndMissingLabelsRemainConservative(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run()
+    GoTo Duplicate
+Duplicate:
+    Call One
+Duplicate:
+    GoTo Missing
+End Sub
+`))
+	var duplicateEdges int
+	for _, edge := range graph.Edges {
+		if edge.Kind == EdgeGoto && edge.Uncertain {
+			duplicateEdges++
+		}
+	}
+	if duplicateEdges != 2 {
+		t.Fatalf("duplicate target edges = %d, want 2; edges=%+v", duplicateEdges, graph.Edges)
+	}
+	requireTransitionTo(t, graph, EdgeUnknown, graph.UnknownExit)
+}
+
+func TestInvalidExitTargetsUnknownFlow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		procedure procedureir.ProcedureIR
+	}{
+		{
+			name: "mismatched procedure exit",
+			procedure: procedureir.ProcedureIR{
+				Symbol: procedureir.ProcedureSymbol{Name: "Value", Kind: procedureir.ProcedureFunction},
+				Statements: []procedureir.Statement{{
+					ID: 1, Kind: procedureir.StatementExit,
+					Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferExitSub},
+				}},
+			},
+		},
+		{
+			name: "loop exit outside loop",
+			procedure: procedureir.ProcedureIR{
+				Symbol: procedureir.ProcedureSymbol{Name: "Run", Kind: procedureir.ProcedureSub},
+				Statements: []procedureir.Statement{{
+					ID: 1, Kind: procedureir.StatementExit,
+					Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferExitFor},
+				}},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			graph := Build(test.procedure)
+			found := false
+			for _, edge := range graph.Edges {
+				if edge.From == blockID(t, graph, 1) && edge.To == graph.UnknownExit && edge.Uncertain {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("invalid exit lacks uncertain unknown flow: %+v", graph.Edges)
+			}
+		})
+	}
+}
+
+func TestForEachZeroIterationDoesNotAssignIterator(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run(ByVal items As Collection)
+    Dim item As Variant
+    For Each item In items
+    Next
+    Debug.Print item
+End Sub
+`))
+	printBlock := blockID(t, graph, statementIDContaining(t, graph, "Debug.Print"))
+	if graph.IsDefinitelyAssigned(
+		printBlock,
+		Variable{Scope: procedureir.ScopeLocal, Name: "item"},
+		EdgeFilter{NormalOnly: true},
+	) {
+		t.Fatal("For Each iterator is not definitely assigned after a possible zero-iteration loop")
+	}
+}
+
+func TestErrorModesProduceSeparateUncertainExceptionalEdges(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run()
+    On Error GoTo Handler
+    Call Work
+    On Error Resume Next
+    Call IgnoreFailure
+    On Error GoTo 0
+    Call Fail
+    Exit Sub
+Handler:
+    Resume Next
+End Sub
+`))
+	var handler, resumeNext, exceptional bool
+	for _, edge := range graph.Edges {
+		if edge.Kind != EdgeError {
+			continue
+		}
+		if edge.Class != EdgeExceptional || !edge.Uncertain {
+			t.Fatalf("error edge is not uncertain exceptional: %+v", edge)
+		}
+		source := graph.block(edge.From).Statement
+		target := graph.block(edge.To).Statement
+		if source != nil && strings.Contains(source.Text, "Work") && target != nil &&
+			target.Kind == procedureir.StatementLabel {
+			handler = true
+		}
+		if source != nil && strings.Contains(source.Text, "IgnoreFailure") && edge.To != graph.ExceptionalExit {
+			resumeNext = true
+		}
+		if source != nil && strings.Contains(source.Text, "Fail") && edge.To == graph.ExceptionalExit {
+			exceptional = true
+		}
+	}
+	if !handler || !resumeNext || !exceptional {
+		t.Fatalf("missing error mode edge: handler=%v next=%v exceptional=%v; edges=%+v",
+			handler, resumeNext, exceptional, graph.Edges)
+	}
+	resume := requireEdge(t, graph, EdgeResume)
+	if resume.Class != EdgeExceptional || !resume.Uncertain || resume.To != graph.UnknownExit {
+		t.Fatalf("dynamic Resume Next edge = %+v, want uncertain exceptional unknown flow", resume)
+	}
+}
+
+func TestMergedErrorModesAndBackwardGotoRemainExplicit(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run(ByVal guarded As Boolean, ByVal repeat As Boolean)
+Start:
+    If guarded Then
+        On Error GoTo Handler
+    Else
+        On Error Resume Next
+    End If
+    Call Work
+    If repeat Then GoTo Start
+    Exit Sub
+Handler:
+    Resume Next
+End Sub
+`))
+	workBlock := blockID(t, graph, statementIDContaining(t, graph, "Call Work"))
+	handlerBlock := blockID(t, graph, statementIDContaining(t, graph, "Handler:"))
+	var handlerMode, resumeNextMode bool
+	for _, edge := range graph.Edges {
+		if edge.From != workBlock || edge.Kind != EdgeError || edge.Class != EdgeExceptional || !edge.Uncertain {
+			continue
+		}
+		handlerMode = handlerMode || edge.To == handlerBlock
+		resumeNextMode = resumeNextMode || edge.To != handlerBlock
+	}
+	if !handlerMode || !resumeNextMode {
+		t.Fatalf("merged error modes missing: handler=%v resume-next=%v edges=%+v",
+			handlerMode, resumeNextMode, graph.Edges)
+	}
+	gotoEdge := requireEdge(t, graph, EdgeGoto)
+	if gotoEdge.To != blockID(t, graph, statementIDContaining(t, graph, "Start:")) {
+		t.Fatalf("backward GoTo target = %d, want Start label", gotoEdge.To)
+	}
+}
+
+func TestRecoveredLabelTargetAlsoRetainsUnknownFlow(t *testing.T) {
+	t.Parallel()
+	graph := Build(procedureir.ProcedureIR{
+		Symbol: procedureir.ProcedureSymbol{Name: "Run", Kind: procedureir.ProcedureSub},
+		Statements: []procedureir.Statement{
+			{
+				ID: 1, Kind: procedureir.StatementGoTo,
+				Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferGoto, Target: "Handler"},
+			},
+			{ID: 2, Kind: procedureir.StatementLabel, Label: "Handler", Recovered: true},
+		},
+	})
+	gotoBlock := blockID(t, graph, 1)
+	labelBlock := blockID(t, graph, 2)
+	if !hasUncertainEdge(graph, gotoBlock, labelBlock) ||
+		!hasUncertainEdge(graph, gotoBlock, graph.UnknownExit) {
+		t.Fatalf("recovered target lacks candidate and unknown flow: %+v", graph.Edges)
+	}
+}
+
+func TestReachabilityDominanceDefiniteAssignmentAndCleanup(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run(ByVal Ready As Boolean)
+    Dim value As Long
+    If Ready Then
+        value = 1
+    Else
+        value = 2
+    End If
+Cleanup:
+    Debug.Print value
+    Exit Sub
+Dead:
+    value = 3
+End Sub
+`))
+	dead := statementIDContaining(t, graph, "value = 3")
+	if graph.IsReachable(blockID(t, graph, dead), EdgeFilter{NormalOnly: true}) {
+		t.Fatal("dead statement is reachable")
+	}
+	if len(graph.Unreachable(EdgeFilter{NormalOnly: true})) == 0 {
+		t.Fatal("expected unreachable statement")
+	}
+	cleanup := statementIDContaining(t, graph, "Cleanup:")
+	printID := statementIDContaining(t, graph, "Debug.Print")
+	printBlock := blockID(t, graph, printID)
+	variable := Variable{Scope: procedureir.ScopeLocal, Name: "VALUE"}
+	if !graph.IsDefinitelyAssigned(printBlock, variable, EdgeFilter{NormalOnly: true}) {
+		t.Fatalf("value is not definitely assigned at print: %+v", graph.DefiniteAssignments(EdgeFilter{NormalOnly: true})[printBlock])
+	}
+	if !graph.IsDefinitelyAssigned(graph.Entry,
+		Variable{Scope: procedureir.ScopeParameter, Name: "READY"}, EdgeFilter{}) {
+		t.Fatal("procedure parameter is not seeded as definitely assigned")
+	}
+	dominators := graph.Dominators(EdgeFilter{NormalOnly: true})
+	if !containsBlock(dominators[graph.NormalExit], blockID(t, graph, cleanup)) {
+		t.Fatalf("cleanup does not dominate normal exit: %+v", dominators[graph.NormalExit])
+	}
+	if !graph.CleanupGuaranteed([]int{cleanup}, ExitSelection{Normal: true}, EdgeFilter{NormalOnly: true}) {
+		t.Fatal("cleanup should cross every normal exit path")
+	}
+	if graph.CleanupGuaranteed([]int{cleanup}, ExitSelection{}, EdgeFilter{}) {
+		t.Fatal("cleanup must not be guaranteed across conservative exceptional exits")
+	}
+	if len(graph.ExitTransitions(ExitSelection{Normal: true}, EdgeFilter{NormalOnly: true})) == 0 {
+		t.Fatal("normal exit transitions missing")
+	}
+	if block, ok := graph.BlockForStatement(0); ok {
+		t.Fatalf("statement ID 0 resolved to synthetic block: %+v", block)
+	}
+	if graph.CleanupGuaranteed([]int{0}, ExitSelection{Normal: true}, EdgeFilter{NormalOnly: true}) {
+		t.Fatal("invalid cleanup statement ID proved a guarantee")
+	}
+}
+
+func TestMultipleCleanupCandidatesCoverNormalExits(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run(ByVal first As Boolean)
+    If first Then
+CleanupA:
+        Exit Sub
+    Else
+CleanupB:
+        Exit Sub
+    End If
+End Sub
+`))
+	cleanupA := statementIDContaining(t, graph, "CleanupA:")
+	cleanupB := statementIDContaining(t, graph, "CleanupB:")
+	if !graph.CleanupGuaranteed(
+		[]int{cleanupA, cleanupB},
+		ExitSelection{Normal: true},
+		EdgeFilter{NormalOnly: true},
+	) {
+		t.Fatal("one of the two cleanup labels crosses every normal exit path")
+	}
+}
+
+func TestCFGRangesPreserveUTF8ByteColumnsAndCRLFOffsets(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, "Public Sub Run()\r\n"+
+		"    Debug.Print \"日本語\": GoTo Done\r\n"+
+		"Done:\r\n"+
+		"End Sub\r\n"))
+	gotoID := statementIDContaining(t, graph, "GoTo Done")
+	gotoBlock, ok := graph.BlockForStatement(gotoID)
+	if !ok || gotoBlock.Statement == nil {
+		t.Fatal("GoTo block missing")
+	}
+	gotoEdge := requireEdge(t, graph, EdgeGoto)
+	if gotoEdge.Range != gotoBlock.Statement.Range {
+		t.Fatalf("edge range = %+v, statement range = %+v", gotoEdge.Range, gotoBlock.Statement.Range)
+	}
+	if gotoEdge.Range.StartLine != 2 || gotoEdge.Range.StartColumn <= 25 || gotoEdge.Range.StartByte <= 20 {
+		t.Fatalf("UTF-8/CRLF range was not preserved: %+v", gotoEdge.Range)
+	}
+}
+
+func TestExceptionalAssignmentEdgeUsesBlockInputSet(t *testing.T) {
+	t.Parallel()
+	graph := Build(buildProcedure(t, `Public Sub Run()
+    Dim value As Long
+    On Error GoTo Handler
+    value = Work()
+    Exit Sub
+Handler:
+    Debug.Print value
+End Sub
+`))
+	handler := blockID(t, graph, statementIDContaining(t, graph, "Handler:"))
+	if graph.IsDefinitelyAssigned(handler,
+		Variable{Scope: procedureir.ScopeLocal, Name: "value"}, EdgeFilter{}) {
+		t.Fatal("faulting assignment write propagated across exceptional edge")
+	}
+}
+
+func TestUnknownRecoveryPreventsPositiveGuarantees(t *testing.T) {
+	t.Parallel()
+	procedure := procedureir.ProcedureIR{
+		Symbol: procedureir.ProcedureSymbol{Name: "Recovered", Kind: procedureir.ProcedureSub},
+		Statements: []procedureir.Statement{
+			{ID: 1, Kind: procedureir.StatementRecovered, Recovered: true},
+			{ID: 2, Kind: procedureir.StatementLabel, Label: "Cleanup"},
+			{ID: 3, Kind: procedureir.StatementExit, Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferExitSub}},
+		},
+	}
+	graph := Build(procedure)
+	if graph.CleanupGuaranteed([]int{2}, ExitSelection{}, EdgeFilter{}) {
+		t.Fatal("recovered control incorrectly proved cleanup")
+	}
+	unknown := false
+	for _, edge := range graph.Edges {
+		unknown = unknown || edge.From == blockID(t, graph, 1) && edge.Kind == EdgeUnknown &&
+			edge.Uncertain && edge.To == graph.UnknownExit
+	}
+	if !unknown {
+		t.Fatal("recovered statement lacks uncertain unknown transition")
+	}
+}
+
+func buildIR(t *testing.T, source string) procedureir.DocumentIR {
+	t.Helper()
+	doc, err := procedureir.BuildSource(procedureir.BuildOptions{Path: "Module1.bas"}, []byte(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func buildProcedure(t *testing.T, source string) procedureir.ProcedureIR {
+	t.Helper()
+	doc := buildIR(t, source)
+	if len(doc.Procedures) != 1 {
+		t.Fatalf("procedures = %d", len(doc.Procedures))
+	}
+	return doc.Procedures[0]
+}
+
+func requireEdge(t *testing.T, graph Graph, kind EdgeKind) Edge {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.Kind == kind {
+			return edge
+		}
+	}
+	t.Fatalf("missing %q edge: %+v", kind, graph.Edges)
+	return Edge{}
+}
+
+func requireEdgeFromKind(t *testing.T, graph Graph, statementKind procedureir.StatementKind, edgeKind EdgeKind) Edge {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		block := graph.block(edge.From)
+		if edge.Kind == edgeKind && block.Statement != nil && block.Statement.Kind == statementKind {
+			return edge
+		}
+	}
+	t.Fatalf("missing %q edge from %q", edgeKind, statementKind)
+	return Edge{}
+}
+
+func requireTransitionTo(t *testing.T, graph Graph, kind EdgeKind, target BlockID) Edge {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.Kind == kind && edge.To == target {
+			return edge
+		}
+	}
+	t.Fatalf("missing %q edge to %d: %+v", kind, target, graph.Edges)
+	return Edge{}
+}
+
+func statementIDContaining(t *testing.T, graph Graph, text string) int {
+	t.Helper()
+	for _, block := range graph.Blocks {
+		if block.Statement != nil && strings.Contains(block.Statement.Text, text) {
+			return block.StatementID
+		}
+	}
+	t.Fatalf("missing statement containing %q", text)
+	return 0
+}
+
+func blockID(t *testing.T, graph Graph, statementID int) BlockID {
+	t.Helper()
+	block, ok := graph.BlockForStatement(statementID)
+	if !ok {
+		t.Fatalf("missing statement block %d", statementID)
+	}
+	return block.ID
+}
+
+func containsBlock(ids []BlockID, target BlockID) bool {
+	for _, id := range ids {
+		if id == target {
+			return true
+		}
+	}
+	return false
+}
+
+func countEdges(graph Graph, kind EdgeKind) int {
+	count := 0
+	for _, edge := range graph.Edges {
+		if edge.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func hasEdge(graph Graph, from, to BlockID, kind EdgeKind) bool {
+	for _, edge := range graph.Edges {
+		if edge.From == from && edge.To == to && edge.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUncertainEdge(graph Graph, from, to BlockID) bool {
+	for _, edge := range graph.Edges {
+		if edge.From == from && edge.To == to && edge.Uncertain {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/vba/cfg/clone.go
+++ b/internal/vba/cfg/clone.go
@@ -1,0 +1,48 @@
+package cfg
+
+import "github.com/harumiWeb/xlflow/internal/vba/procedureir"
+
+// CloneDocument returns a deep copy suitable for publication across cache
+// boundaries.
+func CloneDocument(in Document) Document {
+	out := in
+	out.Graphs = make([]Graph, len(in.Graphs))
+	for i := range in.Graphs {
+		out.Graphs[i] = Clone(in.Graphs[i])
+	}
+	return out
+}
+
+// Clone returns a deep copy of a graph.
+func Clone(in Graph) Graph {
+	out := in
+	out.Procedure.Parameters = append([]procedureir.Parameter(nil), in.Procedure.Parameters...)
+	out.Blocks = make([]Block, len(in.Blocks))
+	for i := range in.Blocks {
+		out.Blocks[i] = in.Blocks[i]
+		out.Blocks[i].Assignments = append([]Variable(nil), in.Blocks[i].Assignments...)
+		if in.Blocks[i].Statement != nil {
+			statement := *in.Blocks[i].Statement
+			statement.ExpressionIDs = append([]int(nil), statement.ExpressionIDs...)
+			statement.Target = cloneExpression(statement.Target)
+			statement.Value = cloneExpression(statement.Value)
+			statement.Condition = cloneExpression(statement.Condition)
+			if statement.Control != nil {
+				control := *statement.Control
+				statement.Control = &control
+			}
+			out.Blocks[i].Statement = &statement
+		}
+	}
+	out.Edges = append([]Edge(nil), in.Edges...)
+	return out
+}
+
+func cloneExpression(in *procedureir.Expression) *procedureir.Expression {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.Children = append([]int(nil), in.Children...)
+	return &out
+}

--- a/internal/vba/cfg/clone.go
+++ b/internal/vba/cfg/clone.go
@@ -35,6 +35,7 @@ func Clone(in Graph) Graph {
 		}
 	}
 	out.Edges = append([]Edge(nil), in.Edges...)
+	out.UnknownFlowSources = append([]BlockID(nil), in.UnknownFlowSources...)
 	return out
 }
 

--- a/internal/vba/cfg/query.go
+++ b/internal/vba/cfg/query.go
@@ -80,14 +80,16 @@ func (g Graph) Dominators(filter EdgeFilter) map[BlockID][]BlockID {
 	changed := true
 	for changed {
 		changed = false
+		unknownDominators, hasUnknown := g.unknownDominatorInput(reachable, dom)
 		for id := range reachable {
 			if id == g.Entry {
 				continue
 			}
 			preds := g.predecessors(id, filter, reachable)
 			next := map[BlockID]bool{id: true}
+			var intersection map[BlockID]bool
 			if len(preds) > 0 {
-				intersection := copySet(dom[preds[0]])
+				intersection = copySet(dom[preds[0]])
 				for _, pred := range preds[1:] {
 					for candidate := range intersection {
 						if !dom[pred][candidate] {
@@ -95,9 +97,20 @@ func (g Graph) Dominators(filter EdgeFilter) map[BlockID][]BlockID {
 						}
 					}
 				}
-				for candidate := range intersection {
-					next[candidate] = true
+			}
+			if hasUnknown && g.block(id).Kind == BlockStatement {
+				if intersection == nil {
+					intersection = copySet(unknownDominators)
+				} else {
+					for candidate := range intersection {
+						if !unknownDominators[candidate] {
+							delete(intersection, candidate)
+						}
+					}
 				}
+			}
+			for candidate := range intersection {
+				next[candidate] = true
 			}
 			if !sameSet(dom[id], next) {
 				dom[id] = next
@@ -113,6 +126,28 @@ func (g Graph) Dominators(filter EdgeFilter) map[BlockID][]BlockID {
 		sort.Slice(out[id], func(i, j int) bool { return out[id][i] < out[id][j] })
 	}
 	return out
+}
+
+func (g Graph) unknownDominatorInput(
+	reachable map[BlockID]bool,
+	dominators map[BlockID]map[BlockID]bool,
+) (map[BlockID]bool, bool) {
+	var intersection map[BlockID]bool
+	for _, source := range g.UnknownFlowSources {
+		if !reachable[source] {
+			continue
+		}
+		if intersection == nil {
+			intersection = copySet(dominators[source])
+			continue
+		}
+		for candidate := range intersection {
+			if !dominators[source][candidate] {
+				delete(intersection, candidate)
+			}
+		}
+	}
+	return intersection, intersection != nil
 }
 
 // DefiniteAssignments returns variables definitely assigned on entry to every
@@ -144,11 +179,15 @@ func (g Graph) DefiniteAssignments(filter EdgeFilter) map[BlockID][]Variable {
 	changed := true
 	for changed {
 		changed = false
+		unknownInput, hasUnknown := g.unknownAssignmentInput(reachable, in)
 		for id := range reachable {
 			if id == g.Entry {
 				continue
 			}
 			incoming := g.assignmentInputs(id, filter, reachable, in, outSet)
+			if hasUnknown && g.block(id).Kind == BlockStatement {
+				incoming = append(incoming, unknownInput)
+			}
 			next := map[Variable]bool{}
 			if len(incoming) > 0 {
 				next = copyVariableSet(incoming[0])
@@ -182,6 +221,28 @@ func (g Graph) DefiniteAssignments(filter EdgeFilter) map[BlockID][]Variable {
 	return result
 }
 
+func (g Graph) unknownAssignmentInput(
+	reachable map[BlockID]bool,
+	in map[BlockID]map[Variable]bool,
+) (map[Variable]bool, bool) {
+	var intersection map[Variable]bool
+	for _, source := range g.UnknownFlowSources {
+		if !reachable[source] {
+			continue
+		}
+		if intersection == nil {
+			intersection = copyVariableSet(in[source])
+			continue
+		}
+		for variable := range intersection {
+			if !in[source][variable] {
+				delete(intersection, variable)
+			}
+		}
+	}
+	return intersection, intersection != nil
+}
+
 func (g Graph) assignmentInputs(
 	id BlockID,
 	filter EdgeFilter,
@@ -196,10 +257,12 @@ func (g Graph) assignmentInputs(
 		source := g.block(edge.From)
 		forEachZeroIteration := source.Statement != nil &&
 			source.Statement.Kind == procedureir.StatementForEach && edge.Kind == EdgeLoopExit
-		if edge.Class == EdgeExceptional || forEachZeroIteration {
+		unknownBeforeCompletion := edge.Kind == EdgeUnknown && edge.Uncertain
+		if edge.Class == EdgeExceptional || forEachZeroIteration || unknownBeforeCompletion {
 			// A fault can occur before the source statement's writes complete.
 			// For Each may also take its zero-iteration exit before assigning
-			// the iterator variable.
+			// the iterator variable. Unknown control may diverge before a
+			// recovered statement's writes complete.
 			inputs = append(inputs, in[edge.From])
 		} else {
 			inputs = append(inputs, out[edge.From])
@@ -242,24 +305,66 @@ func (g Graph) CleanupGuaranteed(cleanupStatementIDs []int, selection ExitSelect
 }
 
 func (g Graph) reachableWithout(filter EdgeFilter, removed map[BlockID]bool) map[BlockID]bool {
+	seen := g.physicalReachable(filter, removed)
+	if g.unknownFlowReached(seen) {
+		for _, block := range g.Blocks {
+			if block.Kind == BlockStatement && !removed[block.ID] {
+				seen[block.ID] = true
+			}
+		}
+		if !removed[g.UnknownExit] {
+			seen[g.UnknownExit] = true
+		}
+		seen = g.expandReachable(filter, removed, seen)
+	}
+	return seen
+}
+
+func (g Graph) physicalReachable(filter EdgeFilter, removed map[BlockID]bool) map[BlockID]bool {
 	seen := map[BlockID]bool{}
 	if removed[g.Entry] {
 		return seen
 	}
-	queue := []BlockID{g.Entry}
 	seen[g.Entry] = true
+	return g.expandReachable(filter, removed, seen)
+}
+
+func (g Graph) expandReachable(
+	filter EdgeFilter,
+	removed map[BlockID]bool,
+	seen map[BlockID]bool,
+) map[BlockID]bool {
+	successors := map[BlockID][]BlockID{}
+	for _, edge := range g.Edges {
+		if filter.accepts(edge) && !removed[edge.To] {
+			successors[edge.From] = append(successors[edge.From], edge.To)
+		}
+	}
+	queue := make([]BlockID, 0, len(seen))
+	for id := range seen {
+		queue = append(queue, id)
+	}
 	for len(queue) > 0 {
 		current := queue[0]
 		queue = queue[1:]
-		for _, edge := range g.Edges {
-			if edge.From != current || !filter.accepts(edge) || removed[edge.To] || seen[edge.To] {
+		for _, target := range successors[current] {
+			if seen[target] {
 				continue
 			}
-			seen[edge.To] = true
-			queue = append(queue, edge.To)
+			seen[target] = true
+			queue = append(queue, target)
 		}
 	}
 	return seen
+}
+
+func (g Graph) unknownFlowReached(reachable map[BlockID]bool) bool {
+	for _, source := range g.UnknownFlowSources {
+		if reachable[source] {
+			return true
+		}
+	}
+	return false
 }
 
 func (g Graph) predecessors(id BlockID, filter EdgeFilter, reachable map[BlockID]bool) []BlockID {

--- a/internal/vba/cfg/query.go
+++ b/internal/vba/cfg/query.go
@@ -1,0 +1,339 @@
+package cfg
+
+import (
+	"sort"
+
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+// BlockForStatement returns the block owning statementID.
+func (g Graph) BlockForStatement(statementID int) (Block, bool) {
+	if statementID <= 0 {
+		return Block{}, false
+	}
+	for _, block := range g.Blocks {
+		if block.Kind == BlockStatement && block.StatementID == statementID {
+			return block, true
+		}
+	}
+	return Block{}, false
+}
+
+// Reachable returns reachable block IDs in stable ID order.
+func (g Graph) Reachable(filter EdgeFilter) []BlockID {
+	seen := g.reachableWithout(filter, nil)
+	out := make([]BlockID, 0, len(seen))
+	for _, block := range g.Blocks {
+		if seen[block.ID] {
+			out = append(out, block.ID)
+		}
+	}
+	return out
+}
+
+// IsReachable reports whether target is reachable from Entry.
+func (g Graph) IsReachable(target BlockID, filter EdgeFilter) bool {
+	return g.reachableWithout(filter, nil)[target]
+}
+
+// Unreachable returns statement blocks that cannot be reached from Entry.
+func (g Graph) Unreachable(filter EdgeFilter) []Block {
+	seen := g.reachableWithout(filter, nil)
+	var out []Block
+	for _, block := range g.Blocks {
+		if block.Kind == BlockStatement && !seen[block.ID] {
+			out = append(out, block)
+		}
+	}
+	return out
+}
+
+// ExitTransitions returns reachable edges into selected synthetic exits.
+func (g Graph) ExitTransitions(selection ExitSelection, filter EdgeFilter) []Edge {
+	reachable := g.reachableWithout(filter, nil)
+	selected := idSet(selection.ids(g))
+	var out []Edge
+	for _, edge := range g.Edges {
+		if filter.accepts(edge) && reachable[edge.From] && selected[edge.To] {
+			out = append(out, edge)
+		}
+	}
+	return out
+}
+
+// Dominators computes conservative dominators. Uncertain edges are always
+// included; NormalOnly may be used for explicitly normal-flow consumers.
+func (g Graph) Dominators(filter EdgeFilter) map[BlockID][]BlockID {
+	reachable := g.reachableWithout(filter, nil)
+	all := map[BlockID]bool{}
+	for id := range reachable {
+		all[id] = true
+	}
+	dom := map[BlockID]map[BlockID]bool{}
+	for id := range reachable {
+		if id == g.Entry {
+			dom[id] = map[BlockID]bool{id: true}
+		} else {
+			dom[id] = copySet(all)
+		}
+	}
+	changed := true
+	for changed {
+		changed = false
+		for id := range reachable {
+			if id == g.Entry {
+				continue
+			}
+			preds := g.predecessors(id, filter, reachable)
+			next := map[BlockID]bool{id: true}
+			if len(preds) > 0 {
+				intersection := copySet(dom[preds[0]])
+				for _, pred := range preds[1:] {
+					for candidate := range intersection {
+						if !dom[pred][candidate] {
+							delete(intersection, candidate)
+						}
+					}
+				}
+				for candidate := range intersection {
+					next[candidate] = true
+				}
+			}
+			if !sameSet(dom[id], next) {
+				dom[id] = next
+				changed = true
+			}
+		}
+	}
+	out := map[BlockID][]BlockID{}
+	for id, set := range dom {
+		for candidate := range set {
+			out[id] = append(out[id], candidate)
+		}
+		sort.Slice(out[id], func(i, j int) bool { return out[id][i] < out[id][j] })
+	}
+	return out
+}
+
+// DefiniteAssignments returns variables definitely assigned on entry to every
+// reachable block. It is a must-analysis and always includes uncertain edges.
+func (g Graph) DefiniteAssignments(filter EdgeFilter) map[BlockID][]Variable {
+	reachable := g.reachableWithout(filter, nil)
+	universe := map[Variable]bool{}
+	parameters := map[Variable]bool{}
+	for _, parameter := range g.Procedure.Parameters {
+		variable := Variable{Scope: procedureir.ScopeParameter, Name: parameter.Name}.canonical()
+		universe[variable] = true
+		parameters[variable] = true
+	}
+	for _, block := range g.Blocks {
+		for _, variable := range block.Assignments {
+			universe[variable.canonical()] = true
+		}
+	}
+	in := map[BlockID]map[Variable]bool{}
+	outSet := map[BlockID]map[Variable]bool{}
+	for id := range reachable {
+		if id == g.Entry {
+			in[id] = copyVariableSet(parameters)
+		} else {
+			in[id] = copyVariableSet(universe)
+		}
+		outSet[id] = withBlockAssignments(in[id], g.block(id))
+	}
+	changed := true
+	for changed {
+		changed = false
+		for id := range reachable {
+			if id == g.Entry {
+				continue
+			}
+			incoming := g.assignmentInputs(id, filter, reachable, in, outSet)
+			next := map[Variable]bool{}
+			if len(incoming) > 0 {
+				next = copyVariableSet(incoming[0])
+				for _, predecessor := range incoming[1:] {
+					for variable := range next {
+						if !predecessor[variable] {
+							delete(next, variable)
+						}
+					}
+				}
+			}
+			if !sameVariableSet(in[id], next) {
+				in[id] = next
+				outSet[id] = withBlockAssignments(next, g.block(id))
+				changed = true
+			}
+		}
+	}
+	result := map[BlockID][]Variable{}
+	for id, set := range in {
+		for variable := range set {
+			result[id] = append(result[id], variable)
+		}
+		sort.Slice(result[id], func(i, j int) bool {
+			if result[id][i].Scope != result[id][j].Scope {
+				return result[id][i].Scope < result[id][j].Scope
+			}
+			return result[id][i].Name < result[id][j].Name
+		})
+	}
+	return result
+}
+
+func (g Graph) assignmentInputs(
+	id BlockID,
+	filter EdgeFilter,
+	reachable map[BlockID]bool,
+	in, out map[BlockID]map[Variable]bool,
+) []map[Variable]bool {
+	var inputs []map[Variable]bool
+	for _, edge := range g.Edges {
+		if edge.To != id || !filter.accepts(edge) || !reachable[edge.From] {
+			continue
+		}
+		source := g.block(edge.From)
+		forEachZeroIteration := source.Statement != nil &&
+			source.Statement.Kind == procedureir.StatementForEach && edge.Kind == EdgeLoopExit
+		if edge.Class == EdgeExceptional || forEachZeroIteration {
+			// A fault can occur before the source statement's writes complete.
+			// For Each may also take its zero-iteration exit before assigning
+			// the iterator variable.
+			inputs = append(inputs, in[edge.From])
+		} else {
+			inputs = append(inputs, out[edge.From])
+		}
+	}
+	return inputs
+}
+
+// IsDefinitelyAssigned is the case-insensitive convenience query.
+func (g Graph) IsDefinitelyAssigned(block BlockID, variable Variable, filter EdgeFilter) bool {
+	variable = variable.canonical()
+	for _, assigned := range g.DefiniteAssignments(filter)[block] {
+		if assigned == variable {
+			return true
+		}
+	}
+	return false
+}
+
+// CleanupGuaranteed reports whether every reachable selected exit path crosses
+// at least one cleanup statement. Unknown/exceptional exits participate by
+// default, and uncertain edges can never be excluded.
+func (g Graph) CleanupGuaranteed(cleanupStatementIDs []int, selection ExitSelection, filter EdgeFilter) bool {
+	removed := map[BlockID]bool{}
+	for _, statementID := range cleanupStatementIDs {
+		if block, ok := g.BlockForStatement(statementID); ok {
+			removed[block.ID] = true
+		}
+	}
+	if len(removed) == 0 {
+		return false
+	}
+	reachable := g.reachableWithout(filter, removed)
+	for _, exit := range selection.ids(g) {
+		if reachable[exit] {
+			return false
+		}
+	}
+	return true
+}
+
+func (g Graph) reachableWithout(filter EdgeFilter, removed map[BlockID]bool) map[BlockID]bool {
+	seen := map[BlockID]bool{}
+	if removed[g.Entry] {
+		return seen
+	}
+	queue := []BlockID{g.Entry}
+	seen[g.Entry] = true
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, edge := range g.Edges {
+			if edge.From != current || !filter.accepts(edge) || removed[edge.To] || seen[edge.To] {
+				continue
+			}
+			seen[edge.To] = true
+			queue = append(queue, edge.To)
+		}
+	}
+	return seen
+}
+
+func (g Graph) predecessors(id BlockID, filter EdgeFilter, reachable map[BlockID]bool) []BlockID {
+	var out []BlockID
+	seen := map[BlockID]bool{}
+	for _, edge := range g.Edges {
+		if edge.To == id && filter.accepts(edge) && reachable[edge.From] && !seen[edge.From] {
+			seen[edge.From] = true
+			out = append(out, edge.From)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func (g Graph) block(id BlockID) Block {
+	if id > 0 && int(id) <= len(g.Blocks) {
+		return g.Blocks[int(id)-1]
+	}
+	return Block{}
+}
+
+func idSet(ids []BlockID) map[BlockID]bool {
+	out := map[BlockID]bool{}
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out
+}
+
+func copySet(in map[BlockID]bool) map[BlockID]bool {
+	out := map[BlockID]bool{}
+	for key := range in {
+		out[key] = true
+	}
+	return out
+}
+
+func sameSet(a, b map[BlockID]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key := range a {
+		if !b[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func copyVariableSet(in map[Variable]bool) map[Variable]bool {
+	out := map[Variable]bool{}
+	for key := range in {
+		out[key] = true
+	}
+	return out
+}
+
+func sameVariableSet(a, b map[Variable]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key := range a {
+		if !b[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func withBlockAssignments(in map[Variable]bool, block Block) map[Variable]bool {
+	out := copyVariableSet(in)
+	for _, variable := range block.Assignments {
+		out[variable.canonical()] = true
+	}
+	return out
+}

--- a/internal/vba/cfg/types.go
+++ b/internal/vba/cfg/types.go
@@ -1,0 +1,145 @@
+// Package cfg builds protocol-neutral, conservative control-flow graphs from
+// normalized VBA procedure IR.
+package cfg
+
+import (
+	"strings"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+type BlockID int
+type EdgeID int
+
+type BlockKind string
+
+const (
+	BlockEntry           BlockKind = "entry"
+	BlockNormalExit      BlockKind = "normal_exit"
+	BlockExceptionalExit BlockKind = "exceptional_exit"
+	BlockTerminationExit BlockKind = "termination_exit"
+	BlockUnknownExit     BlockKind = "unknown_exit"
+	BlockStatement       BlockKind = "statement"
+)
+
+type EdgeClass string
+
+const (
+	EdgeNormal      EdgeClass = "normal"
+	EdgeExceptional EdgeClass = "exceptional"
+)
+
+type EdgeKind string
+
+const (
+	EdgeFallthrough   EdgeKind = "fallthrough"
+	EdgeBranchTrue    EdgeKind = "branch_true"
+	EdgeBranchFalse   EdgeKind = "branch_false"
+	EdgeCase          EdgeKind = "case"
+	EdgeLoopBody      EdgeKind = "loop_body"
+	EdgeLoopExit      EdgeKind = "loop_exit"
+	EdgeLoopBack      EdgeKind = "loop_back"
+	EdgeGoto          EdgeKind = "goto"
+	EdgeProcedureExit EdgeKind = "procedure_exit"
+	EdgeTermination   EdgeKind = "termination"
+	EdgeError         EdgeKind = "error"
+	EdgeResume        EdgeKind = "resume"
+	EdgeUnknown       EdgeKind = "unknown"
+)
+
+// Block is either one normalized VBA statement or a synthetic graph endpoint.
+type Block struct {
+	ID          BlockID                `json:"id"`
+	Kind        BlockKind              `json:"kind"`
+	StatementID int                    `json:"statementId,omitempty"`
+	Statement   *procedureir.Statement `json:"statement,omitempty"`
+	Range       vbaast.Range           `json:"range"`
+	Assignments []Variable             `json:"assignments,omitempty"`
+}
+
+// Edge records uncertainty independently from the normal/exceptional class.
+// StatementID and Range identify the source transition in the original VBA.
+type Edge struct {
+	ID          EdgeID       `json:"id"`
+	From        BlockID      `json:"from"`
+	To          BlockID      `json:"to"`
+	Kind        EdgeKind     `json:"kind"`
+	Class       EdgeClass    `json:"class"`
+	Uncertain   bool         `json:"uncertain,omitempty"`
+	StatementID int          `json:"statementId,omitempty"`
+	Range       vbaast.Range `json:"range"`
+}
+
+// Variable is the case-insensitive identity used by definite-assignment
+// queries. Scope remains part of the key so local and module bindings do not
+// alias.
+type Variable struct {
+	Scope procedureir.SymbolScope `json:"scope"`
+	Name  string                  `json:"name"`
+}
+
+func (v Variable) canonical() Variable {
+	v.Name = strings.ToLower(v.Name)
+	return v
+}
+
+// Graph owns all data for one ProcedureIR. IDs are deterministic for an
+// identical input but are meaningful only within this graph revision.
+type Graph struct {
+	Procedure       procedureir.ProcedureSymbol `json:"procedure"`
+	Blocks          []Block                     `json:"blocks"`
+	Edges           []Edge                      `json:"edges"`
+	Entry           BlockID                     `json:"entry"`
+	NormalExit      BlockID                     `json:"normalExit"`
+	ExceptionalExit BlockID                     `json:"exceptionalExit"`
+	TerminationExit BlockID                     `json:"terminationExit"`
+	UnknownExit     BlockID                     `json:"unknownExit"`
+}
+
+type Document struct {
+	Path   string  `json:"path"`
+	Graphs []Graph `json:"graphs"`
+}
+
+// EdgeFilter selects graph views. Zero value is the conservative guarantee
+// view: every normal and exceptional edge, including uncertain edges.
+type EdgeFilter struct {
+	NormalOnly bool
+}
+
+func (f EdgeFilter) accepts(edge Edge) bool {
+	if f.NormalOnly && edge.Class != EdgeNormal {
+		return false
+	}
+	return true
+}
+
+// ExitSelection controls which synthetic exits participate in path queries.
+// Zero value selects every exit, including unknown analysis outcomes.
+type ExitSelection struct {
+	Normal      bool
+	Exceptional bool
+	Termination bool
+	Unknown     bool
+}
+
+func (s ExitSelection) ids(g Graph) []BlockID {
+	if !s.Normal && !s.Exceptional && !s.Termination && !s.Unknown {
+		return []BlockID{g.NormalExit, g.ExceptionalExit, g.TerminationExit, g.UnknownExit}
+	}
+	var out []BlockID
+	if s.Normal {
+		out = append(out, g.NormalExit)
+	}
+	if s.Exceptional {
+		out = append(out, g.ExceptionalExit)
+	}
+	if s.Termination {
+		out = append(out, g.TerminationExit)
+	}
+	if s.Unknown {
+		out = append(out, g.UnknownExit)
+	}
+	return out
+}

--- a/internal/vba/cfg/types.go
+++ b/internal/vba/cfg/types.go
@@ -87,14 +87,15 @@ func (v Variable) canonical() Variable {
 // Graph owns all data for one ProcedureIR. IDs are deterministic for an
 // identical input but are meaningful only within this graph revision.
 type Graph struct {
-	Procedure       procedureir.ProcedureSymbol `json:"procedure"`
-	Blocks          []Block                     `json:"blocks"`
-	Edges           []Edge                      `json:"edges"`
-	Entry           BlockID                     `json:"entry"`
-	NormalExit      BlockID                     `json:"normalExit"`
-	ExceptionalExit BlockID                     `json:"exceptionalExit"`
-	TerminationExit BlockID                     `json:"terminationExit"`
-	UnknownExit     BlockID                     `json:"unknownExit"`
+	Procedure          procedureir.ProcedureSymbol `json:"procedure"`
+	Blocks             []Block                     `json:"blocks"`
+	Edges              []Edge                      `json:"edges"`
+	UnknownFlowSources []BlockID                   `json:"unknownFlowSources,omitempty"`
+	Entry              BlockID                     `json:"entry"`
+	NormalExit         BlockID                     `json:"normalExit"`
+	ExceptionalExit    BlockID                     `json:"exceptionalExit"`
+	TerminationExit    BlockID                     `json:"terminationExit"`
+	UnknownExit        BlockID                     `json:"unknownExit"`
 }
 
 type Document struct {

--- a/internal/vba/intel/analysis_snapshot.go
+++ b/internal/vba/intel/analysis_snapshot.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/calls"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
@@ -55,6 +56,10 @@ type AnalysisSnapshot struct {
 	procedureIROnce sync.Once
 	procedureIR     procedureir.DocumentIR
 	procedureIRErr  error
+
+	controlFlowOnce sync.Once
+	controlFlow     vbacfg.Document
+	controlFlowErr  error
 
 	indexOnce sync.Once
 	index     *documentIndex
@@ -290,6 +295,25 @@ func (s *AnalysisSnapshot) ProcedureIR(load func() (procedureir.DocumentIR, erro
 	return procedureir.Clone(s.procedureIR), initialized, s.procedureIRErr
 }
 
+// ControlFlowGraphs returns the snapshot-scoped procedure control-flow graphs
+// and whether the lazy value was already initialized. Both successful results
+// and build errors are cached for this immutable revision. The returned
+// document is a deep copy and can be modified by the caller.
+func (s *AnalysisSnapshot) ControlFlowGraphs(load func() (vbacfg.Document, error)) (vbacfg.Document, bool, error) {
+	if s == nil {
+		result, err := load()
+		return vbacfg.CloneDocument(result), false, err
+	}
+	initialized := true
+	s.controlFlowOnce.Do(func() {
+		initialized = false
+		result, err := load()
+		s.controlFlow = vbacfg.CloneDocument(result)
+		s.controlFlowErr = err
+	})
+	return vbacfg.CloneDocument(s.controlFlow), initialized, s.controlFlowErr
+}
+
 // documentIndex returns the immutable lookup index for this snapshot. The
 // caller supplies the same symbol loader used by document analysis so custom
 // analyzers and the normal source-symbol cache retain identical semantics.
@@ -406,6 +430,17 @@ func procedureIRForDocument(doc Document, rootDir string, parsed *ast.ParsedDocu
 	}
 	if snapshot := analysisSnapshotForDocument(doc); snapshot != nil {
 		result, _, err := snapshot.ProcedureIR(load)
+		return result, err
+	}
+	return load()
+}
+
+func controlFlowForDocument(doc Document, ir procedureir.DocumentIR) (vbacfg.Document, error) {
+	load := func() (vbacfg.Document, error) {
+		return vbacfg.BuildDocument(ir), nil
+	}
+	if snapshot := analysisSnapshotForDocument(doc); snapshot != nil {
+		result, _, err := snapshot.ControlFlowGraphs(load)
 		return result, err
 	}
 	return load()

--- a/internal/vba/intel/analysis_snapshot_test.go
+++ b/internal/vba/intel/analysis_snapshot_test.go
@@ -9,6 +9,7 @@ import (
 
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/calls"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/doccomments"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
@@ -317,6 +318,79 @@ func TestAnalysisSnapshotCachesDeterministicProcedureIRError(t *testing.T) {
 	}
 }
 
+func TestAnalysisSnapshotControlFlowIsLazyConcurrentAndDefensive(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{Path: "Main.bas", Source: "Sub Main()\nEnd Sub\n", Version: 1})
+	var loads atomic.Int32
+	load := func() (vbacfg.Document, error) {
+		loads.Add(1)
+		return vbacfg.Document{
+			Path: "Main.bas",
+			Graphs: []vbacfg.Graph{{
+				Procedure: procedureir.ProcedureSymbol{Name: "Main"},
+				Blocks:    []vbacfg.Block{{ID: 1, Kind: vbacfg.BlockEntry}},
+				Entry:     1,
+			}},
+		}, nil
+	}
+	const readers = 24
+	start := make(chan struct{})
+	results := make(chan vbacfg.Document, readers)
+	var wg sync.WaitGroup
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result, _, err := snapshot.ControlFlowGraphs(load)
+			if err != nil {
+				t.Error(err)
+			}
+			results <- result
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		if len(result.Graphs) != 1 || result.Graphs[0].Procedure.Name != "Main" {
+			t.Fatalf("control-flow document = %+v", result)
+		}
+	}
+	if loads.Load() != 1 {
+		t.Fatalf("loads = %d, want 1", loads.Load())
+	}
+
+	result, hit, err := snapshot.ControlFlowGraphs(load)
+	if err != nil || !hit {
+		t.Fatalf("cached control flow = (hit=%v, err=%v)", hit, err)
+	}
+	result.Graphs[0].Procedure.Name = "mutated"
+	result.Graphs[0].Blocks[0].Kind = vbacfg.BlockUnknownExit
+	again, _, _ := snapshot.ControlFlowGraphs(load)
+	if again.Graphs[0].Procedure.Name != "Main" || again.Graphs[0].Blocks[0].Kind != vbacfg.BlockEntry {
+		t.Fatalf("cached control flow was mutated: %+v", again)
+	}
+}
+
+func TestAnalysisSnapshotCachesDeterministicControlFlowError(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{Source: "broken", Version: 1})
+	want := errors.New("control-flow build failed")
+	var loads atomic.Int32
+	load := func() (vbacfg.Document, error) {
+		loads.Add(1)
+		return vbacfg.Document{Path: "Main.bas"}, want
+	}
+	for i := 0; i < 2; i++ {
+		result, hit, err := snapshot.ControlFlowGraphs(load)
+		if !errors.Is(err, want) || hit != (i > 0) || result.Path != "Main.bas" {
+			t.Fatalf("call %d = (result=%+v, hit=%v, err=%v)", i, result, hit, err)
+		}
+	}
+	if loads.Load() != 1 {
+		t.Fatalf("loads = %d, want 1", loads.Load())
+	}
+}
+
 func TestAnalysisSnapshotSharesOneParsedDocumentAcrossDiagnosticsSymbolsAndSemanticTokens(t *testing.T) {
 	snapshot := NewAnalysisSnapshot(Document{
 		URI:        "file:///Main.bas",
@@ -339,6 +413,13 @@ func TestAnalysisSnapshotSharesOneParsedDocumentAcrossDiagnosticsSymbolsAndSeman
 	})
 	if err != nil || !hit || len(procedureIR.Procedures) != 1 {
 		t.Fatalf("procedure IR = (result=%+v, hit=%v, err=%v)", procedureIR, hit, err)
+	}
+	controlFlow, hit, err := snapshot.ControlFlowGraphs(func() (vbacfg.Document, error) {
+		t.Fatal("diagnostics did not initialize the snapshot control-flow graphs")
+		return vbacfg.Document{}, nil
+	})
+	if err != nil || !hit || len(controlFlow.Graphs) != 1 {
+		t.Fatalf("control flow = (result=%+v, hit=%v, err=%v)", controlFlow, hit, err)
 	}
 	if _, err := analyzer.DocumentSymbols(doc); err != nil {
 		t.Fatal(err)

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -218,7 +218,11 @@ func (a Analyzer) DiagnosticsContext(ctx context.Context, doc Document) []Diagno
 	if err != nil {
 		return append(out, lineDiagnostic("VBA000", "error", 0, err.Error()))
 	}
-	findings, err := analyze.SourceRealtimeFindingsParsedIR(a.RootDir, a.Config, parsed, procedureIR)
+	controlFlow, err := controlFlowForDocument(doc, procedureIR)
+	if err != nil {
+		return append(out, lineDiagnostic("VBA000", "error", 0, err.Error()))
+	}
+	findings, err := analyze.SourceRealtimeFindingsParsedIRCFG(a.RootDir, a.Config, parsed, procedureIR, controlFlow)
 	if ctx.Err() != nil {
 		return nil
 	}

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -271,6 +271,27 @@ End Sub
 	}
 }
 
+func TestDiagnosticsVBA204IgnoresHandlerSkippedByGoto(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Public Sub Run()
+    On Error GoTo Handler
+    Debug.Print "work"
+    GoTo Done
+Handler:
+    Debug.Print Err.Description
+Done:
+End Sub
+`,
+	}
+
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VBA204"); len(diagnostics) != 0 {
+		t.Fatalf("VBA204 should not report a handler skipped by GoTo: %+v", diagnostics)
+	}
+}
+
 func TestDiagnosticsSuppressAnalyzerNonShortCircuitObjectGuard(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	doc := Document{

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -292,6 +292,26 @@ End Sub
 	}
 }
 
+func TestDiagnosticsVBA204IgnoresExplicitGotoHandler(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Public Sub Run()
+    On Error GoTo Handler
+    GoTo Handler
+    Exit Sub
+Handler:
+    Debug.Print Err.Description
+End Sub
+`,
+	}
+
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VBA204"); len(diagnostics) != 0 {
+		t.Fatalf("VBA204 should not treat explicit GoTo Handler as fallthrough: %+v", diagnostics)
+	}
+}
+
 func TestDiagnosticsSuppressAnalyzerNonShortCircuitObjectGuard(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	doc := Document{

--- a/internal/vba/procedureir/builder.go
+++ b/internal/vba/procedureir/builder.go
@@ -242,6 +242,8 @@ func statementKind(node *tree_sitter.Node) (StatementKind, bool) {
 		return StatementResume, true
 	case "exit_statement":
 		return StatementExit, true
+	case "end_statement":
+		return StatementEnd, true
 	}
 	switch {
 	case strings.Contains(kind, "else_if") || strings.Contains(kind, "elseif"):

--- a/internal/vba/procedureir/builder_test.go
+++ b/internal/vba/procedureir/builder_test.go
@@ -757,6 +757,27 @@ func TestCloneControlFlowMetadataIsDeep(t *testing.T) {
 	}
 }
 
+func TestResumeNextControlMetadataNormalizesWhitespace(t *testing.T) {
+	t.Parallel()
+	source, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(
+		"Public Sub Run()\nResume    Next\nResume\tNext\nEnd Sub\n",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resumeNext int
+	for _, statement := range source.Procedures[0].Statements {
+		if statement.Kind == StatementResume && statement.Control != nil &&
+			statement.Control.Transfer == TransferResumeNext {
+			resumeNext++
+		}
+	}
+	if resumeNext != 2 {
+		t.Fatalf("Resume Next statements = %d, want 2; statements=%+v",
+			resumeNext, source.Procedures[0].Statements)
+	}
+}
+
 func TestBuildParsedClosedDocument(t *testing.T) {
 	t.Parallel()
 	doc, err := vbaast.ParseDocument("Module1.bas", []byte("Sub Run()\nEnd Sub\n"))

--- a/internal/vba/procedureir/builder_test.go
+++ b/internal/vba/procedureir/builder_test.go
@@ -237,6 +237,97 @@ End Sub
 	}
 }
 
+func TestControlFlowMetadataNormalizesBranchesCasesLoopsAndTransfers(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Function Run() As Long
+    If Ready Then Work 1: GoTo Done Else Work 2: End
+    Select Case value
+    Case 1
+        Work 3
+    Case Else
+        Work 4
+    End Select
+    Do While Ready
+        Exit Do
+    Loop
+    Do Until Ready
+    Loop
+    Do
+    Loop While Ready
+    Do
+    Loop Until Ready
+    For index = 1 To 2
+        Exit For
+    Next
+    On Error GoTo Handler
+    On Error Resume Next
+    On Error GoTo 0
+    Resume
+    Resume Next
+    Resume [Next]
+    Resume Handler
+    Exit Function
+Done:
+    Exit Sub
+Handler:
+    Exit Property
+End Function
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	statements := doc.Procedures[0].Statements
+	assertControl(t, statements, "Work 1", BranchThen, "", "", "", "")
+	assertControl(t, statements, "GoTo Done", BranchThen, "", TransferGoto, "Done", "")
+	assertControl(t, statements, "Work 2", BranchElse, "", "", "", "")
+	assertControl(t, statements, "End", BranchElse, "", TransferTerminate, "", "")
+	assertControl(t, statements, "Case Else", "", "", "", "", "case_else")
+	assertControl(t, statements, "Do While Ready", "", LoopPreWhile, "", "", "")
+	assertControl(t, statements, "Do Until Ready", "", LoopPreUntil, "", "", "")
+	assertControl(t, statements, "Loop While Ready", "", LoopPostWhile, "", "", "")
+	assertControl(t, statements, "Loop Until Ready", "", LoopPostUntil, "", "", "")
+	assertControl(t, statements, "Exit Do", "", "", TransferExitDo, "", "")
+	assertControl(t, statements, "Exit For", "", "", TransferExitFor, "", "")
+	assertControl(t, statements, "On Error GoTo Handler", "", "", TransferOnErrorGoto, "Handler", "")
+	assertControl(t, statements, "On Error Resume Next", "", "", TransferOnErrorResumeNext, "", "")
+	assertControl(t, statements, "On Error GoTo 0", "", "", TransferOnErrorDisable, "", "")
+	assertControl(t, statements, "Resume", "", "", TransferResumeRetry, "", "")
+	assertControl(t, statements, "Resume Next", "", "", TransferResumeNext, "", "")
+	assertControl(t, statements, "Resume [Next]", "", "", TransferResumeLabel, "Next", "")
+	assertControl(t, statements, "Resume Handler", "", "", TransferResumeLabel, "Handler", "")
+	assertControl(t, statements, "Exit Function", "", "", TransferExitFunction, "", "")
+	assertControl(t, statements, "Exit Sub", "", "", TransferExitSub, "", "")
+	assertControl(t, statements, "Exit Property", "", "", TransferExitProperty, "", "")
+}
+
+func TestNumericLineLabelKeepsNestedExecutableStatement(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+100 GoTo 200
+200 Work
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	statements := doc.Procedures[0].Statements
+	if len(statements) != 4 {
+		t.Fatalf("statements = %+v, want two labels and two nested executable statements", statements)
+	}
+	if statements[0].Kind != StatementLabel || statements[0].Label != "100" ||
+		statements[1].Kind != StatementGoTo || statements[1].ParentID != statements[0].ID ||
+		statements[1].Control == nil || statements[1].Control.Target != "200" {
+		t.Fatalf("first numbered statement = %+v / %+v", statements[0], statements[1])
+	}
+	if statements[0].Text != "100" || statements[0].Range.EndByte > statements[1].Range.StartByte {
+		t.Fatalf("numeric label range overlaps nested statement: %+v / %+v", statements[0], statements[1])
+	}
+	if statements[2].Kind != StatementLabel || statements[2].Label != "200" ||
+		statements[3].Kind != StatementCall || statements[3].ParentID != statements[2].ID {
+		t.Fatalf("second numbered statement = %+v / %+v", statements[2], statements[3])
+	}
+}
+
 func TestSetAssignmentRecordsObjectWriteAndRead(t *testing.T) {
 	t.Parallel()
 	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
@@ -653,6 +744,19 @@ func TestCloneIsDeep(t *testing.T) {
 	}
 }
 
+func TestCloneControlFlowMetadataIsDeep(t *testing.T) {
+	t.Parallel()
+	source, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte("Public Sub Run()\nGoTo Done\nDone:\nEnd Sub\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	clone := Clone(source)
+	clone.Procedures[0].Statements[0].Control.Target = "Changed"
+	if source.Procedures[0].Statements[0].Control.Target != "Done" {
+		t.Fatal("Clone shares control-flow metadata")
+	}
+}
+
 func TestBuildParsedClosedDocument(t *testing.T) {
 	t.Parallel()
 	doc, err := vbaast.ParseDocument("Module1.bas", []byte("Sub Run()\nEnd Sub\n"))
@@ -674,6 +778,53 @@ func requireStatementKind(t *testing.T, statements []Statement, want StatementKi
 		}
 	}
 	t.Fatalf("missing statement kind %q in %#v", want, statements)
+}
+
+func assertControl(
+	t *testing.T,
+	statements []Statement,
+	text string,
+	branch BranchRole,
+	loop LoopTest,
+	transfer TransferKind,
+	target string,
+	flag string,
+) {
+	t.Helper()
+	var found *Statement
+	for i := range statements {
+		if statementText := strings.TrimSpace(statements[i].Text); statementText == text {
+			found = &statements[i]
+			break
+		}
+	}
+	if found == nil {
+		bestWidth := -1
+		for i := range statements {
+			if strings.Contains(statements[i].Text, text) {
+				width := len(statements[i].Text)
+				if bestWidth < 0 || width < bestWidth {
+					found = &statements[i]
+					bestWidth = width
+				}
+			}
+		}
+	}
+	if found == nil {
+		t.Fatalf("missing statement containing %q in %+v", text, statements)
+	}
+	if found.Control == nil {
+		t.Fatalf("%q has no control metadata: %+v", text, *found)
+	}
+	if found.Control.Branch != branch || found.Control.Loop != loop ||
+		found.Control.Transfer != transfer || found.Control.Target != target ||
+		(flag == "case_else") != found.Control.CaseElse {
+		t.Fatalf("%q control = %+v, want branch=%q loop=%q transfer=%q target=%q flag=%q",
+			text, found.Control, branch, loop, transfer, target, flag)
+	}
+	if found.Control.Range != found.Range {
+		t.Fatalf("%q control range = %+v, want statement range %+v", text, found.Control.Range, found.Range)
+	}
 }
 
 func assertAccess(t *testing.T, accesses []VariableAccess, name string, scope SymbolScope, mode AccessMode) {

--- a/internal/vba/procedureir/clone.go
+++ b/internal/vba/procedureir/clone.go
@@ -44,6 +44,10 @@ func cloneProcedure(in ProcedureIR) ProcedureIR {
 		out.Statements[i].Target = cloneExpressionPointer(in.Statements[i].Target)
 		out.Statements[i].Value = cloneExpressionPointer(in.Statements[i].Value)
 		out.Statements[i].Condition = cloneExpressionPointer(in.Statements[i].Condition)
+		if in.Statements[i].Control != nil {
+			control := *in.Statements[i].Control
+			out.Statements[i].Control = &control
+		}
 	}
 	out.Expressions = make([]Expression, len(in.Expressions))
 	for i := range in.Expressions {

--- a/internal/vba/procedureir/types.go
+++ b/internal/vba/procedureir/types.go
@@ -107,26 +107,71 @@ const (
 	StatementGoTo        StatementKind = "goto"
 	StatementOnError     StatementKind = "on_error"
 	StatementResume      StatementKind = "resume"
+	StatementEnd         StatementKind = "end"
 	StatementUnknown     StatementKind = "unknown"
 	StatementRecovered   StatementKind = "recovered"
 )
 
+type BranchRole string
+
+const (
+	BranchThen BranchRole = "then"
+	BranchElse BranchRole = "else"
+)
+
+type LoopTest string
+
+const (
+	LoopPreWhile  LoopTest = "pre_while"
+	LoopPreUntil  LoopTest = "pre_until"
+	LoopPostWhile LoopTest = "post_while"
+	LoopPostUntil LoopTest = "post_until"
+)
+
+type TransferKind string
+
+const (
+	TransferGoto              TransferKind = "goto"
+	TransferExitSub           TransferKind = "exit_sub"
+	TransferExitFunction      TransferKind = "exit_function"
+	TransferExitProperty      TransferKind = "exit_property"
+	TransferExitFor           TransferKind = "exit_for"
+	TransferExitDo            TransferKind = "exit_do"
+	TransferOnErrorGoto       TransferKind = "on_error_goto"
+	TransferOnErrorResumeNext TransferKind = "on_error_resume_next"
+	TransferOnErrorDisable    TransferKind = "on_error_disable"
+	TransferResumeRetry       TransferKind = "resume_retry"
+	TransferResumeNext        TransferKind = "resume_next"
+	TransferResumeLabel       TransferKind = "resume_label"
+	TransferTerminate         TransferKind = "terminate"
+)
+
+type ControlFlowMetadata struct {
+	Branch   BranchRole   `json:"branch,omitempty"`
+	CaseElse bool         `json:"caseElse,omitempty"`
+	Loop     LoopTest     `json:"loop,omitempty"`
+	Transfer TransferKind `json:"transfer,omitempty"`
+	Target   string       `json:"target,omitempty"`
+	Range    vbaast.Range `json:"range"`
+}
+
 type Statement struct {
-	ID            int           `json:"id"`
-	ParentID      int           `json:"parentId,omitempty"`
-	Kind          StatementKind `json:"kind"`
-	SyntaxKind    string        `json:"syntaxKind"`
-	Text          string        `json:"text"`
-	Range         vbaast.Range  `json:"range"`
-	Recovered     bool          `json:"recovered,omitempty"`
-	Label         string        `json:"label,omitempty"`
-	Target        *Expression   `json:"target,omitempty"`
-	Value         *Expression   `json:"value,omitempty"`
-	Condition     *Expression   `json:"condition,omitempty"`
-	TargetID      int           `json:"targetId,omitempty"`
-	ValueID       int           `json:"valueId,omitempty"`
-	ConditionID   int           `json:"conditionId,omitempty"`
-	ExpressionIDs []int         `json:"expressionIds,omitempty"`
+	ID            int                  `json:"id"`
+	ParentID      int                  `json:"parentId,omitempty"`
+	Kind          StatementKind        `json:"kind"`
+	SyntaxKind    string               `json:"syntaxKind"`
+	Text          string               `json:"text"`
+	Range         vbaast.Range         `json:"range"`
+	Recovered     bool                 `json:"recovered,omitempty"`
+	Label         string               `json:"label,omitempty"`
+	Target        *Expression          `json:"target,omitempty"`
+	Value         *Expression          `json:"value,omitempty"`
+	Condition     *Expression          `json:"condition,omitempty"`
+	TargetID      int                  `json:"targetId,omitempty"`
+	ValueID       int                  `json:"valueId,omitempty"`
+	ConditionID   int                  `json:"conditionId,omitempty"`
+	ExpressionIDs []int                `json:"expressionIds,omitempty"`
+	Control       *ControlFlowMetadata `json:"control,omitempty"`
 }
 
 type ExpressionKind string

--- a/internal/vba/procedureir/visitor.go
+++ b/internal/vba/procedureir/visitor.go
@@ -253,7 +253,8 @@ func (v *singleVisitor) populateControlMetadata(statement *Statement, node *tree
 		if target := node.ChildByFieldName("target"); target != nil {
 			value.Transfer = TransferResumeLabel
 			value.Target = cleanIdentifier(nodeText(target, v.builder.source))
-		} else if strings.EqualFold(strings.TrimSpace(nodeText(node, v.builder.source)), "Resume Next") {
+		} else if fields := strings.Fields(nodeText(node, v.builder.source)); len(fields) == 2 &&
+			strings.EqualFold(fields[0], "Resume") && strings.EqualFold(fields[1], "Next") {
 			value.Transfer = TransferResumeNext
 		} else {
 			value.Transfer = TransferResumeRetry

--- a/internal/vba/procedureir/visitor.go
+++ b/internal/vba/procedureir/visitor.go
@@ -12,6 +12,7 @@ type visitContext struct {
 	procedure    int
 	statementID  int
 	parentExprID int
+	branch       BranchRole
 	metadata     bool
 	accessMode   AccessMode
 	callIndex    int
@@ -90,7 +91,7 @@ func (v *singleVisitor) visit(node *tree_sitter.Node, ctx visitContext) {
 			if kind == StatementCall && isIndexedAssignmentNode(node, v.builder.source) {
 				kind = StatementAssignment
 			}
-			ctx.statementID = v.addStatement(procedure, node, ctx.statementID, kind)
+			ctx.statementID = v.addStatement(procedure, node, ctx.statementID, ctx.branch, kind)
 		}
 		if isExpressionNode(node.Kind()) {
 			ctx.parentExprID = v.addExpression(procedure, node, ctx)
@@ -158,21 +159,155 @@ func (v *singleVisitor) procedure(index int) *ProcedureIR {
 	return &v.document.Procedures[index]
 }
 
-func (v *singleVisitor) addStatement(procedure *ProcedureIR, node *tree_sitter.Node, parentID int, kind StatementKind) int {
+func (v *singleVisitor) addStatement(
+	procedure *ProcedureIR,
+	node *tree_sitter.Node,
+	parentID int,
+	branch BranchRole,
+	kind StatementKind,
+) int {
 	id := len(procedure.Statements) + 1
 	statement := Statement{
 		ID: id, ParentID: parentID, Kind: kind, SyntaxKind: node.Kind(),
 		Text: nodeText(node, v.builder.source), Range: vbaast.NodeRange(node), Recovered: recovered(node),
 	}
+	if node.Kind() == "line_number_statement" {
+		if number := node.ChildByFieldName("number"); number != nil {
+			statement.Text = nodeText(number, v.builder.source)
+			statement.Range = vbaast.NodeRange(number)
+		}
+	}
 	if statement.Recovered && kind == StatementUnknown {
 		statement.Kind = StatementRecovered
 	}
+	if branch != "" {
+		statement.Control = &ControlFlowMetadata{Branch: branch}
+	}
+	v.populateControlMetadata(&statement, node)
 	switch statement.Kind {
-	case StatementLabel, StatementGoTo, StatementOnError, StatementResume, StatementExit:
+	case StatementLabel:
+		if node.Kind() == "line_number_statement" {
+			statement.Label = nodeText(node.ChildByFieldName("number"), v.builder.source)
+		} else {
+			statement.Label = nodeText(node.ChildByFieldName("name"), v.builder.source)
+		}
+	case StatementGoTo, StatementOnError, StatementResume, StatementExit:
 		statement.Label = statementOperand(statement.Text, statement.Kind)
+		if statement.Control != nil {
+			switch statement.Control.Transfer {
+			case TransferGoto, TransferOnErrorGoto, TransferResumeLabel:
+				statement.Label = statement.Control.Target
+			}
+		}
 	}
 	procedure.Statements = append(procedure.Statements, statement)
 	return id
+}
+
+func (v *singleVisitor) populateControlMetadata(statement *Statement, node *tree_sitter.Node) {
+	if statement == nil || node == nil {
+		return
+	}
+	control := statement.Control
+	ensureControl := func() *ControlFlowMetadata {
+		if control == nil {
+			control = &ControlFlowMetadata{}
+		}
+		return control
+	}
+	switch node.Kind() {
+	case "case_clause":
+		if childByKind(node, "case_expression") == nil && !recovered(node) {
+			ensureControl().CaseElse = true
+		}
+	case "do_statement":
+		if loop := doLoopTest(node, v.builder.source); loop != "" {
+			ensureControl().Loop = loop
+		}
+	case "goto_statement":
+		target := node.ChildByFieldName("target")
+		if target != nil {
+			value := ensureControl()
+			value.Transfer = TransferGoto
+			value.Target = cleanIdentifier(nodeText(target, v.builder.source))
+		}
+	case "exit_statement":
+		if transfer := exitTransfer(node, v.builder.source); transfer != "" {
+			ensureControl().Transfer = transfer
+		}
+	case "on_error_statement":
+		value := ensureControl()
+		if target := node.ChildByFieldName("target"); target != nil {
+			value.Target = cleanIdentifier(nodeText(target, v.builder.source))
+			if value.Target == "0" {
+				value.Transfer = TransferOnErrorDisable
+				value.Target = ""
+			} else {
+				value.Transfer = TransferOnErrorGoto
+			}
+		} else {
+			value.Transfer = TransferOnErrorResumeNext
+		}
+	case "resume_statement":
+		value := ensureControl()
+		if target := node.ChildByFieldName("target"); target != nil {
+			value.Transfer = TransferResumeLabel
+			value.Target = cleanIdentifier(nodeText(target, v.builder.source))
+		} else if strings.EqualFold(strings.TrimSpace(nodeText(node, v.builder.source)), "Resume Next") {
+			value.Transfer = TransferResumeNext
+		} else {
+			value.Transfer = TransferResumeRetry
+		}
+	case "end_statement":
+		ensureControl().Transfer = TransferTerminate
+	}
+	if control != nil {
+		control.Range = vbaast.NodeRange(node)
+		statement.Control = control
+	}
+}
+
+func doLoopTest(node *tree_sitter.Node, source []byte) LoopTest {
+	condition := childByKind(node, "do_condition")
+	if condition == nil {
+		return ""
+	}
+	conditionText := strings.TrimSpace(nodeText(condition, source))
+	until := strings.HasPrefix(strings.ToLower(conditionText), "until")
+	post := condition.StartPosition().Row > node.StartPosition().Row
+	if body := node.ChildByFieldName("body"); body != nil {
+		post = condition.StartByte() >= body.EndByte()
+	} else if int(condition.StartByte()) <= len(source) {
+		prefix := string(source[node.StartByte():condition.StartByte()])
+		post = hasWord(prefix, "Loop")
+	}
+	switch {
+	case post && until:
+		return LoopPostUntil
+	case post:
+		return LoopPostWhile
+	case until:
+		return LoopPreUntil
+	default:
+		return LoopPreWhile
+	}
+}
+
+func exitTransfer(node *tree_sitter.Node, source []byte) TransferKind {
+	switch statementOperand(nodeText(node, source), StatementExit) {
+	case "sub":
+		return TransferExitSub
+	case "function":
+		return TransferExitFunction
+	case "property":
+		return TransferExitProperty
+	case "for":
+		return TransferExitFor
+	case "do":
+		return TransferExitDo
+	default:
+		return ""
+	}
 }
 
 func (v *singleVisitor) addExpression(procedure *ProcedureIR, node *tree_sitter.Node, ctx visitContext) int {
@@ -361,7 +496,7 @@ func (v *singleVisitor) visitBlock(node *tree_sitter.Node, ctx visitContext) {
 				continue
 			}
 			procedure := v.procedure(ctx.procedure)
-			activeParent = v.addStatement(procedure, child, stack[len(stack)-1].ifID, StatementElse)
+			activeParent = v.addStatement(procedure, child, stack[len(stack)-1].ifID, ctx.branch, StatementElse)
 			continue
 		case "end_if_fragment":
 			if len(stack) > 0 {
@@ -419,6 +554,14 @@ func (v *singleVisitor) visitNamedArgument(node *tree_sitter.Node, ctx visitCont
 
 func (v *singleVisitor) childContext(parent, child *tree_sitter.Node, ctx visitContext) visitContext {
 	childCtx := ctx
+	if parent.Kind() == "single_line_if_statement" {
+		switch {
+		case sameNode(child, parent.ChildByFieldName("consequence")):
+			childCtx.branch = BranchThen
+		case sameNode(child, parent.ChildByFieldName("alternative")):
+			childCtx.branch = BranchElse
+		}
+	}
 	if isExpressionNode(parent.Kind()) {
 		childCtx.parentExprID = ctx.parentExprID
 	}

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -480,6 +480,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `on_error_goto`
 - `on_error_resume_next`
 - `on_error_statement`
+- `on_goto_statement`
 - `open_workbook`
 - `opening_column`
 - `opening_line`
@@ -688,6 +689,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `started_at`
 - `static_modifier`
 - `status_hint`
+- `stop_statement`
 - `storage_kinds`
 - `structured_reference`
 - `style_included`

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -45,6 +45,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `before_dialog_action`
 - `binary_expression`
 - `block_kind`
+- `branch_false`
+- `branch_true`
 - `bridge_file_not_openable`
 - `bridge_found`
 - `bridge_mode_invalid`
@@ -74,6 +76,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `capture_state`
 - `carried_streams`
 - `case_clause`
+- `case_else`
+- `case_expression`
 - `cell_diffs`
 - `cells_updated`
 - `changed_only`
@@ -179,6 +183,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `discard_required`
 - `discarded_runs`
 - `display_alerts`
+- `do_condition`
 - `do_statement`
 - `doc_comment`
 - `doctor_workbook_requires_project`
@@ -210,6 +215,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `end_column`
 - `end_if_fragment`
 - `end_line`
+- `end_statement`
 - `enum_declaration`
 - `enum_group`
 - `event_declaration`
@@ -228,11 +234,17 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `excel_instance`
 - `excel_pid`
 - `excel_state_uncertain`
+- `exceptional_exit`
 - `excluded_components`
 - `executable_path`
 - `existing_warning`
 - `exit_code`
+- `exit_do`
+- `exit_for`
+- `exit_function`
+- `exit_property`
 - `exit_statement`
+- `exit_sub`
 - `expanded_formula`
 - `expected_closer`
 - `expected_error`
@@ -392,6 +404,9 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `location_capture`
 - `logical_line`
 - `logical_value_expression`
+- `loop_back`
+- `loop_body`
+- `loop_exit`
 - `lsp_args_invalid`
 - `lsp_check_failed`
 - `macro_disabled`
@@ -450,6 +465,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `no_tests_found`
 - `non_numeric`
 - `non_test`
+- `normal_exit`
 - `not_applicable`
 - `not_attempted`
 - `not_performed`
@@ -460,6 +476,9 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `old_name`
 - `older_than`
 - `on_error`
+- `on_error_disable`
+- `on_error_goto`
+- `on_error_resume_next`
 - `on_error_statement`
 - `open_workbook`
 - `opening_column`
@@ -505,8 +524,13 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `passing_mode`
 - `path_translation`
 - `poison_reason`
+- `post_until`
+- `post_while`
+- `pre_until`
+- `pre_while`
 - `procedure_call`
 - `procedure_declaration`
+- `procedure_exit`
 - `procedure_modifier`
 - `procedure_name`
 - `procedure_name_constant`
@@ -573,6 +597,9 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `response_source`
 - `restored_from`
 - `result_file`
+- `resume_label`
+- `resume_next`
+- `resume_retry`
 - `resume_statement`
 - `retryable_when_busy`
 - `return_slot`
@@ -678,6 +705,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `temporary_copy`
 - `temporary_object_cleanup_failed`
 - `temporary_workbook`
+- `termination_exit`
 - `test_args_invalid`
 - `test_discovery_failed`
 - `test_environment_failed`
@@ -712,6 +740,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `undeclared_variable`
 - `unexpected_helper_mode`
 - `unknown_command`
+- `unknown_exit`
 - `unknown_inline_suppression_rule`
 - `unnamed_control_placeholder`
 - `unsafe_backup_file_path`


### PR DESCRIPTION
## Summary

- Add a conservative control-flow graph (CFG) for VBA procedures.
- Introduce procedure IR, cloning, traversal, and CFG query/build support.
- Integrate CFG-backed analysis snapshots and IntelliSense behavior.
- Document the design, specification, ADR, and error-code inventory updates.
- Add changelog coverage and regression tests across analysis, CFG, IR, LSP, and IntelliSense.

## Testing

- Added and updated unit tests for procedure IR construction, CFG building/querying, analysis snapshots, LSP integration, and IntelliSense behavior.
- Validation not otherwise run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `VBA204` diagnostics to avoid reporting error handlers that normal control flow skips.
  * Improved handling of VBA branches, loops, labels, exits, and error-handling paths.
* **Documentation**
  * Added documentation describing conservative VBA control-flow analysis and its compatibility guarantees.
* **Quality Improvements**
  * Added comprehensive validation for control-flow analysis, incremental parsing consistency, caching, cloning, reachability, and cleanup guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->