### PR TITLE
Model VBA Array arguments as a ParamArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed `VB030` false positives for valid VBA `Array` calls with multiple arguments by modeling its optional argument list as a `ParamArray`.
 - Added default-enabled `VBA214` analysis for `On Error Resume Next` scopes that extend beyond one compatibility probe or can exit without restoration. Findings report the scope's start and effective end line; a confirmed project-local call inside the scope raises severity to `error` without blocking `push` or `run` preflight.
 - Strengthened `VBA203` so all paths after a tracked Excel `Application` state change, including early exits and error handlers, must restore the saved prior value. The diagnostic now covers `ScreenUpdating`, `EnableEvents`, `DisplayAlerts`, `Calculation`, `StatusBar`, `Cursor`, `Interactive`, `AskToUpdateLinks`, `AutomationSecurity`, and `CutCopyMode`.
 - Added a shared, protocol-neutral static-analysis rule registry for `VB...` and `VBA...` diagnostics, plus the source-only `xlflow rules` command, generated rule catalog, LSP documentation links, and registry-driven VS Code inline-suppression eligibility while preserving existing `disabled_rules`, legacy boolean, and inline suppression behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
-- Fixed `VB030` false positives for valid VBA `Array` calls with multiple arguments by modeling its optional argument list as a `ParamArray`.
+- Fixed `VB030` false positives for valid VBA `Array` calls with zero or multiple arguments by modeling its optional argument list as a `ParamArray`.
 - Added default-enabled `VBA214` analysis for `On Error Resume Next` scopes that extend beyond one compatibility probe or can exit without restoration. Findings report the scope's start and effective end line; a confirmed project-local call inside the scope raises severity to `error` without blocking `push` or `run` preflight.
 - Strengthened `VBA203` so all paths after a tracked Excel `Application` state change, including early exits and error handlers, must restore the saved prior value. The diagnostic now covers `ScreenUpdating`, `EnableEvents`, `DisplayAlerts`, `Calculation`, `StatusBar`, `Cursor`, `Interactive`, `AskToUpdateLinks`, `AutomationSecurity`, and `CutCopyMode`.
 - Added a shared, protocol-neutral static-analysis rule registry for `VB...` and `VBA...` diagnostics, plus the source-only `xlflow rules` command, generated rule catalog, LSP documentation links, and registry-driven VS Code inline-suppression eligibility while preserving existing `disabled_rules`, legacy boolean, and inline suppression behavior.

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -944,6 +944,26 @@ End Sub
 	}
 }
 
+func TestArgumentDiagnosticsAllowBuiltinArrayParamArray(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Sub Test()
+    Dim values As Variant
+    values = Array()
+    values = Array(1)
+    values = Array(1, 2, 3, 4)
+    values = Array("a", 10, True, Empty)
+End Sub
+`,
+	}
+
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VB030"); len(diagnostics) != 0 {
+		t.Fatalf("built-in Array ParamArray calls should not produce argument diagnostics: %+v", diagnostics)
+	}
+}
+
 func TestArgumentDiagnosticsReportProjectArrayObjectMismatch(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	if err := analyzer.DB.MergeJSON([]byte(`{

--- a/internal/vbadb/builtin/vba-core.json
+++ b/internal/vbadb/builtin/vba-core.json
@@ -177,7 +177,7 @@
         {
           "name": "Array",
           "return_type": "Variant",
-          "parameters": [{ "name": "ArgList", "type": "Variant", "optional": true }]
+          "parameters": [{ "name": "ArgList", "type": "Variant", "optional": true, "param_array": true }]
         },
         {
           "name": "LBound",

--- a/internal/vbadb/db_test.go
+++ b/internal/vbadb/db_test.go
@@ -303,6 +303,21 @@ func TestBuiltinVBAStandardLibraryCoverage(t *testing.T) {
 	}
 }
 
+func TestBuiltinArrayUsesOptionalParamArray(t *testing.T) {
+	db, err := LoadBuiltin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	array, ok := db.ResolveMember("VBA.Global", "Array")
+	if !ok || len(array.Parameters) != 1 {
+		t.Fatalf("VBA.Global.Array = %+v, %v", array, ok)
+	}
+	if param := array.Parameters[0]; !param.Optional || !param.ParamArray {
+		t.Fatalf("Array parameter = %+v, want optional ParamArray", param)
+	}
+}
+
 func TestResolveMemberIncludesEvents(t *testing.T) {
 	db := &DB{Types: map[string]TypeInfo{}, Aliases: map[string]string{}}
 	db.addType(TypeInfo{

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -104,3 +104,4 @@
 - Treat same-module `Pop*` and `Restore*` names as alternative restore aliases, not ambiguous candidates; reserve uniqueness checks for cross-module helper lookup.
 - Direct-effect extraction must distinguish statement syntax from value-returning functions with the same VBA name, such as `Error 5` versus `Error(5)`.
 - When resolver policy depends on new symbol metadata, verify every resolver entry point actually consumes that metadata; copying it into only one index does not enforce the policy across compatibility wrappers.
+- Changelog entries for corrected variadic APIs must explicitly cover every validated boundary case, including zero arguments when the regression suite tests it.


### PR DESCRIPTION
## Summary

- Fix false-positive `VB030` diagnostics for valid VBA `Array` calls with zero or multiple arguments.
- Mark the built-in `Array` argument list as an optional `ParamArray`.
- Add regression coverage for argument diagnostics and builtin metadata.

## Testing

- Added unit tests covering valid `Array` calls and `ParamArray` metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed false VB030 argument diagnostics for valid VBA `Array` calls with zero or multiple arguments.
  - Updated VBA metadata to correctly recognize `Array` as accepting a variable number of arguments.

- **Tests**
  - Added regression coverage for valid `Array` call patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->