### PR TITLE
Update tree-sitter-vba to v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Updated `tree-sitter-vba` to v0.11.1 so VBE-exported procedure `Attribute`
+  statements, including `Load` and `Name` targets, parse without recovery nodes.
 - Made `VBA206` a default-enabled, real-time non-blocking warning. It now
   detects unsafe resolved project-local `ByRef` arguments, including explicit
   type mismatches, temporary values, indirect member/array expressions, and

--- a/THIRD_PARTY_LICENCES.md
+++ b/THIRD_PARTY_LICENCES.md
@@ -14,7 +14,7 @@ This file is provided for attribution and licence review. It is not a substitute
 | `github.com/bmatcuk/doublestar/v4`      | `v4.10.0` | MIT               | `https://github.com/bmatcuk/doublestar/blob/v4.10.0/LICENSE`         |
 | `github.com/charmbracelet/bubbletea`    | `v1.3.10` | MIT               | `https://github.com/charmbracelet/bubbletea/blob/v1.3.10/LICENSE`    |
 | `github.com/charmbracelet/lipgloss`     |  `v1.1.0` | MIT               | `https://github.com/charmbracelet/lipgloss/blob/v1.1.0/LICENSE`      |
-| `github.com/harumiWeb/tree-sitter-vba`  | `v0.11.0` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.11.0/LICENSE`  |
+| `github.com/harumiWeb/tree-sitter-vba`  | `v0.11.1` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.11.1/LICENSE`  |
 | `github.com/sourcegraph/jsonrpc2`       |  `v0.2.0` | MIT               | `https://github.com/sourcegraph/jsonrpc2/blob/v0.2.0/LICENSE`        |
 | `github.com/spf13/cobra`                | `v1.10.2` | Apache-2.0        | `https://github.com/spf13/cobra/blob/v1.10.2/LICENSE.txt`            |
 | `github.com/tliron/glsp`                |  `v0.2.2` | Apache-2.0        | `https://github.com/tliron/glsp/blob/v0.2.2/LICENSE`                 |

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/harumiWeb/tree-sitter-vba v0.11.0
+	github.com/harumiWeb/tree-sitter-vba v0.11.1
 	github.com/richardlehane/mscfb v1.0.7
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-github.com/harumiWeb/tree-sitter-vba v0.11.0 h1:h2HyHJRQ+bBEheKZslTMzhIYwrm0MD6RfOYlW8RS1Mw=
-github.com/harumiWeb/tree-sitter-vba v0.11.0/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
+github.com/harumiWeb/tree-sitter-vba v0.11.1 h1:vCojRD2qoF8234lrTD8CdR9259p29smDVNBwdXHFVcU=
+github.com/harumiWeb/tree-sitter-vba v0.11.1/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/internal/vba/ast/ast_test.go
+++ b/internal/vba/ast/ast_test.go
@@ -63,6 +63,45 @@ func TestParserParsesNestedInlineLoopsWithSharedNextVariables(t *testing.T) {
 	}
 }
 
+func TestParserParsesVBEProcedureAttributesWithContextualNames(t *testing.T) {
+	parser, err := NewParser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parser.Close()
+
+	result := parser.Parse("Exported.cls", []byte(`Attribute VB_Name = "Exported"
+Public Function Load() As String
+Attribute Load.VB_Description = "Loads the document."
+End Function
+
+Public Property Get Name() As String
+Attribute Name.VB_Description = "Returns the name."
+End Property
+`))
+	defer result.Close()
+
+	if result.HasError || result.HasMissing {
+		t.Fatalf("unexpected recovery state: error=%t missing=%t tree=%s", result.HasError, result.HasMissing, result.Root.ToSexp())
+	}
+	attributes := map[string]bool{}
+	Walk(result.Root, func(node *tree_sitter.Node) bool {
+		if node.Kind() != "attribute_statement" {
+			return true
+		}
+		name := node.ChildByFieldName("name")
+		if name != nil {
+			attributes[name.Utf8Text(result.Source)] = name.Kind() == "qualified_member_expression"
+		}
+		return true
+	})
+	for _, want := range []string{"Load.VB_Description", "Name.VB_Description"} {
+		if !attributes[want] {
+			t.Fatalf("procedure Attribute %q was not parsed as a qualified member expression: %+v", want, attributes)
+		}
+	}
+}
+
 func TestParsedDocumentOwnsRecoveryStateAndClosesAfterReaders(t *testing.T) {
 	doc, err := ParseDocument("Broken.bas", []byte("Public Function Foo(ByVal x As String\nEnd Function\n"))
 	if err != nil {

--- a/vitepress/reference/diagnostics.md
+++ b/vitepress/reference/diagnostics.md
@@ -994,7 +994,7 @@ Use [`xlflow rules`](../commands/rules) to inspect the same metadata from an ins
 
 ## VBA206
 
-**Unsafe ByRef argument.** A resolved project-local ByRef call has an explicit type mismatch, a temporary value, or an indirect argument whose mutation may be lost or surprising. Parentheses around one VBA argument force expression evaluation into a temporary value, so callee changes do not update the original variable.
+**Unsafe ByRef argument.** A resolved project-local ByRef call receives an incompatible type, a temporary value, or an indirect property, member, or array expression whose mutation may be lost or surprising.
 
 | Property                    | Value                            |
 | --------------------------- | -------------------------------- |


### PR DESCRIPTION
## Summary

- update tree-sitter-vba to v0.11.1 and refresh the licence inventory
- add parser coverage for VBE procedure Attribute statements using Load and Name
- regenerate the stale diagnostics reference

## Validation

- scripts/dev/go.ps1 test ./...
- scripts/dev/go.ps1 mod verify
- scripts/dev/check-third-party-licences.ps1
- task lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of VBE-exported VBA procedure attributes, including `Load` and `Name` targets.
  * Added support for procedure attributes with contextual names.

* **Documentation**
  * Updated VBA206 diagnostic guidance to clarify unsafe `ByRef` arguments, including incompatible types and indirect expressions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->