### PR TITLE
Update dependency overrides and fix staticcheck nil guards

### DIFF
--- a/editors/vscode/pnpm-lock.yaml
+++ b/editors/vscode/pnpm-lock.yaml
@@ -5,8 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: 5.0.8
-  fast-uri: 3.1.4
+  brace-expansion: 5.0.9
+  fast-uri: 3.1.5
+  undici: 7.29.0
   js-yaml: 4.3.0
   linkify-it: 5.0.2
 
@@ -583,8 +584,8 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -788,8 +789,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1446,8 +1447,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -1984,7 +1985,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2031,7 +2032,7 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2090,7 +2091,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chownr@1.1.4:
@@ -2265,7 +2266,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -2564,7 +2565,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8:
     optional: true
@@ -2995,7 +2996,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/editors/vscode/pnpm-workspace.yaml
+++ b/editors/vscode/pnpm-workspace.yaml
@@ -4,8 +4,9 @@ allowBuilds:
   keytar: true
 
 overrides:
-  brace-expansion: 5.0.8
-  fast-uri: 3.1.4
+  brace-expansion: 5.0.9
+  fast-uri: 3.1.5
+  undici: 7.29.0
   js-yaml: 4.3.0
   linkify-it: 5.0.2
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -685,6 +685,7 @@ func TestLSPPerformanceLogFlagIsOptIn(t *testing.T) {
 	flag := cmd.Flags().Lookup("performance-log")
 	if flag == nil {
 		t.Fatal("lsp --performance-log flag is not registered")
+		return
 	}
 	if flag.DefValue != "false" {
 		t.Fatalf("performance-log default = %q, want false", flag.DefValue)

--- a/internal/vba/procedureir/builder_test.go
+++ b/internal/vba/procedureir/builder_test.go
@@ -913,6 +913,7 @@ func assertControl(
 	}
 	if found == nil {
 		t.Fatalf("missing statement containing %q in %+v", text, statements)
+		return
 	}
 	if found.Control == nil {
 		t.Fatalf("%q has no control metadata: %+v", text, *found)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   esbuild@<=0.24.2: '>=0.25.0'
-  postcss: 8.5.18
+  postcss: 8.5.23
   vite@<=6.4.1: '>=6.4.3'
 
 importers:
@@ -27,7 +27,7 @@ importers:
         version: 6.4.3(lightningcss@1.32.0)
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.52.1)(lightningcss@1.32.0)(postcss@8.5.18)(search-insights@2.17.3)
+        version: 1.6.4(@algolia/client-search@5.52.1)(lightningcss@1.32.0)(postcss@8.5.23)(search-insights@2.17.3)
       vue:
         specifier: 3.5.0
         version: 3.5.0
@@ -1226,8 +1226,8 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1262,8 +1262,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.29.1:
@@ -1393,7 +1393,7 @@ packages:
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
-      postcss: 8.5.18
+      postcss: 8.5.23
     peerDependenciesMeta:
       markdown-it-mathjax3:
         optional: true
@@ -2028,7 +2028,7 @@ snapshots:
       '@vue/shared': 3.5.0
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.18
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.34':
@@ -2040,7 +2040,7 @@ snapshots:
       '@vue/shared': 3.5.34
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.18
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.0':
@@ -2378,7 +2378,7 @@ snapshots:
 
   mitt@3.0.1: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.17: {}
 
   oniguruma-to-es@3.1.1:
     dependencies:
@@ -2438,9 +2438,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2568,14 +2568,14 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vitepress@1.6.4(@algolia/client-search@5.52.1)(lightningcss@1.32.0)(postcss@8.5.18)(search-insights@2.17.3):
+  vitepress@1.6.4(@algolia/client-search@5.52.1)(lightningcss@1.32.0)(postcss@8.5.23)(search-insights@2.17.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.52.1)(search-insights@2.17.3)
@@ -2596,7 +2596,7 @@ snapshots:
       vite: 6.4.3(lightningcss@1.32.0)
       vue: 3.5.34
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ allowBuilds:
 
 overrides:
   esbuild@<=0.24.2: ">=0.25.0"
-  postcss: 8.5.18
+  postcss: 8.5.23
   vite@<=6.4.1: ">=6.4.3"
 
 ignoredBuiltDependencies:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -108,3 +108,4 @@
 - Changelog entries for corrected variadic APIs must explicitly cover every validated boundary case, including zero arguments when the regression suite tests it.
 - For regex-backed VBA diagnostics, evaluate each repeated call occurrence within its single-line `If` branch, accept valid non-identifier `Set` lvalues, and keep remediation valid for the enclosing workbook context such as add-ins.
 - For CFG-based resource ownership, start only from entry-reachable acquisitions, preserve pre-acquisition scalar-handle equivalences, apply assignments only on normal edges, and treat Function-return ownership transfer as complete only at a successful normal exit.
+- In Go tests, add an explicit `return` after `t.Fatal`/`t.Fatalf` nil guards before dereferencing the guarded pointer; newer staticcheck versions may report SA5011 otherwise.


### PR DESCRIPTION
## Summary

- Update frontend dependency overrides and lockfiles for `brace-expansion`, `fast-uri`, `undici`, `postcss`, and `nanoid`.
- Add explicit returns after fatal nil guards in Go tests to satisfy newer staticcheck diagnostics.
- Record the staticcheck nil-guard lesson for future tests.

## Testing

- Not run (not requested)