### PR TITLE
feat: add local Excel/VBE oracle harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,24 @@ Before generating or modifying code, perform the following steps according to th
 - If modifying session-aware workflows, also include the sequence `session start -> push --fast --session --no-save -> run/test --session -> save --session -> session stop` in the release gate checks.
 - When combining multiple workbook-backed commands during real device E2E testing for Windows + Excel, even if not altering the session-aware workflow, prioritize first performing `session start -> push --fast --session --no-save -> run/test --session -> save --session -> session stop`.
 
+### Local VBE oracle for static-analysis changes
+
+When changing static-analysis semantics, parser interpretation used by
+diagnostics, type/call/argument validation, object or `Set` diagnostics,
+diagnostic severity, or LSP projections, determine whether the behavior
+depends on actual VBE semantics. If it does, run the focused local VBE oracle
+cases on Windows with Excel and trusted VBIDE access enabled. Add an `observe`
+fixture when needed, run the known accept/reject controls first, and promote
+only confirmed outcomes through the explicit promotion command. Oracle cases
+must run sequentially. A timeout, unknown modal, failed Compile invocation,
+worker/COM failure, or unconfirmed Excel cleanup is an infrastructure failure
+and a stop-the-line condition: do not promote fixtures or change analyzer
+behavior based on that result. Record the executed case IDs in the PR.
+
+The oracle is developer-only and local. Never invoke it from production xlflow
+commands, ordinary tests, or GitHub Actions. See
+`docs/specs/vbe-oracle.md` for the complete workflow and contract.
+
 ## - In final reports, retain the absolute paths of used `tmp_workspaces`, the execution commands, test results, and any unverified items.
 
 ## 3. Documentation Retention Policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added the local-only Windows Excel/VBE oracle harness for focused static-
+  analysis compile evidence, with sequential disposable workbooks, known
+  accept/reject controls, observational and strict JSON modes, explicit
+  promotion, provenance metadata, and deterministic Excel-free fixture
+  contracts. The oracle is not invoked by production commands or GitHub
+  Actions; contributors should run relevant cases locally when changing VBA
+  semantics.
 - Added default-enabled `VBA223` security warnings for likely hardcoded VBA
   credentials, with structural matching, placeholder filtering, fixed
   `[REDACTED]` diagnostics, and independent configuration/inline suppression.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,25 @@ task verify:security
 
 Excel COM E2E verification should be done on Windows with Microsoft Excel installed and **Trust access to the VBA project object model** enabled.
 
+When a change modifies static-analysis behavior, use the local VBE oracle for
+the focused VBA semantics it relies on. The oracle is a developer-only,
+Windows/Excel check and is intentionally excluded from normal tests and CI.
+Start with an `observe` fixture when behavior is not already recorded, run the
+known accept/reject controls, run the selected cases sequentially, and promote
+only confirmed `accepted` or `rejected` observations. Treat timeouts, unknown
+modals, failed Compile invocation, COM/worker errors, and unconfirmed cleanup
+as infrastructure failures; do not promote or adjust analyzer behavior from
+such a run.
+
+```powershell
+./scripts/dev/test-vbe-oracle.ps1 --case <case-id>
+./scripts/dev/test-vbe-oracle.ps1 --case <case-id> --strict
+```
+
+Include the executed oracle case IDs in the pull request, or state why an
+oracle run was not applicable. See [`docs/specs/vbe-oracle.md`](docs/specs/vbe-oracle.md)
+for fixture format, promotion, prerequisites, and the PR checklist.
+
 ## Release preflight
 
 Before a release that touches workbook automation, VBA import/export, run/test behavior, session handling, or other Excel COM paths, do not rely on CI alone.

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/CommandRegistry.cs
@@ -42,6 +42,7 @@ public sealed class CommandRegistry
             new TestCommand(),
             new TypeDbImportCommand(),
             new UICommand(),
+            new VbeOracleCommand(),
         });
     }
 
@@ -66,7 +67,8 @@ public sealed class CommandRegistry
         ISessionService? sessionService = null,
         ITestService? testService = null,
         TypeLibImporterService? typeLibImporterService = null,
-        IUIService? uiService = null)
+        IUIService? uiService = null,
+        IVbeOracleService? vbeOracleService = null)
     {
         return new CommandRegistry(new ICommandHandler[]
         {
@@ -91,6 +93,7 @@ public sealed class CommandRegistry
             new TestCommand(testService),
             new TypeDbImportCommand(typeLibImporterService),
             new UICommand(uiService),
+            new VbeOracleCommand(vbeOracleService),
         });
     }
 

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/VbeOracleCommand.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Commands/VbeOracleCommand.cs
@@ -1,0 +1,57 @@
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Commands;
+
+/// <summary>
+/// Developer-only bridge command used by the local VBE oracle harness.
+/// The public xlflow command registry intentionally does not expose this
+/// command; the standalone oracle executable calls the bridge directly.
+/// </summary>
+public sealed class VbeOracleCommand : ICommandHandler
+{
+    private readonly IVbeOracleService _service;
+
+    public VbeOracleCommand(IVbeOracleService? service = null)
+    {
+        _service = service ?? new VbeOracleService();
+    }
+
+    public string CommandName => "vbe-oracle";
+
+    public bool Supports(BridgeRequest request) =>
+        string.Equals(request.Command, CommandName, StringComparison.OrdinalIgnoreCase);
+
+    public BridgeResponse Handle(BridgeRequest request, CancellationToken cancellationToken)
+    {
+        var planJson64 = BridgePayload.GetString(request.Payload, "FixtureJSON64")
+            ?? BridgePayload.GetString(request.Payload, "PlanJson64")
+            ?? "";
+        if (string.IsNullOrWhiteSpace(planJson64))
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                "vbe_oracle_args_invalid",
+                "PlanJson64 is required",
+                "vbe-oracle",
+                "xlflow-excel-bridge"));
+        }
+
+        var timeoutMilliseconds = BridgePayload.GetInt(
+            request.Payload,
+            "TimeoutMS",
+            BridgePayload.GetInt(request.Payload, "TimeoutMs", 300_000));
+        if (timeoutMilliseconds <= 0)
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                "vbe_oracle_args_invalid",
+                "TimeoutMs must be greater than zero",
+                "vbe-oracle",
+                "xlflow-excel-bridge"));
+        }
+
+        return _service.Execute(
+            request,
+            new VbeOracleCommandArguments(planJson64, TimeSpan.FromMilliseconds(timeoutMilliseconds)),
+            cancellationToken);
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -1576,9 +1576,10 @@ internal static class ExcelBridgeSupport
 
     // The developer oracle owns a disposable, unsaved workbook. Releasing its
     // COM wrappers and terminating the captured process avoids allowing a
-    // modal VBE/Excel state to block app.Quit indefinitely. The PID and start
-    // time are captured before any worker is launched, so this cannot target
-    // an unrelated user's Excel instance.
+    // modal VBE/Excel state to block app.Quit indefinitely. Newly discovered
+    // Excel processes are adopted only when they are the captured instance or
+    // descendants of the bridge/oracle process tree; a baseline-only check is
+    // not sufficient because a user can start Excel while the oracle runs.
     public static bool ReleaseOracleExcelAndConfirmExit(
         object? workbook,
         object? excel,
@@ -1592,24 +1593,38 @@ internal static class ExcelBridgeSupport
         var confirmed = true;
         // Re-enumerate for a short bounded drain after releasing COM wrappers:
         // Excel may materialize a second /automation server while the VBE
-        // worker apartment drains. Only processes absent from the pre-run
-        // baseline are eligible for termination.
+        // worker apartment drains. Only processes proven to be part of the
+        // oracle process tree are eligible for termination.
         for (var attempt = 0; attempt < 3; attempt++)
         {
+            var discovered = false;
+            var unexpectedProcess = false;
             foreach (var process in CaptureOwnedExcelProcesses())
             {
-                if (!baselineProcesses.Any(existing => SameOwnedProcess(existing, process)) &&
+                if (IsOracleOwnedProcess(process, ownedProcesses) &&
                     !ownedProcesses.Any(existing => SameOwnedProcess(existing, process)))
                 {
                     ownedProcesses.Add(process);
+                    discovered = true;
+                }
+                else if (!baselineProcesses.Any(existing => SameOwnedProcess(existing, process)))
+                {
+                    // A new Excel process without a proven oracle relationship
+                    // is evidence that cleanup cannot be confirmed. Leave it
+                    // untouched rather than risking a user's unsaved work.
+                    unexpectedProcess = true;
                 }
             }
-            var attemptConfirmed = true;
+            var attemptConfirmed = !unexpectedProcess;
             foreach (var ownedProcess in ownedProcesses)
             {
                 attemptConfirmed &= EnsureOwnedExcelProcessExited(ownedProcess);
             }
             confirmed = attemptConfirmed;
+            if (confirmed && !discovered)
+            {
+                break;
+            }
             if (attempt < 2)
             {
                 Thread.Sleep(250);
@@ -1815,10 +1830,88 @@ internal static class ExcelBridgeSupport
         }
     }
 
-    private static bool SameOwnedProcess(OwnedExcelProcess left, OwnedExcelProcess right)
+    internal static bool SameOwnedProcess(OwnedExcelProcess left, OwnedExcelProcess right)
     {
         return left.ProcessId == right.ProcessId &&
                (left.StartTime is null || right.StartTime is null || left.StartTime.Value == right.StartTime.Value);
+    }
+
+    internal static bool IsOracleOwnedProcess(OwnedExcelProcess candidate, IEnumerable<OwnedExcelProcess> ownedProcesses)
+    {
+        if (candidate.ProcessId <= 0)
+        {
+            return false;
+        }
+        if (ownedProcesses.Any(existing => SameOwnedProcess(existing, candidate)))
+        {
+            return true;
+        }
+
+        var roots = ownedProcesses
+            .Where(process => process.ProcessId > 0)
+            .Select(process => process.ProcessId)
+            .ToHashSet();
+        roots.Add(Environment.ProcessId);
+        return HasProcessAncestor(candidate.ProcessId, roots);
+    }
+
+    private static bool HasProcessAncestor(int processId, IReadOnlySet<int> roots)
+    {
+        var visited = new HashSet<int> { processId };
+        var current = processId;
+        while (current > 0)
+        {
+            var parent = TryGetParentProcessId(current);
+            if (parent <= 0 || !visited.Add(parent))
+            {
+                return false;
+            }
+            if (roots.Contains(parent))
+            {
+                return true;
+            }
+            current = parent;
+        }
+        return false;
+    }
+
+    private static int TryGetParentProcessId(int processId)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return 0;
+        }
+
+        var snapshot = NativeMethods.CreateToolhelp32Snapshot(NativeMethods.Th32csSnapProcess, 0);
+        if (snapshot == IntPtr.Zero || snapshot == new IntPtr(-1))
+        {
+            return 0;
+        }
+
+        try
+        {
+            var entry = new NativeMethods.ProcessEntry32
+            {
+                Size = (uint)Marshal.SizeOf<NativeMethods.ProcessEntry32>(),
+            };
+            if (!NativeMethods.Process32First(snapshot, ref entry))
+            {
+                return 0;
+            }
+            do
+            {
+                if (entry.ProcessId == processId)
+                {
+                    return unchecked((int)entry.ParentProcessId);
+                }
+            }
+            while (NativeMethods.Process32Next(snapshot, ref entry));
+        }
+        finally
+        {
+            _ = NativeMethods.CloseHandle(snapshot);
+        }
+        return 0;
     }
 
     private static bool IsExcelProcess(Process process)
@@ -2016,6 +2109,7 @@ internal static class ExcelBridgeSupport
     private static class NativeMethods
     {
         public const uint PmRemove = 0x0001;
+        public const uint Th32csSnapProcess = 0x00000002;
 
         public delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
 
@@ -2029,6 +2123,22 @@ internal static class ExcelBridgeSupport
             public uint Time;
             public int PtX;
             public int PtY;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct ProcessEntry32
+        {
+            public uint Size;
+            public uint Usage;
+            public uint ProcessId;
+            public IntPtr DefaultHeapId;
+            public uint ModuleId;
+            public uint Threads;
+            public uint ParentProcessId;
+            public int BasePriority;
+            public uint Flags;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+            public string ExeFile;
         }
 
         [DllImport("user32.dll")]
@@ -2045,6 +2155,18 @@ internal static class ExcelBridgeSupport
 
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool IsWow64Process2(IntPtr process, out ushort processMachine, out ushort nativeMachine);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr CreateToolhelp32Snapshot(uint flags, uint processId);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool Process32First(IntPtr snapshot, ref ProcessEntry32 entry);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool Process32Next(IntPtr snapshot, ref ProcessEntry32 entry);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool CloseHandle(IntPtr handle);
 
         [DllImport("ole32.dll", CharSet = CharSet.Unicode)]
         public static extern int CLSIDFromProgID(string lpszProgID, out Guid lpclsid);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -1601,11 +1601,13 @@ internal static class ExcelBridgeSupport
             var unexpectedProcess = false;
             foreach (var process in CaptureOwnedExcelProcesses())
             {
-                if (IsOracleOwnedProcess(process, ownedProcesses) &&
-                    !ownedProcesses.Any(existing => SameOwnedProcess(existing, process)))
+                if (IsOracleOwnedProcess(process, ownedProcesses))
                 {
-                    ownedProcesses.Add(process);
-                    discovered = true;
+                    if (!ownedProcesses.Any(existing => SameOwnedProcess(existing, process)))
+                    {
+                        ownedProcesses.Add(process);
+                        discovered = true;
+                    }
                 }
                 else if (!baselineProcesses.Any(existing => SameOwnedProcess(existing, process)))
                 {

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -777,6 +777,34 @@ internal static class ExcelBridgeSupport
         return processId;
     }
 
+    public static string GetProcessBitness(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            if (!NativeMethods.IsWow64Process2(process.Handle, out var processMachine, out var nativeMachine))
+            {
+                return "unknown";
+            }
+
+            const ushort imageFileMachineI386 = 0x014c;
+            const ushort imageFileMachineAmd64 = 0x8664;
+            const ushort imageFileMachineArm64 = 0xAA64;
+            var machine = processMachine != 0 ? processMachine : nativeMachine;
+            return machine switch
+            {
+                imageFileMachineI386 => "x86",
+                imageFileMachineAmd64 => "x64",
+                imageFileMachineArm64 => "arm64",
+                _ => "unknown",
+            };
+        }
+        catch
+        {
+            return "unknown";
+        }
+    }
+
     public static string GetRangeAddress(object range)
     {
         try
@@ -1546,6 +1574,50 @@ internal static class ExcelBridgeSupport
         return CloseWorkbookAndQuitApplicationCore(workbook, excel, CaptureOwnedExcelProcess(ownedProcessId));
     }
 
+    // The developer oracle owns a disposable, unsaved workbook. Releasing its
+    // COM wrappers and terminating the captured process avoids allowing a
+    // modal VBE/Excel state to block app.Quit indefinitely. The PID and start
+    // time are captured before any worker is launched, so this cannot target
+    // an unrelated user's Excel instance.
+    public static bool ReleaseOracleExcelAndConfirmExit(
+        object? workbook,
+        object? excel,
+        IList<OwnedExcelProcess> ownedProcesses,
+        IReadOnlyList<OwnedExcelProcess> baselineProcesses)
+    {
+        ReleaseComObject(workbook);
+        ReleaseComObject(excel);
+        CollectComGarbage();
+
+        var confirmed = true;
+        // Re-enumerate for a short bounded drain after releasing COM wrappers:
+        // Excel may materialize a second /automation server while the VBE
+        // worker apartment drains. Only processes absent from the pre-run
+        // baseline are eligible for termination.
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            foreach (var process in CaptureOwnedExcelProcesses())
+            {
+                if (!baselineProcesses.Any(existing => SameOwnedProcess(existing, process)) &&
+                    !ownedProcesses.Any(existing => SameOwnedProcess(existing, process)))
+                {
+                    ownedProcesses.Add(process);
+                }
+            }
+            var attemptConfirmed = true;
+            foreach (var ownedProcess in ownedProcesses)
+            {
+                attemptConfirmed &= EnsureOwnedExcelProcessExited(ownedProcess);
+            }
+            confirmed = attemptConfirmed;
+            if (attempt < 2)
+            {
+                Thread.Sleep(250);
+            }
+        }
+        return confirmed;
+    }
+
     private static bool CloseWorkbookAndQuitApplicationCore(object? workbook, object? excel, OwnedExcelProcess ownedProcess)
     {
         if (workbook is not null)
@@ -1621,6 +1693,27 @@ internal static class ExcelBridgeSupport
         }
     }
 
+    public static IReadOnlyList<OwnedExcelProcess> CaptureOwnedExcelProcesses()
+    {
+        var result = new List<OwnedExcelProcess>();
+        foreach (var process in Process.GetProcessesByName("EXCEL"))
+        {
+            try
+            {
+                var owned = CaptureOwnedExcelProcess(process.Id);
+                if (owned.ProcessId > 0)
+                {
+                    result.Add(owned);
+                }
+            }
+            finally
+            {
+                process.Dispose();
+            }
+        }
+        return result;
+    }
+
     private static bool EnsureOwnedExcelProcessExited(OwnedExcelProcess ownedProcess)
     {
         if (ownedProcess.ProcessId <= 0)
@@ -1642,7 +1735,12 @@ internal static class ExcelBridgeSupport
             }
 
             process.Kill(entireProcessTree: true);
-            return process.WaitForExit(3000);
+            // Excel can take several seconds to tear down a VBE worker and
+            // release its COM apartment after a modal compile error. Keep the
+            // ownership check bounded, but allow the dedicated process time
+            // to acknowledge the termination before reporting infrastructure
+            // failure.
+            return process.WaitForExit(10000);
         }
         catch (ArgumentException)
         {
@@ -1715,6 +1813,12 @@ internal static class ExcelBridgeSupport
         {
             return false;
         }
+    }
+
+    private static bool SameOwnedProcess(OwnedExcelProcess left, OwnedExcelProcess right)
+    {
+        return left.ProcessId == right.ProcessId &&
+               (left.StartTime is null || right.StartTime is null || left.StartTime.Value == right.StartTime.Value);
     }
 
     private static bool IsExcelProcess(Process process)
@@ -1938,6 +2042,9 @@ internal static class ExcelBridgeSupport
 
         [DllImport("user32.dll")]
         public static extern IntPtr GetForegroundWindow();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool IsWow64Process2(IntPtr process, out ushort processMachine, out ushort nativeMachine);
 
         [DllImport("ole32.dll", CharSet = CharSet.Unicode)]
         public static extern int CLSIDFromProgID(string lpszProgID, out Guid lpclsid);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -1620,7 +1620,7 @@ internal static class ExcelBridgeSupport
             {
                 attemptConfirmed &= EnsureOwnedExcelProcessExited(ownedProcess);
             }
-            confirmed = attemptConfirmed;
+            confirmed = confirmed && attemptConfirmed;
             if (confirmed && !discovered)
             {
                 break;

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleCommandArguments.cs
@@ -2,8 +2,8 @@ namespace Xlflow.ExcelBridge.Services;
 
 public sealed record VbeOracleCommandArguments(string PlanJson64, TimeSpan Timeout)
 {
-    // FixtureJSON64 is the name used by the standalone Go oracle runner;
-    // PlanJson64 remains accepted for compatibility with early prototypes.
+    // FixtureJson64 remains exposed for compatibility with the bridge service;
+    // the standalone Go runner sends PlanJson64.
     public string FixtureJson64 => PlanJson64;
 }
 

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleCommandArguments.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleCommandArguments.cs
@@ -1,0 +1,13 @@
+namespace Xlflow.ExcelBridge.Services;
+
+public sealed record VbeOracleCommandArguments(string PlanJson64, TimeSpan Timeout)
+{
+    // FixtureJSON64 is the name used by the standalone Go oracle runner;
+    // PlanJson64 remains accepted for compatibility with early prototypes.
+    public string FixtureJson64 => PlanJson64;
+}
+
+public interface IVbeOracleService
+{
+    Contract.BridgeResponse Execute(Contract.BridgeRequest request, VbeOracleCommandArguments args, CancellationToken cancellationToken);
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleService.cs
@@ -1,0 +1,675 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Windows;
+using Xlflow.ExcelBridge.Workers;
+
+namespace Xlflow.ExcelBridge.Services;
+
+/// <summary>
+/// Executes one isolated, compile-only VBE oracle case.  This service is
+/// deliberately not used by any of the production xlflow commands.
+/// </summary>
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "The oracle is a Windows/Excel-only developer tool.")]
+[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "COM, worker, and UI failures are returned as oracle infrastructure failures.")]
+public sealed class VbeOracleService : IVbeOracleService
+{
+    private static readonly JsonSerializerOptions PlanJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static readonly Regex AttributeNamePattern = new(
+        "^\\s*Attribute\\s+VB_Name\\s*=\\s*\\\"([^\\\"]+)\\\"",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+    public BridgeResponse Execute(BridgeRequest request, VbeOracleCommandArguments args, CancellationToken cancellationToken)
+    {
+        OraclePlan plan;
+        try
+        {
+            plan = DecodePlan(args.PlanJson64);
+            ValidatePlan(plan);
+        }
+        catch (VbeOracleValidationException ex)
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                "vbe_oracle_plan_invalid",
+                ex.Message,
+                "vbe-oracle.validate",
+                "xlflow-excel-bridge"));
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException or DecoderFallbackException)
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                "vbe_oracle_plan_invalid",
+                ex.Message,
+                "vbe-oracle.validate",
+                "xlflow-excel-bridge"));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or ArgumentException)
+        {
+            return BridgeResponse.Failed(request, new BridgeError(
+                "vbe_oracle_plan_invalid",
+                ex.Message,
+                "vbe-oracle.validate",
+                "xlflow-excel-bridge"));
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            return InfrastructureResponse(
+                request,
+                plan,
+                "oracle_windows_only",
+                "The VBE oracle requires Windows with a locally installed Excel instance.",
+                "platform",
+                0,
+                TimeSpan.Zero,
+                new Dictionary<string, object?>());
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        object? excel = null;
+        object? workbook = null;
+        var excelProcessId = 0;
+        var excelHwnd = 0L;
+        var ownedExcelProcess = OwnedExcelProcess.None;
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "xlflow-vbe-oracle-" + Guid.NewGuid().ToString("N"));
+        var stage = "startup";
+        var cleanupConfirmed = true;
+        var tempCleanupConfirmed = true;
+        IReadOnlyList<OwnedExcelProcess> baselineExcelProcesses = Array.Empty<OwnedExcelProcess>();
+        var ownedExcelProcesses = new List<OwnedExcelProcess>();
+        OracleObservation? observation = null;
+        Dictionary<string, object?> excelMetadata = new();
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            baselineExcelProcesses = ExcelBridgeSupport.CaptureOwnedExcelProcesses();
+            Directory.CreateDirectory(tempDirectory);
+            stage = "create_excel";
+            var excelType = Type.GetTypeFromProgID("Excel.Application")
+                ?? throw new InvalidOperationException("Excel.Application COM class is not registered");
+            excel = Activator.CreateInstance(excelType)
+                ?? throw new InvalidOperationException("Failed to create Excel.Application COM instance");
+            dynamic app = excel;
+            app.Visible = plan.Visible;
+            app.DisplayAlerts = false;
+            app.EnableEvents = false;
+
+            stage = "create_workbook";
+            object? workbooks = null;
+            try
+            {
+                workbooks = ExcelBridgeSupport.Get(excel, "Workbooks")
+                    ?? throw new InvalidOperationException("Excel Workbooks collection is unavailable");
+                dynamic workbooksObject = workbooks;
+                workbook = workbooksObject.Add()
+                    ?? throw new InvalidOperationException("Excel could not create a disposable workbook");
+            }
+            finally
+            {
+                ExcelBridgeSupport.ReleaseComObject(workbooks);
+            }
+
+            excelProcessId = ExcelBridgeSupport.GetExcelProcessId(excel);
+            excelHwnd = ExcelBridgeSupport.GetExcelMainHwnd(excel);
+            if (excelProcessId <= 0 || excelHwnd == 0)
+            {
+                throw new InvalidOperationException("Could not resolve the dedicated Excel process identity");
+            }
+            ownedExcelProcess = ExcelBridgeSupport.CaptureOwnedExcelProcess(excelProcessId);
+            if (ownedExcelProcess.ProcessId <= 0)
+            {
+                throw new InvalidOperationException("Could not capture the dedicated Excel process identity");
+            }
+            if (baselineExcelProcesses.Any(process => SameProcess(process, ownedExcelProcess)))
+            {
+                throw new InvalidOperationException("Excel.Application did not create a dedicated process instance");
+            }
+            ownedExcelProcesses.Add(ownedExcelProcess);
+            foreach (var process in ExcelBridgeSupport.CaptureOwnedExcelProcesses())
+            {
+                if (!baselineExcelProcesses.Any(existing => SameProcess(existing, process)) &&
+                    !ownedExcelProcesses.Any(existing => SameProcess(existing, process)))
+                {
+                    ownedExcelProcesses.Add(process);
+                }
+            }
+
+            excelMetadata = ReadExcelMetadata(excel, excelProcessId);
+            stage = "import_modules";
+            ImportModules(workbook, plan.Modules ?? [], tempDirectory, cancellationToken);
+
+            stage = "vbe_compile";
+            var selectionLocator = new VbeSelectionLocator(
+                excelProcessId,
+                excelHwnd,
+                new VbeSourceMappingOptions("", "", "", "", "sidecar", false, "ignore", false));
+            var invocation = ExcelWorkerInvocation.InvokeWithWorker(
+                new MacroRunWorkerRequest(
+                    excelProcessId,
+                    excelHwnd,
+                    "",
+                    Operation: "compile",
+                    WorkbookPath: ""),
+                excelHwnd,
+                DialogKind.Compile,
+                suppressModalErrors: true,
+                args.Timeout,
+                cancellationToken,
+                selectionLocator);
+            observation = ClassifyInvocation(invocation, stopwatch.Elapsed, excelMetadata);
+            if (observation.Outcome == "accepted")
+            {
+                var lingeringDialogs = new DialogWatcher().CaptureOracleDialogs(
+                    new DialogWatchRequest(
+                        excelProcessId,
+                        excelHwnd,
+                        DialogKind.Any,
+                        DialogActionPolicy.ObserveOnly,
+                        TimeSpan.Zero,
+                        TimeSpan.Zero));
+                var lingeringDialog = lingeringDialogs.Count == 0 ? null : lingeringDialogs[0];
+                if (lingeringDialog is not null)
+                {
+                    observation = InfrastructureObservation(
+                        "oracle_unknown_modal",
+                        "A modal dialog remained after VBE Compile completed.",
+                        "vbe_compile",
+                        stopwatch.Elapsed,
+                        excelMetadata,
+                        lingeringDialog);
+                }
+            }
+        }
+        catch (OperationCanceledException ex)
+        {
+            observation = InfrastructureObservation("oracle_cancelled", ex.Message, stage, stopwatch.Elapsed, excelMetadata);
+        }
+        catch (Exception ex)
+        {
+            observation = InfrastructureObservation(
+                ClassifyInfrastructureCode(stage, ex),
+                ExcelBridgeSupport.FormatExceptionDetail(ex),
+                stage,
+                stopwatch.Elapsed,
+                excelMetadata);
+        }
+        finally
+        {
+            if (excel is not null || workbook is not null)
+            {
+                foreach (var process in ExcelBridgeSupport.CaptureOwnedExcelProcesses())
+                {
+                    if (!baselineExcelProcesses.Any(existing => SameProcess(existing, process)) &&
+                        !ownedExcelProcesses.Any(existing => SameProcess(existing, process)))
+                    {
+                        ownedExcelProcesses.Add(process);
+                    }
+                }
+                cleanupConfirmed = ExcelBridgeSupport.ReleaseOracleExcelAndConfirmExit(
+                    workbook,
+                    excel,
+                    ownedExcelProcesses,
+                    baselineExcelProcesses);
+                workbook = null;
+                excel = null;
+            }
+
+            try
+            {
+                if (Directory.Exists(tempDirectory))
+                {
+                    Directory.Delete(tempDirectory, recursive: true);
+                }
+            }
+            catch
+            {
+                tempCleanupConfirmed = false;
+            }
+        }
+
+        observation ??= InfrastructureObservation(
+            "oracle_worker_output_invalid",
+            "The VBE oracle did not produce an observation.",
+            stage,
+            stopwatch.Elapsed,
+            excelMetadata);
+
+        // A process that did not exit cleanly is never VBA evidence.  This
+        // deliberately overrides an otherwise accepted or rejected result.
+        if (!cleanupConfirmed || !tempCleanupConfirmed)
+        {
+            observation = InfrastructureObservation(
+                "oracle_cleanup_unconfirmed",
+                !cleanupConfirmed
+                    ? "The dedicated Excel process did not exit cleanly."
+                    : "The oracle temporary directory could not be removed.",
+                "excel_cleanup",
+                stopwatch.Elapsed,
+                excelMetadata);
+        }
+
+        return BuildResponse(request, plan, observation, excelProcessId, cleanupConfirmed && tempCleanupConfirmed);
+    }
+
+    private static OraclePlan DecodePlan(string planJson64)
+    {
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(planJson64);
+        }
+        catch (FormatException ex)
+        {
+            throw new VbeOracleValidationException("PlanJson64 is not valid base64", ex);
+        }
+
+        var plan = JsonSerializer.Deserialize<OraclePlan>(Encoding.UTF8.GetString(bytes), PlanJsonOptions);
+        if (plan is null)
+        {
+            throw new VbeOracleValidationException("FixtureJSON64 contains an empty oracle fixture");
+        }
+
+        if (plan.SchemaVersion != 1)
+        {
+            throw new VbeOracleValidationException($"unsupported oracle fixture schema_version {plan.SchemaVersion}");
+        }
+
+        // The fixture contract uses {id, probe:{mode}, modules:[...]}; the
+        // original bridge prototype used {case_id, probe_mode}.  Normalize
+        // both spellings at the bridge boundary so the execution path stays
+        // deliberately small.
+        plan.CaseId = string.IsNullOrWhiteSpace(plan.CaseId) ? plan.Id : plan.CaseId;
+        plan.ProbeMode = string.IsNullOrWhiteSpace(plan.ProbeMode) ? plan.Probe?.Mode ?? "" : plan.ProbeMode;
+        plan.Modules ??= [];
+        foreach (var module in plan.Modules)
+        {
+            if (string.IsNullOrWhiteSpace(module.SourcePath))
+            {
+                module.SourcePath = module.Path;
+            }
+            if (!string.IsNullOrWhiteSpace(module.SourcePath))
+            {
+                module.SourcePath = Path.GetFullPath(module.SourcePath);
+            }
+        }
+        return plan;
+    }
+
+    private static void ValidatePlan(OraclePlan plan)
+    {
+        if (string.IsNullOrWhiteSpace(plan.CaseId))
+        {
+            throw new VbeOracleValidationException("oracle plan case_id is required");
+        }
+        if (!string.Equals(plan.ProbeMode, "compile", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new VbeOracleValidationException("only probe_mode=compile is supported by oracle schema v1");
+        }
+        if (plan.Modules is null || plan.Modules.Count == 0)
+        {
+            throw new VbeOracleValidationException("oracle plan must contain at least one module");
+        }
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var module in plan.Modules)
+        {
+            if (module is null)
+            {
+                throw new VbeOracleValidationException("oracle plan contains a null module entry");
+            }
+            if (!string.Equals(module.Kind, "standard", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new VbeOracleValidationException($"module '{module.Name}' must have kind=standard");
+            }
+            if (string.IsNullOrWhiteSpace(module.Name) || !names.Add(module.Name))
+            {
+                throw new VbeOracleValidationException($"module name '{module.Name}' is missing or duplicated");
+            }
+            if (string.IsNullOrWhiteSpace(module.Source) &&
+                (string.IsNullOrWhiteSpace(module.SourcePath) ||
+                 !string.Equals(Path.GetExtension(module.SourcePath), ".bas", StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new VbeOracleValidationException($"module '{module.Name}' must provide a .bas source path or inline source");
+            }
+
+            var source = module.Source;
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                var sourcePath = Path.GetFullPath(module.SourcePath);
+                if (!File.Exists(sourcePath))
+                {
+                    throw new VbeOracleValidationException($"module '{module.Name}' source does not exist: {module.SourcePath}");
+                }
+                source = File.ReadAllText(sourcePath, Encoding.UTF8);
+            }
+            var match = AttributeNamePattern.Match(source);
+            if (!match.Success || !string.Equals(match.Groups[1].Value.Trim(), module.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new VbeOracleValidationException($"module '{module.Name}' source Attribute VB_Name does not match");
+            }
+        }
+    }
+
+    private static void ImportModules(object workbook, IReadOnlyList<OracleModule> modules, string tempDirectory, CancellationToken cancellationToken)
+    {
+        object? project = null;
+        object? components = null;
+        try
+        {
+            project = ExcelBridgeSupport.Get(workbook, "VBProject")
+                ?? throw new InvalidOperationException("VBProject access is denied; enable trusted access to the VBA project object model");
+            components = ExcelBridgeSupport.Get(project, "VBComponents")
+                ?? throw new InvalidOperationException("VBComponents are unavailable");
+
+            foreach (var module in modules)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var importPath = Path.Combine(tempDirectory, "imports", module.Name + ".bas");
+                var sourcePath = module.SourcePath;
+                if (!string.IsNullOrWhiteSpace(module.Source))
+                {
+                    sourcePath = Path.Combine(tempDirectory, "sources", module.Name + ".bas");
+                    var sourceParent = Path.GetDirectoryName(sourcePath);
+                    if (!string.IsNullOrWhiteSpace(sourceParent))
+                    {
+                        Directory.CreateDirectory(sourceParent);
+                    }
+                    File.WriteAllText(sourcePath, module.Source, new UTF8Encoding(false));
+                }
+                VbaSourceHelper.PrepareSourceForImport(sourcePath, importPath, null, "off");
+                object? imported = null;
+                try
+                {
+                    imported = ExcelBridgeSupport.InvokeViaDynamic(components, "Import", importPath)
+                        ?? throw new InvalidOperationException($"failed to import VBA module '{module.Name}'");
+                    var importedName = ExcelBridgeSupport.GetString(imported, "Name") ?? "";
+                    if (!string.Equals(importedName, module.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException($"imported VBA module name '{importedName}' did not match expected name '{module.Name}'");
+                    }
+                }
+                finally
+                {
+                    ExcelBridgeSupport.ReleaseComObject(imported);
+                }
+            }
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(components);
+            ExcelBridgeSupport.ReleaseComObject(project);
+        }
+    }
+
+    private static OracleObservation ClassifyInvocation(WorkerInvocationResult invocation, TimeSpan elapsed, IReadOnlyDictionary<string, object?> excel)
+    {
+        if (invocation.TimedOut)
+        {
+            return InfrastructureObservation("oracle_timeout", "VBE Compile timed out.", "vbe_compile", elapsed, excel);
+        }
+
+        if (invocation.Dialog is not null)
+        {
+            if (string.Equals(invocation.Dialog.Kind, "compile", StringComparison.OrdinalIgnoreCase))
+            {
+                var rejected = new OracleObservation(
+                    "rejected",
+                    "compile",
+                    "vbe_compile",
+                    elapsed,
+                    true,
+                    invocation.Dialog,
+                    excel,
+                    null);
+                rejected.Location = invocation.LocationCapture.Location;
+                return rejected;
+            }
+            var blocked = InfrastructureObservation("oracle_unknown_modal", "A non-compile modal dialog blocked the VBE oracle.", "vbe_compile", elapsed, excel, invocation.Dialog);
+            blocked.Location = invocation.LocationCapture.Location;
+            return blocked;
+        }
+
+        if (invocation.Result is null)
+        {
+            return InfrastructureObservation("oracle_worker_output_invalid", "The VBE worker exited without a result.", "vbe_compile", elapsed, excel);
+        }
+        if (!invocation.Result.Completed || !invocation.Result.Ok)
+        {
+            var message = invocation.Result.Error?.Message ?? "The VBE worker failed without a structured error.";
+            return InfrastructureObservation("oracle_worker_failed", message, invocation.Result.Error?.Stage ?? "vbe_compile", elapsed, excel);
+        }
+
+        var disabled = TryGetString(invocation.Result.Value, "reason");
+        var compileInvoked = !string.Equals(disabled, "compile_command_disabled", StringComparison.OrdinalIgnoreCase);
+        var accepted = new OracleObservation(
+            "accepted",
+            "compile",
+            "vbe_compile",
+            elapsed,
+            compileInvoked,
+            null,
+            excel,
+            null);
+        accepted.Location = invocation.LocationCapture.Location;
+        return accepted;
+    }
+
+    private static Dictionary<string, object?> ReadExcelMetadata(object excel, int excelProcessId)
+    {
+        var version = ExcelBridgeSupport.GetString(excel, "Version");
+        var build = ExcelBridgeSupport.GetString(excel, "Build");
+        var locale = CultureInfo.CurrentUICulture.Name;
+        object? languageSettings = null;
+        try
+        {
+            languageSettings = ExcelBridgeSupport.Get(excel, "LanguageSettings");
+            if (languageSettings is not null)
+            {
+                dynamic settings = languageSettings;
+                var lcid = Convert.ToInt32(settings.LanguageID(2), CultureInfo.InvariantCulture);
+                if (lcid > 0)
+                {
+                    locale = CultureInfo.GetCultureInfo(lcid).Name;
+                }
+            }
+        }
+        catch
+        {
+            // Excel language settings are not exposed by every installation;
+            // retain the bridge UI locale as a diagnostic fallback.
+        }
+        finally
+        {
+            ExcelBridgeSupport.ReleaseComObject(languageSettings);
+        }
+        return new Dictionary<string, object?>
+        {
+            ["version"] = string.IsNullOrWhiteSpace(version) ? null : version,
+            ["build"] = string.IsNullOrWhiteSpace(build) ? null : build,
+            ["excel_version"] = string.IsNullOrWhiteSpace(version) ? null : version,
+            ["excel_build"] = string.IsNullOrWhiteSpace(build) ? null : build,
+            ["bitness"] = ExcelBridgeSupport.GetProcessBitness(excelProcessId),
+            ["locale"] = locale,
+        };
+    }
+
+    private static BridgeResponse BuildResponse(BridgeRequest request, OraclePlan plan, OracleObservation observation, int processId, bool cleanupConfirmed)
+    {
+        var oracle = new Dictionary<string, object?>
+        {
+            ["schema_version"] = 1,
+            ["case_id"] = plan.CaseId,
+            ["outcome"] = observation.Outcome,
+            ["evidence_phase"] = observation.EvidencePhase,
+            ["last_stage"] = observation.LastStage,
+            ["duration_ms"] = Math.Max(0L, (long)observation.Duration.TotalMilliseconds),
+            ["compile_invoked"] = observation.CompileInvoked,
+            ["cleanup_confirmed"] = cleanupConfirmed,
+            ["excel_process_id"] = processId > 0 ? processId : null,
+            ["excel"] = observation.Excel,
+            ["metadata"] = new Dictionary<string, object?>
+            {
+                ["excel_version"] = observation.Excel.TryGetValue("version", out var version) ? version : null,
+                ["excel_build"] = observation.Excel.TryGetValue("build", out var build) ? build : null,
+                ["bitness"] = observation.Excel.TryGetValue("bitness", out var bitness) ? bitness : null,
+                ["locale"] = observation.Excel.TryGetValue("locale", out var locale) ? locale : null,
+            },
+        };
+        if (observation.Dialog is not null)
+        {
+            oracle["dialog"] = observation.Dialog;
+        }
+        if (observation.Location is not null)
+        {
+            oracle["location"] = observation.Location;
+        }
+        if (!string.IsNullOrWhiteSpace(observation.ErrorCode))
+        {
+            oracle["error_code"] = observation.ErrorCode;
+            oracle["error"] = observation.ErrorMessage ?? observation.ErrorCode;
+        }
+
+        if (string.Equals(observation.Outcome, "infrastructure_failure", StringComparison.OrdinalIgnoreCase))
+        {
+            return new BridgeResponse
+            {
+                RequestId = request.RequestId,
+                Command = request.Command,
+                Status = BridgeStatus.Failed,
+                Error = new BridgeError(
+                    observation.ErrorCode ?? "oracle_infrastructure_failure",
+                    observation.ErrorMessage ?? "VBE oracle infrastructure failure.",
+                    observation.LastStage,
+                    "xlflow-excel-bridge",
+                    Details: new Dictionary<string, object?> { ["oracle"] = oracle }),
+                Extensions = new Dictionary<string, object?> { ["oracle"] = oracle },
+            };
+        }
+
+        return BridgeResponse.Ok(request, new Dictionary<string, object?> { ["oracle"] = oracle });
+    }
+
+    private static BridgeResponse InfrastructureResponse(BridgeRequest request, OraclePlan plan, string code, string message, string stage, int processId, TimeSpan elapsed, Dictionary<string, object?> excel)
+    {
+        var observation = InfrastructureObservation(code, message, stage, elapsed, excel);
+        return BuildResponse(request, plan, observation, processId, cleanupConfirmed: false);
+    }
+
+    private static OracleObservation InfrastructureObservation(string code, string message, string stage, TimeSpan elapsed, IReadOnlyDictionary<string, object?> excel, DialogSnapshot? dialog = null)
+    {
+        return new OracleObservation("infrastructure_failure", "unknown", stage, elapsed, false, dialog, excel, code, message);
+    }
+
+    private static string ClassifyInfrastructureCode(string stage, Exception exception)
+    {
+        if (exception.Message.Contains("VBProject", StringComparison.OrdinalIgnoreCase))
+        {
+            return "oracle_vbproject_access_denied";
+        }
+        if (stage == "create_excel" || stage == "create_workbook")
+        {
+            return "oracle_excel_startup_failed";
+        }
+        if (stage == "import_modules")
+        {
+            return "oracle_import_failed";
+        }
+        if (stage == "vbe_compile")
+        {
+            return "oracle_compile_invocation_failed";
+        }
+        return "oracle_infrastructure_failure";
+    }
+
+    private static string? TryGetString(object? value, string property)
+    {
+        if (value is JsonElement element && element.ValueKind == JsonValueKind.Object && element.TryGetProperty(property, out var propertyValue))
+        {
+            return propertyValue.ValueKind == JsonValueKind.String ? propertyValue.GetString() : propertyValue.ToString();
+        }
+        return null;
+    }
+
+    private static bool SameProcess(OwnedExcelProcess left, OwnedExcelProcess right)
+    {
+        return left.ProcessId == right.ProcessId &&
+               (left.StartTime is null || right.StartTime is null || left.StartTime.Value == right.StartTime.Value);
+    }
+
+    private sealed class VbeOracleValidationException(string message, Exception? inner = null) : Exception(message, inner);
+
+    private sealed record OracleObservation(
+        string Outcome,
+        string EvidencePhase,
+        string LastStage,
+        TimeSpan Duration,
+        bool CompileInvoked,
+        DialogSnapshot? Dialog,
+        IReadOnlyDictionary<string, object?> Excel,
+        string? ErrorCode,
+        string? ErrorMessage = null)
+    {
+        public object? Location { get; set; }
+    }
+
+    private sealed class OraclePlan
+    {
+        [JsonPropertyName("schema_version")]
+        public int SchemaVersion { get; init; }
+
+        [JsonPropertyName("case_id")]
+        public string CaseId { get; set; } = "";
+
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = "";
+
+        [JsonPropertyName("probe_mode")]
+        public string ProbeMode { get; set; } = "";
+
+        [JsonPropertyName("probe")]
+        public OracleProbe? Probe { get; init; }
+
+        [JsonPropertyName("visible")]
+        public bool Visible { get; init; }
+
+        [JsonPropertyName("timeout_ms")]
+        public int TimeoutMilliseconds { get; init; }
+
+        [JsonPropertyName("modules")]
+        public List<OracleModule>? Modules { get; set; } = [];
+    }
+
+    private sealed class OracleProbe
+    {
+        [JsonPropertyName("mode")]
+        public string Mode { get; init; } = "";
+    }
+
+    private sealed class OracleModule
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = "";
+
+        [JsonPropertyName("kind")]
+        public string Kind { get; init; } = "";
+
+        [JsonPropertyName("source_path")]
+        public string SourcePath { get; set; } = "";
+
+        [JsonPropertyName("path")]
+        public string Path { get; init; } = "";
+
+        [JsonPropertyName("source")]
+        public string Source { get; init; } = "";
+
+    }
+}

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleService.cs
@@ -130,15 +130,15 @@ public sealed class VbeOracleService : IVbeOracleService
             {
                 throw new InvalidOperationException("Could not capture the dedicated Excel process identity");
             }
-            if (baselineExcelProcesses.Any(process => SameProcess(process, ownedExcelProcess)))
+            if (baselineExcelProcesses.Any(process => ExcelBridgeSupport.SameOwnedProcess(process, ownedExcelProcess)))
             {
                 throw new InvalidOperationException("Excel.Application did not create a dedicated process instance");
             }
             ownedExcelProcesses.Add(ownedExcelProcess);
             foreach (var process in ExcelBridgeSupport.CaptureOwnedExcelProcesses())
             {
-                if (!baselineExcelProcesses.Any(existing => SameProcess(existing, process)) &&
-                    !ownedExcelProcesses.Any(existing => SameProcess(existing, process)))
+                if (ExcelBridgeSupport.IsOracleOwnedProcess(process, ownedExcelProcesses) &&
+                    !ownedExcelProcesses.Any(existing => ExcelBridgeSupport.SameOwnedProcess(existing, process)))
                 {
                     ownedExcelProcesses.Add(process);
                 }
@@ -209,8 +209,8 @@ public sealed class VbeOracleService : IVbeOracleService
             {
                 foreach (var process in ExcelBridgeSupport.CaptureOwnedExcelProcesses())
                 {
-                    if (!baselineExcelProcesses.Any(existing => SameProcess(existing, process)) &&
-                        !ownedExcelProcesses.Any(existing => SameProcess(existing, process)))
+                    if (ExcelBridgeSupport.IsOracleOwnedProcess(process, ownedExcelProcesses) &&
+                        !ownedExcelProcesses.Any(existing => ExcelBridgeSupport.SameOwnedProcess(existing, process)))
                     {
                         ownedExcelProcesses.Add(process);
                     }
@@ -450,6 +450,15 @@ public sealed class VbeOracleService : IVbeOracleService
 
         var disabled = TryGetString(invocation.Result.Value, "reason");
         var compileInvoked = !string.Equals(disabled, "compile_command_disabled", StringComparison.OrdinalIgnoreCase);
+        if (!compileInvoked)
+        {
+            return InfrastructureObservation(
+                "oracle_compile_command_disabled",
+                "The VBE Compile command was disabled and no compile evidence was observed.",
+                "vbe_compile",
+                elapsed,
+                excel);
+        }
         var accepted = new OracleObservation(
             "accepted",
             "compile",
@@ -597,12 +606,6 @@ public sealed class VbeOracleService : IVbeOracleService
             return propertyValue.ValueKind == JsonValueKind.String ? propertyValue.GetString() : propertyValue.ToString();
         }
         return null;
-    }
-
-    private static bool SameProcess(OwnedExcelProcess left, OwnedExcelProcess right)
-    {
-        return left.ProcessId == right.ProcessId &&
-               (left.StartTime is null || right.StartTime is null || left.StartTime.Value == right.StartTime.Value);
     }
 
     private sealed class VbeOracleValidationException(string message, Exception? inner = null) : Exception(message, inner);

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Windows/DialogWatcher.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Windows/DialogWatcher.cs
@@ -340,19 +340,22 @@ public sealed class DialogWatcher
 
 internal static class DialogFingerprint
 {
-    internal static bool IsDialogLike(WindowCandidate candidate, UiaDialogDescription? uia)
+    private static bool HasDialogClassName(WindowCandidate candidate)
     {
         return candidate.ClassName.Equals("#32770", StringComparison.OrdinalIgnoreCase) ||
                candidate.ClassName.StartsWith("bosa_sdm_", StringComparison.OrdinalIgnoreCase) ||
-               candidate.ClassName.Equals("NUIDialog", StringComparison.OrdinalIgnoreCase) ||
+               candidate.ClassName.Equals("NUIDialog", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool IsDialogLike(WindowCandidate candidate, UiaDialogDescription? uia)
+    {
+        return HasDialogClassName(candidate) ||
                string.Equals(uia?.ControlType, "Window", StringComparison.OrdinalIgnoreCase);
     }
 
     internal static bool IsOracleDialogLike(WindowCandidate candidate, UiaDialogDescription? uia)
     {
-        if (candidate.ClassName.Equals("#32770", StringComparison.OrdinalIgnoreCase) ||
-            candidate.ClassName.StartsWith("bosa_sdm_", StringComparison.OrdinalIgnoreCase) ||
-            candidate.ClassName.Equals("NUIDialog", StringComparison.OrdinalIgnoreCase))
+        if (HasDialogClassName(candidate))
         {
             return true;
         }

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Windows/DialogWatcher.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Windows/DialogWatcher.cs
@@ -9,6 +9,10 @@ namespace Xlflow.ExcelBridge.Windows;
 public enum DialogKind
 {
     Any,
+    // Used only by the developer VBE oracle's passive modal inspection. The
+    // normal run/push watcher never requests this kind and keeps its existing
+    // dialog classification behavior unchanged.
+    Unknown,
     MacroError,
     Runtime,
     Compile,
@@ -186,6 +190,38 @@ public sealed class DialogWatcher
         return null;
     }
 
+    /// <summary>
+    /// Captures every dialog-like window owned by the target Excel process,
+    /// including windows whose text does not match the known VBA dialog
+    /// fingerprints. This is intentionally a separate oracle-only API so the
+    /// production run/push suppression paths remain unchanged.
+    /// </summary>
+    internal IReadOnlyList<DialogSnapshot> CaptureOracleDialogs(DialogWatchRequest request, bool includeUia = true)
+    {
+        var result = new List<DialogSnapshot>();
+        foreach (var candidate in _windows.Enumerate(request.ExcelProcessId, request.VbeThreadId))
+        {
+            if (!BelongsToTarget(candidate, request))
+            {
+                continue;
+            }
+
+            var uia = includeUia ? _uia.Describe(candidate.Hwnd) : null;
+            var kind = DialogFingerprint.Classify(candidate, uia);
+            if (kind is null)
+            {
+                if (!DialogFingerprint.IsOracleDialogLike(candidate, uia))
+                {
+                    continue;
+                }
+                result.Add(BuildSnapshot(candidate, uia, DialogKind.Unknown, 0, DialogAction.None, DialogActionResult.None));
+                continue;
+            }
+            result.Add(BuildSnapshot(candidate, uia, kind.Value, 0, DialogAction.None, DialogActionResult.None));
+        }
+        return result;
+    }
+
     public IReadOnlyList<DialogSnapshot> CaptureCurrentDialogs(DialogWatchRequest request, bool includeUia)
     {
         var result = new List<DialogSnapshot>();
@@ -304,6 +340,29 @@ public sealed class DialogWatcher
 
 internal static class DialogFingerprint
 {
+    internal static bool IsDialogLike(WindowCandidate candidate, UiaDialogDescription? uia)
+    {
+        return candidate.ClassName.Equals("#32770", StringComparison.OrdinalIgnoreCase) ||
+               candidate.ClassName.StartsWith("bosa_sdm_", StringComparison.OrdinalIgnoreCase) ||
+               candidate.ClassName.Equals("NUIDialog", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(uia?.ControlType, "Window", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool IsOracleDialogLike(WindowCandidate candidate, UiaDialogDescription? uia)
+    {
+        if (candidate.ClassName.Equals("#32770", StringComparison.OrdinalIgnoreCase) ||
+            candidate.ClassName.StartsWith("bosa_sdm_", StringComparison.OrdinalIgnoreCase) ||
+            candidate.ClassName.Equals("NUIDialog", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // UIA reports many normal Excel/VBE top-level windows as Window. Only
+        // treat those as oracle dialogs when they also expose dialog content.
+        return string.Equals(uia?.ControlType, "Window", StringComparison.OrdinalIgnoreCase) &&
+               (candidate.Buttons.Count > 0 || candidate.Text.Any(text => !string.IsNullOrWhiteSpace(text)));
+    }
+
     public static DialogKind? Classify(WindowCandidate candidate, UiaDialogDescription? uia)
     {
         var title = candidate.Title;
@@ -311,10 +370,7 @@ internal static class DialogFingerprint
         var text = string.Join("\n", candidate.Text);
         var buttons = string.Join("\n", candidate.Buttons.Select(button => button.Text));
         var combined = string.Join("\n", title, text, buttons, uia?.Name ?? "");
-        var dialogLike = className.Equals("#32770", StringComparison.OrdinalIgnoreCase) ||
-                         className.StartsWith("bosa_sdm_", StringComparison.OrdinalIgnoreCase) ||
-                         className.Equals("NUIDialog", StringComparison.OrdinalIgnoreCase) ||
-                         string.Equals(uia?.ControlType, "Window", StringComparison.OrdinalIgnoreCase);
+        var dialogLike = IsDialogLike(candidate, uia);
         if (!dialogLike)
         {
             return null;

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeHostTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/BridgeHostTests.cs
@@ -53,6 +53,7 @@ public sealed class BridgeHostTests
         Assert.Contains("test", commands);
         Assert.Contains("type-db-import", commands);
         Assert.Contains("ui", commands);
+        Assert.Contains("vbe-oracle", commands);
     }
 
     [Fact]

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/DialogWatcherTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/DialogWatcherTests.cs
@@ -274,6 +274,27 @@ public sealed class DialogWatcherTests
         Assert.Equal("compile_close", dialog.Action);
     }
 
+    [Fact]
+    public void OracleCaptureReportsUnknownDialogLikeWindows()
+    {
+        var watcher = new DialogWatcher(
+            new StaticWindowEnumerator([Candidate(title: "Microsoft Visual Basic", text: ["Mystery prompt"], buttons: [])]),
+            new NullUiaDialogAdapter());
+        var request = new DialogWatchRequest(
+            ExcelProcessId: 100,
+            ExcelMainHwnd: 2,
+            Kind: DialogKind.Any,
+            ActionPolicy: DialogActionPolicy.ObserveOnly,
+            Timeout: TimeSpan.Zero,
+            PollInterval: TimeSpan.Zero);
+
+        var dialogs = watcher.CaptureOracleDialogs(request, includeUia: false);
+
+        var dialog = Assert.Single(dialogs);
+        Assert.Equal("unknown", dialog.Kind);
+        Assert.Equal("Mystery prompt", dialog.Text.Single());
+    }
+
     private static WindowCandidate Candidate(
         string title,
         string className = "#32770",

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/DialogWatcherTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/DialogWatcherTests.cs
@@ -295,6 +295,32 @@ public sealed class DialogWatcherTests
         Assert.Equal("Mystery prompt", dialog.Text.Single());
     }
 
+    [Fact]
+    public void OracleCaptureUsesUiaWindowContentGate()
+    {
+        var request = new DialogWatchRequest(
+            ExcelProcessId: 100,
+            ExcelMainHwnd: 2,
+            Kind: DialogKind.Any,
+            ActionPolicy: DialogActionPolicy.ObserveOnly,
+            Timeout: TimeSpan.Zero,
+            PollInterval: TimeSpan.Zero);
+        var uia = new StaticUiaDialogAdapter(new UiaDialogDescription(null, null, "Window"));
+
+        var emptyWindow = new DialogWatcher(
+            new StaticWindowEnumerator([Candidate(title: "Excel", className: "XLMAIN")]),
+            uia);
+        Assert.Empty(emptyWindow.CaptureOracleDialogs(request, includeUia: true));
+
+        var textWindow = new DialogWatcher(
+            new StaticWindowEnumerator([Candidate(title: "Excel", className: "XLMAIN", text: ["Mystery prompt"])]),
+            uia);
+        var dialogs = textWindow.CaptureOracleDialogs(request, includeUia: true);
+        var dialog = Assert.Single(dialogs);
+        Assert.Equal("unknown", dialog.Kind);
+        Assert.Equal("Mystery prompt", dialog.Text.Single());
+    }
+
     private static WindowCandidate Candidate(
         string title,
         string className = "#32770",
@@ -333,6 +359,12 @@ public sealed class DialogWatcherTests
     private sealed class NullUiaDialogAdapter : IUiaDialogAdapter
     {
         public UiaDialogDescription? Describe(long hwnd) => null;
+        public bool TryInvoke(long hwnd) => false;
+    }
+
+    private sealed class StaticUiaDialogAdapter(UiaDialogDescription description) : IUiaDialogAdapter
+    {
+        public UiaDialogDescription? Describe(long hwnd) => description;
         public bool TryInvoke(long hwnd) => false;
     }
 }

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/VbeOracleCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/VbeOracleCommandTests.cs
@@ -31,6 +31,29 @@ public sealed class VbeOracleCommandTests
     }
 
     [Fact]
+    public void HandleAcceptsRunnerPlanJson64AndTimeoutMs()
+    {
+        var planJson64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("{}"));
+        var command = new VbeOracleCommand(new FakeOracleService((request, args) =>
+        {
+            Assert.Equal(planJson64, args.PlanJson64);
+            Assert.Equal(planJson64, args.FixtureJson64);
+            Assert.Equal(TimeSpan.FromSeconds(30), args.Timeout);
+            return BridgeResponse.Ok(request);
+        }));
+
+        var response = command.Handle(new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-oracle-runner-keys",
+            Command = "vbe-oracle",
+            Payload = JsonDocument.Parse($$"""{ "PlanJson64": "{{planJson64}}", "TimeoutMs": "30000" }""").RootElement.Clone(),
+        }, CancellationToken.None);
+
+        Assert.Equal(BridgeStatus.Ok, response.Status);
+    }
+
+    [Fact]
     public void HandleRejectsMissingFixture()
     {
         var response = new VbeOracleCommand(new FakeOracleService((request, _) => BridgeResponse.Ok(request)))

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/VbeOracleCommandTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/VbeOracleCommandTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Xlflow.ExcelBridge.Commands;
+using Xlflow.ExcelBridge.Contract;
+using Xlflow.ExcelBridge.Services;
+
+namespace Xlflow.ExcelBridge.Tests;
+
+public sealed class VbeOracleCommandTests
+{
+    [Fact]
+    public void HandleAcceptsFixtureJson64AndTimeoutMilliseconds()
+    {
+        var fixtureJson64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("{}"));
+        var command = new VbeOracleCommand(new FakeOracleService((request, args) =>
+        {
+            Assert.Equal("vbe-oracle", request.Command);
+            Assert.Equal(fixtureJson64, args.PlanJson64);
+            Assert.Equal(TimeSpan.FromSeconds(12), args.Timeout);
+            return BridgeResponse.Ok(request);
+        }));
+
+        var response = command.Handle(new BridgeRequest
+        {
+            ProtocolVersion = ProtocolVersion.Current,
+            RequestId = "req-oracle",
+            Command = "vbe-oracle",
+            Payload = JsonDocument.Parse($$"""{ "FixtureJSON64": "{{fixtureJson64}}", "TimeoutMS": "12000" }""").RootElement.Clone(),
+        }, CancellationToken.None);
+
+        Assert.Equal(BridgeStatus.Ok, response.Status);
+    }
+
+    [Fact]
+    public void HandleRejectsMissingFixture()
+    {
+        var response = new VbeOracleCommand(new FakeOracleService((request, _) => BridgeResponse.Ok(request)))
+            .Handle(new BridgeRequest
+            {
+                ProtocolVersion = ProtocolVersion.Current,
+                RequestId = "req-oracle-invalid",
+                Command = "vbe-oracle",
+                Payload = JsonDocument.Parse("{}").RootElement.Clone(),
+            }, CancellationToken.None);
+
+        Assert.Equal(BridgeStatus.Failed, response.Status);
+        Assert.Equal("vbe_oracle_args_invalid", response.Error?.Code);
+    }
+
+    [Fact]
+    public void HandleRejectsNonPositiveTimeout()
+    {
+        var fixtureJson64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("{}"));
+        var response = new VbeOracleCommand(new FakeOracleService((request, _) => BridgeResponse.Ok(request)))
+            .Handle(new BridgeRequest
+            {
+                ProtocolVersion = ProtocolVersion.Current,
+                RequestId = "req-oracle-timeout",
+                Command = "vbe-oracle",
+                Payload = JsonDocument.Parse($$"""{ "FixtureJSON64": "{{fixtureJson64}}", "TimeoutMS": "0" }""").RootElement.Clone(),
+            }, CancellationToken.None);
+
+        Assert.Equal(BridgeStatus.Failed, response.Status);
+        Assert.Equal("vbe_oracle_args_invalid", response.Error?.Code);
+    }
+
+    private sealed class FakeOracleService(Func<BridgeRequest, VbeOracleCommandArguments, BridgeResponse> handler) : IVbeOracleService
+    {
+        public BridgeResponse Execute(BridgeRequest request, VbeOracleCommandArguments args, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request, args);
+        }
+    }
+}

--- a/cmd/xlflow-vbe-oracle/main.go
+++ b/cmd/xlflow-vbe-oracle/main.go
@@ -14,20 +14,23 @@ import (
 	"github.com/harumiWeb/xlflow/internal/oracle"
 )
 
-type caseFlags []string
+type caseFlags struct {
+	values []string
+	name   string
+}
 
-func (f *caseFlags) String() string { return strings.Join(*f, ",") }
+func (f *caseFlags) String() string { return strings.Join(f.values, ",") }
 func (f *caseFlags) Set(value string) error {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return errors.New("--case cannot be empty")
+		return fmt.Errorf("%s cannot be empty", f.name)
 	}
-	*f = append(*f, value)
+	f.values = append(f.values, value)
 	return nil
 }
 
 func main() {
-	var cases caseFlags
+	cases := caseFlags{name: "--case"}
 	var manifest string
 	var strict, promote bool
 	var timeout time.Duration
@@ -39,13 +42,18 @@ func main() {
 	flags.BoolVar(&strict, "strict", false, "fail when observed behavior differs from asserted expectation")
 	flags.BoolVar(&promote, "promote-observed", false, "promote selected observe fixtures")
 	flags.DurationVar(&timeout, "timeout", oracle.DefaultTimeout, "per-case timeout")
-	var meaningFlags caseFlags
+	meaningFlags := caseFlags{name: "--diagnostic-meaning"}
 	flags.Var(&meaningFlags, "diagnostic-meaning", "accepted promotion meaning as case-id=specification|policy|maintainability")
 	if err := flags.Parse(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			flags.SetOutput(os.Stdout)
+			flags.Usage()
+			return
+		}
 		writeFailure(2, err.Error())
 		return
 	}
-	for _, value := range meaningFlags {
+	for _, value := range meaningFlags.values {
 		id, meaning, ok := strings.Cut(value, "=")
 		if !ok || strings.TrimSpace(id) == "" || strings.TrimSpace(meaning) == "" {
 			writeFailure(2, "--diagnostic-meaning must be case-id=meaning")
@@ -55,7 +63,7 @@ func main() {
 	}
 	report, err := oracle.Run(context.Background(), oracle.Options{
 		ManifestPath:      manifest,
-		CaseIDs:           cases,
+		CaseIDs:           cases.values,
 		Strict:            strict,
 		PromoteObserved:   promote,
 		DiagnosticMeaning: meanings,

--- a/cmd/xlflow-vbe-oracle/main.go
+++ b/cmd/xlflow-vbe-oracle/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/harumiWeb/xlflow/internal/oracle"
+)
+
+type caseFlags []string
+
+func (f *caseFlags) String() string { return strings.Join(*f, ",") }
+func (f *caseFlags) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("--case cannot be empty")
+	}
+	*f = append(*f, value)
+	return nil
+}
+
+func main() {
+	var cases caseFlags
+	var manifest string
+	var strict, promote bool
+	var timeout time.Duration
+	meanings := map[string]string{}
+	flags := flag.NewFlagSet("xlflow-vbe-oracle", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.StringVar(&manifest, "manifest", "testdata/vbe-oracle/manifest.json", "oracle fixture manifest")
+	flags.Var(&cases, "case", "case ID to execute (repeatable)")
+	flags.BoolVar(&strict, "strict", false, "fail when observed behavior differs from asserted expectation")
+	flags.BoolVar(&promote, "promote-observed", false, "promote selected observe fixtures")
+	flags.DurationVar(&timeout, "timeout", oracle.DefaultTimeout, "per-case timeout")
+	var meaningFlags caseFlags
+	flags.Var(&meaningFlags, "diagnostic-meaning", "accepted promotion meaning as case-id=specification|policy|maintainability")
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		writeFailure(2, err.Error())
+		return
+	}
+	for _, value := range meaningFlags {
+		id, meaning, ok := strings.Cut(value, "=")
+		if !ok || strings.TrimSpace(id) == "" || strings.TrimSpace(meaning) == "" {
+			writeFailure(2, "--diagnostic-meaning must be case-id=meaning")
+			return
+		}
+		meanings[strings.TrimSpace(id)] = strings.TrimSpace(meaning)
+	}
+	report, err := oracle.Run(context.Background(), oracle.Options{
+		ManifestPath:      manifest,
+		CaseIDs:           cases,
+		Strict:            strict,
+		PromoteObserved:   promote,
+		DiagnosticMeaning: meanings,
+		Timeout:           timeout,
+	})
+	if err != nil {
+		code := 3
+		var exitErr *oracle.ExitError
+		if errors.As(err, &exitErr) {
+			code = exitErr.Code
+		}
+		writeReport(report)
+		os.Exit(code)
+	}
+	writeReport(report)
+}
+
+func writeReport(report oracle.Report) {
+	body, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		writeFailure(3, err.Error())
+		return
+	}
+	fmt.Println(string(body))
+}
+
+func writeFailure(code int, message string) {
+	report := oracle.Report{SchemaVersion: oracle.SchemaVersion, Status: "failed", Outcome: oracle.OutcomeInfrastructureFailure, Error: &oracle.ReportError{Code: "cli_error", Message: message}}
+	writeReport(report)
+	if code != 0 {
+		// Keep this helper testable while ensuring the process exits for CLI use.
+		os.Exit(code)
+	}
+}

--- a/docs/adr/ADR-0026-local-vbe-oracle-evidence.md
+++ b/docs/adr/ADR-0026-local-vbe-oracle-evidence.md
@@ -1,0 +1,91 @@
+# ADR-0026: Local Excel/VBE Oracle Evidence Harness
+
+## Status
+
+Accepted
+
+## Context
+
+VBA has host-specific compile and call semantics that are not safely inferred
+from general language rules. xlflow's lint, analyze, type-analysis, and LSP
+diagnostics therefore need a way to check focused questions against a real VBE
+without making Excel a dependency of normal analysis. A VBE answer is useful
+evidence for compile-equivalent claims, but VBE acceptance does not invalidate
+policy, safety, portability, or maintainability warnings.
+
+There is no Excel-installed self-hosted GitHub Actions runner. Excel/VBE UI and
+COM automation is also slow, stateful, and machine-dependent, so the check must
+remain a developer-operated local validation tool.
+
+## Decision
+
+Add a Windows-only, developer-only oracle command backed by the existing .NET
+Excel bridge and dialog infrastructure. The first schema supports only
+standard-module compile probes. Go owns fixture loading and validation,
+deterministic sequential selection, strict expectation checking, analyzer
+contracts, and explicit promotion. The bridge owns one disposable workbook and
+one real VBE Compile observation at a time.
+
+Fixtures store source in ordinary `.bas` files and begin as `observe` with
+pending provenance. An explicit promotion command may assert only confirmed
+`accepted` or `rejected` outcomes for explicitly selected cases. Rejected
+compile evidence is `compile-error`; accepted compile evidence must carry an
+explicit non-runtime diagnostic meaning. Excel version/build, bitness, locale,
+phase, and verification time are retained as provenance.
+
+Only `accepted` and `rejected` are behavioral evidence. Timeouts, startup/VBOM
+or import failures, missing Compile commands, unknown modals, worker/COM
+failures, malformed output, and unconfirmed cleanup are infrastructure
+failures. They stop a batch and cannot be promoted. Known accept/reject control
+fixtures run first to detect a broken watcher or command invocation.
+
+The oracle is never called by production xlflow commands, deterministic tests,
+or GitHub Actions. Contributors changing static-analysis semantics must run
+the relevant focused cases locally and record their IDs in the PR.
+
+## Consequences
+
+- Analyzer changes can cite empirical VBE compile evidence while normal tests
+  remain deterministic and Excel-free.
+- The observation/promotion boundary prevents guessed VBA behavior from being
+  silently committed as authority.
+- Local-only execution leaves a manual Windows prerequisite and cannot provide
+  CI coverage until an Excel-capable self-hosted runner is available.
+- Sequential disposable workbooks and strict cleanup handling reduce cross-case
+  contamination at the cost of slower fixture runs.
+- VBE evidence must remain separate from policy and maintainability rule
+  ownership; accepted VBA may still produce xlflow warnings.
+
+## Alternatives considered
+
+1. **Invoke Excel from production lint/analyze/LSP** - Rejected because it
+   would make diagnostics nondeterministic and require Office/COM everywhere.
+2. **Use a PowerShell-only oracle implementation** - Rejected because the
+   existing .NET bridge already owns Excel lifecycle, VBE Compile invocation,
+   dialog correlation, timeout handling, and cleanup.
+3. **Treat timeouts or missed dialogs as VBA rejection** - Rejected because
+   infrastructure failure is not language evidence and would create false
+   compile-error claims.
+4. **Run fixtures in parallel** - Rejected because Excel/VBE command bars,
+   modal dialogs, and process cleanup are single-user resources.
+5. **Automatically promote observations** - Rejected because promotion is a
+   reviewable evidence decision and must never overwrite an asserted result.
+
+## Evidence
+
+- `docs/specs/vbe-oracle.md`
+- `docs/adr/ADR-0008-dotnet-excel-bridge.md`
+- `docs/adr/ADR-0010-hybrid-excel-dialog-watcher.md`
+- `docs/adr/ADR-0013-analyze-runtime-risk-ownership.md`
+- `docs/adr/ADR-0024-shared-static-analysis-rule-registry.md`
+- `bridge/dotnet/src/Xlflow.ExcelBridge/Services`
+- `bridge/dotnet/src/Xlflow.ExcelBridge/Workers`
+- `testdata/vbe-oracle/manifest.json`
+
+## Related
+
+- Issue #502
+- `docs/adr/ADR-0008-dotnet-excel-bridge.md`
+- `docs/adr/ADR-0010-hybrid-excel-dialog-watcher.md`
+- `docs/adr/ADR-0013-analyze-runtime-risk-ownership.md`
+- `docs/adr/ADR-0024-shared-static-analysis-rule-registry.md`

--- a/docs/bridge/dotnet-bridge.md
+++ b/docs/bridge/dotnet-bridge.md
@@ -51,6 +51,35 @@ recovery-required outcome even when no Excel PID was returned.
 
 ## Implemented Commands
 
+### Internal `vbe-oracle`
+
+The developer-only `vbe-oracle` bridge command is invoked by
+`cmd/xlflow-vbe-oracle`; it is not registered in the public xlflow command
+tree. Go sends one base64-encoded JSON plan per fixture through the normal
+bridge protocol. Schema v1 plans contain `schema_version`, `case_id`,
+`probe_mode: "compile"`, `timeout_ms`, and one or more standard `.bas` modules
+with `name`, `kind`, and `source_path`.
+
+The bridge creates a disposable unsaved workbook, imports the verified sources,
+activates the target VBProject, and invokes the existing VBE Compile command.
+It reuses the worker timeout and Win32/UI Automation dialog watcher. A compile
+dialog is `rejected`; a completed worker with no compile dialog is `accepted`.
+Dialog identity is correlated with the target Excel/VBE owner chain; the
+oracle does not use `SendKeys` or keyboard-focus scripting.
+Timeouts, startup/VBIDE/import/COM failures, unknown modals, malformed worker
+output, and unconfirmed cleanup are `infrastructure_failure` and are returned
+under the typed oracle response. The target Excel PID and cleanup status are
+always included when known, and cleanup failure overrides an earlier behavior
+observation.
+
+Successful responses expose the extension field `oracle` with `outcome`,
+`evidence_phase`, `last_stage`, `duration_ms`, `compile_invoked`,
+`cleanup_confirmed`, dialog/location metadata when present, and Excel
+version/build/bitness/locale metadata. Infrastructure responses preserve the
+same oracle payload in `error.details.oracle` so the Go runner can classify the
+failure without parsing localized messages. Only the bridge-created Excel
+process may be closed or terminated.
+
 ### `doctor`
 
 `xlflow doctor --bridge dotnet --json` runs environment diagnostics through the .NET bridge without launching PowerShell. The response includes a `diagnostics` object at the top level:

--- a/docs/bridge/dotnet-bridge.md
+++ b/docs/bridge/dotnet-bridge.md
@@ -63,7 +63,8 @@ with `name`, `kind`, and `source_path`.
 The bridge creates a disposable unsaved workbook, imports the verified sources,
 activates the target VBProject, and invokes the existing VBE Compile command.
 It reuses the worker timeout and Win32/UI Automation dialog watcher. A compile
-dialog is `rejected`; a completed worker with no compile dialog is `accepted`.
+dialog is `rejected`; a completed worker with no target-owned compile dialog is
+`accepted` only when `cleanup_confirmed` is true.
 Dialog identity is correlated with the target Excel/VBE owner chain; the
 oracle does not use `SendKeys` or keyboard-focus scripting.
 Timeouts, startup/VBIDE/import/COM failures, unknown modals, malformed worker

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -1,0 +1,164 @@
+# Local Excel/VBE oracle
+
+The VBE oracle is an optional developer tool for answering focused VBA
+compile-time questions with a real local Excel/VBE instance. It is evidence for
+static-analysis maintenance; it is not part of the `xlflow` production command
+surface, a normal test dependency, or a GitHub Actions check.
+
+## Prerequisites and safety
+
+Oracle execution requires Windows, a locally installed Excel desktop client,
+and **Trust access to the VBA project object model** enabled in Excel's Trust
+Center. The command creates one unsaved disposable workbook per case and must
+be run sequentially. Do not run two oracle processes at the same time: Excel,
+the VBE command bars, modal dialogs, and cleanup ownership are single-user
+resources.
+
+The command only terminates the Excel process it created and recorded. If a run
+reports an unconfirmed cleanup or an infrastructure failure, inspect Task
+Manager before starting another run and do not promote a fixture.
+
+Dialog detection is tied to the target Excel process/VBE owner chain through
+the existing Win32/UI Automation watcher. The oracle does not use
+`SendKeys` or keyboard-focus scripting.
+
+## Running cases
+
+From the repository root, run one case through the PowerShell wrapper:
+
+```powershell
+./scripts/dev/test-vbe-oracle.ps1 --case byref-parenthesized-variable
+```
+
+The direct equivalent is:
+
+```powershell
+go run ./cmd/xlflow-vbe-oracle --case byref-parenthesized-variable
+```
+
+Omit `--case` to select all cases in the deterministic order in
+`testdata/vbe-oracle/manifest.json`. Repeat `--case` to select a focused set.
+The runner always executes the known-accept and known-reject controls first.
+Use `--timeout 5m` (the default) to set the per-case timeout. Progress is sent
+to stderr; stdout is a schema-versioned JSON result suitable for scripts.
+
+To run the health controls explicitly in strict mode:
+
+```powershell
+./scripts/dev/test-vbe-oracle.ps1 `
+  --case known-compile-accept `
+  --case known-compile-reject `
+  --strict
+```
+
+## Fixture format
+
+The manifest has `schema_version: 1`, a `controls` object with `accept` and
+`reject` case IDs, and an ordered `cases` list. The two control entries also
+carry `control_role` metadata for reviewers. Each case directory contains a
+`case.json` and ordinary `.bas` sources. V1 accepts standard modules only and
+requires `probe.mode: "compile"`; runtime probes and class/UserForm modules are
+future extensions.
+
+Case expectations start as observational fixtures:
+
+```json
+{
+  "vbe": {
+    "expected": "observe",
+    "evidence_phase": "unknown",
+    "diagnostic_meaning": "observation"
+  },
+  "provenance": { "status": "pending", "verified_on": [] }
+}
+```
+
+Source is kept in normal module files so the same fixture can be consumed by
+parser, lint, analyze, type-analysis, LSP, and oracle tests. The analyzer
+contract uses `analysis.expected_diagnostics` and
+`analysis.forbidden_diagnostics`; entries may specify `code`, `severity`, an
+optional source range, and (when needed) `surfaces` from `lint`, `analyze`, and
+`lsp`.
+
+## Outcomes and strict mode
+
+Only `accepted` and `rejected` are VBA evidence. A compile dialog associated
+with the target Excel/VBE process is `rejected`. A successful Compile command
+with no delayed compile dialog and confirmed cleanup is `accepted`. A disabled
+Compile command is recorded as accepted with `compile_invoked: false` because
+the project was already compiled.
+
+Timeouts, Excel startup/VBOM/import/project activation failures, inability to
+find or invoke Compile, worker crashes or malformed output, unknown/unrelated
+modals, COM disconnection, and unconfirmed cleanup are
+`infrastructure_failure`. They are never converted to VBA acceptance or
+rejection. A cleanup failure overrides any earlier accepted/rejected result.
+
+Default observational runs print what Excel reported and do not change fixture
+files. `--strict` fails when a case is still `observe` or when an asserted
+expectation does not match. The known controls are a harness health gate: if
+the accept control is rejected, or the reject control is accepted, the run
+stops and the batch is unhealthy.
+
+Exit codes are stable for automation: `0` success/observation, `1` strict
+expectation mismatch, `2` CLI or fixture validation error, and `3` oracle
+infrastructure failure.
+
+## Promoting observed evidence
+
+Promotion is explicit and must select one or more case IDs:
+
+```powershell
+./scripts/dev/test-vbe-oracle.ps1 `
+  --case byref-parenthesized-variable `
+  --promote-observed
+```
+
+Promotion is atomic for the selected batch. It refuses an already asserted
+fixture, an implicit all-case selection, infrastructure failures, or an
+unconfirmed cleanup. A rejected compile is classified as `compile-error`.
+Accepted compile evidence requires an explicit diagnostic meaning of
+`specification`, `policy`, or `maintainability`; `runtime-error` cannot be
+proven by a compile probe. Supply meanings with the command's
+`--diagnostic-meaning <case-id>=<meaning>` option. Promotion records the
+observed phase and Excel version/build, process bitness, UI locale, and UTC
+verification timestamp in `provenance.verified_on`.
+
+## Static-analysis workflow
+
+VBE is authoritative for whether this source compiles, but not for policy or
+maintainability advice. A rule must distinguish compile-equivalent errors from
+deterministic runtime-risk warnings and non-VBE policy/maintainability
+warnings. Normal Go and .NET tests consume committed fixture expectations and
+never launch Excel.
+
+When changing static-analysis semantics (including call/argument validation,
+type inference, object/`Set` diagnostics, parser interpretation, severity, or
+LSP projections):
+
+1. Decide whether the behavior depends on actual VBE semantics.
+2. Add or update an `observe` fixture if there is no existing evidence.
+3. Run both known controls and the focused oracle case IDs locally.
+4. Promote only accepted/rejected observations with confirmed cleanup.
+5. Run deterministic Go and .NET tests.
+6. Include the executed oracle case IDs, or a reason for non-applicability, in
+   the pull request description.
+
+Oracle infrastructure failures are stop-the-line failures for agents and
+contributors. Do not change analyzer behavior or promote fixtures based on a
+timeout, unknown modal, failed Compile invocation, or unconfirmed Excel
+cleanup.
+
+## Pull request checklist
+
+```markdown
+- [ ] This change does not alter static-analysis behavior.
+- [ ] Relevant VBE oracle cases were run locally:
+      `<case-id-1>`, `<case-id-2>`
+- [ ] A VBE oracle run was not applicable because:
+      `<reason>`
+```
+
+The oracle remains local-only until an appropriate Excel-installed self-hosted
+runner exists. No CI workflow may install, launch, or automate Excel for this
+tool.

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -85,8 +85,8 @@ optional source range, and (when needed) `surfaces` from `lint`, `analyze`, and
 Only `accepted` and `rejected` are VBA evidence. A compile dialog associated
 with the target Excel/VBE process is `rejected`. A successful Compile command
 with no delayed compile dialog and confirmed cleanup is `accepted`. A disabled
-Compile command is recorded as accepted with `compile_invoked: false` because
-the project was already compiled.
+Compile command is `infrastructure_failure` with `compile_invoked: false`
+because no VBE Compile evidence was observed.
 
 Timeouts, Excel startup/VBOM/import/project activation failures, inability to
 find or invoke Compile, worker crashes or malformed output, unknown/unrelated

--- a/internal/excel/bridge/dotnet.go
+++ b/internal/excel/bridge/dotnet.go
@@ -161,11 +161,7 @@ func (p DotNetProvider) bridgeCommand() (string, []string, error) {
 			if err != nil {
 				return "", nil, &Error{Kind: ErrorDotNetRuntime, Message: "dotnet executable not found while resolving the repo-local Excel bridge project", Err: err}
 			}
-			return dotnetExe, []string{
-				"run", "--project", projectPath, "--configuration", "Release",
-				"--disable-build-servers", "-p:UseSharedCompilation=false",
-				"-p:BuildInParallel=false", "--",
-			}, nil
+			return dotnetExe, repoLocalDotNetRunArgs(projectPath), nil
 		}
 	}
 	return DotNetBridgeCommand()
@@ -205,15 +201,7 @@ func DotNetBridgeCommand() (string, []string, error) {
 	if projectPath, ok := repoLocalDotNetBridgeProjectPathFunc(); ok {
 		dotnetExe, err := dotNetLookPath("dotnet")
 		if err == nil {
-			return dotnetExe, []string{
-				"run",
-				"--project", projectPath,
-				"--configuration", "Release",
-				"--disable-build-servers",
-				"-p:UseSharedCompilation=false",
-				"-p:BuildInParallel=false",
-				"--",
-			}, nil
+			return dotnetExe, repoLocalDotNetRunArgs(projectPath), nil
 		}
 		if deferredErr == nil {
 			deferredErr = &Error{
@@ -237,6 +225,14 @@ func DotNetBridgeCommand() (string, []string, error) {
 	return "", nil, &Error{
 		Kind:    ErrorDotNetMissing,
 		Message: ".NET Excel bridge executable was not found; build bridge/dotnet/Xlflow.ExcelBridge.sln or install xlflow-excel-bridge beside xlflow",
+	}
+}
+
+func repoLocalDotNetRunArgs(projectPath string) []string {
+	return []string{
+		"run", "--project", projectPath, "--configuration", "Release",
+		"--disable-build-servers", "-p:UseSharedCompilation=false",
+		"-p:BuildInParallel=false", "--",
 	}
 }
 

--- a/internal/excel/bridge/dotnet.go
+++ b/internal/excel/bridge/dotnet.go
@@ -49,7 +49,8 @@ var dotNetSupportedCommands = map[string]struct{}{
 }
 
 type DotNetProvider struct {
-	RootDir string
+	RootDir         string
+	PreferRepoLocal bool
 }
 
 type dotNetBridgeInfo struct {
@@ -76,7 +77,7 @@ func (p DotNetProvider) Supports(command string) bool {
 }
 
 func (p DotNetProvider) Info(ctx context.Context) (Info, error) {
-	command, args, err := DotNetBridgeCommand()
+	command, args, err := p.bridgeCommand()
 	if err != nil {
 		return Info{}, err
 	}
@@ -101,7 +102,7 @@ func (p DotNetProvider) Info(ctx context.Context) (Info, error) {
 }
 
 func (p DotNetProvider) Execute(ctx context.Context, req Request) (Response, error) {
-	command, args, err := DotNetBridgeCommand()
+	command, args, err := p.bridgeCommand()
 	if err != nil {
 		return Response{}, err
 	}
@@ -148,6 +149,26 @@ func (p DotNetProvider) Execute(ctx context.Context, req Request) (Response, err
 		return response, err
 	}
 	return response, nil
+}
+
+// bridgeCommand lets developer-only callers force the repository bridge. This
+// avoids accidentally invoking a stale published bridge beside the binary
+// while leaving production provider resolution unchanged.
+func (p DotNetProvider) bridgeCommand() (string, []string, error) {
+	if p.PreferRepoLocal {
+		if projectPath, ok := repoLocalDotNetBridgeProjectPathFunc(); ok {
+			dotnetExe, err := dotNetLookPath("dotnet")
+			if err != nil {
+				return "", nil, &Error{Kind: ErrorDotNetRuntime, Message: "dotnet executable not found while resolving the repo-local Excel bridge project", Err: err}
+			}
+			return dotnetExe, []string{
+				"run", "--project", projectPath, "--configuration", "Release",
+				"--disable-build-servers", "-p:UseSharedCompilation=false",
+				"-p:BuildInParallel=false", "--",
+			}, nil
+		}
+	}
+	return DotNetBridgeCommand()
 }
 
 func dotNetBridgeRuntimeArgs(args []string) []string {

--- a/internal/oracle/contract.go
+++ b/internal/oracle/contract.go
@@ -77,9 +77,10 @@ func CheckDiagnosticProjections(expect AnalysisExpectation, projections map[stri
 	all := make([]Diagnostic, 0)
 	for surface, diagnostics := range projections {
 		for _, diagnostic := range diagnostics {
-			if diagnostic.Surface == "" {
-				diagnostic.Surface = surface
+			if diagnostic.Surface != "" && diagnostic.Surface != surface {
+				return fmt.Errorf("diagnostic %s has surface %q in %q projection", diagnostic.Code, diagnostic.Surface, surface)
 			}
+			diagnostic.Surface = surface
 			all = append(all, diagnostic)
 		}
 	}

--- a/internal/oracle/contract.go
+++ b/internal/oracle/contract.go
@@ -1,0 +1,219 @@
+package oracle
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Diagnostic is the normalized shape consumed by fixture contract tests. The
+// analyzer and LSP adapters can project their native diagnostics into this
+// shape without importing Excel or COM code.
+type Diagnostic struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity,omitempty"`
+	Range    *Range `json:"range,omitempty"`
+	Surface  string `json:"surface,omitempty"`
+}
+
+// CheckDiagnostics applies the case's deterministic analyzer expectation.
+func (c Case) CheckDiagnostics(actual []Diagnostic) error {
+	return CheckDiagnosticContract(c.Analysis, actual)
+}
+
+// CheckDiagnosticSurfaces applies the case expectation to lint/analyze/LSP
+// projections represented by surface name.
+func (c Case) CheckDiagnosticSurfaces(projections map[string][]Diagnostic) error {
+	return CheckDiagnosticProjections(c.Analysis, projections)
+}
+
+func CheckDiagnosticContract(expect AnalysisExpectation, actual []Diagnostic) error {
+	for _, forbidden := range expect.ForbiddenDiagnostics {
+		if countDiagnostics(forbidden, actual) > 0 {
+			return fmt.Errorf("forbidden diagnostic %s was emitted", forbidden.Code)
+		}
+	}
+	used := make([]bool, len(actual))
+	for _, required := range expect.ExpectedDiagnostics {
+		if len(required.Surfaces) > 0 {
+			// An explicitly scoped expectation applies once on every named
+			// projection surface. This prevents a fixture from claiming LSP
+			// parity while only checking one surface in the union.
+			for _, surface := range required.Surfaces {
+				matched := false
+				for i, diagnostic := range actual {
+					if used[i] || diagnostic.Surface != surface || !diagnosticMatches(required, diagnostic) {
+						continue
+					}
+					used[i] = true
+					matched = true
+					break
+				}
+				if !matched {
+					return fmt.Errorf("expected diagnostic %s was not emitted on %s", required.Code, surface)
+				}
+			}
+			continue
+		}
+		matched := false
+		for i, diagnostic := range actual {
+			if used[i] || !diagnosticMatches(required, diagnostic) {
+				continue
+			}
+			used[i] = true
+			matched = true
+			break
+		}
+		if !matched {
+			return fmt.Errorf("expected diagnostic %s was not emitted", required.Code)
+		}
+	}
+	return nil
+}
+
+// CheckDiagnosticProjections applies one fixture contract to diagnostics
+// projected by lint, analyze, and LSP adapters. It is intentionally Excel-free
+// and can be called from ordinary Go tests.
+func CheckDiagnosticProjections(expect AnalysisExpectation, projections map[string][]Diagnostic) error {
+	all := make([]Diagnostic, 0)
+	for surface, diagnostics := range projections {
+		for _, diagnostic := range diagnostics {
+			if diagnostic.Surface == "" {
+				diagnostic.Surface = surface
+			}
+			all = append(all, diagnostic)
+		}
+	}
+	if err := CheckDiagnosticContract(expect, all); err != nil {
+		return err
+	}
+	// Duplicate diagnostics are a contract failure when the fixture explicitly
+	// claims that a diagnostic is present. Unrelated diagnostics are left to
+	// the owning analyzer surface because some projections intentionally use
+	// different ranges or severity policies for advisory findings.
+	for _, required := range expect.ExpectedDiagnostics {
+		for surface, diagnostics := range projections {
+			if len(required.Surfaces) > 0 && !containsString(required.Surfaces, surface) {
+				continue
+			}
+			count := 0
+			for _, diagnostic := range diagnostics {
+				if diagnostic.Code == required.Code &&
+					(required.Severity == "" || diagnostic.Severity == required.Severity) &&
+					(required.Range == nil || rangesEqual(required.Range, diagnostic.Range)) {
+					count++
+				}
+			}
+			if count > 1 {
+				return fmt.Errorf("diagnostic %s is duplicated on %s", required.Code, surface)
+			}
+		}
+	}
+	// A shared rule must not silently change severity/range when projected to a
+	// different protocol surface. Duplicate code-only observations are allowed
+	// because one source can legitimately produce multiple diagnostics.
+	expectedCodes := map[string]bool{}
+	for _, required := range expect.ExpectedDiagnostics {
+		expectedCodes[required.Code] = true
+	}
+	seen := map[string]map[string]Diagnostic{}
+	for _, diagnostic := range all {
+		if !expectedCodes[diagnostic.Code] {
+			continue
+		}
+		if required, ok := expectedForCode(expect.ExpectedDiagnostics, diagnostic.Code); ok && len(required.Surfaces) > 0 && !containsString(required.Surfaces, diagnostic.Surface) {
+			continue
+		}
+		bySurface := seen[diagnostic.Code]
+		if bySurface == nil {
+			bySurface = map[string]Diagnostic{}
+			seen[diagnostic.Code] = bySurface
+		}
+		if _, ok := bySurface[diagnostic.Surface]; ok {
+			continue
+		}
+		for _, prior := range bySurface {
+			if prior.Severity != diagnostic.Severity || !rangesEqual(prior.Range, diagnostic.Range) {
+				return fmt.Errorf("diagnostic %s differs across projections", diagnostic.Code)
+			}
+		}
+		bySurface[diagnostic.Surface] = diagnostic
+	}
+	return nil
+}
+
+func expectedForCode(expectations []DiagnosticExpectation, code string) (DiagnosticExpectation, bool) {
+	for _, expectation := range expectations {
+		if expectation.Code == code {
+			return expectation, true
+		}
+	}
+	return DiagnosticExpectation{}, false
+}
+
+func countDiagnostics(expect DiagnosticExpectation, actual []Diagnostic) int {
+	count := 0
+	for _, diagnostic := range actual {
+		if diagnosticMatches(expect, diagnostic) {
+			count++
+		}
+	}
+	return count
+}
+
+func diagnosticMatches(expect DiagnosticExpectation, diagnostic Diagnostic) bool {
+	if diagnostic.Code != expect.Code {
+		return false
+	}
+	if expect.Severity != "" && diagnostic.Severity != expect.Severity {
+		return false
+	}
+	if expect.Range != nil && !rangesEqual(expect.Range, diagnostic.Range) {
+		return false
+	}
+	if len(expect.Surfaces) > 0 && !containsString(expect.Surfaces, diagnostic.Surface) {
+		return false
+	}
+	return true
+}
+
+func rangesEqual(left, right *Range) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func containsString(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeDiagnostics gives tests deterministic ordering while preserving
+// duplicates (duplicate diagnostics are meaningful contract failures).
+func NormalizeDiagnostics(diagnostics []Diagnostic) []Diagnostic {
+	result := append([]Diagnostic(nil), diagnostics...)
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].Code != result[j].Code {
+			return result[i].Code < result[j].Code
+		}
+		if result[i].Severity != result[j].Severity {
+			return result[i].Severity < result[j].Severity
+		}
+		if result[i].Surface != result[j].Surface {
+			return result[i].Surface < result[j].Surface
+		}
+		return rangeKey(result[i].Range) < rangeKey(result[j].Range)
+	})
+	return result
+}
+
+func rangeKey(value *Range) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%08d:%08d:%08d:%08d", value.StartLine, value.StartColumn, value.EndLine, value.EndColumn)
+}

--- a/internal/oracle/contract_surface_test.go
+++ b/internal/oracle/contract_surface_test.go
@@ -1,0 +1,25 @@
+package oracle
+
+import "testing"
+
+func TestDiagnosticSurfaceExpectationRequiresEveryNamedProjection(t *testing.T) {
+	expect := AnalysisExpectation{ExpectedDiagnostics: []DiagnosticExpectation{{Code: "VBA001", Severity: "warning", Surfaces: []string{"lint", "analyze"}}}}
+	projections := map[string][]Diagnostic{
+		"lint":    {{Code: "VBA001", Severity: "warning", Surface: "lint"}},
+		"analyze": {{Code: "VBA001", Severity: "warning", Surface: "analyze"}},
+	}
+	if err := CheckDiagnosticProjections(expect, projections); err != nil {
+		t.Fatal(err)
+	}
+	delete(projections, "analyze")
+	if err := CheckDiagnosticProjections(expect, projections); err == nil {
+		t.Fatal("expected missing explicitly scoped projection to fail")
+	}
+}
+
+func TestDiagnosticContractRejectsDuplicateNamedSurface(t *testing.T) {
+	expect := AnalysisExpectation{ExpectedDiagnostics: []DiagnosticExpectation{{Code: "VBA001", Surfaces: []string{"lint", "lint"}}}}
+	if err := validateDiagnosticExpectations(expect.ExpectedDiagnostics, "expected", "sample"); err == nil {
+		t.Fatal("expected duplicate surface validation error")
+	}
+}

--- a/internal/oracle/contract_surface_test.go
+++ b/internal/oracle/contract_surface_test.go
@@ -23,3 +23,13 @@ func TestDiagnosticContractRejectsDuplicateNamedSurface(t *testing.T) {
 		t.Fatal("expected duplicate surface validation error")
 	}
 }
+
+func TestDiagnosticProjectionRejectsMismatchedSurface(t *testing.T) {
+	expect := AnalysisExpectation{ExpectedDiagnostics: []DiagnosticExpectation{{Code: "VBA001", Surfaces: []string{"analyze"}}}}
+	projections := map[string][]Diagnostic{
+		"lint": {{Code: "VBA001", Surface: "analyze"}},
+	}
+	if err := CheckDiagnosticProjections(expect, projections); err == nil {
+		t.Fatal("expected mismatched projection surface to fail")
+	}
+}

--- a/internal/oracle/fixture_contract_test.go
+++ b/internal/oracle/fixture_contract_test.go
@@ -1,0 +1,92 @@
+package oracle
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/analyze"
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/lint"
+	"github.com/harumiWeb/xlflow/internal/vba/intel"
+	"github.com/harumiWeb/xlflow/internal/vbadb"
+)
+
+// The committed fixture contract is deliberately Excel-free. This test keeps
+// the same sources usable by batch lint/analyze and the realtime/LSP analyzer,
+// while the VBE observations remain an optional local developer step.
+func TestCommittedFixtureContractsWithoutExcel(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "testdata", "vbe-oracle", "manifest.json")
+	manifest, root, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	db, err := vbadb.LoadBuiltin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range manifest.Cases {
+		entry := entry
+		t.Run(entry.ID, func(t *testing.T) {
+			c, sources, err := LoadCase(root, entry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			projectRoot := t.TempDir()
+			modulesRoot := filepath.Join(projectRoot, "src", "modules")
+			if err := os.MkdirAll(modulesRoot, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			projections := map[string][]Diagnostic{}
+			for _, module := range c.Modules {
+				path := filepath.Join(modulesRoot, module.Name+".bas")
+				if err := os.WriteFile(path, sources[module.Name], 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			lintResult, err := (lint.Linter{RootDir: projectRoot, Config: cfg}).RunResult()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, issue := range lintResult.Issues {
+				projections["lint"] = append(projections["lint"], Diagnostic{
+					Code: issue.Code, Severity: issue.Severity,
+					Range: &Range{StartLine: issue.Line, StartColumn: issue.Column, EndLine: issue.Line, EndColumn: issue.Column},
+				})
+			}
+
+			analyzeResult, err := (analyze.Analyzer{RootDir: projectRoot, Config: cfg}).RunResult()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, finding := range analyzeResult.Findings {
+				projections["analyze"] = append(projections["analyze"], Diagnostic{
+					Code: finding.Code, Severity: finding.Severity,
+					Range: &Range{StartLine: finding.Line, StartColumn: finding.Column, EndLine: finding.EndLine, EndColumn: finding.EndColumn},
+				})
+			}
+
+			lspAnalyzer := intel.Analyzer{RootDir: projectRoot, Config: cfg, DB: db}
+			for _, module := range c.Modules {
+				path := filepath.Join(modulesRoot, module.Name+".bas")
+				for _, diagnostic := range lspAnalyzer.DiagnosticsContext(context.Background(), intel.Document{
+					URI: path, Path: path, Source: string(sources[module.Name]), ModuleKind: "standard",
+				}) {
+					projections["lsp"] = append(projections["lsp"], Diagnostic{
+						Code: diagnostic.Code, Severity: diagnostic.Severity,
+						Range: &Range{
+							StartLine: diagnostic.Range.Start.Line + 1, StartColumn: diagnostic.Range.Start.Character + 1,
+							EndLine: diagnostic.Range.End.Line + 1, EndColumn: diagnostic.Range.End.Character + 1,
+						},
+					})
+				}
+			}
+			if err := CheckDiagnosticProjections(c.Analysis, projections); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/oracle/manifest.go
+++ b/internal/oracle/manifest.go
@@ -1,0 +1,452 @@
+package oracle
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	SchemaVersion = 1
+
+	ProbeCompile = "compile"
+
+	ExpectedObserve  = "observe"
+	ExpectedAccepted = "accepted"
+	ExpectedRejected = "rejected"
+
+	EvidenceUnknown = "unknown"
+	EvidenceCompile = "compile"
+
+	MeaningObservation     = "observation"
+	MeaningCompileError    = "compile-error"
+	MeaningRuntimeError    = "runtime-error"
+	MeaningSpecification   = "specification"
+	MeaningPolicy          = "policy"
+	MeaningMaintainability = "maintainability"
+)
+
+var caseIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+var vbNamePattern = regexp.MustCompile(`(?im)^\s*Attribute\s+VB_Name\s*=\s*"([^"]+)"`)
+
+type Manifest struct {
+	SchemaVersion int             `json:"schema_version"`
+	Cases         []ManifestEntry `json:"cases"`
+	Controls      Controls        `json:"controls"`
+}
+
+func (m *Manifest) UnmarshalJSON(data []byte) error {
+	var value struct {
+		SchemaVersion int             `json:"schema_version"`
+		Cases         []ManifestEntry `json:"cases"`
+		Controls      Controls        `json:"controls"`
+		KnownAccept   string          `json:"known_accept"`
+		KnownReject   string          `json:"known_reject"`
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	m.SchemaVersion, m.Cases, m.Controls = value.SchemaVersion, value.Cases, value.Controls
+	if m.Controls.Accept == "" {
+		m.Controls.Accept = value.KnownAccept
+	}
+	if m.Controls.Reject == "" {
+		m.Controls.Reject = value.KnownReject
+	}
+	return nil
+}
+
+// ManifestEntry keeps the manifest extensible while allowing the concise
+// `"cases": ["case-id"]` form used by early local manifests.
+type ManifestEntry struct {
+	ID          string `json:"id"`
+	Path        string `json:"path,omitempty"`
+	ControlRole string `json:"control_role,omitempty"`
+	Role        string `json:"role,omitempty"`
+}
+
+func (e *ManifestEntry) UnmarshalJSON(data []byte) error {
+	var id string
+	if err := json.Unmarshal(data, &id); err == nil {
+		e.ID = strings.TrimSpace(id)
+		return nil
+	}
+	type alias ManifestEntry
+	var value alias
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*e = ManifestEntry(value)
+	if e.ControlRole == "" {
+		e.ControlRole = e.Role
+	}
+	return nil
+}
+
+type Controls struct {
+	Accept string `json:"accept"`
+	Reject string `json:"reject"`
+}
+
+func (c *Controls) UnmarshalJSON(data []byte) error {
+	type alias Controls
+	var value alias
+	if err := json.Unmarshal(data, &value); err == nil && (value.Accept != "" || value.Reject != "") {
+		*c = Controls(value)
+		return nil
+	}
+	var legacy struct {
+		KnownAccept string `json:"known_accept"`
+		KnownReject string `json:"known_reject"`
+	}
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return err
+	}
+	c.Accept, c.Reject = legacy.KnownAccept, legacy.KnownReject
+	return nil
+}
+
+type Case struct {
+	SchemaVersion int                 `json:"schema_version"`
+	ID            string              `json:"id"`
+	Description   string              `json:"description,omitempty"`
+	Modules       []Module            `json:"modules"`
+	Probe         Probe               `json:"probe"`
+	VBE           VBEExpectation      `json:"vbe"`
+	Analysis      AnalysisExpectation `json:"analysis,omitempty"`
+	Provenance    Provenance          `json:"provenance"`
+}
+
+type Module struct {
+	Name  string `json:"name"`
+	Kind  string `json:"kind"`
+	Path  string `json:"path"`
+	Entry bool   `json:"entry,omitempty"`
+}
+
+type Probe struct {
+	Mode string `json:"mode"`
+}
+
+type VBEExpectation struct {
+	Expected          string `json:"expected"`
+	EvidencePhase     string `json:"evidence_phase"`
+	DiagnosticMeaning string `json:"diagnostic_meaning"`
+}
+
+type AnalysisExpectation struct {
+	ExpectedDiagnostics  []DiagnosticExpectation `json:"expected_diagnostics,omitempty"`
+	ForbiddenDiagnostics []DiagnosticExpectation `json:"forbidden_diagnostics,omitempty"`
+}
+
+type DiagnosticExpectation struct {
+	Code     string   `json:"code"`
+	Severity string   `json:"severity,omitempty"`
+	Range    *Range   `json:"range,omitempty"`
+	Surfaces []string `json:"surfaces,omitempty"`
+}
+
+type Range struct {
+	StartLine   int `json:"start_line,omitempty"`
+	StartColumn int `json:"start_column,omitempty"`
+	EndLine     int `json:"end_line,omitempty"`
+	EndColumn   int `json:"end_column,omitempty"`
+}
+
+type Provenance struct {
+	Status     string                 `json:"status"`
+	VerifiedOn []VerificationMetadata `json:"verified_on,omitempty"`
+}
+
+type VerificationMetadata struct {
+	ExcelVersion string `json:"excel_version,omitempty"`
+	ExcelBuild   string `json:"excel_build,omitempty"`
+	Bitness      string `json:"bitness,omitempty"`
+	Locale       string `json:"locale,omitempty"`
+	VerifiedAt   string `json:"verified_at,omitempty"`
+}
+
+func (v *VerificationMetadata) UnmarshalJSON(data []byte) error {
+	var value struct {
+		ExcelVersion string `json:"excel_version,omitempty"`
+		ExcelBuild   string `json:"excel_build,omitempty"`
+		Bitness      string `json:"bitness,omitempty"`
+		Locale       string `json:"locale,omitempty"`
+		VerifiedAt   string `json:"verified_at,omitempty"`
+	}
+	if err := json.Unmarshal(data, &value); err == nil {
+		*v = VerificationMetadata{ExcelVersion: value.ExcelVersion, ExcelBuild: value.ExcelBuild, Bitness: value.Bitness, Locale: value.Locale, VerifiedAt: value.VerifiedAt}
+		return nil
+	}
+	var timestamp string
+	if err := json.Unmarshal(data, &timestamp); err != nil {
+		return err
+	}
+	v.VerifiedAt = timestamp
+	return nil
+}
+
+func LoadManifest(path string) (Manifest, string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return Manifest{}, "", err
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, "", fmt.Errorf("read oracle manifest: %w", err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		return Manifest{}, "", fmt.Errorf("decode oracle manifest: %w", err)
+	}
+	root := filepath.Dir(path)
+	if err := ValidateManifest(manifest); err != nil {
+		return Manifest{}, "", err
+	}
+	return manifest, root, nil
+}
+
+func ValidateManifest(manifest Manifest) error {
+	if manifest.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported oracle manifest schema_version %d (want %d)", manifest.SchemaVersion, SchemaVersion)
+	}
+	if len(manifest.Cases) == 0 {
+		return errors.New("oracle manifest contains no cases")
+	}
+	seen := map[string]struct{}{}
+	for _, entry := range manifest.Cases {
+		if !caseIDPattern.MatchString(entry.ID) {
+			return fmt.Errorf("invalid oracle case id %q", entry.ID)
+		}
+		if _, ok := seen[entry.ID]; ok {
+			return fmt.Errorf("duplicate oracle case %q", entry.ID)
+		}
+		if entry.Path != "" {
+			if filepath.IsAbs(entry.Path) || !strings.EqualFold(filepath.Clean(filepath.FromSlash(entry.Path)), filepath.Join("cases", entry.ID, "case.json")) {
+				return fmt.Errorf("oracle case %q path must be cases/%s/case.json", entry.ID, entry.ID)
+			}
+		}
+		seen[entry.ID] = struct{}{}
+		role := strings.ToLower(strings.TrimSpace(entry.ControlRole))
+		if role != "" && role != "accept" && role != "reject" {
+			return fmt.Errorf("case %q has invalid control_role %q", entry.ID, entry.ControlRole)
+		}
+		if role == "accept" && manifest.Controls.Accept != "" && entry.ID != manifest.Controls.Accept {
+			return fmt.Errorf("case %q is marked control_role=accept but controls.accept is %q", entry.ID, manifest.Controls.Accept)
+		}
+		if role == "reject" && manifest.Controls.Reject != "" && entry.ID != manifest.Controls.Reject {
+			return fmt.Errorf("case %q is marked control_role=reject but controls.reject is %q", entry.ID, manifest.Controls.Reject)
+		}
+	}
+	if manifest.Controls.Accept == "" || manifest.Controls.Reject == "" {
+		return errors.New("oracle manifest must declare controls.accept and controls.reject")
+	}
+	if _, ok := seen[manifest.Controls.Accept]; !ok {
+		return fmt.Errorf("controls.accept references unknown case %q", manifest.Controls.Accept)
+	}
+	if _, ok := seen[manifest.Controls.Reject]; !ok {
+		return fmt.Errorf("controls.reject references unknown case %q", manifest.Controls.Reject)
+	}
+	if manifest.Controls.Accept == manifest.Controls.Reject {
+		return errors.New("controls.accept and controls.reject must differ")
+	}
+	return nil
+}
+
+func LoadCase(manifestRoot string, entry ManifestEntry) (Case, map[string][]byte, error) {
+	casePath := entry.Path
+	if casePath == "" {
+		casePath = filepath.Join("cases", entry.ID, "case.json")
+	}
+	path, err := confinedPath(manifestRoot, casePath)
+	if err != nil {
+		return Case{}, nil, err
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return Case{}, nil, fmt.Errorf("read oracle case %q: %w", entry.ID, err)
+	}
+	var c Case
+	if err := json.Unmarshal(body, &c); err != nil {
+		return Case{}, nil, fmt.Errorf("decode oracle case %q: %w", entry.ID, err)
+	}
+	caseDir := filepath.Dir(path)
+	if !strings.EqualFold(filepath.Base(path), "case.json") || !strings.EqualFold(filepath.Base(caseDir), entry.ID) || !strings.EqualFold(filepath.Base(filepath.Dir(caseDir)), "cases") {
+		return Case{}, nil, fmt.Errorf("oracle case %q must be stored at cases/%s/case.json", entry.ID, entry.ID)
+	}
+	if err := ValidateCase(c, entry.ID, caseDir); err != nil {
+		return Case{}, nil, err
+	}
+	sources := make(map[string][]byte, len(c.Modules))
+	for _, module := range c.Modules {
+		modulePath, err := confinedPath(caseDir, module.Path)
+		if err != nil {
+			return Case{}, nil, fmt.Errorf("oracle case %q module %q: %w", c.ID, module.Name, err)
+		}
+		source, err := os.ReadFile(modulePath)
+		if err != nil {
+			return Case{}, nil, fmt.Errorf("read oracle module %q: %w", module.Path, err)
+		}
+		matches := vbNamePattern.FindSubmatch(bytes.TrimPrefix(source, []byte{0xEF, 0xBB, 0xBF}))
+		if len(matches) < 2 || !strings.EqualFold(string(matches[1]), module.Name) {
+			return Case{}, nil, fmt.Errorf("oracle module %q Attribute VB_Name does not match declared name %q", module.Path, module.Name)
+		}
+		sources[module.Name] = source
+	}
+	return c, sources, nil
+}
+
+func ValidateCase(c Case, manifestID, caseDir string) error {
+	if c.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("oracle case %q has unsupported schema_version %d", manifestID, c.SchemaVersion)
+	}
+	if c.ID != manifestID || !caseIDPattern.MatchString(c.ID) {
+		return fmt.Errorf("oracle case id %q does not match manifest entry %q", c.ID, manifestID)
+	}
+	if c.Probe.Mode != ProbeCompile {
+		return fmt.Errorf("oracle case %q: probe.mode must be %q", c.ID, ProbeCompile)
+	}
+	if len(c.Modules) == 0 {
+		return fmt.Errorf("oracle case %q has no modules", c.ID)
+	}
+	seenNames := map[string]struct{}{}
+	for _, module := range c.Modules {
+		if strings.ToLower(strings.TrimSpace(module.Kind)) != "standard" {
+			return fmt.Errorf("oracle case %q module %q: only standard modules are supported", c.ID, module.Name)
+		}
+		if module.Name == "" || module.Path == "" || strings.ToLower(filepath.Ext(module.Path)) != ".bas" {
+			return fmt.Errorf("oracle case %q module has invalid name/path", c.ID)
+		}
+		key := strings.ToLower(module.Name)
+		if _, ok := seenNames[key]; ok {
+			return fmt.Errorf("oracle case %q has duplicate module name %q", c.ID, module.Name)
+		}
+		seenNames[key] = struct{}{}
+		if _, err := confinedPath(caseDir, module.Path); err != nil {
+			return fmt.Errorf("oracle case %q module %q: %w", c.ID, module.Name, err)
+		}
+	}
+	if err := validateDiagnosticExpectations(c.Analysis.ExpectedDiagnostics, "expected", c.ID); err != nil {
+		return err
+	}
+	if err := validateDiagnosticExpectations(c.Analysis.ForbiddenDiagnostics, "forbidden", c.ID); err != nil {
+		return err
+	}
+	switch c.VBE.Expected {
+	case ExpectedObserve:
+		if strings.TrimSpace(c.Provenance.Status) != "pending" {
+			return fmt.Errorf("oracle case %q: observe fixture provenance.status must be pending", c.ID)
+		}
+		if len(c.Provenance.VerifiedOn) != 0 {
+			return fmt.Errorf("oracle case %q: pending fixture must not contain verified provenance", c.ID)
+		}
+		if c.VBE.EvidencePhase != EvidenceUnknown {
+			return fmt.Errorf("oracle case %q: observe fixture evidence_phase must be unknown", c.ID)
+		}
+		if c.VBE.DiagnosticMeaning != MeaningObservation {
+			return fmt.Errorf("oracle case %q: observe fixture diagnostic_meaning must be observation", c.ID)
+		}
+	case ExpectedAccepted, ExpectedRejected:
+		if c.VBE.EvidencePhase != EvidenceCompile {
+			return fmt.Errorf("oracle case %q: asserted fixture evidence_phase must be compile", c.ID)
+		}
+		if strings.TrimSpace(c.Provenance.Status) != "asserted" || len(c.Provenance.VerifiedOn) == 0 {
+			return fmt.Errorf("oracle case %q: asserted fixture requires verified provenance", c.ID)
+		}
+		for _, metadata := range c.Provenance.VerifiedOn {
+			if strings.TrimSpace(metadata.ExcelVersion) == "" || strings.TrimSpace(metadata.ExcelBuild) == "" || strings.TrimSpace(metadata.Bitness) == "" || strings.TrimSpace(metadata.Locale) == "" {
+				return fmt.Errorf("oracle case %q: asserted provenance metadata is incomplete", c.ID)
+			}
+			verifiedAt, err := time.Parse(time.RFC3339, metadata.VerifiedAt)
+			if err != nil {
+				return fmt.Errorf("oracle case %q: asserted provenance verified_at must be RFC3339", c.ID)
+			}
+			if _, offset := verifiedAt.Zone(); offset != 0 {
+				return fmt.Errorf("oracle case %q: asserted provenance verified_at must be UTC", c.ID)
+			}
+		}
+		if c.VBE.Expected == ExpectedRejected && c.VBE.DiagnosticMeaning != MeaningCompileError {
+			return fmt.Errorf("oracle case %q: rejected fixture diagnostic_meaning must be compile-error", c.ID)
+		}
+		if c.VBE.Expected == ExpectedAccepted && c.VBE.DiagnosticMeaning != MeaningSpecification && c.VBE.DiagnosticMeaning != MeaningPolicy && c.VBE.DiagnosticMeaning != MeaningMaintainability {
+			return fmt.Errorf("oracle case %q: accepted fixture has invalid diagnostic_meaning", c.ID)
+		}
+	default:
+		return fmt.Errorf("oracle case %q has invalid vbe.expected %q", c.ID, c.VBE.Expected)
+	}
+	return nil
+}
+
+func validateDiagnosticExpectations(expectations []DiagnosticExpectation, kind, caseID string) error {
+	for _, expectation := range expectations {
+		if strings.TrimSpace(expectation.Code) == "" {
+			return fmt.Errorf("oracle case %q has an empty %s diagnostic code", caseID, kind)
+		}
+		if severity := strings.TrimSpace(expectation.Severity); severity != "" && severity != "error" && severity != "warning" {
+			return fmt.Errorf("oracle case %q diagnostic %q has invalid severity %q", caseID, expectation.Code, expectation.Severity)
+		}
+		seenSurfaces := map[string]struct{}{}
+		for _, surface := range expectation.Surfaces {
+			surface = strings.TrimSpace(surface)
+			if surface != "lint" && surface != "analyze" && surface != "lsp" {
+				return fmt.Errorf("oracle case %q diagnostic %q has invalid surface %q", caseID, expectation.Code, surface)
+			}
+			if _, duplicate := seenSurfaces[surface]; duplicate {
+				return fmt.Errorf("oracle case %q diagnostic %q repeats surface %q", caseID, expectation.Code, surface)
+			}
+			seenSurfaces[surface] = struct{}{}
+		}
+		if expectation.Range != nil {
+			if expectation.Range.StartLine < 0 || expectation.Range.StartColumn < 0 || expectation.Range.EndLine < 0 || expectation.Range.EndColumn < 0 {
+				return fmt.Errorf("oracle case %q diagnostic %q has a negative source range", caseID, expectation.Code)
+			}
+		}
+	}
+	return nil
+}
+
+func confinedPath(root, relative string) (string, error) {
+	if filepath.IsAbs(relative) {
+		return "", errors.New("path must be relative")
+	}
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	path, err := filepath.Abs(filepath.Join(root, filepath.FromSlash(relative)))
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("path escapes fixture directory")
+	}
+	// Reject an existing symlink that resolves outside the fixture root while
+	// retaining lexical containment checks for paths that will be created later.
+	if resolvedRoot, resolveErr := filepath.EvalSymlinks(root); resolveErr == nil {
+		if resolvedPath, resolveErr := filepath.EvalSymlinks(path); resolveErr == nil {
+			resolvedRel, relErr := filepath.Rel(resolvedRoot, resolvedPath)
+			if relErr != nil || resolvedRel == ".." || strings.HasPrefix(resolvedRel, ".."+string(filepath.Separator)) {
+				return "", errors.New("path escapes fixture directory through symlink")
+			}
+		}
+	}
+	return path, nil
+}
+
+// SortedCaseIDs is useful for deterministic diagnostics and tests.
+func SortedCaseIDs(cases []Case) []string {
+	ids := make([]string, 0, len(cases))
+	for _, c := range cases {
+		ids = append(ids, c.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/oracle/manifest_test.go
+++ b/internal/oracle/manifest_test.go
@@ -1,0 +1,96 @@
+package oracle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFixture(t *testing.T, expected string) (string, Manifest) {
+	t.Helper()
+	root := t.TempDir()
+	caseDir := filepath.Join(root, "cases", "sample")
+	if err := os.MkdirAll(caseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := "Attribute VB_Name = \"Main\"\nPublic Sub Main()\nEnd Sub\n"
+	if err := os.WriteFile(filepath.Join(caseDir, "Main.bas"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	caseJSON := Case{SchemaVersion: SchemaVersion, ID: "sample", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas", Entry: true}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: expected, EvidencePhase: EvidenceUnknown, DiagnosticMeaning: MeaningObservation}, Provenance: Provenance{Status: "pending"}}
+	body, _ := json.Marshal(caseJSON)
+	if err := os.WriteFile(filepath.Join(caseDir, "case.json"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := Manifest{SchemaVersion: SchemaVersion, Cases: []ManifestEntry{{ID: "sample"}}, Controls: Controls{Accept: "sample", Reject: "sample-reject"}}
+	manifest.Cases = append(manifest.Cases, ManifestEntry{ID: "sample-reject", Path: "cases/sample-reject/case.json"})
+	rejectDir := filepath.Join(root, "cases", "sample-reject")
+	if err := os.MkdirAll(rejectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rejectDir, "Main.bas"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reject := caseJSON
+	reject.ID = "sample-reject"
+	reject.VBE.Expected = ExpectedObserve
+	rejectBody, _ := json.Marshal(reject)
+	if err := os.WriteFile(filepath.Join(rejectDir, "case.json"), rejectBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifestBody, _ := json.Marshal(manifest)
+	manifestPath := filepath.Join(root, "manifest.json")
+	if err := os.WriteFile(manifestPath, manifestBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return manifestPath, manifest
+}
+
+func TestValidateManifestAndCaseContainment(t *testing.T) {
+	manifestPath, _ := writeFixture(t, ExpectedObserve)
+	manifest, root, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadCase(root, manifest.Cases[0]); err != nil {
+		t.Fatal(err)
+	}
+	bad := manifest.Cases[0]
+	bad.Path = "../case.json"
+	if _, _, err := LoadCase(root, bad); err == nil {
+		t.Fatal("expected path containment error")
+	}
+}
+
+func TestValidateManifestRequiresCaseDirectoryAndEntryAgreement(t *testing.T) {
+	manifestPath, _ := writeFixture(t, ExpectedObserve)
+	manifest, _, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Cases[0].Path = "cases/other/case.json"
+	if err := ValidateManifest(manifest); err == nil {
+		t.Fatal("expected manifest case path mismatch")
+	}
+}
+
+func TestValidateCaseRequiresAssertedProvenance(t *testing.T) {
+	c := Case{SchemaVersion: SchemaVersion, ID: "x", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas"}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: ExpectedAccepted, EvidencePhase: EvidenceCompile}}
+	if err := ValidateCase(c, "x", t.TempDir()); err == nil {
+		t.Fatal("expected provenance validation error")
+	}
+}
+
+func TestRepositoryManifestLoadsAllCases(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "testdata", "vbe-oracle", "manifest.json")
+	manifest, root, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Skipf("repository fixtures unavailable: %v", err)
+	}
+	for _, entry := range manifest.Cases {
+		if _, _, err := LoadCase(root, entry); err != nil {
+			t.Fatalf("case %s: %v", entry.ID, err)
+		}
+	}
+}

--- a/internal/oracle/manifest_test.go
+++ b/internal/oracle/manifest_test.go
@@ -39,6 +39,20 @@ func writeFixture(t *testing.T, expected string) (string, Manifest) {
 	if err := os.WriteFile(filepath.Join(rejectDir, "case.json"), rejectBody, 0o644); err != nil {
 		t.Fatal(err)
 	}
+	strictDir := filepath.Join(root, "cases", "sample-strict")
+	if err := os.MkdirAll(strictDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(strictDir, "Main.bas"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	strict := caseJSON
+	strict.ID = "sample-strict"
+	strictBody, _ := json.Marshal(strict)
+	if err := os.WriteFile(filepath.Join(strictDir, "case.json"), strictBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest.Cases = append(manifest.Cases, ManifestEntry{ID: "sample-strict", Path: "cases/sample-strict/case.json"})
 	manifestBody, _ := json.Marshal(manifest)
 	manifestPath := filepath.Join(root, "manifest.json")
 	if err := os.WriteFile(manifestPath, manifestBody, 0o644); err != nil {

--- a/internal/oracle/runner.go
+++ b/internal/oracle/runner.go
@@ -120,6 +120,13 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 	if runtime.GOOS != "windows" {
 		return failReport(&report, 3, "oracle is available only on Windows with Excel installed", "unsupported_host")
 	}
+	return runValidated(ctx, opts)
+}
+
+// runValidated contains the deterministic orchestration after the Windows
+// host gate. Tests can inject a fake bridge here without requiring Excel.
+func runValidated(ctx context.Context, opts Options) (Report, error) {
+	report := Report{SchemaVersion: SchemaVersion, Status: "ok"}
 	if opts.ManifestPath == "" {
 		opts.ManifestPath = filepath.Join("testdata", "vbe-oracle", "manifest.json")
 	}

--- a/internal/oracle/runner.go
+++ b/internal/oracle/runner.go
@@ -18,6 +18,7 @@ import (
 const (
 	CommandName                  = "vbe-oracle"
 	DefaultTimeout               = 5 * time.Minute
+	bridgeShutdownMargin         = 30 * time.Second
 	OutcomeAccepted              = "accepted"
 	OutcomeRejected              = "rejected"
 	OutcomeInfrastructureFailure = "infrastructure_failure"
@@ -80,8 +81,6 @@ func (e *ExitError) Error() string {
 	}
 	return e.Message
 }
-
-func (e *ExitError) IsInfrastructure() bool { return e != nil && e.Code == 3 }
 
 type fixtureRequest struct {
 	SchemaVersion int             `json:"schema_version"`
@@ -183,8 +182,8 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 		if runErr != nil {
 			return failRun(&report, runErr)
 		}
-		if opts.Strict && result.Outcome != entryExpected(entry, root) {
-			return failReport(&report, 1, fmt.Sprintf("oracle case %q expected %s, observed %s", entry.ID, entryExpected(entry, root), result.Outcome), "expectation_mismatch")
+		if opts.Strict && result.Outcome != result.Expected {
+			return failReport(&report, 1, fmt.Sprintf("oracle case %q expected %s, observed %s", entry.ID, result.Expected, result.Outcome), "expectation_mismatch")
 		}
 	}
 	if opts.PromoteObserved {
@@ -230,14 +229,6 @@ func SelectCases(manifest Manifest, ids []string) ([]ManifestEntry, error) {
 	return selectEntries(manifest, ids)
 }
 
-func entryExpected(entry ManifestEntry, root string) string {
-	c, _, err := LoadCase(root, entry)
-	if err != nil {
-		return ""
-	}
-	return c.VBE.Expected
-}
-
 func runEntry(parent context.Context, root string, entry ManifestEntry, timeout time.Duration, executor BridgeExecutor) (CaseResult, error) {
 	started := time.Now()
 	c, _, err := LoadCase(root, entry)
@@ -264,7 +255,9 @@ func runEntry(parent context.Context, root string, entry ManifestEntry, timeout 
 	if err != nil {
 		return CaseResult{ID: c.ID, Outcome: OutcomeInfrastructureFailure, Error: err.Error()}, &ExitError{Code: 3, Message: err.Error()}
 	}
-	ctx, cancel := context.WithTimeout(parent, timeout)
+	// Let the bridge timeout expire first so it can close Excel and report
+	// structured cleanup status before the Go process deadline fires.
+	ctx, cancel := context.WithTimeout(parent, timeout+bridgeShutdownMargin)
 	defer cancel()
 	response, execErr := executor.Execute(ctx, excelbridge.Request{Command: CommandName, Args: map[string]string{
 		"PlanJson64": base64.StdEncoding.EncodeToString(payload),
@@ -495,20 +488,10 @@ func promoteSelected(root string, selected []ManifestEntry, results []CaseResult
 	}
 	committed := 0
 	for i, item := range staged {
-		// Windows does not permit rename-overwrite. Remove only the validated
-		// fixture target, then rename the staged document into place.
-		if err := os.Remove(item.path); err != nil && !os.IsNotExist(err) {
-			for _, left := range staged[i:] {
-				_ = os.Remove(left.temp)
-			}
-			rollbackPromotion(staged[:committed])
-			return err
-		}
 		if err := os.Rename(item.temp, item.path); err != nil {
 			for _, left := range staged[i:] {
 				_ = os.Remove(left.temp)
 			}
-			_ = os.WriteFile(item.path, item.original, 0o644)
 			rollbackPromotion(staged[:committed])
 			return err
 		}

--- a/internal/oracle/runner.go
+++ b/internal/oracle/runner.go
@@ -1,0 +1,539 @@
+package oracle
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
+)
+
+const (
+	CommandName                  = "vbe-oracle"
+	DefaultTimeout               = 5 * time.Minute
+	OutcomeAccepted              = "accepted"
+	OutcomeRejected              = "rejected"
+	OutcomeInfrastructureFailure = "infrastructure_failure"
+)
+
+type BridgeExecutor interface {
+	Execute(context.Context, excelbridge.Request) (excelbridge.Response, error)
+}
+
+type Options struct {
+	ManifestPath      string
+	CaseIDs           []string
+	Strict            bool
+	PromoteObserved   bool
+	DiagnosticMeaning map[string]string
+	Timeout           time.Duration
+	Executor          BridgeExecutor
+	Now               func() time.Time
+}
+
+type Report struct {
+	SchemaVersion int          `json:"schema_version"`
+	Status        string       `json:"status"`
+	Outcome       string       `json:"outcome,omitempty"`
+	Cases         []CaseResult `json:"cases,omitempty"`
+	Controls      []CaseResult `json:"controls,omitempty"`
+	Error         *ReportError `json:"error,omitempty"`
+}
+
+type ReportError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type CaseResult struct {
+	ID               string               `json:"id"`
+	Expected         string               `json:"expected,omitempty"`
+	Outcome          string               `json:"outcome"`
+	EvidencePhase    string               `json:"evidence_phase,omitempty"`
+	LastStage        string               `json:"last_stage,omitempty"`
+	CompileInvoked   bool                 `json:"compile_invoked,omitempty"`
+	CleanupConfirmed bool                 `json:"cleanup_confirmed,omitempty"`
+	DurationMS       int64                `json:"duration_ms,omitempty"`
+	Dialog           any                  `json:"dialog,omitempty"`
+	Location         any                  `json:"location,omitempty"`
+	ExcelProcessID   int                  `json:"excel_process_id,omitempty"`
+	Metadata         VerificationMetadata `json:"metadata,omitempty"`
+	Error            string               `json:"error,omitempty"`
+}
+
+type ExitError struct {
+	Code    int
+	Message string
+	Report  *Report
+}
+
+func (e *ExitError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *ExitError) IsInfrastructure() bool { return e != nil && e.Code == 3 }
+
+type fixtureRequest struct {
+	SchemaVersion int             `json:"schema_version"`
+	CaseID        string          `json:"case_id"`
+	ProbeMode     string          `json:"probe_mode"`
+	Visible       bool            `json:"visible"`
+	TimeoutMS     int64           `json:"timeout_ms"`
+	Modules       []fixtureModule `json:"modules"`
+}
+
+type fixtureModule struct {
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	SourcePath string `json:"source_path"`
+}
+
+type bridgeObservation struct {
+	Outcome          string               `json:"outcome"`
+	EvidencePhase    string               `json:"evidence_phase"`
+	LastStage        string               `json:"last_stage"`
+	DurationMS       int64                `json:"duration_ms"`
+	CompileInvoked   bool                 `json:"compile_invoked"`
+	CleanupConfirmed bool                 `json:"cleanup_confirmed"`
+	Dialog           any                  `json:"dialog,omitempty"`
+	Location         any                  `json:"location,omitempty"`
+	ExcelProcessID   int                  `json:"excel_process_id,omitempty"`
+	Metadata         VerificationMetadata `json:"metadata,omitempty"`
+	Excel            map[string]any       `json:"excel,omitempty"`
+	Error            string               `json:"error,omitempty"`
+	ErrorCode        string               `json:"error_code,omitempty"`
+}
+
+// Run loads, validates, and executes the selected cases. It intentionally has
+// no parallelism: an Excel/VBE instance is a single-user UI resource.
+func Run(ctx context.Context, opts Options) (Report, error) {
+	report := Report{SchemaVersion: SchemaVersion, Status: "ok"}
+	if runtime.GOOS != "windows" {
+		return failReport(&report, 3, "oracle is available only on Windows with Excel installed", "unsupported_host")
+	}
+	if opts.ManifestPath == "" {
+		opts.ManifestPath = filepath.Join("testdata", "vbe-oracle", "manifest.json")
+	}
+	manifest, root, err := LoadManifest(opts.ManifestPath)
+	if err != nil {
+		return failReport(&report, 2, err.Error(), "fixture_invalid")
+	}
+	if opts.Timeout < 0 {
+		return failReport(&report, 2, "oracle timeout must be greater than zero", "timeout_invalid")
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = DefaultTimeout
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.Executor == nil {
+		provider := excelbridge.DotNetProvider{RootDir: root, PreferRepoLocal: true}
+		opts.Executor = provider
+	}
+	entries := make(map[string]ManifestEntry, len(manifest.Cases))
+	for _, e := range manifest.Cases {
+		entries[e.ID] = e
+	}
+	selected, err := selectEntries(manifest, opts.CaseIDs)
+	if err != nil {
+		return failReport(&report, 2, err.Error(), "case_selection_invalid")
+	}
+	if opts.PromoteObserved && len(opts.CaseIDs) == 0 {
+		return failReport(&report, 2, "--promote-observed requires one or more explicit --case values", "promotion_invalid")
+	}
+	// Controls always run first, even when --case selects another fixture.
+	controlIDs := []string{manifest.Controls.Accept, manifest.Controls.Reject}
+	seen := map[string]bool{}
+	for _, id := range controlIDs {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		result, runErr := runEntry(ctx, root, entries[id], opts.Timeout, opts.Executor)
+		report.Controls = append(report.Controls, result)
+		if runErr != nil {
+			return failRun(&report, runErr)
+		}
+		expected := ExpectedAccepted
+		if id == manifest.Controls.Reject {
+			expected = ExpectedRejected
+		}
+		if result.Outcome != expected {
+			return failReport(&report, 3, fmt.Sprintf("oracle control %q returned %s, want %s", id, result.Outcome, expected), "control_failed")
+		}
+	}
+	for _, entry := range selected {
+		if seen[entry.ID] {
+			continue
+		}
+		seen[entry.ID] = true
+		result, runErr := runEntry(ctx, root, entry, opts.Timeout, opts.Executor)
+		report.Cases = append(report.Cases, result)
+		if runErr != nil {
+			return failRun(&report, runErr)
+		}
+		if opts.Strict && result.Outcome != entryExpected(entry, root) {
+			return failReport(&report, 1, fmt.Sprintf("oracle case %q expected %s, observed %s", entry.ID, entryExpected(entry, root), result.Outcome), "expectation_mismatch")
+		}
+	}
+	if opts.PromoteObserved {
+		promotionResults := append(append([]CaseResult(nil), report.Controls...), report.Cases...)
+		if err := promoteSelected(root, selected, promotionResults, opts.DiagnosticMeaning, opts.Now()); err != nil {
+			return failReport(&report, 2, err.Error(), "promotion_invalid")
+		}
+	}
+	return report, nil
+}
+
+func selectEntries(manifest Manifest, ids []string) ([]ManifestEntry, error) {
+	if len(ids) == 0 {
+		return append([]ManifestEntry(nil), manifest.Cases...), nil
+	}
+	entries := make(map[string]ManifestEntry, len(manifest.Cases))
+	for _, e := range manifest.Cases {
+		entries[e.ID] = e
+	}
+	seen := map[string]bool{}
+	selected := make([]ManifestEntry, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, errors.New("--case cannot be empty")
+		}
+		if seen[id] {
+			return nil, fmt.Errorf("duplicate --case %q", id)
+		}
+		seen[id] = true
+		e, ok := entries[id]
+		if !ok {
+			return nil, fmt.Errorf("unknown oracle case %q", id)
+		}
+		selected = append(selected, e)
+	}
+	return selected, nil
+}
+
+// SelectCases resolves an explicit filter while preserving manifest order.
+// An empty filter returns every manifest case in that order.
+func SelectCases(manifest Manifest, ids []string) ([]ManifestEntry, error) {
+	return selectEntries(manifest, ids)
+}
+
+func entryExpected(entry ManifestEntry, root string) string {
+	c, _, err := LoadCase(root, entry)
+	if err != nil {
+		return ""
+	}
+	return c.VBE.Expected
+}
+
+func runEntry(parent context.Context, root string, entry ManifestEntry, timeout time.Duration, executor BridgeExecutor) (CaseResult, error) {
+	started := time.Now()
+	c, _, err := LoadCase(root, entry)
+	if err != nil {
+		return CaseResult{ID: entry.ID, Outcome: OutcomeInfrastructureFailure, Error: err.Error()}, &ExitError{Code: 2, Message: err.Error()}
+	}
+	modules := make([]fixtureModule, 0, len(c.Modules))
+	casePath := entry.Path
+	if casePath == "" {
+		casePath = filepath.Join("cases", entry.ID, "case.json")
+	}
+	caseDir, err := confinedPath(root, filepath.Dir(casePath))
+	if err != nil {
+		return CaseResult{ID: c.ID, Outcome: OutcomeInfrastructureFailure, Error: err.Error()}, &ExitError{Code: 2, Message: err.Error()}
+	}
+	for _, module := range c.Modules {
+		modulePath, err := confinedPath(caseDir, module.Path)
+		if err != nil {
+			return CaseResult{ID: c.ID, Outcome: OutcomeInfrastructureFailure, Error: err.Error()}, &ExitError{Code: 2, Message: err.Error()}
+		}
+		modules = append(modules, fixtureModule{Name: module.Name, Kind: module.Kind, SourcePath: modulePath})
+	}
+	payload, err := json.Marshal(fixtureRequest{SchemaVersion: SchemaVersion, CaseID: c.ID, ProbeMode: c.Probe.Mode, TimeoutMS: timeout.Milliseconds(), Modules: modules})
+	if err != nil {
+		return CaseResult{ID: c.ID, Outcome: OutcomeInfrastructureFailure, Error: err.Error()}, &ExitError{Code: 3, Message: err.Error()}
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	response, execErr := executor.Execute(ctx, excelbridge.Request{Command: CommandName, Args: map[string]string{
+		"PlanJson64": base64.StdEncoding.EncodeToString(payload),
+		"TimeoutMs":  fmt.Sprintf("%d", timeout.Milliseconds()),
+	}})
+	if execErr != nil || response.TimedOut {
+		msg := "oracle bridge execution failed"
+		if execErr != nil {
+			msg = execErr.Error()
+		}
+		return CaseResult{ID: c.ID, Outcome: OutcomeInfrastructureFailure, Error: msg, DurationMS: time.Since(started).Milliseconds()}, &ExitError{Code: 3, Message: msg}
+	}
+	obs, err := decodeObservation(response.Stdout)
+	if err != nil {
+		code := 3
+		if strings.Contains(strings.ToLower(bridgeErrorCode(response.Stdout)), "plan_invalid") {
+			code = 2
+		}
+		return CaseResult{ID: c.ID, Outcome: OutcomeInfrastructureFailure, Error: err.Error()}, &ExitError{Code: code, Message: err.Error()}
+	}
+	metadata := obs.Metadata
+	if metadata.ExcelVersion == "" {
+		metadata.ExcelVersion = stringValue(obs.Excel, "version")
+	}
+	if metadata.ExcelBuild == "" {
+		metadata.ExcelBuild = stringValue(obs.Excel, "build")
+	}
+	if metadata.Bitness == "" {
+		metadata.Bitness = stringValue(obs.Excel, "bitness")
+	}
+	if metadata.Locale == "" {
+		metadata.Locale = stringValue(obs.Excel, "locale")
+	}
+	result := CaseResult{ID: c.ID, Expected: c.VBE.Expected, Outcome: obs.Outcome, EvidencePhase: obs.EvidencePhase, LastStage: obs.LastStage, CompileInvoked: obs.CompileInvoked, CleanupConfirmed: obs.CleanupConfirmed, DurationMS: obs.DurationMS, Dialog: obs.Dialog, Location: obs.Location, ExcelProcessID: obs.ExcelProcessID, Metadata: metadata, Error: obs.Error}
+	if result.DurationMS == 0 {
+		result.DurationMS = time.Since(started).Milliseconds()
+	}
+	if result.Outcome != OutcomeAccepted && result.Outcome != OutcomeRejected {
+		result.Outcome = OutcomeInfrastructureFailure
+	}
+	if result.Outcome == OutcomeInfrastructureFailure || !result.CleanupConfirmed {
+		result.Outcome = OutcomeInfrastructureFailure
+		if result.Error == "" {
+			result.Error = "oracle cleanup or infrastructure failure"
+		}
+		code := 3
+		if strings.Contains(strings.ToLower(obs.ErrorCode), "plan_invalid") || strings.Contains(strings.ToLower(obs.ErrorCode), "args_invalid") {
+			code = 2
+		}
+		return result, &ExitError{Code: code, Message: result.Error}
+	}
+	return result, nil
+}
+
+func decodeObservation(data []byte) (bridgeObservation, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return bridgeObservation{}, fmt.Errorf("malformed oracle bridge output: %w", err)
+	}
+	if oracleJSON, ok := raw["oracle"]; ok {
+		var observation bridgeObservation
+		if err := json.Unmarshal(oracleJSON, &observation); err != nil {
+			return bridgeObservation{}, fmt.Errorf("malformed oracle observation: %w", err)
+		}
+		return observation, nil
+	}
+	var failed struct {
+		Error struct {
+			Details struct {
+				Oracle *bridgeObservation `json:"oracle"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &failed); err == nil && failed.Error.Details.Oracle != nil {
+		return *failed.Error.Details.Oracle, nil
+	}
+	if errorJSON, ok := raw["error"]; ok {
+		var bridgeErr struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(errorJSON, &bridgeErr)
+		message := bridgeErr.Message
+		if message == "" {
+			message = "oracle bridge returned a failure"
+		}
+		return bridgeObservation{Outcome: OutcomeInfrastructureFailure, EvidencePhase: EvidenceUnknown, CleanupConfirmed: false, Error: bridgeErr.Code + ": " + message, ErrorCode: bridgeErr.Code}, nil
+	}
+	var direct bridgeObservation
+	if err := json.Unmarshal(data, &direct); err != nil {
+		return bridgeObservation{}, fmt.Errorf("malformed oracle bridge output: %w", err)
+	}
+	if direct.Outcome == "" {
+		return bridgeObservation{}, errors.New("malformed oracle bridge output: missing outcome")
+	}
+	return direct, nil
+}
+
+func bridgeErrorCode(data []byte) string {
+	var value struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(data, &value) == nil {
+		return value.Error.Code
+	}
+	return ""
+}
+
+func stringValue(values map[string]any, key string) string {
+	if value, ok := values[key]; ok {
+		if text, ok := value.(string); ok {
+			return text
+		}
+	}
+	return ""
+}
+
+func failReport(report *Report, code int, message, kind string) (Report, error) {
+	report.Status, report.Outcome = "failed", OutcomeInfrastructureFailure
+	report.Error = &ReportError{Code: kind, Message: message}
+	return *report, &ExitError{Code: code, Message: message, Report: report}
+}
+
+func failRun(report *Report, err error) (Report, error) {
+	var exit *ExitError
+	if errors.As(err, &exit) {
+		report.Status, report.Outcome = "failed", OutcomeInfrastructureFailure
+		report.Error = &ReportError{Code: "oracle_failure", Message: exit.Message}
+		exit.Report = report
+		return *report, exit
+	}
+	return failReport(report, 3, err.Error(), "oracle_failure")
+}
+
+type promotionUpdate struct {
+	path     string
+	original []byte
+	body     []byte
+}
+
+type promotionStage struct {
+	promotionUpdate
+	temp string
+}
+
+func promoteSelected(root string, selected []ManifestEntry, results []CaseResult, meanings map[string]string, now time.Time) error {
+	resultByID := map[string]CaseResult{}
+	for _, result := range results {
+		resultByID[result.ID] = result
+	}
+	updates := []promotionUpdate{}
+	for _, entry := range selected {
+		casePath := entry.Path
+		if casePath == "" {
+			casePath = filepath.Join("cases", entry.ID, "case.json")
+		}
+		path, err := confinedPath(root, casePath)
+		if err != nil {
+			return err
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var c Case
+		if err := json.Unmarshal(body, &c); err != nil {
+			return err
+		}
+		if c.VBE.Expected != ExpectedObserve {
+			return fmt.Errorf("oracle case %q is already asserted", c.ID)
+		}
+		result, ok := resultByID[c.ID]
+		if !ok {
+			return fmt.Errorf("oracle case %q was not executed", c.ID)
+		}
+		if result.Outcome != OutcomeAccepted && result.Outcome != OutcomeRejected {
+			return fmt.Errorf("oracle case %q has non-evidence outcome %s", c.ID, result.Outcome)
+		}
+		meaning := MeaningCompileError
+		if result.Outcome == OutcomeAccepted {
+			meaning = strings.TrimSpace(meanings[c.ID])
+			if meaning == "" || (meaning != MeaningSpecification && meaning != MeaningPolicy && meaning != MeaningMaintainability) {
+				return fmt.Errorf("accepted case %q requires diagnostic meaning specification, policy, or maintainability", c.ID)
+			}
+		}
+		c.VBE.Expected, c.VBE.EvidencePhase, c.VBE.DiagnosticMeaning = result.Outcome, EvidenceCompile, meaning
+		c.Provenance.Status = "asserted"
+		metadata := result.Metadata
+		if missingMetadata(metadata.ExcelVersion) || missingMetadata(metadata.ExcelBuild) || missingMetadata(metadata.Bitness) || missingMetadata(metadata.Locale) {
+			return fmt.Errorf("oracle case %q cannot be promoted without complete Excel version, build, bitness, and locale metadata", c.ID)
+		}
+		metadata.VerifiedAt = now.UTC().Format(time.RFC3339)
+		c.Provenance.VerifiedOn = append(c.Provenance.VerifiedOn, metadata)
+		updated, err := json.MarshalIndent(c, "", "  ")
+		if err != nil {
+			return err
+		}
+		updated = append(updated, '\n')
+		updates = append(updates, promotionUpdate{path: path, original: body, body: updated})
+	}
+	// Stage every new document before touching an existing fixture. Validation
+	// above therefore cannot leave a partially promoted batch behind.
+	staged := make([]promotionStage, 0, len(updates))
+	for _, u := range updates {
+		tmp, err := os.CreateTemp(filepath.Dir(u.path), ".oracle-promote-*")
+		if err != nil {
+			for _, item := range staged {
+				_ = os.Remove(item.temp)
+			}
+			return err
+		}
+		name := tmp.Name()
+		if _, err = tmp.Write(u.body); err == nil {
+			err = tmp.Close()
+		} else {
+			_ = tmp.Close()
+		}
+		if err != nil {
+			_ = os.Remove(name)
+			for _, item := range staged {
+				_ = os.Remove(item.temp)
+			}
+			return err
+		}
+		staged = append(staged, promotionStage{promotionUpdate: u, temp: name})
+	}
+	committed := 0
+	for i, item := range staged {
+		// Windows does not permit rename-overwrite. Remove only the validated
+		// fixture target, then rename the staged document into place.
+		if err := os.Remove(item.path); err != nil && !os.IsNotExist(err) {
+			for _, left := range staged[i:] {
+				_ = os.Remove(left.temp)
+			}
+			rollbackPromotion(staged[:committed])
+			return err
+		}
+		if err := os.Rename(item.temp, item.path); err != nil {
+			for _, left := range staged[i:] {
+				_ = os.Remove(left.temp)
+			}
+			_ = os.WriteFile(item.path, item.original, 0o644)
+			rollbackPromotion(staged[:committed])
+			return err
+		}
+		committed++
+	}
+	return nil
+}
+
+func missingMetadata(value string) bool {
+	value = strings.TrimSpace(value)
+	return value == "" || strings.EqualFold(value, "unknown")
+}
+
+// PromoteObserved atomically promotes selected observe fixtures after the
+// caller has completed a successful oracle run.
+func PromoteObserved(root string, selected []ManifestEntry, results []CaseResult, meanings map[string]string, now time.Time) error {
+	if len(selected) == 0 {
+		return errors.New("promotion requires explicit case selection")
+	}
+	return promoteSelected(root, selected, results, meanings, now)
+}
+
+func rollbackPromotion(committed []promotionStage) {
+	for i := len(committed) - 1; i >= 0; i-- {
+		item := committed[i]
+		_ = os.WriteFile(item.path, item.original, 0o644)
+	}
+}

--- a/internal/oracle/runner_test.go
+++ b/internal/oracle/runner_test.go
@@ -1,0 +1,124 @@
+package oracle
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
+)
+
+func TestNormalizeDiagnosticsAndContract(t *testing.T) {
+	expect := AnalysisExpectation{ExpectedDiagnostics: []DiagnosticExpectation{{Code: "VBA001", Severity: "warning", Range: &Range{StartLine: 1, EndLine: 1}}}, ForbiddenDiagnostics: []DiagnosticExpectation{{Code: "VBA999"}}}
+	actual := []Diagnostic{{Code: "VBA001", Severity: "warning", Range: &Range{StartLine: 1, EndLine: 1}, Surface: "lint"}}
+	if err := CheckDiagnosticContract(expect, actual); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckDiagnosticContract(expect, append(actual, Diagnostic{Code: "VBA999"})); err == nil {
+		t.Fatal("expected forbidden diagnostic failure")
+	}
+	expect.ExpectedDiagnostics = append(expect.ExpectedDiagnostics, expect.ExpectedDiagnostics[0])
+	if err := CheckDiagnosticContract(expect, actual); err == nil {
+		t.Fatal("expected duplicate expectation failure")
+	}
+}
+
+func TestDecodeObservationSupportsBridgeExtension(t *testing.T) {
+	data := []byte(`{"oracle":{"outcome":"accepted","evidence_phase":"compile","cleanup_confirmed":true}}`)
+	obs, err := decodeObservation(data)
+	if err != nil || obs.Outcome != OutcomeAccepted || !obs.CleanupConfirmed {
+		t.Fatalf("obs=%+v err=%v", obs, err)
+	}
+	data = []byte(`{"error":{"details":{"oracle":{"outcome":"infrastructure_failure","cleanup_confirmed":false}}}}`)
+	obs, err = decodeObservation(data)
+	if err != nil || obs.Outcome != OutcomeInfrastructureFailure {
+		t.Fatalf("failed obs=%+v err=%v", obs, err)
+	}
+}
+
+func TestFixtureRequestUsesBridgePlanContract(t *testing.T) {
+	payload, err := json.Marshal(fixtureRequest{SchemaVersion: SchemaVersion, CaseID: "x", ProbeMode: ProbeCompile, Modules: []fixtureModule{{Name: "Main", Kind: "standard", SourcePath: "C:/x/Main.bas"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(payload)
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil || !json.Valid(decoded) {
+		t.Fatalf("payload is not valid base64 JSON: %v", err)
+	}
+	var plan fixtureRequest
+	if err := json.Unmarshal(decoded, &plan); err != nil || plan.SchemaVersion != SchemaVersion || plan.CaseID != "x" || plan.ProbeMode != ProbeCompile {
+		t.Fatalf("plan=%+v err=%v", plan, err)
+	}
+}
+
+type oracleFakeBridge struct{ calls []string }
+
+func (f *oracleFakeBridge) Execute(_ context.Context, req excelbridge.Request) (excelbridge.Response, error) {
+	planBytes, err := base64.StdEncoding.DecodeString(req.Args["PlanJson64"])
+	if err != nil {
+		return excelbridge.Response{}, err
+	}
+	var plan fixtureRequest
+	if err := json.Unmarshal(planBytes, &plan); err != nil {
+		return excelbridge.Response{}, err
+	}
+	f.calls = append(f.calls, plan.CaseID)
+	outcome := OutcomeAccepted
+	if plan.CaseID == "sample-reject" {
+		outcome = OutcomeRejected
+	}
+	body, _ := json.Marshal(map[string]any{"oracle": map[string]any{"outcome": outcome, "evidence_phase": EvidenceCompile, "cleanup_confirmed": true, "excel": map[string]string{"version": "16.0", "build": "17932", "bitness": "x64", "locale": "ja-JP"}}})
+	return excelbridge.Response{Stdout: body}, nil
+}
+
+func TestRunControlsStrictAndPromotion(t *testing.T) {
+	manifestPath, _ := writeFixture(t, ExpectedObserve)
+	bridge := &oracleFakeBridge{}
+	report, err := Run(context.Background(), Options{ManifestPath: manifestPath, CaseIDs: []string{"sample"}, PromoteObserved: true, DiagnosticMeaning: map[string]string{"sample": MeaningSpecification}, Executor: bridge, Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("run promotion failed: %v report=%+v", err, report)
+	}
+	if len(bridge.calls) != 2 || bridge.calls[0] != "sample" || bridge.calls[1] != "sample-reject" {
+		t.Fatalf("calls=%v", bridge.calls)
+	}
+	_, root, _ := LoadManifest(manifestPath)
+	c, _, err := LoadCase(root, ManifestEntry{ID: "sample"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.VBE.Expected != ExpectedAccepted || c.Provenance.Status != "asserted" {
+		t.Fatalf("promotion=%+v", c)
+	}
+}
+
+func TestPromoteObservedRequiresExcelMetadata(t *testing.T) {
+	manifestPath, _ := writeFixture(t, ExpectedObserve)
+	_, root, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = PromoteObserved(root, []ManifestEntry{{ID: "sample"}}, []CaseResult{{ID: "sample", Outcome: OutcomeAccepted}}, map[string]string{"sample": MeaningSpecification}, time.Now())
+	if err == nil {
+		t.Fatal("expected incomplete metadata promotion failure")
+	}
+}
+
+func TestRunRejectsImplicitPromotionBeforeBridgeExecution(t *testing.T) {
+	manifestPath, _ := writeFixture(t, ExpectedObserve)
+	bridge := &oracleFakeBridge{}
+	_, err := Run(context.Background(), Options{ManifestPath: manifestPath, PromoteObserved: true, Executor: bridge, Timeout: time.Second})
+	if err == nil {
+		t.Fatal("expected implicit promotion validation error")
+	}
+	if len(bridge.calls) != 0 {
+		t.Fatalf("bridge calls=%v, want none", bridge.calls)
+	}
+	var exit *ExitError
+	if !errors.As(err, &exit) || exit.Code != 2 {
+		t.Fatalf("err=%v, want exit code 2", err)
+	}
+}

--- a/internal/oracle/runner_test.go
+++ b/internal/oracle/runner_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"runtime"
 	"testing"
 	"time"
 
@@ -77,12 +76,9 @@ func (f *oracleFakeBridge) Execute(_ context.Context, req excelbridge.Request) (
 }
 
 func TestRunControlsStrictAndPromotion(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("oracle runner execution requires Windows with Excel")
-	}
 	manifestPath, _ := writeFixture(t, ExpectedObserve)
 	bridge := &oracleFakeBridge{}
-	report, err := Run(context.Background(), Options{ManifestPath: manifestPath, CaseIDs: []string{"sample"}, PromoteObserved: true, DiagnosticMeaning: map[string]string{"sample": MeaningSpecification}, Executor: bridge, Timeout: time.Second})
+	report, err := runValidated(context.Background(), Options{ManifestPath: manifestPath, CaseIDs: []string{"sample"}, PromoteObserved: true, DiagnosticMeaning: map[string]string{"sample": MeaningSpecification}, Executor: bridge, Timeout: time.Second})
 	if err != nil {
 		t.Fatalf("run promotion failed: %v report=%+v", err, report)
 	}
@@ -112,12 +108,9 @@ func TestPromoteObservedRequiresExcelMetadata(t *testing.T) {
 }
 
 func TestRunRejectsImplicitPromotionBeforeBridgeExecution(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("oracle runner execution requires Windows with Excel")
-	}
 	manifestPath, _ := writeFixture(t, ExpectedObserve)
 	bridge := &oracleFakeBridge{}
-	_, err := Run(context.Background(), Options{ManifestPath: manifestPath, PromoteObserved: true, Executor: bridge, Timeout: time.Second})
+	_, err := runValidated(context.Background(), Options{ManifestPath: manifestPath, PromoteObserved: true, Executor: bridge, Timeout: time.Second})
 	if err == nil {
 		t.Fatal("expected implicit promotion validation error")
 	}
@@ -127,5 +120,26 @@ func TestRunRejectsImplicitPromotionBeforeBridgeExecution(t *testing.T) {
 	var exit *ExitError
 	if !errors.As(err, &exit) || exit.Code != 2 {
 		t.Fatalf("err=%v, want exit code 2", err)
+	}
+}
+
+func TestRunValidatedStrictMismatchReturnsExitCodeOne(t *testing.T) {
+	manifestPath, _ := writeFixture(t, ExpectedObserve)
+	report, err := runValidated(context.Background(), Options{
+		ManifestPath: manifestPath,
+		CaseIDs:      []string{"sample-strict"},
+		Strict:       true,
+		Executor:     &oracleFakeBridge{},
+		Timeout:      time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected strict expectation mismatch")
+	}
+	var exit *ExitError
+	if !errors.As(err, &exit) || exit.Code != 1 {
+		t.Fatalf("err=%v, want exit code 1", err)
+	}
+	if report.Error == nil || report.Error.Code != "expectation_mismatch" {
+		t.Fatalf("report=%+v, want expectation_mismatch", report)
 	}
 }

--- a/internal/oracle/runner_test.go
+++ b/internal/oracle/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -76,6 +77,9 @@ func (f *oracleFakeBridge) Execute(_ context.Context, req excelbridge.Request) (
 }
 
 func TestRunControlsStrictAndPromotion(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("oracle runner execution requires Windows with Excel")
+	}
 	manifestPath, _ := writeFixture(t, ExpectedObserve)
 	bridge := &oracleFakeBridge{}
 	report, err := Run(context.Background(), Options{ManifestPath: manifestPath, CaseIDs: []string{"sample"}, PromoteObserved: true, DiagnosticMeaning: map[string]string{"sample": MeaningSpecification}, Executor: bridge, Timeout: time.Second})
@@ -108,6 +112,9 @@ func TestPromoteObservedRequiresExcelMetadata(t *testing.T) {
 }
 
 func TestRunRejectsImplicitPromotionBeforeBridgeExecution(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("oracle runner execution requires Windows with Excel")
+	}
 	manifestPath, _ := writeFixture(t, ExpectedObserve)
 	bridge := &oracleFakeBridge{}
 	_, err := Run(context.Background(), Options{ManifestPath: manifestPath, PromoteObserved: true, Executor: bridge, Timeout: time.Second})

--- a/scripts/dev/test-vbe-oracle.ps1
+++ b/scripts/dev/test-vbe-oracle.ps1
@@ -1,0 +1,21 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $OracleArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($env:OS -ne "Windows_NT") {
+    throw "The VBE oracle is Windows-only and requires a local Excel installation."
+}
+
+$goScript = Join-Path $PSScriptRoot "go.ps1"
+if (-not (Test-Path -LiteralPath $goScript)) {
+    throw "Cannot find the repository Go wrapper: $goScript"
+}
+
+# Keep the oracle outside the public xlflow command tree. One invocation owns
+# one sequential Excel/VBE run; do not start this script concurrently.
+& $goScript run ./cmd/xlflow-vbe-oracle @OracleArgs
+exit $LASTEXITCODE

--- a/scripts/dev/test-vbe-oracle.ps1
+++ b/scripts/dev/test-vbe-oracle.ps1
@@ -17,5 +17,7 @@ if (-not (Test-Path -LiteralPath $goScript)) {
 
 # Keep the oracle outside the public xlflow command tree. One invocation owns
 # one sequential Excel/VBE run; do not start this script concurrently.
+$global:LASTEXITCODE = 0
 & $goScript run ./cmd/xlflow-vbe-oracle @OracleArgs
-exit $LASTEXITCODE
+$oracleExitCode = if ($null -ne $global:LASTEXITCODE) { [int]$global:LASTEXITCODE } else { 0 }
+exit $oracleExitCode

--- a/testdata/vbe-oracle/cases/byref-bare-variable/Main.bas
+++ b/testdata/vbe-oracle/cases/byref-bare-variable/Main.bas
@@ -1,0 +1,12 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeByRefBareVariable()
+    Dim value As Long
+    value = 1
+    MutateLong value
+End Sub
+
+Private Sub MutateLong(ByRef value As Long)
+    value = value + 1
+End Sub

--- a/testdata/vbe-oracle/cases/byref-bare-variable/case.json
+++ b/testdata/vbe-oracle/cases/byref-bare-variable/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "byref-bare-variable",
+  "description": "Pass a bare variable to a ByRef parameter as the adjacent control.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/byref-compatible/Main.bas
+++ b/testdata/vbe-oracle/cases/byref-compatible/Main.bas
@@ -1,0 +1,12 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeByRefCompatible()
+    Dim value As Long
+    value = 1
+    MutateLong value
+End Sub
+
+Private Sub MutateLong(ByRef value As Long)
+    value = value + 1
+End Sub

--- a/testdata/vbe-oracle/cases/byref-compatible/case.json
+++ b/testdata/vbe-oracle/cases/byref-compatible/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "byref-compatible",
+  "description": "Pass a Long variable to a matching ByRef Long parameter.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/byref-incompatible/Main.bas
+++ b/testdata/vbe-oracle/cases/byref-incompatible/Main.bas
@@ -1,0 +1,12 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeByRefIncompatible()
+    Dim value As String
+    value = "1"
+    MutateLong value
+End Sub
+
+Private Sub MutateLong(ByRef value As Long)
+    value = value + 1
+End Sub

--- a/testdata/vbe-oracle/cases/byref-incompatible/case.json
+++ b/testdata/vbe-oracle/cases/byref-incompatible/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "byref-incompatible",
+  "description": "Pass a String variable to a ByRef Long parameter.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "rejected",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "compile-error"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/byref-parenthesized-variable/Main.bas
+++ b/testdata/vbe-oracle/cases/byref-parenthesized-variable/Main.bas
@@ -1,0 +1,12 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeByRefParenthesizedVariable()
+    Dim value As Long
+    value = 1
+    MutateLong (value)
+End Sub
+
+Private Sub MutateLong(ByRef value As Long)
+    value = value + 1
+End Sub

--- a/testdata/vbe-oracle/cases/byref-parenthesized-variable/case.json
+++ b/testdata/vbe-oracle/cases/byref-parenthesized-variable/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "byref-parenthesized-variable",
+  "description": "Pass a parenthesized variable to a ByRef parameter.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/duplicate-named-argument/Main.bas
+++ b/testdata/vbe-oracle/cases/duplicate-named-argument/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeDuplicateNamedArgument()
+    Dim result As Long
+    result = AddTwo(first:=1, first:=2)
+End Sub
+
+Private Function AddTwo(ByVal first As Long, ByVal second As Long) As Long
+    AddTwo = first + second
+End Function

--- a/testdata/vbe-oracle/cases/duplicate-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/duplicate-named-argument/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "duplicate-named-argument",
+  "description": "Supply the same named argument twice.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "rejected",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "compile-error"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/function-bare-call/Main.bas
+++ b/testdata/vbe-oracle/cases/function-bare-call/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeFunctionBareCall()
+    Dim result As Long
+    result = AddOne(1)
+End Sub
+
+Private Function AddOne(ByVal value As Long) As Long
+    AddOne = value + 1
+End Function

--- a/testdata/vbe-oracle/cases/function-bare-call/case.json
+++ b/testdata/vbe-oracle/cases/function-bare-call/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "function-bare-call",
+  "description": "Use a bare Function call in an expression as the adjacent control.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/function-parenthesized-call/Main.bas
+++ b/testdata/vbe-oracle/cases/function-parenthesized-call/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeFunctionParenthesizedCall()
+    Dim result As Long
+    result = AddOne((1))
+End Sub
+
+Private Function AddOne(ByVal value As Long) As Long
+    AddOne = value + 1
+End Function

--- a/testdata/vbe-oracle/cases/function-parenthesized-call/case.json
+++ b/testdata/vbe-oracle/cases/function-parenthesized-call/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "function-parenthesized-call",
+  "description": "Use a parenthesized Function call in an expression.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/known-as-type/Main.bas
+++ b/testdata/vbe-oracle/cases/known-as-type/Main.bas
@@ -1,0 +1,7 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeKnownAsType()
+    Dim value As Long
+    value = 1
+End Sub

--- a/testdata/vbe-oracle/cases/known-as-type/case.json
+++ b/testdata/vbe-oracle/cases/known-as-type/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "known-as-type",
+  "description": "Declare a variable with a built-in type as the adjacent control.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/known-compile-accept/Main.bas
+++ b/testdata/vbe-oracle/cases/known-compile-accept/Main.bas
@@ -1,0 +1,7 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub OracleControlAccept()
+    Dim value As Long
+    value = 42
+End Sub

--- a/testdata/vbe-oracle/cases/known-compile-accept/case.json
+++ b/testdata/vbe-oracle/cases/known-compile-accept/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "known-compile-accept",
+  "description": "Known-good compile control used to verify the VBE harness.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/known-compile-reject/Main.bas
+++ b/testdata/vbe-oracle/cases/known-compile-reject/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub OracleControlReject()
+    Dim value As Long
+    value = MissingRequiredArgument(1)
+End Sub
+
+Private Function MissingRequiredArgument(ByVal first As Long, ByVal second As Long) As Long
+    MissingRequiredArgument = first + second
+End Function

--- a/testdata/vbe-oracle/cases/known-compile-reject/case.json
+++ b/testdata/vbe-oracle/cases/known-compile-reject/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "known-compile-reject",
+  "description": "Known-bad compile control used to verify compile-dialog detection.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "rejected",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "compile-error"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/known-named-argument/Main.bas
+++ b/testdata/vbe-oracle/cases/known-named-argument/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeKnownNamedArgument()
+    Dim result As Long
+    result = AddTwo(second:=2, first:=1)
+End Sub
+
+Private Function AddTwo(ByVal first As Long, ByVal second As Long) As Long
+    AddTwo = first + second
+End Function

--- a/testdata/vbe-oracle/cases/known-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/known-named-argument/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "known-named-argument",
+  "description": "Use distinct named arguments in a valid call.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/missing-required-argument/Main.bas
+++ b/testdata/vbe-oracle/cases/missing-required-argument/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeMissingRequiredArgument()
+    Dim result As Long
+    result = AddTwo(1)
+End Sub
+
+Private Function AddTwo(ByVal first As Long, ByVal second As Long) As Long
+    AddTwo = first + second
+End Function

--- a/testdata/vbe-oracle/cases/missing-required-argument/case.json
+++ b/testdata/vbe-oracle/cases/missing-required-argument/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "missing-required-argument",
+  "description": "Call a function without its required second positional argument.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "rejected",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "compile-error"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/missing-set-object-assignment/Main.bas
+++ b/testdata/vbe-oracle/cases/missing-set-object-assignment/Main.bas
@@ -1,0 +1,7 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeMissingSetObjectAssignment()
+    Dim value As Object
+    value = CreateObject("Scripting.Dictionary")
+End Sub

--- a/testdata/vbe-oracle/cases/missing-set-object-assignment/case.json
+++ b/testdata/vbe-oracle/cases/missing-set-object-assignment/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "missing-set-object-assignment",
+  "description": "Assign an object expression without Set.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/object-to-object-parameter/Main.bas
+++ b/testdata/vbe-oracle/cases/object-to-object-parameter/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeObjectToObjectParameter()
+    Dim value As Object
+    Set value = CreateObject("Scripting.Dictionary")
+    AcceptObject value
+End Sub
+
+Private Sub AcceptObject(ByVal value As Object)
+End Sub

--- a/testdata/vbe-oracle/cases/object-to-object-parameter/case.json
+++ b/testdata/vbe-oracle/cases/object-to-object-parameter/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "object-to-object-parameter",
+  "description": "Pass an object value to an Object parameter.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/optional-argument-omitted/Main.bas
+++ b/testdata/vbe-oracle/cases/optional-argument-omitted/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeOptionalArgumentOmitted()
+    Dim result As String
+    result = JoinText("left")
+End Sub
+
+Private Function JoinText(ByVal first As String, Optional ByVal second As String = "right") As String
+    JoinText = first & second
+End Function

--- a/testdata/vbe-oracle/cases/optional-argument-omitted/case.json
+++ b/testdata/vbe-oracle/cases/optional-argument-omitted/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "optional-argument-omitted",
+  "description": "Omit an Optional argument while supplying the required argument.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/scalar-assignment/Main.bas
+++ b/testdata/vbe-oracle/cases/scalar-assignment/Main.bas
@@ -1,0 +1,7 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeScalarAssignment()
+    Dim value As Long
+    value = 1
+End Sub

--- a/testdata/vbe-oracle/cases/scalar-assignment/case.json
+++ b/testdata/vbe-oracle/cases/scalar-assignment/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "scalar-assignment",
+  "description": "Adjacent valid scalar assignment control for Set diagnostics.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/scalar-to-object-parameter/Main.bas
+++ b/testdata/vbe-oracle/cases/scalar-to-object-parameter/Main.bas
@@ -1,0 +1,9 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeScalarToObjectParameter()
+    AcceptObject 1
+End Sub
+
+Private Sub AcceptObject(ByVal value As Object)
+End Sub

--- a/testdata/vbe-oracle/cases/scalar-to-object-parameter/case.json
+++ b/testdata/vbe-oracle/cases/scalar-to-object-parameter/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "scalar-to-object-parameter",
+  "description": "Pass a scalar value to an Object parameter.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "rejected",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "compile-error"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/set-object-target/Main.bas
+++ b/testdata/vbe-oracle/cases/set-object-target/Main.bas
@@ -1,0 +1,7 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeSetObjectTarget()
+    Dim value As Object
+    Set value = CreateObject("Scripting.Dictionary")
+End Sub

--- a/testdata/vbe-oracle/cases/set-object-target/case.json
+++ b/testdata/vbe-oracle/cases/set-object-target/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "set-object-target",
+  "description": "Use Set for an object assignment with a compatible object expression.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/set-scalar-target/Main.bas
+++ b/testdata/vbe-oracle/cases/set-scalar-target/Main.bas
@@ -1,0 +1,7 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeSetScalarTarget()
+    Dim value As Long
+    Set value = 1
+End Sub

--- a/testdata/vbe-oracle/cases/set-scalar-target/case.json
+++ b/testdata/vbe-oracle/cases/set-scalar-target/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "set-scalar-target",
+  "description": "Apply Set to a scalar assignment target.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "rejected",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "compile-error"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/sub-bare-call/Main.bas
+++ b/testdata/vbe-oracle/cases/sub-bare-call/Main.bas
@@ -1,0 +1,9 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeSubBareCall()
+    WriteValue 1
+End Sub
+
+Private Sub WriteValue(ByVal value As Long)
+End Sub

--- a/testdata/vbe-oracle/cases/sub-bare-call/case.json
+++ b/testdata/vbe-oracle/cases/sub-bare-call/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "sub-bare-call",
+  "description": "Call a Sub with a bare argument in statement context.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/sub-parenthesized-call/Main.bas
+++ b/testdata/vbe-oracle/cases/sub-parenthesized-call/Main.bas
@@ -1,0 +1,9 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeSubParenthesizedCall()
+    WriteValue (1)
+End Sub
+
+Private Sub WriteValue(ByVal value As Long)
+End Sub

--- a/testdata/vbe-oracle/cases/sub-parenthesized-call/case.json
+++ b/testdata/vbe-oracle/cases/sub-parenthesized-call/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "sub-parenthesized-call",
+  "description": "Call a Sub with parenthesized arguments in statement context.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "accepted",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "specification"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/unknown-as-type/Main.bas
+++ b/testdata/vbe-oracle/cases/unknown-as-type/Main.bas
@@ -1,0 +1,7 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeUnknownAsType()
+    Dim value As DefinitelyNotARealType
+    value = 1
+End Sub

--- a/testdata/vbe-oracle/cases/unknown-as-type/case.json
+++ b/testdata/vbe-oracle/cases/unknown-as-type/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "unknown-as-type",
+  "description": "Declare a variable using an unknown As type name.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "rejected",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "compile-error"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/cases/unknown-named-argument/Main.bas
+++ b/testdata/vbe-oracle/cases/unknown-named-argument/Main.bas
@@ -1,0 +1,11 @@
+Attribute VB_Name = "Main"
+Option Explicit
+
+Public Sub ProbeUnknownNamedArgument()
+    Dim result As Long
+    result = AddTwo(first:=1, third:=3)
+End Sub
+
+Private Function AddTwo(ByVal first As Long, ByVal second As Long) As Long
+    AddTwo = first + second
+End Function

--- a/testdata/vbe-oracle/cases/unknown-named-argument/Main.bas
+++ b/testdata/vbe-oracle/cases/unknown-named-argument/Main.bas
@@ -3,7 +3,7 @@ Option Explicit
 
 Public Sub ProbeUnknownNamedArgument()
     Dim result As Long
-    result = AddTwo(first:=1, third:=3)
+    result = AddTwo(first:=1, second:=2, third:=3)
 End Sub
 
 Private Function AddTwo(ByVal first As Long, ByVal second As Long) As Long

--- a/testdata/vbe-oracle/cases/unknown-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/unknown-named-argument/case.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "unknown-named-argument",
+  "description": "Use a named argument that does not exist in the target procedure.",
+  "modules": [
+    {
+      "name": "Main",
+      "kind": "standard",
+      "path": "Main.bas",
+      "entry": true
+    }
+  ],
+  "probe": {
+    "mode": "compile"
+  },
+  "vbe": {
+    "expected": "rejected",
+    "evidence_phase": "compile",
+    "diagnostic_meaning": "compile-error"
+  },
+  "analysis": {},
+  "provenance": {
+    "status": "asserted",
+    "verified_on": [
+      {
+        "excel_version": "16.0",
+        "excel_build": "17932",
+        "bitness": "x64",
+        "locale": "ja-JP",
+        "verified_at": "2026-08-06T04:33:57Z"
+      }
+    ]
+  }
+}

--- a/testdata/vbe-oracle/manifest.json
+++ b/testdata/vbe-oracle/manifest.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "description": "Focused Windows Excel/VBE compile probes for static-analysis evidence.",
+  "controls": {
+    "accept": "known-compile-accept",
+    "reject": "known-compile-reject"
+  },
+  "cases": [
+    {
+      "id": "known-compile-accept",
+      "path": "cases/known-compile-accept/case.json",
+      "control_role": "accept"
+    },
+    {
+      "id": "known-compile-reject",
+      "path": "cases/known-compile-reject/case.json",
+      "control_role": "reject"
+    },
+    { "id": "missing-required-argument", "path": "cases/missing-required-argument/case.json" },
+    { "id": "optional-argument-omitted", "path": "cases/optional-argument-omitted/case.json" },
+    { "id": "duplicate-named-argument", "path": "cases/duplicate-named-argument/case.json" },
+    { "id": "known-named-argument", "path": "cases/known-named-argument/case.json" },
+    { "id": "unknown-named-argument", "path": "cases/unknown-named-argument/case.json" },
+    { "id": "set-scalar-target", "path": "cases/set-scalar-target/case.json" },
+    { "id": "set-object-target", "path": "cases/set-object-target/case.json" },
+    {
+      "id": "missing-set-object-assignment",
+      "path": "cases/missing-set-object-assignment/case.json"
+    },
+    { "id": "scalar-assignment", "path": "cases/scalar-assignment/case.json" },
+    { "id": "scalar-to-object-parameter", "path": "cases/scalar-to-object-parameter/case.json" },
+    { "id": "object-to-object-parameter", "path": "cases/object-to-object-parameter/case.json" },
+    { "id": "byref-incompatible", "path": "cases/byref-incompatible/case.json" },
+    { "id": "byref-compatible", "path": "cases/byref-compatible/case.json" },
+    {
+      "id": "byref-parenthesized-variable",
+      "path": "cases/byref-parenthesized-variable/case.json"
+    },
+    { "id": "byref-bare-variable", "path": "cases/byref-bare-variable/case.json" },
+    { "id": "unknown-as-type", "path": "cases/unknown-as-type/case.json" },
+    { "id": "known-as-type", "path": "cases/known-as-type/case.json" },
+    { "id": "sub-parenthesized-call", "path": "cases/sub-parenthesized-call/case.json" },
+    { "id": "sub-bare-call", "path": "cases/sub-bare-call/case.json" },
+    { "id": "function-parenthesized-call", "path": "cases/function-parenthesized-call/case.json" },
+    { "id": "function-bare-call", "path": "cases/function-bare-call/case.json" }
+  ]
+}

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -9,6 +9,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `ambiguous_test_name`
 - `analyze_disabled_rules_precedence`
 - `analyze_failed`
+- `args_invalid`
 - `argument_count`
 - `argument_diagnostics`
 - `argument_list`
@@ -81,6 +82,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `case_clause`
 - `case_else`
 - `case_expression`
+- `case_id`
+- `case_selection_invalid`
 - `cell_diffs`
 - `cells_updated`
 - `cfg_builds`
@@ -113,6 +116,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `command_line_argument`
 - `command_reads_saved_file`
 - `comparison_expression`
+- `compile_invoked`
 - `compile_vba`
 - `component_type`
 - `components_applied`
@@ -131,6 +135,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `constant_name`
 - `control_count`
 - `control_enumeration_failed`
+- `control_failed`
 - `coordinate_system`
 - `coordination_acquire_failed`
 - `coordination_identity_failed`
@@ -199,6 +204,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `detect_unused_local_variables`
 - `detect_unused_private_procedures`
 - `detect_worksheet_root_mismatch`
+- `diagnostic_meaning`
 - `diagnostic_runs`
 - `dialog_id`
 - `diff_args_invalid`
@@ -250,6 +256,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `environment_variable`
 - `event_declaration`
 - `event_statement`
+- `evidence_phase`
 - `example_cell`
 - `example_formula`
 - `exceeds_keep_last`
@@ -276,6 +283,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `exit_statement`
 - `exit_sub`
 - `expanded_formula`
+- `expectation_mismatch`
 - `expected_closer`
 - `expected_error`
 - `export_image_args_invalid`
@@ -290,6 +298,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `file_picker`
 - `files_changed`
 - `files_to_change`
+- `fixture_invalid`
 - `fmt_args_invalid`
 - `fmt_check_failed`
 - `fmt_failed`
@@ -378,6 +387,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `incompressible_short_over_limit_errors`
 - `incompressible_short_under_limit_roundtrips`
 - `incremental_parse_unavailable`
+- `infrastructure_failure`
 - `init_failed`
 - `inspect_args_invalid`
 - `inspect_failed`
@@ -406,7 +416,10 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `invoke_macro`
 - `is_wsl`
 - `keyword_casing`
+- `known_accept`
+- `known_reject`
 - `label_statement`
+- `last_stage`
 - `latest_source_modified_at`
 - `launches_process`
 - `lbl_child`
@@ -522,6 +535,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `operator_spacing`
 - `option_statement`
 - `optional_modifier`
+- `oracle_failure`
 - `original_error`
 - `original_workbook_path`
 - `output_file_exists`
@@ -558,11 +572,13 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `parser_token`
 - `passing_mode`
 - `path_translation`
+- `plan_invalid`
 - `poison_reason`
 - `post_until`
 - `post_while`
 - `pre_until`
 - `pre_while`
+- `probe_mode`
 - `procedure_call`
 - `procedure_declaration`
 - `procedure_exit`
@@ -587,6 +603,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `project_create`
 - `project_init`
 - `project_name`
+- `promotion_invalid`
 - `property_declaration`
 - `property_diagnostics`
 - `property_get`
@@ -765,6 +782,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `test_not_found`
 - `test_run`
 - `timed_out`
+- `timeout_invalid`
+- `timeout_ms`
 - `too_long`
 - `total_diffs`
 - `tree_sitter_vba`


### PR DESCRIPTION
## Summary

- Closes #502.
- Adds the developer-only, Windows/Excel local `xlflow-vbe-oracle` command with schema-v1 fixture loading, sequential compile probes, control-fixture health gating, strict validation, and explicit atomic promotion.
- Adds the internal .NET bridge command for disposable Excel/VBE observations, dialog classification, cleanup protection, and Excel environment metadata.
- Adds 23 committed standard-module fixtures, deterministic analyzer contract tests, ADR-0026, the VBE oracle specification, bridge documentation, and contributor/agent guidance.
- Keeps Oracle execution out of production commands, normal tests, and GitHub Actions.

## Tests

- `scripts/dev/go.ps1 test ./...`
- `scripts/dev/go.ps1 vet ./...`
- `scripts/dev/go.ps1 build ./...`
- `dotnet build .\\bridge\\dotnet\\src\\Xlflow.ExcelBridge\\Xlflow.ExcelBridge.csproj --no-restore -c Release`
- `dotnet test .\\bridge\\dotnet\\tests\\Xlflow.ExcelBridge.Tests\\Xlflow.ExcelBridge.Tests.csproj --no-restore --no-build` (413 passed)
- PowerShell lint, format checks, documentation checks, and `git diff --check`
- Real Excel/VBE: known controls, all 23 cases observed, all 23 cases promoted, and all 23 cases re-run in strict mode; no target Excel processes remained after cleanup verification.

## Oracle cases run locally

`known-compile-accept`, `known-compile-reject`, `missing-required-argument`, `optional-argument-omitted`, `duplicate-named-argument`, `known-named-argument`, `unknown-named-argument`, `set-scalar-target`, `set-object-target`, `missing-set-object-assignment`, `scalar-assignment`, `scalar-to-object-parameter`, `object-to-object-parameter`, `byref-incompatible`, `byref-compatible`, `byref-parenthesized-variable`, `byref-bare-variable`, `unknown-as-type`, `known-as-type`, `sub-parenthesized-call`, `sub-bare-call`, `function-parenthesized-call`, `function-bare-call`.

## Notes

- The Oracle is compile-probe-only in schema v1; `run` and `compile_then_run` remain unsupported for future expansion.
- Infrastructure failures are never promoted as VBA evidence, and cleanup failure overrides an otherwise accepted/rejected result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows-only local Excel/VBE oracle for validating VBA compilation behavior.
  * Added CLI controls for case selection, strict validation, timeouts, diagnostics, and explicit evidence promotion.
  * Added structured reports for compile outcomes, diagnostics, metadata, and cleanup status.
  * Added broad VBA fixtures covering arguments, assignments, type compatibility, and call syntax.

* **Documentation**
  * Added setup, usage, safety, troubleshooting, and contribution guidance.
  * Documented local-only execution and exclusion from production and CI workflows.

* **Tests**
  * Added deterministic Excel-free fixture and diagnostic contract coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->