### PR TITLE
feat: add VBE oracle binding metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to xlflow will be documented in this file.
   analysis compile evidence, with sequential disposable workbooks, known
   accept/reject controls, observational and strict JSON modes, explicit
   promotion, provenance metadata, and deterministic Excel-free fixture
-  contracts. The oracle is not invoked by production commands or GitHub
-  Actions; contributors should run relevant cases locally when changing VBA
-  semantics.
+  contracts. Fixtures now also carry explicit diagnostic binding metadata so
+  unbound, partially-bound, bound, and not-applicable evidence can be validated
+  independently of the later rule-catalogue and coverage work. The oracle is
+  not invoked by production commands or GitHub Actions; contributors should run
+  relevant cases locally when changing VBA semantics.
 - Added default-enabled `VBA223` security warnings for likely hardcoded VBA
   credentials, with structural matching, placeholder filtering, fixed
   `[REDACTED]` diagnostics, and independent configuration/inline suppression.

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -80,6 +80,35 @@ contract uses `analysis.expected_diagnostics` and
 optional source range, and (when needed) `surfaces` from `lint`, `analyze`, and
 `lsp`.
 
+Every fixture must also declare its diagnostic binding state under `analysis`:
+
+```json
+{
+  "analysis": {
+    "binding_status": "unbound"
+  }
+}
+```
+
+The supported states are:
+
+- `unbound`: VBE evidence exists, but no analyzer rule has been connected yet.
+- `partially-bound`: at least one rule is connected, but coverage is incomplete;
+  `rule_codes` and a non-empty `binding_note` are required.
+- `bound`: the fixture is fully connected to declared rules. It requires at
+  least one rule code, each code must appear in an expected or forbidden
+  diagnostic contract, and the contract must match the VBE result (`expected`
+  for rejected cases, `forbidden` for accepted cases).
+- `not-applicable`: the fixture is intentionally a harness control or language
+  observation and cannot declare rule codes or diagnostic contracts.
+
+Binding status is structural metadata only. Diagnostic code existence,
+severity, and supported analyzer surfaces are validated by the rule-catalogue
+and binding work tracked separately from this fixture-schema change. Until a
+fixture is connected to an implemented rule, keep it `unbound` and do not alter
+the VBE expectation to satisfy an analyzer test. Binding notes must be omitted
+when unnecessary; an explicitly empty or whitespace-only note is invalid.
+
 ## Outcomes and strict mode
 
 Only `accepted` and `rejected` are VBA evidence. A compile dialog associated

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -96,9 +96,9 @@ The supported states are:
 - `partially-bound`: at least one rule is connected, but coverage is incomplete;
   `rule_codes` and a non-empty `binding_note` are required.
 - `bound`: the fixture is fully connected to declared rules. It requires at
-  least one rule code, each code must appear in an expected or forbidden
-  diagnostic contract, and the contract must match the VBE result (`expected`
-  for rejected cases, `forbidden` for accepted cases).
+  least one rule code, and every declared code must appear in the contract that
+  matches the VBE result (`expected` for rejected cases, `forbidden` for
+  accepted cases).
 - `not-applicable`: the fixture is intentionally a harness control or language
   observation and cannot declare rule codes or diagnostic contracts.
 

--- a/internal/oracle/fixture_contract_test.go
+++ b/internal/oracle/fixture_contract_test.go
@@ -34,6 +34,13 @@ func TestCommittedFixtureContractsWithoutExcel(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if entry.ID == manifest.Controls.Accept || entry.ID == manifest.Controls.Reject {
+				if c.Analysis.BindingStatus != BindingNotApplicable {
+					t.Fatalf("control fixture binding_status = %q, want %q", c.Analysis.BindingStatus, BindingNotApplicable)
+				}
+			} else if c.Analysis.BindingStatus != BindingUnbound {
+				t.Fatalf("fixture binding_status = %q, want initial migration status %q", c.Analysis.BindingStatus, BindingUnbound)
+			}
 			projectRoot := t.TempDir()
 			modulesRoot := filepath.Join(projectRoot, "src", "modules")
 			if err := os.MkdirAll(modulesRoot, 0o755); err != nil {

--- a/internal/oracle/manifest.go
+++ b/internal/oracle/manifest.go
@@ -435,17 +435,23 @@ func validateAnalysisBinding(c Case) error {
 		if len(analysis.RuleCodes) == 0 {
 			return fmt.Errorf("oracle case %q: bound fixture requires analysis.rule_codes", c.ID)
 		}
-		if c.VBE.Expected == ExpectedObserve {
+		var boundExpectations []DiagnosticExpectation
+		switch c.VBE.Expected {
+		case ExpectedRejected:
+			if !hasExpected {
+				return fmt.Errorf("oracle case %q: bound rejected fixture requires expected diagnostics", c.ID)
+			}
+			boundExpectations = analysis.ExpectedDiagnostics
+		case ExpectedAccepted:
+			if !hasForbidden {
+				return fmt.Errorf("oracle case %q: bound accepted fixture requires forbidden diagnostics", c.ID)
+			}
+			boundExpectations = analysis.ForbiddenDiagnostics
+		default:
 			return fmt.Errorf("oracle case %q: bound fixture requires asserted VBE evidence", c.ID)
 		}
-		if c.VBE.Expected == ExpectedRejected && !hasExpected {
-			return fmt.Errorf("oracle case %q: bound rejected fixture requires expected diagnostics", c.ID)
-		}
-		if c.VBE.Expected == ExpectedAccepted && !hasForbidden {
-			return fmt.Errorf("oracle case %q: bound accepted fixture requires forbidden diagnostics", c.ID)
-		}
 		for _, code := range analysis.RuleCodes {
-			if !diagnosticCodeDeclared(code, analysis.ExpectedDiagnostics) && !diagnosticCodeDeclared(code, analysis.ForbiddenDiagnostics) {
+			if !diagnosticCodeDeclared(code, boundExpectations) {
 				return fmt.Errorf("oracle case %q: bound rule code %q is not declared by an analysis contract", c.ID, code)
 			}
 		}

--- a/internal/oracle/manifest.go
+++ b/internal/oracle/manifest.go
@@ -31,6 +31,11 @@ const (
 	MeaningSpecification   = "specification"
 	MeaningPolicy          = "policy"
 	MeaningMaintainability = "maintainability"
+
+	BindingUnbound        = "unbound"
+	BindingPartiallyBound = "partially-bound"
+	BindingBound          = "bound"
+	BindingNotApplicable  = "not-applicable"
 )
 
 var caseIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -142,6 +147,9 @@ type VBEExpectation struct {
 }
 
 type AnalysisExpectation struct {
+	BindingStatus        string                  `json:"binding_status"`
+	RuleCodes            []string                `json:"rule_codes,omitempty"`
+	BindingNote          *string                 `json:"binding_note,omitempty"`
 	ExpectedDiagnostics  []DiagnosticExpectation `json:"expected_diagnostics,omitempty"`
 	ForbiddenDiagnostics []DiagnosticExpectation `json:"forbidden_diagnostics,omitempty"`
 }
@@ -339,6 +347,9 @@ func ValidateCase(c Case, manifestID, caseDir string) error {
 	if err := validateDiagnosticExpectations(c.Analysis.ForbiddenDiagnostics, "forbidden", c.ID); err != nil {
 		return err
 	}
+	if err := validateAnalysisBinding(c); err != nil {
+		return err
+	}
 	switch c.VBE.Expected {
 	case ExpectedObserve:
 		if strings.TrimSpace(c.Provenance.Status) != "pending" {
@@ -382,6 +393,77 @@ func ValidateCase(c Case, manifestID, caseDir string) error {
 		return fmt.Errorf("oracle case %q has invalid vbe.expected %q", c.ID, c.VBE.Expected)
 	}
 	return nil
+}
+
+func validateAnalysisBinding(c Case) error {
+	analysis := c.Analysis
+	switch analysis.BindingStatus {
+	case BindingUnbound, BindingPartiallyBound, BindingBound, BindingNotApplicable:
+	default:
+		return fmt.Errorf("oracle case %q has invalid analysis.binding_status %q", c.ID, analysis.BindingStatus)
+	}
+
+	seenCodes := make(map[string]struct{}, len(analysis.RuleCodes))
+	for _, code := range analysis.RuleCodes {
+		if strings.TrimSpace(code) == "" || code != strings.TrimSpace(code) {
+			return fmt.Errorf("oracle case %q has an empty or padded analysis rule code", c.ID)
+		}
+		if _, ok := seenCodes[code]; ok {
+			return fmt.Errorf("oracle case %q repeats analysis rule code %q", c.ID, code)
+		}
+		seenCodes[code] = struct{}{}
+	}
+	if analysis.BindingNote != nil && strings.TrimSpace(*analysis.BindingNote) == "" {
+		return fmt.Errorf("oracle case %q has an empty analysis.binding_note", c.ID)
+	}
+
+	hasExpected := len(analysis.ExpectedDiagnostics) > 0
+	hasForbidden := len(analysis.ForbiddenDiagnostics) > 0
+	switch analysis.BindingStatus {
+	case BindingUnbound:
+		if len(analysis.RuleCodes) > 0 && analysis.BindingNote == nil {
+			return fmt.Errorf("oracle case %q: unbound fixture with rule codes requires analysis.binding_note", c.ID)
+		}
+	case BindingPartiallyBound:
+		if len(analysis.RuleCodes) == 0 {
+			return fmt.Errorf("oracle case %q: partially-bound fixture requires analysis.rule_codes", c.ID)
+		}
+		if analysis.BindingNote == nil {
+			return fmt.Errorf("oracle case %q: partially-bound fixture requires analysis.binding_note", c.ID)
+		}
+	case BindingBound:
+		if len(analysis.RuleCodes) == 0 {
+			return fmt.Errorf("oracle case %q: bound fixture requires analysis.rule_codes", c.ID)
+		}
+		if c.VBE.Expected == ExpectedObserve {
+			return fmt.Errorf("oracle case %q: bound fixture requires asserted VBE evidence", c.ID)
+		}
+		if c.VBE.Expected == ExpectedRejected && !hasExpected {
+			return fmt.Errorf("oracle case %q: bound rejected fixture requires expected diagnostics", c.ID)
+		}
+		if c.VBE.Expected == ExpectedAccepted && !hasForbidden {
+			return fmt.Errorf("oracle case %q: bound accepted fixture requires forbidden diagnostics", c.ID)
+		}
+		for _, code := range analysis.RuleCodes {
+			if !diagnosticCodeDeclared(code, analysis.ExpectedDiagnostics) && !diagnosticCodeDeclared(code, analysis.ForbiddenDiagnostics) {
+				return fmt.Errorf("oracle case %q: bound rule code %q is not declared by an analysis contract", c.ID, code)
+			}
+		}
+	case BindingNotApplicable:
+		if len(analysis.RuleCodes) > 0 || hasExpected || hasForbidden {
+			return fmt.Errorf("oracle case %q: not-applicable fixture cannot declare analyzer bindings", c.ID)
+		}
+	}
+	return nil
+}
+
+func diagnosticCodeDeclared(code string, expectations []DiagnosticExpectation) bool {
+	for _, expectation := range expectations {
+		if expectation.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func validateDiagnosticExpectations(expectations []DiagnosticExpectation, kind, caseID string) error {

--- a/internal/oracle/manifest_test.go
+++ b/internal/oracle/manifest_test.go
@@ -18,7 +18,7 @@ func writeFixture(t *testing.T, expected string) (string, Manifest) {
 	if err := os.WriteFile(filepath.Join(caseDir, "Main.bas"), []byte(source), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	caseJSON := Case{SchemaVersion: SchemaVersion, ID: "sample", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas", Entry: true}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: expected, EvidencePhase: EvidenceUnknown, DiagnosticMeaning: MeaningObservation}, Provenance: Provenance{Status: "pending"}}
+	caseJSON := Case{SchemaVersion: SchemaVersion, ID: "sample", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas", Entry: true}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: expected, EvidencePhase: EvidenceUnknown, DiagnosticMeaning: MeaningObservation}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}, Provenance: Provenance{Status: "pending"}}
 	body, _ := json.Marshal(caseJSON)
 	if err := os.WriteFile(filepath.Join(caseDir, "case.json"), body, 0o644); err != nil {
 		t.Fatal(err)
@@ -90,9 +90,142 @@ func TestValidateManifestRequiresCaseDirectoryAndEntryAgreement(t *testing.T) {
 }
 
 func TestValidateCaseRequiresAssertedProvenance(t *testing.T) {
-	c := Case{SchemaVersion: SchemaVersion, ID: "x", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas"}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: ExpectedAccepted, EvidencePhase: EvidenceCompile}}
+	c := Case{SchemaVersion: SchemaVersion, ID: "x", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas"}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: ExpectedAccepted, EvidencePhase: EvidenceCompile}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}}
 	if err := ValidateCase(c, "x", t.TempDir()); err == nil {
 		t.Fatal("expected provenance validation error")
+	}
+}
+
+func analysisNote(value string) *string {
+	return &value
+}
+
+func validAssertedCase(expected string) Case {
+	meaning := MeaningSpecification
+	if expected == ExpectedRejected {
+		meaning = MeaningCompileError
+	}
+	return Case{
+		SchemaVersion: SchemaVersion,
+		ID:            "x",
+		Modules:       []Module{{Name: "Main", Kind: "standard", Path: "Main.bas"}},
+		Probe:         Probe{Mode: ProbeCompile},
+		VBE:           VBEExpectation{Expected: expected, EvidencePhase: EvidenceCompile, DiagnosticMeaning: meaning},
+		Analysis:      AnalysisExpectation{BindingStatus: BindingUnbound},
+		Provenance: Provenance{
+			Status: "asserted",
+			VerifiedOn: []VerificationMetadata{{
+				ExcelVersion: "16.0", ExcelBuild: "17932", Bitness: "x64", Locale: "ja-JP", VerifiedAt: "2026-08-06T00:00:00Z",
+			}},
+		},
+	}
+}
+
+func TestValidateCaseBindingMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*Case)
+		wantErr bool
+	}{
+		{name: "unbound", prepare: func(c *Case) {}},
+		{name: "partially-bound", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+			c.Analysis.BindingNote = analysisNote("positive contract is pending")
+		}},
+		{name: "bound rejected", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA001", Severity: "error"}}
+		}},
+		{name: "bound accepted", prepare: func(c *Case) {
+			c.VBE.Expected = ExpectedAccepted
+			c.VBE.DiagnosticMeaning = MeaningSpecification
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VBA001"}}
+		}},
+		{name: "not-applicable", prepare: func(c *Case) {
+			c.VBE.Expected = ExpectedAccepted
+			c.VBE.DiagnosticMeaning = MeaningSpecification
+			c.Analysis.BindingStatus = BindingNotApplicable
+		}},
+		{name: "missing status", prepare: func(c *Case) { c.Analysis.BindingStatus = "" }, wantErr: true},
+		{name: "invalid status", prepare: func(c *Case) { c.Analysis.BindingStatus = "future" }, wantErr: true},
+		{name: "unbound rule code needs note", prepare: func(c *Case) {
+			c.Analysis.RuleCodes = []string{"VBA001"}
+		}, wantErr: true},
+		{name: "partially-bound needs rule code", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.BindingNote = analysisNote("pending")
+		}, wantErr: true},
+		{name: "partially-bound needs note", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+		}, wantErr: true},
+		{name: "bound needs rule code", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA001"}}
+		}, wantErr: true},
+		{name: "bound code needs contract", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA002"}}
+		}, wantErr: true},
+		{name: "bound rejected needs expected", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+		}, wantErr: true},
+		{name: "bound accepted needs forbidden", prepare: func(c *Case) {
+			c.VBE.Expected = ExpectedAccepted
+			c.VBE.DiagnosticMeaning = MeaningSpecification
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+		}, wantErr: true},
+		{name: "bound observe rejected", prepare: func(c *Case) {
+			c.VBE.Expected = ExpectedObserve
+			c.VBE.EvidencePhase = EvidenceUnknown
+			c.VBE.DiagnosticMeaning = MeaningObservation
+			c.Provenance = Provenance{Status: "pending"}
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA001"}}
+		}, wantErr: true},
+		{name: "not-applicable rule code", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingNotApplicable
+			c.Analysis.RuleCodes = []string{"VBA001"}
+		}, wantErr: true},
+		{name: "not-applicable expected", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingNotApplicable
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA001"}}
+		}, wantErr: true},
+		{name: "not-applicable forbidden", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingNotApplicable
+			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VBA001"}}
+		}, wantErr: true},
+		{name: "empty rule code", prepare: func(c *Case) {
+			c.Analysis.RuleCodes = []string{""}
+		}, wantErr: true},
+		{name: "padded rule code", prepare: func(c *Case) {
+			c.Analysis.RuleCodes = []string{" VBA001"}
+		}, wantErr: true},
+		{name: "duplicate rule code", prepare: func(c *Case) {
+			c.Analysis.RuleCodes = []string{"VBA001", "VBA001"}
+		}, wantErr: true},
+		{name: "empty binding note", prepare: func(c *Case) {
+			c.Analysis.BindingNote = analysisNote("  ")
+		}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validAssertedCase(ExpectedRejected)
+			tt.prepare(&c)
+			err := ValidateCase(c, c.ID, t.TempDir())
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateCase() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/oracle/manifest_test.go
+++ b/internal/oracle/manifest_test.go
@@ -18,7 +18,7 @@ func writeFixture(t *testing.T, expected string) (string, Manifest) {
 	if err := os.WriteFile(filepath.Join(caseDir, "Main.bas"), []byte(source), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	caseJSON := Case{SchemaVersion: SchemaVersion, ID: "sample", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas", Entry: true}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: expected, EvidencePhase: EvidenceUnknown, DiagnosticMeaning: MeaningObservation}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}, Provenance: Provenance{Status: "pending"}}
+	caseJSON := Case{SchemaVersion: SchemaVersion, ID: "sample", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas", Entry: true}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: expected, EvidencePhase: EvidenceUnknown, DiagnosticMeaning: MeaningObservation}, Analysis: AnalysisExpectation{BindingStatus: BindingNotApplicable}, Provenance: Provenance{Status: "pending"}}
 	body, _ := json.Marshal(caseJSON)
 	if err := os.WriteFile(filepath.Join(caseDir, "case.json"), body, 0o644); err != nil {
 		t.Fatal(err)
@@ -172,6 +172,12 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 			c.Analysis.RuleCodes = []string{"VBA001"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA002"}}
 		}, wantErr: true},
+		{name: "rejected bound code cannot be forbidden-only", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA002"}}
+			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VBA001"}}
+		}, wantErr: true},
 		{name: "bound rejected needs expected", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
 			c.Analysis.RuleCodes = []string{"VBA001"}
@@ -181,6 +187,14 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 			c.VBE.DiagnosticMeaning = MeaningSpecification
 			c.Analysis.BindingStatus = BindingBound
 			c.Analysis.RuleCodes = []string{"VBA001"}
+		}, wantErr: true},
+		{name: "accepted bound code cannot be expected-only", prepare: func(c *Case) {
+			c.VBE.Expected = ExpectedAccepted
+			c.VBE.DiagnosticMeaning = MeaningSpecification
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.RuleCodes = []string{"VBA001"}
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA001"}}
+			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VBA002"}}
 		}, wantErr: true},
 		{name: "bound observe rejected", prepare: func(c *Case) {
 			c.VBE.Expected = ExpectedObserve

--- a/internal/oracle/runner_test.go
+++ b/internal/oracle/runner_test.go
@@ -90,7 +90,7 @@ func TestRunControlsStrictAndPromotion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.VBE.Expected != ExpectedAccepted || c.Provenance.Status != "asserted" {
+	if c.VBE.Expected != ExpectedAccepted || c.Provenance.Status != "asserted" || c.Analysis.BindingStatus != BindingUnbound {
 		t.Fatalf("promotion=%+v", c)
 	}
 }

--- a/internal/oracle/runner_test.go
+++ b/internal/oracle/runner_test.go
@@ -90,7 +90,7 @@ func TestRunControlsStrictAndPromotion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.VBE.Expected != ExpectedAccepted || c.Provenance.Status != "asserted" || c.Analysis.BindingStatus != BindingUnbound {
+	if c.VBE.Expected != ExpectedAccepted || c.Provenance.Status != "asserted" || c.Analysis.BindingStatus != BindingNotApplicable {
 		t.Fatalf("promotion=%+v", c)
 	}
 }

--- a/scripts/docs/generate-reference-inventory.mjs
+++ b/scripts/docs/generate-reference-inventory.mjs
@@ -87,6 +87,9 @@ function walk(dir) {
 walk(path.join(repo, "internal"));
 
 const source = sourceFiles.map((file) => fs.readFileSync(file, "utf8")).join("\n");
+// Some structured metadata keys use the same snake_case shape as error-code
+// literals but are not user-facing errors and do not belong in this inventory.
+const excludedErrorInventoryLiterals = new Set(["binding_status"]);
 const errors = [
   ...new Set([...source.matchAll(/"([a-z][a-z0-9]*(?:_[a-z0-9]+)+)"/g)].map((m) => m[1])),
 ]
@@ -96,7 +99,8 @@ const errors = [
       !code.startsWith("go_") &&
       !code.startsWith("http_") &&
       code !== "default_enabled" &&
-      code !== "default_severity",
+      code !== "default_severity" &&
+      !excludedErrorInventoryLiterals.has(code),
   )
   .sort();
 

--- a/scripts/docs/generate-reference-inventory.mjs
+++ b/scripts/docs/generate-reference-inventory.mjs
@@ -89,7 +89,11 @@ walk(path.join(repo, "internal"));
 const source = sourceFiles.map((file) => fs.readFileSync(file, "utf8")).join("\n");
 // Some structured metadata keys use the same snake_case shape as error-code
 // literals but are not user-facing errors and do not belong in this inventory.
-const excludedErrorInventoryLiterals = new Set(["binding_status"]);
+const excludedErrorInventoryLiterals = new Set([
+  "binding_status",
+  "rule_codes",
+  "binding_note",
+]);
 const errors = [
   ...new Set([...source.matchAll(/"([a-z][a-z0-9]*(?:_[a-z0-9]+)+)"/g)].map((m) => m[1])),
 ]

--- a/testdata/vbe-oracle/cases/byref-bare-variable/case.json
+++ b/testdata/vbe-oracle/cases/byref-bare-variable/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/byref-compatible/case.json
+++ b/testdata/vbe-oracle/cases/byref-compatible/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/byref-incompatible/case.json
+++ b/testdata/vbe-oracle/cases/byref-incompatible/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "compile-error"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/byref-parenthesized-variable/case.json
+++ b/testdata/vbe-oracle/cases/byref-parenthesized-variable/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/duplicate-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/duplicate-named-argument/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "compile-error"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/function-bare-call/case.json
+++ b/testdata/vbe-oracle/cases/function-bare-call/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/function-parenthesized-call/case.json
+++ b/testdata/vbe-oracle/cases/function-parenthesized-call/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/known-as-type/case.json
+++ b/testdata/vbe-oracle/cases/known-as-type/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/known-compile-accept/case.json
+++ b/testdata/vbe-oracle/cases/known-compile-accept/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "not-applicable"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/known-compile-reject/case.json
+++ b/testdata/vbe-oracle/cases/known-compile-reject/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "compile-error"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "not-applicable"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/known-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/known-named-argument/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/missing-required-argument/case.json
+++ b/testdata/vbe-oracle/cases/missing-required-argument/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "compile-error"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/missing-set-object-assignment/case.json
+++ b/testdata/vbe-oracle/cases/missing-set-object-assignment/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/object-to-object-parameter/case.json
+++ b/testdata/vbe-oracle/cases/object-to-object-parameter/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/optional-argument-omitted/case.json
+++ b/testdata/vbe-oracle/cases/optional-argument-omitted/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/scalar-assignment/case.json
+++ b/testdata/vbe-oracle/cases/scalar-assignment/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/scalar-to-object-parameter/case.json
+++ b/testdata/vbe-oracle/cases/scalar-to-object-parameter/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "compile-error"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/set-object-target/case.json
+++ b/testdata/vbe-oracle/cases/set-object-target/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/set-scalar-target/case.json
+++ b/testdata/vbe-oracle/cases/set-scalar-target/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "compile-error"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/sub-bare-call/case.json
+++ b/testdata/vbe-oracle/cases/sub-bare-call/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/sub-parenthesized-call/case.json
+++ b/testdata/vbe-oracle/cases/sub-parenthesized-call/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "specification"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/unknown-as-type/case.json
+++ b/testdata/vbe-oracle/cases/unknown-as-type/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "compile-error"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/testdata/vbe-oracle/cases/unknown-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/unknown-named-argument/case.json
@@ -18,7 +18,9 @@
     "evidence_phase": "compile",
     "diagnostic_meaning": "compile-error"
   },
-  "analysis": {},
+  "analysis": {
+    "binding_status": "unbound"
+  },
   "provenance": {
     "status": "asserted",
     "verified_on": [

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -47,7 +47,6 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `base_workbook`
 - `before_dialog_action`
 - `binary_expression`
-- `binding_status`
 - `block_kind`
 - `branch_false`
 - `branch_true`

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -47,6 +47,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `base_workbook`
 - `before_dialog_action`
 - `binary_expression`
+- `binding_status`
 - `block_kind`
 - `branch_false`
 - `branch_true`


### PR DESCRIPTION
## Summary

- Add explicit `analysis.binding_status`, `rule_codes`, and optional `binding_note` metadata to VBE oracle fixtures.
- Validate all four binding states and their diagnostic-contract invariants in Excel-free Go tests.
- Migrate the 23 committed fixtures to `not-applicable` controls or `unbound` cases, and update the oracle specification and changelog.
- Closes #509.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test .\\internal\\oracle`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./...`
- `rtk task lint`
- `rtk pnpm format:check`
- `rtk git diff --check`

## Scope

- No Excel/VBE execution was added.
- Rule-catalogue validation, concrete diagnostic bindings, and coverage/pairing reports remain in follow-up issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit binding-status metadata to analysis fixtures, covering unbound, partially bound, bound, and not-applicable states.
  - Added support for binding notes and associated rule-code metadata where applicable.

- **Documentation**
  - Documented required binding metadata, supported statuses, and validation rules for fixtures.

- **Bug Fixes**
  - Prevented binding metadata from being incorrectly included in generated error-code references.

- **Tests**
  - Expanded validation coverage for valid and invalid binding metadata combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->