### PR TITLE
Add VBE oracle binding coverage and positive/negative pairing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,21 @@ The oracle is developer-only and local. Never invoke it from production xlflow
 commands, ordinary tests, or GitHub Actions. See
 `docs/specs/vbe-oracle.md` for the complete workflow and contract.
 
+When binding a compile-error diagnostic to oracle evidence, first search the
+existing fixtures and use confirmed VBA behavior rather than general-language
+assumptions. Bind both sides of the VBE boundary: rejected fixtures must carry
+expected diagnostics and `analysis.negative_controls` pointing to accepted
+fixtures whose forbidden contracts protect the same rule on every declared
+surface. Do not change VBE evidence merely to make analyzer tests pass.
+
+Run the known controls and focused cases sequentially. A timeout, unknown modal,
+failed Compile invocation, worker/COM failure, or unconfirmed cleanup is an
+infrastructure failure and a stop-the-line condition; do not promote evidence
+or change analyzer behavior after such a result. Report executed oracle case
+IDs and bound rule codes in the PR. If an asserted VBE case has no matching
+diagnostic implementation, keep it `unbound` or `partially-bound` with a clear
+note and create a follow-up issue rather than silently leaving the gap.
+
 ## - In final reports, retain the absolute paths of used `tmp_workspaces`, the execution commands, test results, and any unverified items.
 
 ## 3. Documentation Retention Policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added Excel-free VBE oracle binding coverage validation. Rejected fixtures
+  can now declare accepted `negative_controls`; bound rules require rejected
+  positive evidence and accepted forbidden coverage across all declared
+  analyzer surfaces, while historical unbound fixtures remain visible in a
+  deterministic coverage report.
 - Extended the VBE oracle binding contract to resolve diagnostic codes against
   the shared static-analysis registry and validate supported surfaces and
   severities. The public `xlflow rules --json` metadata now includes additive

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ For a compile-error-equivalent diagnostic, use this binding workflow:
 The coverage check is deterministic and does not open Excel:
 
 ```powershell
-go test ./internal/oracle -run TestOracleBindingCoverage -v
+rtk go test ./internal/oracle -run TestOracleBindingCoverage -v
 ```
 
 Malformed pairings and incomplete `bound` rules fail normal tests. Historical

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,32 @@ Include the executed oracle case IDs in the pull request, or state why an
 oracle run was not applicable. See [`docs/specs/vbe-oracle.md`](docs/specs/vbe-oracle.md)
 for fixture format, promotion, prerequisites, and the PR checklist.
 
+For a compile-error-equivalent diagnostic, use this binding workflow:
+
+1. Search the existing oracle corpus before creating a new fixture.
+2. Add or identify a minimal VBE-rejected fixture.
+3. Add or identify an adjacent VBE-accepted control.
+4. Run the known controls and the focused oracle cases sequentially.
+5. Promote only confirmed observations with verified cleanup.
+6. Implement the diagnostic from confirmed VBA behavior.
+7. Add the expected diagnostic contract to rejected fixtures.
+8. Add the forbidden contract to accepted controls and list those IDs in the
+   rejected fixture's `analysis.negative_controls`.
+9. Mark the relationship `bound` only when all declared analyzer surfaces are
+   protected; otherwise use `partially-bound` with a binding note.
+10. Run the Excel-free contracts and coverage report, then record rule codes,
+    rejected IDs, accepted control IDs, and executed oracle IDs in the PR.
+
+The coverage check is deterministic and does not open Excel:
+
+```powershell
+go test ./internal/oracle -run TestOracleBindingCoverage -v
+```
+
+Malformed pairings and incomplete `bound` rules fail normal tests. Historical
+`unbound` fixtures are reported but are not failures until their bindings are
+migrated.
+
 ## Release preflight
 
 Before a release that touches workbook automation, VBA import/export, run/test behavior, session handling, or other Excel COM paths, do not rely on CI alone.

--- a/docs/adr/ADR-0026-local-vbe-oracle-evidence.md
+++ b/docs/adr/ADR-0026-local-vbe-oracle-evidence.md
@@ -43,6 +43,15 @@ The oracle is never called by production xlflow commands, deterministic tests,
 or GitHub Actions. Contributors changing static-analysis semantics must run
 the relevant focused cases locally and record their IDs in the PR.
 
+Binding metadata remains fixture-local. A rejected fixture may list accepted
+`negative_controls`; Go validates the complete corpus and requires every bound
+rule to have rejected expected evidence plus accepted forbidden evidence. The
+referenced controls must cover all declared diagnostic surfaces, while
+historical unbound fixtures are reported without becoming an initial CI gate.
+This keeps the relationship reviewable beside the source that needs the
+false-positive protection and makes rule-to-control coverage queryable without
+launching Excel.
+
 ## Consequences
 
 - Analyzer changes can cite empirical VBE compile evidence while normal tests
@@ -55,6 +64,9 @@ the relevant focused cases locally and record their IDs in the PR.
   contamination at the cost of slower fixture runs.
 - VBE evidence must remain separate from policy and maintainability rule
   ownership; accepted VBA may still produce xlflow warnings.
+- Positive/negative coverage catches analyzer drift across future bindings while
+  preserving the Excel-free CI boundary; the trade-off is that a fixture must
+  remain `partially-bound` until every declared surface has an accepted control.
 
 ## Alternatives considered
 
@@ -85,6 +97,7 @@ the relevant focused cases locally and record their IDs in the PR.
 ## Related
 
 - Issue #502
+- Issue #514
 - `docs/adr/ADR-0008-dotnet-excel-bridge.md`
 - `docs/adr/ADR-0010-hybrid-excel-dialog-watcher.md`
 - `docs/adr/ADR-0013-analyze-runtime-risk-ownership.md`

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -148,7 +148,7 @@ themselves; malformed relationships and incomplete `bound` rules do fail.
 Run the Excel-free deterministic report with:
 
 ```powershell
-go test ./internal/oracle -run TestOracleBindingCoverage -v
+rtk go test ./internal/oracle -run TestOracleBindingCoverage -v
 ```
 
 The test reports fixture state counts, complete and incomplete rule counts,

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -141,7 +141,10 @@ the rule registry's supported surfaces are used for this comparison.
 The corpus validator also checks that every bound rule has rejected positive
 evidence and an accepted negative control. Existing historical `unbound` and
 `partially-bound` fixtures remain visible in the report and do not fail CI by
-themselves; malformed relationships and incomplete `bound` rules do fail.
+themselves; malformed relationships and incomplete `bound` rules do fail. A
+valid pair attached to a `partially-bound` rejected fixture is informational
+until that parent fixture becomes `bound`, but its controls must still forbid
+one of the parent's declared rule codes.
 
 ## Binding coverage report
 

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -114,6 +114,50 @@ fixture is connected to an implemented rule, keep it `unbound` and do not alter
 the VBE expectation to satisfy an analyzer test. Binding notes must be omitted
 when unnecessary; an explicitly empty or whitespace-only note is invalid.
 
+## Positive/negative binding pairs
+
+Rejected fixtures may identify the accepted fixtures that protect their rules
+from false positives:
+
+```json
+{
+  "analysis": {
+    "binding_status": "bound",
+    "rule_codes": ["VBAxxx"],
+    "negative_controls": ["optional-argument-omitted", "known-named-argument"],
+    "expected_diagnostics": [{ "code": "VBAxxx", "surfaces": ["analyze", "lsp"] }]
+  }
+}
+```
+
+`negative_controls` is valid only on rejected `partially-bound` or `bound`
+fixtures. Each ID must name a distinct, existing, VBE-accepted, bound fixture;
+self-references, rejected controls, duplicate IDs, and cycles are invalid. The
+accepted fixture must forbid the same rule code. A bound rejected fixture is
+complete only when the union of its referenced controls' forbidden surfaces
+covers every surface in its positive contract. When a contract omits surfaces,
+the rule registry's supported surfaces are used for this comparison.
+
+The corpus validator also checks that every bound rule has rejected positive
+evidence and an accepted negative control. Existing historical `unbound` and
+`partially-bound` fixtures remain visible in the report and do not fail CI by
+themselves; malformed relationships and incomplete `bound` rules do fail.
+
+## Binding coverage report
+
+Run the Excel-free deterministic report with:
+
+```powershell
+go test ./internal/oracle -run TestOracleBindingCoverage -v
+```
+
+The test reports fixture state counts, complete and incomplete rule counts,
+sorted unbound/partially-bound fixture IDs, and sorted rule-to-case and
+surface coverage. The committed corpus currently reports 23 asserted fixtures,
+21 `unbound`, 2 `not-applicable`, and no bound rules. The report is emitted
+before a validation failure so missing positive/negative evidence remains
+visible in CI logs.
+
 ## Outcomes and strict mode
 
 Only `accepted` and `rejected` are VBA evidence. A compile dialog associated
@@ -170,13 +214,19 @@ When changing static-analysis semantics (including call/argument validation,
 type inference, object/`Set` diagnostics, parser interpretation, severity, or
 LSP projections):
 
-1. Decide whether the behavior depends on actual VBE semantics.
-2. Add or update an `observe` fixture if there is no existing evidence.
-3. Run both known controls and the focused oracle case IDs locally.
-4. Promote only accepted/rejected observations with confirmed cleanup.
-5. Run deterministic Go and .NET tests.
-6. Include the executed oracle case IDs, or a reason for non-applicability, in
-   the pull request description.
+1. Search existing oracle fixtures before creating new evidence.
+2. Add or update a minimal rejected `observe` fixture when needed.
+3. Add or identify one or more adjacent accepted controls.
+4. Run both known controls and the focused oracle case IDs locally.
+5. Promote only accepted/rejected observations with confirmed cleanup.
+6. Implement the diagnostic using confirmed VBA behavior.
+7. Add `expected_diagnostics` to rejected fixtures.
+8. Add `forbidden_diagnostics` and `negative_controls` to accepted/rejected
+   binding pairs, respectively.
+9. Mark fixtures `bound` only after all declared surfaces are covered; keep
+   incomplete work `partially-bound` with a note.
+10. Run Excel-free contracts and the coverage report, then record rule codes
+    and all executed case IDs in the pull request.
 
 Oracle infrastructure failures are stop-the-line failures for agents and
 contributors. Do not change analyzer behavior or promote fixtures based on a
@@ -191,6 +241,14 @@ cleanup.
       `<case-id-1>`, `<case-id-2>`
 - [ ] A VBE oracle run was not applicable because:
       `<reason>`
+- [ ] Rejected fixtures contain expected diagnostics and `negative_controls`.
+- [ ] Accepted controls forbid the bound rule codes on all declared surfaces.
+- [ ] Rule codes:
+      `<VBAxxx>`
+- [ ] Rejected cases:
+      `<case-id>`
+- [ ] Accepted controls:
+      `<control-id>`
 ```
 
 The oracle remains local-only until an appropriate Excel-installed self-hosted

--- a/internal/oracle/binding_coverage.go
+++ b/internal/oracle/binding_coverage.go
@@ -30,13 +30,14 @@ type BindingCoverage struct {
 // BindingRuleCoverage describes positive and negative evidence for one
 // diagnostic rule. Missing fields explain why a bound rule is incomplete.
 type BindingRuleCoverage struct {
-	Code             string
-	RejectedCases    []string
-	AcceptedControls []string
-	CoveredSurfaces  []string
-	MissingSurfaces  []string
-	MissingPositive  bool
-	MissingNegative  bool
+	Code              string
+	RejectedCases     []string
+	AcceptedControls  []string
+	CoveredSurfaces   []string
+	MissingSurfaces   []string
+	MissingPositive   bool
+	MissingNegative   bool
+	InformationalOnly bool
 }
 
 // ValidateBindingCoverage validates relationships that require the complete
@@ -118,6 +119,16 @@ func ValidateBindingCoverage(cases []Case) (BindingCoverage, error) {
 			if control.Analysis.BindingStatus != BindingBound {
 				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: negative control %q must be bound", c.ID, trimmed))
 			}
+			matchingRule := false
+			for _, forbidden := range control.Analysis.ForbiddenDiagnostics {
+				if containsString(c.Analysis.RuleCodes, forbidden.Code) {
+					matchingRule = true
+					break
+				}
+			}
+			if !matchingRule {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: negative control %q forbids none of the parent rule codes", c.ID, trimmed))
+			}
 		}
 	}
 
@@ -192,12 +203,18 @@ func ValidateBindingCoverage(cases []Case) (BindingCoverage, error) {
 		}
 		for _, code := range c.Analysis.RuleCodes {
 			coverage := ruleMap[code]
-			if coverage == nil || !acceptedReferencedByRejected(c.ID, code, cases) {
-				if coverage == nil {
-					coverage = &BindingRuleCoverage{Code: code}
-					ruleMap[code] = coverage
+			boundReference := acceptedReferencedByRejected(c.ID, code, cases, BindingBound)
+			partialReference := acceptedReferencedByRejected(c.ID, code, cases, BindingPartiallyBound)
+			if coverage == nil {
+				coverage = &BindingRuleCoverage{Code: code}
+				ruleMap[code] = coverage
+			}
+			if !boundReference {
+				if partialReference {
+					coverage.InformationalOnly = true
+				} else {
+					coverage.MissingPositive = true
 				}
-				coverage.MissingPositive = true
 			}
 		}
 	}
@@ -207,13 +224,13 @@ func ValidateBindingCoverage(cases []Case) (BindingCoverage, error) {
 		coverage.AcceptedControls = sortedUnique(coverage.AcceptedControls)
 		coverage.CoveredSurfaces = sortedUnique(coverage.CoveredSurfaces)
 		coverage.MissingSurfaces = sortedUnique(coverage.MissingSurfaces)
-		if coverage.MissingNegative || len(coverage.MissingSurfaces) > 0 || len(coverage.AcceptedControls) == 0 {
+		if !coverage.InformationalOnly && (coverage.MissingNegative || len(coverage.MissingSurfaces) > 0 || len(coverage.AcceptedControls) == 0) {
 			report.MissingNegativeRules++
 		}
-		if coverage.MissingPositive || len(coverage.RejectedCases) == 0 {
+		if !coverage.InformationalOnly && (coverage.MissingPositive || len(coverage.RejectedCases) == 0) {
 			report.MissingPositiveRules++
 		}
-		if !coverage.MissingPositive && !coverage.MissingNegative && len(coverage.RejectedCases) > 0 && len(coverage.AcceptedControls) > 0 && len(coverage.MissingSurfaces) == 0 {
+		if !coverage.InformationalOnly && !coverage.MissingPositive && !coverage.MissingNegative && len(coverage.RejectedCases) > 0 && len(coverage.AcceptedControls) > 0 && len(coverage.MissingSurfaces) == 0 {
 			report.CompleteRules++
 		}
 		report.Rules = append(report.Rules, *coverage)
@@ -233,10 +250,10 @@ func ValidateBindingCoverage(cases []Case) (BindingCoverage, error) {
 func coverageValidationErrors(rulesCoverage []BindingRuleCoverage) []string {
 	var result []string
 	for _, coverage := range rulesCoverage {
-		if coverage.MissingPositive || len(coverage.RejectedCases) == 0 {
+		if !coverage.InformationalOnly && (coverage.MissingPositive || len(coverage.RejectedCases) == 0) {
 			result = append(result, fmt.Sprintf("rule %s: missing rejected positive evidence", coverage.Code))
 		}
-		if coverage.MissingNegative || len(coverage.MissingSurfaces) > 0 || len(coverage.AcceptedControls) == 0 {
+		if !coverage.InformationalOnly && (coverage.MissingNegative || len(coverage.MissingSurfaces) > 0 || len(coverage.AcceptedControls) == 0) {
 			message := fmt.Sprintf("rule %s: missing accepted negative coverage", coverage.Code)
 			if len(coverage.MissingSurfaces) > 0 {
 				message += fmt.Sprintf(" on surfaces %s", strings.Join(coverage.MissingSurfaces, ", "))
@@ -288,9 +305,9 @@ func validateNegativeControlCycles(cases []Case, byID map[string]Case) []string 
 	return uniqueStrings(result)
 }
 
-func acceptedReferencedByRejected(controlID, code string, cases []Case) bool {
+func acceptedReferencedByRejected(controlID, code string, cases []Case, status string) bool {
 	for _, c := range cases {
-		if c.VBE.Expected != ExpectedRejected || c.Analysis.BindingStatus != BindingBound || !containsString(c.Analysis.RuleCodes, code) {
+		if c.VBE.Expected != ExpectedRejected || c.Analysis.BindingStatus != status || !containsString(c.Analysis.RuleCodes, code) {
 			continue
 		}
 		if containsString(c.Analysis.NegativeControls, controlID) {
@@ -383,7 +400,7 @@ func (r BindingCoverage) String() string {
 	if len(r.Rules) > 0 {
 		fmt.Fprintln(&b, "\nRules:")
 		for _, coverage := range r.Rules {
-			fmt.Fprintf(&b, "- %s: rejected=[%s] accepted=[%s] covered_surfaces=[%s] missing_surfaces=[%s]\n", coverage.Code, strings.Join(coverage.RejectedCases, ", "), strings.Join(coverage.AcceptedControls, ", "), strings.Join(coverage.CoveredSurfaces, ", "), strings.Join(coverage.MissingSurfaces, ", "))
+			fmt.Fprintf(&b, "- %s: rejected=[%s] accepted=[%s] covered_surfaces=[%s] missing_surfaces=[%s] informational_only=%t\n", coverage.Code, strings.Join(coverage.RejectedCases, ", "), strings.Join(coverage.AcceptedControls, ", "), strings.Join(coverage.CoveredSurfaces, ", "), strings.Join(coverage.MissingSurfaces, ", "), coverage.InformationalOnly)
 		}
 	}
 	return strings.TrimRight(b.String(), "\n")

--- a/internal/oracle/binding_coverage.go
+++ b/internal/oracle/binding_coverage.go
@@ -1,0 +1,390 @@
+package oracle
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/staticanalysis/rules"
+)
+
+// BindingCoverage is the deterministic, Excel-free summary of the oracle
+// corpus. Rules and fixture IDs are sorted before they are stored in the
+// report so callers can safely render or compare it.
+type BindingCoverage struct {
+	AssertedFixtures int
+	BoundFixtures    int
+	PartialFixtures  int
+	UnboundFixtures  int
+	NotApplicable    int
+
+	CompleteRules        int
+	MissingNegativeRules int
+	MissingPositiveRules int
+
+	UnboundIDs []string
+	PartialIDs []string
+	Rules      []BindingRuleCoverage
+}
+
+// BindingRuleCoverage describes positive and negative evidence for one
+// diagnostic rule. Missing fields explain why a bound rule is incomplete.
+type BindingRuleCoverage struct {
+	Code             string
+	RejectedCases    []string
+	AcceptedControls []string
+	CoveredSurfaces  []string
+	MissingSurfaces  []string
+	MissingPositive  bool
+	MissingNegative  bool
+}
+
+// ValidateBindingCoverage validates relationships that require the complete
+// fixture corpus. It returns a report even when validation fails, allowing a
+// caller to print useful deterministic diagnostics before failing CI.
+func ValidateBindingCoverage(cases []Case) (BindingCoverage, error) {
+	report := BindingCoverage{}
+	byID := make(map[string]Case, len(cases))
+	var validationErrors []string
+	for _, c := range cases {
+		if _, exists := byID[c.ID]; exists {
+			validationErrors = append(validationErrors, fmt.Sprintf("duplicate oracle case %q", c.ID))
+			continue
+		}
+		byID[c.ID] = c
+		switch c.VBE.Expected {
+		case ExpectedAccepted, ExpectedRejected:
+			report.AssertedFixtures++
+		}
+		switch c.Analysis.BindingStatus {
+		case BindingBound:
+			report.BoundFixtures++
+		case BindingPartiallyBound:
+			report.PartialFixtures++
+			report.PartialIDs = append(report.PartialIDs, c.ID)
+		case BindingUnbound:
+			report.UnboundFixtures++
+			report.UnboundIDs = append(report.UnboundIDs, c.ID)
+		case BindingNotApplicable:
+			report.NotApplicable++
+		}
+		for _, code := range c.Analysis.RuleCodes {
+			if _, err := canonicalRuleMetadata(code); err != nil {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: %v", c.ID, err))
+			}
+		}
+		for _, expectation := range append(append([]DiagnosticExpectation(nil), c.Analysis.ExpectedDiagnostics...), c.Analysis.ForbiddenDiagnostics...) {
+			if _, err := canonicalRuleMetadata(expectation.Code); err != nil {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: %v", c.ID, err))
+			}
+		}
+	}
+
+	for _, c := range cases {
+		controls := c.Analysis.NegativeControls
+		if len(controls) == 0 {
+			continue
+		}
+		if c.VBE.Expected != ExpectedRejected {
+			validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: negative_controls are allowed only on rejected fixtures", c.ID))
+		}
+		if c.Analysis.BindingStatus != BindingPartiallyBound && c.Analysis.BindingStatus != BindingBound {
+			validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: negative_controls require partially-bound or bound status", c.ID))
+		}
+		seenControls := make(map[string]struct{}, len(controls))
+		for _, controlID := range controls {
+			trimmed := strings.TrimSpace(controlID)
+			if trimmed == "" || trimmed != controlID || !caseIDPattern.MatchString(trimmed) {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: invalid negative control ID %q", c.ID, controlID))
+				continue
+			}
+			if _, duplicate := seenControls[trimmed]; duplicate {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: duplicate negative control %q", c.ID, trimmed))
+				continue
+			}
+			seenControls[trimmed] = struct{}{}
+			if trimmed == c.ID {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: negative control cannot reference itself", c.ID))
+				continue
+			}
+			control, ok := byID[trimmed]
+			if !ok {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: negative control %q does not exist", c.ID, trimmed))
+				continue
+			}
+			if control.VBE.Expected != ExpectedAccepted {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: negative control %q is not VBE accepted", c.ID, trimmed))
+			}
+			if control.Analysis.BindingStatus != BindingBound {
+				validationErrors = append(validationErrors, fmt.Sprintf("oracle case %q: negative control %q must be bound", c.ID, trimmed))
+			}
+		}
+	}
+
+	// Keep the graph check explicit even though the accepted-only target rule
+	// makes cycles impossible in valid data. This protects the contract if the
+	// relationship rules are extended later.
+	validationErrors = append(validationErrors, validateNegativeControlCycles(cases, byID)...)
+
+	ruleMap := make(map[string]*BindingRuleCoverage)
+	for _, c := range cases {
+		if c.Analysis.BindingStatus != BindingBound {
+			continue
+		}
+		for _, code := range c.Analysis.RuleCodes {
+			coverage := ruleMap[code]
+			if coverage == nil {
+				coverage = &BindingRuleCoverage{Code: code}
+				ruleMap[code] = coverage
+			}
+			if c.VBE.Expected == ExpectedRejected {
+				coverage.RejectedCases = appendUnique(coverage.RejectedCases, c.ID)
+			}
+		}
+	}
+
+	for _, c := range cases {
+		if c.Analysis.BindingStatus != BindingBound || c.VBE.Expected != ExpectedRejected {
+			continue
+		}
+		for _, code := range c.Analysis.RuleCodes {
+			coverage := ruleMap[code]
+			positiveSurfaces := expectedSurfaces(c.Analysis.ExpectedDiagnostics, code)
+			controlIDs := c.Analysis.NegativeControls
+			matchedControl := false
+			localCoveredSurfaces := []string{}
+			for _, controlID := range controlIDs {
+				control, ok := byID[controlID]
+				if !ok || control.Analysis.BindingStatus != BindingBound || control.VBE.Expected != ExpectedAccepted {
+					continue
+				}
+				for _, forbidden := range control.Analysis.ForbiddenDiagnostics {
+					if forbidden.Code != code {
+						continue
+					}
+					matchedControl = true
+					coverage.AcceptedControls = appendUnique(coverage.AcceptedControls, control.ID)
+					for _, surface := range effectiveSurfaces(code, forbidden.Surfaces) {
+						coverage.CoveredSurfaces = appendUnique(coverage.CoveredSurfaces, surface)
+						localCoveredSurfaces = appendUnique(localCoveredSurfaces, surface)
+					}
+				}
+			}
+			if !matchedControl {
+				coverage.MissingNegative = true
+			}
+			localMissingSurfaces := []string{}
+			for _, surface := range positiveSurfaces {
+				if !containsString(localCoveredSurfaces, surface) {
+					localMissingSurfaces = appendUnique(localMissingSurfaces, surface)
+					coverage.MissingSurfaces = appendUnique(coverage.MissingSurfaces, surface)
+				}
+			}
+			if len(localMissingSurfaces) > 0 {
+				validationErrors = append(validationErrors, fmt.Sprintf("fixture %s rule %s: missing accepted coverage on surfaces %s", c.ID, code, strings.Join(sortedUnique(localMissingSurfaces), ", ")))
+			}
+		}
+	}
+
+	for _, c := range cases {
+		if c.Analysis.BindingStatus != BindingBound || c.VBE.Expected != ExpectedAccepted {
+			continue
+		}
+		for _, code := range c.Analysis.RuleCodes {
+			coverage := ruleMap[code]
+			if coverage == nil || !acceptedReferencedByRejected(c.ID, code, cases) {
+				if coverage == nil {
+					coverage = &BindingRuleCoverage{Code: code}
+					ruleMap[code] = coverage
+				}
+				coverage.MissingPositive = true
+			}
+		}
+	}
+
+	for _, coverage := range ruleMap {
+		coverage.RejectedCases = sortedUnique(coverage.RejectedCases)
+		coverage.AcceptedControls = sortedUnique(coverage.AcceptedControls)
+		coverage.CoveredSurfaces = sortedUnique(coverage.CoveredSurfaces)
+		coverage.MissingSurfaces = sortedUnique(coverage.MissingSurfaces)
+		if coverage.MissingNegative || len(coverage.MissingSurfaces) > 0 || len(coverage.AcceptedControls) == 0 {
+			report.MissingNegativeRules++
+		}
+		if coverage.MissingPositive || len(coverage.RejectedCases) == 0 {
+			report.MissingPositiveRules++
+		}
+		if !coverage.MissingPositive && !coverage.MissingNegative && len(coverage.RejectedCases) > 0 && len(coverage.AcceptedControls) > 0 && len(coverage.MissingSurfaces) == 0 {
+			report.CompleteRules++
+		}
+		report.Rules = append(report.Rules, *coverage)
+	}
+	sort.Slice(report.Rules, func(i, j int) bool { return report.Rules[i].Code < report.Rules[j].Code })
+	sort.Strings(report.UnboundIDs)
+	sort.Strings(report.PartialIDs)
+
+	validationErrors = append(validationErrors, coverageValidationErrors(report.Rules)...)
+	if len(validationErrors) > 0 {
+		sort.Strings(validationErrors)
+		return report, fmt.Errorf("oracle binding coverage validation failed:\n- %s", strings.Join(uniqueStrings(validationErrors), "\n- "))
+	}
+	return report, nil
+}
+
+func coverageValidationErrors(rulesCoverage []BindingRuleCoverage) []string {
+	var result []string
+	for _, coverage := range rulesCoverage {
+		if coverage.MissingPositive || len(coverage.RejectedCases) == 0 {
+			result = append(result, fmt.Sprintf("rule %s: missing rejected positive evidence", coverage.Code))
+		}
+		if coverage.MissingNegative || len(coverage.MissingSurfaces) > 0 || len(coverage.AcceptedControls) == 0 {
+			message := fmt.Sprintf("rule %s: missing accepted negative coverage", coverage.Code)
+			if len(coverage.MissingSurfaces) > 0 {
+				message += fmt.Sprintf(" on surfaces %s", strings.Join(coverage.MissingSurfaces, ", "))
+			}
+			result = append(result, message)
+		}
+	}
+	return result
+}
+
+func validateNegativeControlCycles(cases []Case, byID map[string]Case) []string {
+	graph := make(map[string][]string)
+	for _, c := range cases {
+		graph[c.ID] = append([]string(nil), c.Analysis.NegativeControls...)
+	}
+	state := make(map[string]uint8)
+	var stack []string
+	var result []string
+	var visit func(string)
+	visit = func(id string) {
+		switch state[id] {
+		case 1:
+			start := 0
+			for i, value := range stack {
+				if value == id {
+					start = i
+					break
+				}
+			}
+			cycle := append(append([]string(nil), stack[start:]...), id)
+			result = append(result, fmt.Sprintf("negative control cycle: %s", strings.Join(cycle, " -> ")))
+			return
+		case 2:
+			return
+		}
+		state[id] = 1
+		stack = append(stack, id)
+		for _, target := range graph[id] {
+			if _, ok := byID[target]; ok {
+				visit(target)
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[id] = 2
+	}
+	for _, c := range cases {
+		visit(c.ID)
+	}
+	return uniqueStrings(result)
+}
+
+func acceptedReferencedByRejected(controlID, code string, cases []Case) bool {
+	for _, c := range cases {
+		if c.VBE.Expected != ExpectedRejected || c.Analysis.BindingStatus != BindingBound || !containsString(c.Analysis.RuleCodes, code) {
+			continue
+		}
+		if containsString(c.Analysis.NegativeControls, controlID) {
+			return true
+		}
+	}
+	return false
+}
+
+func expectedSurfaces(expectations []DiagnosticExpectation, code string) []string {
+	var surfaces []string
+	for _, expectation := range expectations {
+		if expectation.Code == code {
+			surfaces = append(surfaces, effectiveSurfaces(code, expectation.Surfaces)...)
+		}
+	}
+	if len(surfaces) == 0 {
+		return effectiveSurfaces(code, nil)
+	}
+	return sortedUnique(surfaces)
+}
+
+func effectiveSurfaces(code string, declared []string) []string {
+	if len(declared) > 0 {
+		return sortedUnique(append([]string(nil), declared...))
+	}
+	rule, ok := rules.Lookup(code)
+	if !ok {
+		return nil
+	}
+	surfaces := make([]string, 0, len(rule.Surfaces))
+	for _, surface := range rule.Surfaces {
+		surfaces = append(surfaces, string(surface))
+	}
+	return sortedUnique(surfaces)
+}
+
+func appendUnique(values []string, value string) []string {
+	if !containsString(values, value) {
+		return append(values, value)
+	}
+	return values
+}
+
+func sortedUnique(values []string) []string {
+	result := uniqueStrings(values)
+	sort.Strings(result)
+	return result
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+// String renders a stable human-readable report suitable for go test -v.
+func (r BindingCoverage) String() string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "VBE oracle binding coverage")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "Asserted fixtures: %d\n", r.AssertedFixtures)
+	fmt.Fprintf(&b, "Bound: %d\n", r.BoundFixtures)
+	fmt.Fprintf(&b, "Partially bound: %d\n", r.PartialFixtures)
+	fmt.Fprintf(&b, "Unbound: %d\n", r.UnboundFixtures)
+	fmt.Fprintf(&b, "Not applicable: %d\n", r.NotApplicable)
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "Rules with complete positive/negative coverage: %d\n", r.CompleteRules)
+	fmt.Fprintf(&b, "Rules missing accepted controls: %d\n", r.MissingNegativeRules)
+	fmt.Fprintf(&b, "Rules missing rejected evidence: %d\n", r.MissingPositiveRules)
+	if len(r.UnboundIDs) > 0 {
+		fmt.Fprintln(&b, "\nUnbound fixtures:")
+		for _, id := range r.UnboundIDs {
+			fmt.Fprintf(&b, "- %s\n", id)
+		}
+	}
+	if len(r.PartialIDs) > 0 {
+		fmt.Fprintln(&b, "\nPartially-bound fixtures:")
+		for _, id := range r.PartialIDs {
+			fmt.Fprintf(&b, "- %s\n", id)
+		}
+	}
+	if len(r.Rules) > 0 {
+		fmt.Fprintln(&b, "\nRules:")
+		for _, coverage := range r.Rules {
+			fmt.Fprintf(&b, "- %s: rejected=[%s] accepted=[%s] covered_surfaces=[%s] missing_surfaces=[%s]\n", coverage.Code, strings.Join(coverage.RejectedCases, ", "), strings.Join(coverage.AcceptedControls, ", "), strings.Join(coverage.CoveredSurfaces, ", "), strings.Join(coverage.MissingSurfaces, ", "))
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/oracle/binding_coverage_test.go
+++ b/internal/oracle/binding_coverage_test.go
@@ -131,6 +131,35 @@ func TestValidateBindingCoverageRequiresCompletePositiveNegativeCoverage(t *test
 	}
 }
 
+func TestValidateBindingCoverageKeepsPartiallyBoundPairsInformational(t *testing.T) {
+	partial := coverageRejected("partial", "VBA101", []string{"accepted"}, nil)
+	partial.Analysis.BindingStatus = BindingPartiallyBound
+	report, err := ValidateBindingCoverage([]Case{
+		partial,
+		coverageAccepted("accepted", "VBA101", nil),
+	})
+	if err != nil {
+		t.Fatalf("ValidateBindingCoverage() error = %v", err)
+	}
+	if report.MissingPositiveRules != 0 || report.CompleteRules != 0 {
+		t.Fatalf("partial relationship should remain informational: %+v", report)
+	}
+	if len(report.Rules) != 1 || !report.Rules[0].InformationalOnly {
+		t.Fatalf("expected informational-only rule coverage: %+v", report.Rules)
+	}
+}
+
+func TestValidateBindingCoverageRequiresParentRuleMatchForControls(t *testing.T) {
+	partial := coverageRejected("partial", "VBA101", []string{"unrelated"}, nil)
+	partial.Analysis.BindingStatus = BindingPartiallyBound
+	if _, err := ValidateBindingCoverage([]Case{
+		partial,
+		coverageAccepted("unrelated", "VBA102", nil),
+	}); err == nil || !strings.Contains(err.Error(), "forbids none of the parent rule codes") {
+		t.Fatalf("ValidateBindingCoverage() error = %v, want parent-rule mismatch", err)
+	}
+}
+
 func TestValidateBindingCoverageRejectsNegativeControlCycle(t *testing.T) {
 	a := coverageRejected("a", "VBA101", []string{"b"}, nil)
 	b := coverageRejected("b", "VBA101", []string{"a"}, nil)

--- a/internal/oracle/binding_coverage_test.go
+++ b/internal/oracle/binding_coverage_test.go
@@ -1,0 +1,185 @@
+package oracle
+
+import (
+	"strings"
+	"testing"
+)
+
+func coverageRejected(id, code string, controls []string, surfaces []string) Case {
+	return Case{
+		ID:  id,
+		VBE: VBEExpectation{Expected: ExpectedRejected},
+		Analysis: AnalysisExpectation{
+			BindingStatus:    BindingBound,
+			RuleCodes:        []string{code},
+			NegativeControls: controls,
+			ExpectedDiagnostics: []DiagnosticExpectation{{
+				Code: code, Surfaces: surfaces,
+			}},
+		},
+	}
+}
+
+func coverageAccepted(id, code string, surfaces []string) Case {
+	return Case{
+		ID:  id,
+		VBE: VBEExpectation{Expected: ExpectedAccepted},
+		Analysis: AnalysisExpectation{
+			BindingStatus: BindingBound,
+			RuleCodes:     []string{code},
+			ForbiddenDiagnostics: []DiagnosticExpectation{{
+				Code: code, Surfaces: surfaces,
+			}},
+		},
+	}
+}
+
+func TestValidateBindingCoverageAcceptsCompletePair(t *testing.T) {
+	cases := []Case{
+		coverageRejected("rejected", "VBA101", []string{"accepted"}, nil),
+		coverageAccepted("accepted", "VBA101", nil),
+	}
+	report, err := ValidateBindingCoverage(cases)
+	if err != nil {
+		t.Fatalf("ValidateBindingCoverage() error = %v", err)
+	}
+	if report.CompleteRules != 1 || report.MissingNegativeRules != 0 || report.MissingPositiveRules != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if got := report.Rules[0].CoveredSurfaces; len(got) != 1 || got[0] != "analyze" {
+		t.Fatalf("covered surfaces = %v, want [analyze]", got)
+	}
+}
+
+func TestValidateBindingCoverageRejectsInvalidControls(t *testing.T) {
+	tests := []struct {
+		name       string
+		controls   []string
+		extraCases []Case
+		errSubstr  string
+	}{
+		{name: "unknown", controls: []string{"missing"}, errSubstr: "does not exist"},
+		{name: "self", controls: []string{"rejected"}, errSubstr: "cannot reference itself"},
+		{name: "duplicate", controls: []string{"accepted", "accepted"}, extraCases: []Case{coverageAccepted("accepted", "VBA101", nil)}, errSubstr: "duplicate negative control"},
+		{name: "rejected control", controls: []string{"other"}, extraCases: []Case{coverageRejected("other", "VBA101", nil, nil)}, errSubstr: "is not VBE accepted"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cases := []Case{coverageRejected("rejected", "VBA101", tt.controls, nil)}
+			cases = append(cases, tt.extraCases...)
+			if _, err := ValidateBindingCoverage(cases); err == nil || !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("ValidateBindingCoverage() error = %v, want substring %q", err, tt.errSubstr)
+			}
+		})
+	}
+}
+
+func TestValidateBindingCoverageRequiresCompletePositiveNegativeCoverage(t *testing.T) {
+	tests := []struct {
+		name      string
+		cases     []Case
+		errSubstr string
+	}{
+		{
+			name: "missing control",
+			cases: []Case{
+				coverageRejected("rejected", "VBA101", nil, []string{"analyze"}),
+				coverageAccepted("accepted", "VBA101", []string{"analyze"}),
+			},
+			errSubstr: "missing accepted negative coverage",
+		},
+		{
+			name: "control does not forbid code",
+			cases: []Case{
+				coverageRejected("rejected", "VBA101", []string{"accepted"}, []string{"analyze"}),
+				coverageAccepted("accepted", "VBA102", []string{"analyze"}),
+			},
+			errSubstr: "missing accepted negative coverage",
+		},
+		{
+			name: "missing positive",
+			cases: []Case{
+				coverageAccepted("accepted", "VBA101", []string{"analyze"}),
+			},
+			errSubstr: "missing rejected positive evidence",
+		},
+		{
+			name: "surface gap",
+			cases: []Case{
+				coverageRejected("rejected", "VBA206", []string{"accepted"}, []string{"analyze", "lsp"}),
+				coverageAccepted("accepted", "VBA206", []string{"analyze"}),
+			},
+			errSubstr: "on surfaces lsp",
+		},
+		{
+			name: "surfaces split across rejected fixtures",
+			cases: []Case{
+				coverageRejected("rejected-analyze", "VBA206", []string{"analyze-control"}, []string{"analyze", "lsp"}),
+				coverageRejected("rejected-lsp", "VBA206", []string{"lsp-control"}, []string{"analyze", "lsp"}),
+				coverageAccepted("analyze-control", "VBA206", []string{"analyze"}),
+				coverageAccepted("lsp-control", "VBA206", []string{"lsp"}),
+			},
+			errSubstr: "fixture rejected-analyze rule VBA206",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ValidateBindingCoverage(tt.cases); err == nil || !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("ValidateBindingCoverage() error = %v, want substring %q", err, tt.errSubstr)
+			}
+		})
+	}
+}
+
+func TestValidateBindingCoverageRejectsNegativeControlCycle(t *testing.T) {
+	a := coverageRejected("a", "VBA101", []string{"b"}, nil)
+	b := coverageRejected("b", "VBA101", []string{"a"}, nil)
+	if _, err := ValidateBindingCoverage([]Case{a, b}); err == nil || !strings.Contains(err.Error(), "negative control cycle") {
+		t.Fatalf("ValidateBindingCoverage() error = %v, want cycle error", err)
+	}
+}
+
+func TestValidateBindingCoverageRejectsControlsOnWrongFixtureState(t *testing.T) {
+	accepted := coverageAccepted("accepted", "VBA101", nil)
+	accepted.Analysis.NegativeControls = []string{"rejected"}
+	if _, err := ValidateBindingCoverage([]Case{
+		coverageRejected("rejected", "VBA101", nil, nil),
+		accepted,
+	}); err == nil || !strings.Contains(err.Error(), "allowed only on rejected fixtures") {
+		t.Fatalf("ValidateBindingCoverage() error = %v, want wrong-state error", err)
+	}
+
+	partial := coverageRejected("partial", "VBA101", []string{"accepted"}, nil)
+	partial.Analysis.BindingStatus = BindingUnbound
+	if _, err := ValidateBindingCoverage([]Case{partial, coverageAccepted("accepted", "VBA101", nil)}); err == nil || !strings.Contains(err.Error(), "require partially-bound or bound status") {
+		t.Fatalf("ValidateBindingCoverage() error = %v, want status error", err)
+	}
+
+	partialControl := coverageAccepted("partial-control", "VBA101", nil)
+	partialControl.Analysis.BindingStatus = BindingPartiallyBound
+	if _, err := ValidateBindingCoverage([]Case{
+		coverageRejected("partial", "VBA101", []string{"partial-control"}, nil),
+		partialControl,
+	}); err == nil || !strings.Contains(err.Error(), "must be bound") {
+		t.Fatalf("ValidateBindingCoverage() error = %v, want control-bound error", err)
+	}
+}
+
+func TestBindingCoverageStringIsDeterministic(t *testing.T) {
+	report, err := ValidateBindingCoverage([]Case{
+		coverageRejected("z-rejected", "VBA101", []string{"a-accepted"}, nil),
+		coverageAccepted("a-accepted", "VBA101", nil),
+		{ID: "unbound-z", VBE: VBEExpectation{Expected: ExpectedAccepted}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}},
+		{ID: "unbound-a", VBE: VBEExpectation{Expected: ExpectedRejected}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := report.String()
+	if strings.Index(output, "- unbound-a") > strings.Index(output, "- unbound-z") {
+		t.Fatalf("unbound IDs are not sorted:\n%s", output)
+	}
+	if !strings.Contains(output, "Rules with complete positive/negative coverage: 1") {
+		t.Fatalf("report missing complete rule count:\n%s", output)
+	}
+}

--- a/internal/oracle/fixture_contract_test.go
+++ b/internal/oracle/fixture_contract_test.go
@@ -22,6 +22,17 @@ func TestCommittedFixtureContractsWithoutExcel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	corpus := make([]Case, 0, len(manifest.Cases))
+	for _, entry := range manifest.Cases {
+		c, _, err := LoadCase(root, entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		corpus = append(corpus, c)
+	}
+	if _, err := ValidateBindingCoverage(corpus); err != nil {
+		t.Fatal(err)
+	}
 	cfg := config.Default()
 	db, err := vbadb.LoadBuiltin()
 	if err != nil {
@@ -38,8 +49,6 @@ func TestCommittedFixtureContractsWithoutExcel(t *testing.T) {
 				if c.Analysis.BindingStatus != BindingNotApplicable {
 					t.Fatalf("control fixture binding_status = %q, want %q", c.Analysis.BindingStatus, BindingNotApplicable)
 				}
-			} else if c.Analysis.BindingStatus != BindingUnbound {
-				t.Fatalf("fixture binding_status = %q, want initial migration status %q", c.Analysis.BindingStatus, BindingUnbound)
 			}
 			projectRoot := t.TempDir()
 			modulesRoot := filepath.Join(projectRoot, "src", "modules")
@@ -95,5 +104,29 @@ func TestCommittedFixtureContractsWithoutExcel(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestOracleBindingCoverage(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "testdata", "vbe-oracle", "manifest.json")
+	manifest, root, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corpus := make([]Case, 0, len(manifest.Cases))
+	for _, entry := range manifest.Cases {
+		c, _, err := LoadCase(root, entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		corpus = append(corpus, c)
+	}
+	report, err := ValidateBindingCoverage(corpus)
+	t.Log("\n" + report.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.AssertedFixtures != 23 || report.UnboundFixtures != 21 || report.NotApplicable != 2 {
+		t.Fatalf("unexpected current corpus coverage: %+v", report)
 	}
 }

--- a/internal/oracle/manifest.go
+++ b/internal/oracle/manifest.go
@@ -152,6 +152,7 @@ type AnalysisExpectation struct {
 	BindingStatus        string                  `json:"binding_status"`
 	RuleCodes            []string                `json:"rule_codes,omitempty"`
 	BindingNote          *string                 `json:"binding_note,omitempty"`
+	NegativeControls     []string                `json:"negative_controls,omitempty"`
 	ExpectedDiagnostics  []DiagnosticExpectation `json:"expected_diagnostics,omitempty"`
 	ForbiddenDiagnostics []DiagnosticExpectation `json:"forbidden_diagnostics,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Add machine-readable `analysis.negative_controls` relationships for VBE oracle fixtures.
- Validate rejected/accepted diagnostic pairing, rule evidence, and complete analyzer-surface coverage across the corpus.
- Add deterministic Excel-free binding coverage reporting and contributor/agent guidance.
- Rebase the branch onto the latest `main` (`4fe4b036`, #517).
- Keep historical unbound fixtures visible without requiring Excel/VBE in CI.

## Tests

- `rtk task verify`
- `rtk task lint`
- `rtk pnpm format:check`

## VBE oracle evidence

- This change adds Excel-free binding validation only; no VBE oracle execution was required.

Closes #514


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic coverage reporting for Excel-free VBE validation.
  * Added support for linking accepted and rejected cases through negative controls.
  * Added checks for diagnostic rules, evidence coverage, duplicate references, and circular controls.

* **Documentation**
  * Updated contributor guidance, specifications, architecture records, and changelog details.
  * Documented diagnostic contracts, rule codes, and required case reporting.

* **Tests**
  * Expanded validation for fixture relationships, incomplete evidence, invalid controls, and consistent report formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->