### PR TITLE
Bind VBA type oracle fixtures

### DIFF
--- a/testdata/vbe-oracle/cases/known-as-type/case.json
+++ b/testdata/vbe-oracle/cases/known-as-type/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "No production diagnostic currently covers local As <Type> declarations, so this accepted built-in-type control cannot yet forbid a corresponding rule. See follow-up issue #519."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/unknown-as-type/case.json
+++ b/testdata/vbe-oracle/cases/unknown-as-type/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "compile-error"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "No production diagnostic currently covers unresolved local As <Type> declarations; VBA222 is limited to public API signatures and is not applicable. See follow-up issue #519."
   },
   "provenance": {
     "status": "asserted",


### PR DESCRIPTION
## Summary

- Keep the `unknown-as-type` and `known-as-type` VBE oracle fixtures explicitly `unbound` because the current production analyzer has no diagnostic for local `As <Type>` declarations.
- Record the rationale and follow-up issue #519 in both fixture binding notes.
- Preserve the asserted VBE expectations and leave Analyzer, LSP, type-database, and fixture source behavior unchanged.

Closes #513

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/oracle -run 'TestCommittedFixtureContractsWithoutExcel|TestOracleBindingCoverage' -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run 'TestVBA222' -count=1`
- Fixture JSON validation and `git diff --check`

The full repository test suite was not run; targeted tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified analysis notes for local `As <Type>` declarations that lack a production diagnostic.
  - Documented that unresolved local type declarations remain unbound and are not covered by VBA222.
  - Added a reference to the related follow-up issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->