### PR TITLE
test: bind VBE oracle argument fixtures

### DIFF
--- a/internal/oracle/fixture_contract_test.go
+++ b/internal/oracle/fixture_contract_test.go
@@ -126,7 +126,7 @@ func TestOracleBindingCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.AssertedFixtures != 23 || report.UnboundFixtures != 21 || report.NotApplicable != 2 {
+	if report.AssertedFixtures != 23 || report.BoundFixtures != 3 || report.PartialFixtures != 2 || report.UnboundFixtures != 16 || report.NotApplicable != 2 {
 		t.Fatalf("unexpected current corpus coverage: %+v", report)
 	}
 }

--- a/internal/oracle/manifest.go
+++ b/internal/oracle/manifest.go
@@ -427,6 +427,9 @@ func validateAnalysisBinding(c Case) error {
 	hasForbidden := len(analysis.ForbiddenDiagnostics) > 0
 	switch analysis.BindingStatus {
 	case BindingUnbound:
+		if hasExpected || hasForbidden {
+			return fmt.Errorf("oracle case %q: unbound fixture cannot declare analyzer diagnostic contracts", c.ID)
+		}
 		if len(analysis.RuleCodes) > 0 && analysis.BindingNote == nil {
 			return fmt.Errorf("oracle case %q: unbound fixture with rule codes requires analysis.binding_note", c.ID)
 		}

--- a/internal/oracle/manifest.go
+++ b/internal/oracle/manifest.go
@@ -466,18 +466,21 @@ func validateAnalysisBinding(c Case) error {
 			return fmt.Errorf("oracle case %q: not-applicable fixture cannot declare analyzer bindings", c.ID)
 		}
 	}
-	if analysis.BindingStatus != BindingNotApplicable {
+	if analysis.BindingStatus == BindingBound || analysis.BindingStatus == BindingPartiallyBound {
 		contracts := append(append([]DiagnosticExpectation(nil), analysis.ExpectedDiagnostics...), analysis.ForbiddenDiagnostics...)
-		for _, code := range analysis.RuleCodes {
-			if !diagnosticCodeDeclared(code, contracts) {
-				return fmt.Errorf("oracle case %q: analysis rule code %q is not declared by an expected or forbidden diagnostic contract", c.ID, code)
+		if analysis.BindingStatus == BindingBound {
+			for _, code := range analysis.RuleCodes {
+				if !diagnosticCodeDeclared(code, contracts) {
+					return fmt.Errorf("oracle case %q: analysis rule code %q is not declared by an expected or forbidden diagnostic contract", c.ID, code)
+				}
 			}
 		}
-		if analysis.BindingStatus == BindingBound {
-			for _, expectation := range contracts {
-				if _, ok := seenCodes[expectation.Code]; !ok {
+		for _, expectation := range contracts {
+			if _, ok := seenCodes[expectation.Code]; !ok {
+				if analysis.BindingStatus == BindingBound {
 					return fmt.Errorf("oracle case %q: bound diagnostic code %q is not declared by analysis.rule_codes", c.ID, expectation.Code)
 				}
+				return fmt.Errorf("oracle case %q: partially-bound diagnostic code %q is not declared by analysis.rule_codes", c.ID, expectation.Code)
 			}
 		}
 	}

--- a/internal/oracle/manifest_test.go
+++ b/internal/oracle/manifest_test.go
@@ -162,6 +162,12 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 		{name: "unbound rule code needs note", prepare: func(c *Case) {
 			c.Analysis.RuleCodes = []string{"VBA101"}
 		}, wantErr: true},
+		{name: "unbound expected contract", prepare: func(c *Case) {
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
+		}, wantErr: true},
+		{name: "unbound forbidden contract", prepare: func(c *Case) {
+			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
+		}, wantErr: true},
 		{name: "partially-bound needs rule code", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
 			c.Analysis.BindingNote = analysisNote("pending")
@@ -258,9 +264,15 @@ func TestValidateCaseRuleRegistryBindings(t *testing.T) {
 		errSubstr string
 	}{
 		{name: "canonical registry diagnostic", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.RuleCodes = []string{"VBA101"}
+			c.Analysis.BindingNote = analysisNote("registry validation test")
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101", Severity: "warning", Surfaces: []string{"analyze"}}}
 		}},
 		{name: "dynamic severity", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.RuleCodes = []string{"VBA214"}
+			c.Analysis.BindingNote = analysisNote("registry validation test")
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA214", Severity: "error"}}
 		}},
 		{name: "unknown diagnostic code", prepare: func(c *Case) {

--- a/internal/oracle/manifest_test.go
+++ b/internal/oracle/manifest_test.go
@@ -135,6 +135,11 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 			c.Analysis.BindingNote = analysisNote("positive contract is pending")
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 		}},
+		{name: "partially-bound pending contract", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.RuleCodes = []string{"VBA101"}
+			c.Analysis.BindingNote = analysisNote("contract cannot be expressed yet")
+		}},
 		{name: "bound rejected", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
 			c.Analysis.RuleCodes = []string{"VBA101"}
@@ -273,12 +278,12 @@ func TestValidateCaseRuleRegistryBindings(t *testing.T) {
 		{name: "unsupported severity", prepare: func(c *Case) {
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101", Severity: "error"}}
 		}, wantErr: true, errSubstr: "unsupported severity"},
-		{name: "partially-bound rule code needs contract", prepare: func(c *Case) {
+		{name: "partially-bound contract needs declared rule code", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
 			c.Analysis.BindingNote = analysisNote("pending")
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VB002"}}
-		}, wantErr: true, errSubstr: "expected or forbidden diagnostic contract"},
+		}, wantErr: true, errSubstr: "partially-bound diagnostic code"},
 		{name: "bound contract needs rule code", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
 			c.Analysis.RuleCodes = []string{"VBA101"}

--- a/testdata/vbe-oracle/cases/duplicate-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/duplicate-named-argument/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "compile-error"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "VBE rejects duplicate named-argument assignment, but the current analyzer has no corresponding compile-error-equivalent diagnostic. The rejected fixture and its known-named-argument control are tracked in follow-up issue #520."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/function-bare-call/case.json
+++ b/testdata/vbe-oracle/cases/function-bare-call/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "VBE accepts the bare Function call in expression context and the current analyzer emits no compile-error-equivalent diagnostic for this accepted form. No binding contract is applicable in issue #511."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/function-parenthesized-call/case.json
+++ b/testdata/vbe-oracle/cases/function-parenthesized-call/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "VBE accepts the parenthesized Function call in expression context and the current analyzer emits no compile-error-equivalent diagnostic for this accepted form. No binding contract is applicable in issue #511."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/known-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/known-named-argument/case.json
@@ -19,7 +19,14 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VB030"],
+    "forbidden_diagnostics": [
+      {
+        "code": "VB030",
+        "surfaces": ["lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/missing-required-argument/case.json
+++ b/testdata/vbe-oracle/cases/missing-required-argument/case.json
@@ -19,7 +19,16 @@
     "diagnostic_meaning": "compile-error"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VB030"],
+    "negative_controls": ["optional-argument-omitted", "known-named-argument"],
+    "expected_diagnostics": [
+      {
+        "code": "VB030",
+        "severity": "warning",
+        "surfaces": ["lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/optional-argument-omitted/case.json
+++ b/testdata/vbe-oracle/cases/optional-argument-omitted/case.json
@@ -19,7 +19,14 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VB030"],
+    "forbidden_diagnostics": [
+      {
+        "code": "VB030",
+        "surfaces": ["lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/sub-bare-call/case.json
+++ b/testdata/vbe-oracle/cases/sub-bare-call/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "VBE accepts the bare Sub call and the current analyzer emits no compile-error-equivalent diagnostic for this accepted form. No binding contract is applicable in issue #511."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/sub-parenthesized-call/case.json
+++ b/testdata/vbe-oracle/cases/sub-parenthesized-call/case.json
@@ -19,7 +19,9 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "partially-bound",
+    "rule_codes": ["VB022"],
+    "binding_note": "VBE accepts this syntax. Current VB022 is an intentional maintainability warning on lint and LSP, not a compile-error-equivalent diagnostic, so this fixture has no expected or forbidden diagnostic contract in issue #511."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/unknown-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/unknown-named-argument/case.json
@@ -19,7 +19,10 @@
     "diagnostic_meaning": "compile-error"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "partially-bound",
+    "rule_codes": ["VB030"],
+    "binding_note": "The current LSP emits two VB030 diagnostics for this call (excess argument and unknown named argument), while the Excel-free contract intentionally rejects duplicate same-code diagnostics. The incomplete binding is tracked in follow-up issue #520.",
+    "negative_controls": ["known-named-argument"]
   },
   "provenance": {
     "status": "asserted",


### PR DESCRIPTION
## Summary

- Bind the VBE oracle argument fixtures to the existing `VB030` LSP diagnostic with accepted negative controls.
- Record partial and unbound coverage for named-argument and call-syntax cases without changing analyzer behavior or VBE expectations.
- Update partial-binding validation and coverage expectations so incomplete diagnostic contracts remain machine-readable.
- Create follow-up issue [#520](https://github.com/harumiWeb/xlflow/issues/520) for duplicate named arguments and same-code multi-diagnostic handling.
- Closes #511

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/oracle ./internal/lint ./internal/vba/intel` — passed
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/oracle -run 'TestCommittedFixtureContractsWithoutExcel|TestOracleBindingCoverage' -v` — passed
- `rtk pnpm format:check` — passed
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./...` — one unrelated Windows temp-file cleanup failure in `internal/lspserver`; the failing test passed when rerun in isolation
- VBE oracle not rerun; existing fixture evidence is asserted and analyzer semantics are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of diagnostic expectations for fully and partially recognized code patterns.
  * Corrected handling of named-argument scenarios, including missing, optional, known, and unknown arguments.
  * Clarified results for bare and parenthesized procedure calls, distinguishing accepted syntax from warnings or unsupported diagnostics.

* **Tests**
  * Expanded coverage for partial recognition, pending diagnostic contracts, rule-code mismatches, and diagnostic suppression.
  * Updated expected coverage reporting and test metadata for more accurate analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->