### PR TITLE
test(oracle): bind VBE fixtures to existing diagnostics

### DIFF
--- a/internal/oracle/fixture_contract_test.go
+++ b/internal/oracle/fixture_contract_test.go
@@ -126,7 +126,7 @@ func TestOracleBindingCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.AssertedFixtures != 23 || report.UnboundFixtures != 21 || report.NotApplicable != 2 {
+	if report.AssertedFixtures != 23 || report.BoundFixtures != 6 || report.PartialFixtures != 0 || report.UnboundFixtures != 15 || report.NotApplicable != 2 {
 		t.Fatalf("unexpected current corpus coverage: %+v", report)
 	}
 }

--- a/testdata/vbe-oracle/cases/byref-bare-variable/case.json
+++ b/testdata/vbe-oracle/cases/byref-bare-variable/case.json
@@ -19,7 +19,15 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VBA206"],
+    "forbidden_diagnostics": [
+      {
+        "code": "VBA206",
+        "severity": "warning",
+        "surfaces": ["analyze", "lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/byref-compatible/case.json
+++ b/testdata/vbe-oracle/cases/byref-compatible/case.json
@@ -19,7 +19,15 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VBA206"],
+    "forbidden_diagnostics": [
+      {
+        "code": "VBA206",
+        "severity": "warning",
+        "surfaces": ["analyze", "lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/byref-incompatible/case.json
+++ b/testdata/vbe-oracle/cases/byref-incompatible/case.json
@@ -19,7 +19,16 @@
     "diagnostic_meaning": "compile-error"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VBA206"],
+    "negative_controls": ["byref-compatible", "byref-bare-variable"],
+    "expected_diagnostics": [
+      {
+        "code": "VBA206",
+        "severity": "warning",
+        "surfaces": ["analyze", "lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/byref-parenthesized-variable/case.json
+++ b/testdata/vbe-oracle/cases/byref-parenthesized-variable/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "VBE accepts the parenthesized ByRef argument, while the existing VBA206 runtime-safety warning intentionally reports possible mutation loss; it cannot forbid VBA206."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/missing-set-object-assignment/case.json
+++ b/testdata/vbe-oracle/cases/missing-set-object-assignment/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "VBE accepts this policy-level missing-Set case; the existing VBA101 analyze warning is intentionally preserved and is not a compile-equivalent forbidden diagnostic."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/object-to-object-parameter/case.json
+++ b/testdata/vbe-oracle/cases/object-to-object-parameter/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "Accepted Object-to-Object parameter control retained for the missing scalar/Object compatibility rule; no existing diagnostic is bound yet."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/scalar-assignment/case.json
+++ b/testdata/vbe-oracle/cases/scalar-assignment/case.json
@@ -19,7 +19,15 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VB037"],
+    "forbidden_diagnostics": [
+      {
+        "code": "VB037",
+        "severity": "warning",
+        "surfaces": ["lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/scalar-to-object-parameter/case.json
+++ b/testdata/vbe-oracle/cases/scalar-to-object-parameter/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "compile-error"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "binding_note": "VBE rejects scalar-to-Object parameter compatibility, but no existing xlflow diagnostic covers this rule; track a focused follow-up."
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/set-object-target/case.json
+++ b/testdata/vbe-oracle/cases/set-object-target/case.json
@@ -19,7 +19,15 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VB037"],
+    "forbidden_diagnostics": [
+      {
+        "code": "VB037",
+        "severity": "warning",
+        "surfaces": ["lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/set-scalar-target/case.json
+++ b/testdata/vbe-oracle/cases/set-scalar-target/case.json
@@ -19,7 +19,16 @@
     "diagnostic_meaning": "compile-error"
   },
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "bound",
+    "rule_codes": ["VB037"],
+    "negative_controls": ["set-object-target", "scalar-assignment"],
+    "expected_diagnostics": [
+      {
+        "code": "VB037",
+        "severity": "warning",
+        "surfaces": ["lsp"]
+      }
+    ]
   },
   "provenance": {
     "status": "asserted",


### PR DESCRIPTION
## Summary

- Bind six VBE oracle fixtures to the existing `VB037` and `VBA206` diagnostics with positive and negative contracts.
- Keep four fixtures unbound with notes for the existing `VBA101` policy warning and missing scalar/Object compatibility coverage.
- Update the Excel-free binding coverage contract to assert 6 bound, 15 unbound, and 2 not-applicable fixtures.
- Leave analyzer behavior, VBE expectations, provenance, and VBA sources unchanged.

Closes #512

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/oracle -run 'TestCommittedFixtureContractsWithoutExcel|TestOracleBindingCoverage' -v`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/oracle ./internal/analyze ./internal/vba/intel`
- `rtk git diff --check`
- Pre-commit hooks passed after repository formatting.

## VBE oracle status

- The strict command was attempted with both known controls and all ten fixture IDs.
- Execution stopped at `known-compile-accept` because the dedicated Excel process did not exit cleanly during cleanup (Excel 16.0, build 17932, x64). The ten fixture strict cases therefore remain unverified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility analysis for `ByRef` arguments and scalar/object assignments.
  * Added or refined diagnostics for unsafe bindings, including `VBA206` and `VB037`.
  * Clarified handling of accepted VBA/VBE compatibility cases and existing warnings.

* **Tests**
  * Expanded oracle fixture coverage and updated expected analysis and LSP diagnostic results.
  * Added negative controls and compatibility notes for unsupported or intentionally unbound scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->