### PR TITLE
fix: stabilize VBE oracle Excel cleanup and batch locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Stabilized the local VBE oracle cleanup path by closing the disposable
+  workbook before quitting Excel, allowing delayed owned-process exit within a
+  bounded drain, preserving fail-closed behavior for unexpected Excel
+  processes, and emitting structured cleanup diagnostics. Oracle batches now
+  use a crash-released Windows cross-process lock and reject concurrent local
+  runs with `oracle_already_running`.
 - Added Excel-free VBE oracle binding coverage validation. Rejected fixtures
   can now declare accepted `negative_controls`; bound rules require rejected
   positive evidence and accepted forbidden coverage across all declared

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -142,6 +142,29 @@ internal sealed record OwnedExcelProcess(int ProcessId, DateTime? StartTime = nu
     public static OwnedExcelProcess None { get; } = new(0);
 }
 
+internal sealed record OracleCleanupProcessDiagnostic(
+    int ProcessId,
+    DateTime? StartTime,
+    bool ExitConfirmed,
+    string OwnershipBasis);
+
+internal sealed record OracleCleanupDiagnostics(
+    bool Confirmed,
+    IReadOnlyList<OracleCleanupProcessDiagnostic> OwnedProcesses,
+    int DrainAttempts,
+    int RemainingWindows,
+    int RemainingProcesses,
+    string? FailureStage)
+{
+    public static OracleCleanupDiagnostics NotAttempted { get; } = new(
+        true,
+        Array.Empty<OracleCleanupProcessDiagnostic>(),
+        0,
+        0,
+        0,
+        null);
+}
+
 internal sealed class SessionPoisonedException(SessionMetadata metadata)
     : InvalidOperationException("xlflow session is poisoned after an unsafe workbook or Excel COM failure")
 {
@@ -1586,26 +1609,70 @@ internal static class ExcelBridgeSupport
         IList<OwnedExcelProcess> ownedProcesses,
         IReadOnlyList<OwnedExcelProcess> baselineProcesses)
     {
-        ReleaseComObject(workbook);
-        ReleaseComObject(excel);
-        CollectComGarbage();
+        return ReleaseOracleExcelAndGetDiagnostics(workbook, excel, ownedProcesses, baselineProcesses).Confirmed;
+    }
 
-        var confirmed = true;
-        // Re-enumerate for a short bounded drain after releasing COM wrappers:
-        // Excel may materialize a second /automation server while the VBE
-        // worker apartment drains. Only processes proven to be part of the
-        // oracle process tree are eligible for termination.
+    internal static OracleCleanupDiagnostics ReleaseOracleExcelAndGetDiagnostics(
+        object? workbook,
+        object? excel,
+        IList<OwnedExcelProcess> ownedProcesses,
+        IReadOnlyList<OwnedExcelProcess> baselineProcesses)
+    {
+        // Close and quit before releasing the last COM wrappers. Releasing
+        // wrappers alone can leave the dedicated Excel instance alive until
+        // the bridge process exits, which makes cleanup confirmation race the
+        // outer Go deadline.
+        CloseWorkbookAndQuitApplication(workbook, excel);
+        return ConfirmOracleProcessCleanup(
+            ownedProcesses,
+            baselineProcesses,
+            CaptureOwnedExcelProcesses,
+            EnsureOwnedExcelProcessExited,
+            delay: duration => Thread.Sleep(duration));
+    }
+
+    // This overload keeps the process-state decision deterministic and
+    // injectable for tests. The real Excel path above supplies the OS-backed
+    // discovery and exit functions.
+    internal static OracleCleanupDiagnostics ConfirmOracleProcessCleanup(
+        IList<OwnedExcelProcess> ownedProcesses,
+        IReadOnlyList<OwnedExcelProcess> baselineProcesses,
+        Func<IReadOnlyList<OwnedExcelProcess>> discoverProcesses,
+        Func<OwnedExcelProcess, bool> ensureExited,
+        Action<TimeSpan>? delay = null)
+    {
+        var diagnostics = new Dictionary<string, OracleCleanupProcessDiagnostic>(StringComparer.Ordinal);
+        foreach (var process in ownedProcesses)
+        {
+            diagnostics[ProcessDiagnosticKey(process)] = new OracleCleanupProcessDiagnostic(
+                process.ProcessId,
+                process.StartTime,
+                false,
+                "captured-process-pid");
+        }
+
+        var unexpectedProcessObserved = false;
+        var remainingProcesses = 0;
+        var drainAttempts = 0;
+        var allOwnedExited = ownedProcesses.Count == 0;
+
         for (var attempt = 0; attempt < 3; attempt++)
         {
+            drainAttempts++;
             var discovered = false;
-            var unexpectedProcess = false;
-            foreach (var process in CaptureOwnedExcelProcesses())
+            var unexpectedProcessesThisAttempt = 0;
+            foreach (var process in discoverProcesses())
             {
                 if (IsOracleOwnedProcess(process, ownedProcesses))
                 {
                     if (!ownedProcesses.Any(existing => SameOwnedProcess(existing, process)))
                     {
                         ownedProcesses.Add(process);
+                        diagnostics[ProcessDiagnosticKey(process)] = new OracleCleanupProcessDiagnostic(
+                            process.ProcessId,
+                            process.StartTime,
+                            false,
+                            "process-tree-descendant");
                         discovered = true;
                     }
                 }
@@ -1614,26 +1681,58 @@ internal static class ExcelBridgeSupport
                     // A new Excel process without a proven oracle relationship
                     // is evidence that cleanup cannot be confirmed. Leave it
                     // untouched rather than risking a user's unsaved work.
-                    unexpectedProcess = true;
+                    unexpectedProcessObserved = true;
+                    unexpectedProcessesThisAttempt++;
                 }
             }
-            var attemptConfirmed = !unexpectedProcess;
+
+            allOwnedExited = true;
             foreach (var ownedProcess in ownedProcesses)
             {
-                attemptConfirmed &= EnsureOwnedExcelProcessExited(ownedProcess);
+                var exited = ensureExited(ownedProcess);
+                var key = ProcessDiagnosticKey(ownedProcess);
+                var prior = diagnostics.TryGetValue(key, out var existing)
+                    ? existing
+                    : new OracleCleanupProcessDiagnostic(
+                        ownedProcess.ProcessId,
+                        ownedProcess.StartTime,
+                        false,
+                        "captured-process-pid");
+                diagnostics[key] = prior with { ExitConfirmed = exited };
+                allOwnedExited &= exited;
             }
-            confirmed = confirmed && attemptConfirmed;
-            if (confirmed && !discovered)
+
+            remainingProcesses = Math.Max(
+                remainingProcesses,
+                unexpectedProcessesThisAttempt + diagnostics.Values.Count(item => !item.ExitConfirmed));
+            if (!unexpectedProcessObserved && allOwnedExited && !discovered)
             {
                 break;
             }
             if (attempt < 2)
             {
-                Thread.Sleep(250);
+                delay?.Invoke(TimeSpan.FromMilliseconds(250));
             }
         }
-        return confirmed;
+
+        var confirmed = !unexpectedProcessObserved && allOwnedExited && diagnostics.Values.All(item => item.ExitConfirmed);
+        var failureStage = confirmed
+            ? null
+            : unexpectedProcessObserved
+                ? "unexpected-process"
+                : "process-exit-confirmation";
+        return new OracleCleanupDiagnostics(
+            confirmed,
+            diagnostics.Values.OrderBy(item => item.ProcessId).ToArray(),
+            drainAttempts,
+            0,
+            remainingProcesses,
+            failureStage);
     }
+
+    private static string ProcessDiagnosticKey(OwnedExcelProcess process) =>
+        process.ProcessId.ToString(CultureInfo.InvariantCulture) + ":" +
+        (process.StartTime?.Ticks.ToString(CultureInfo.InvariantCulture) ?? "unknown");
 
     private static bool CloseWorkbookAndQuitApplicationCore(object? workbook, object? excel, OwnedExcelProcess ownedProcess)
     {
@@ -1748,7 +1847,9 @@ internal static class ExcelBridgeSupport
 
             if (!IsSameOwnedExcelProcess(process, ownedProcess))
             {
-                return true;
+                // The PID may have been reused. Without a matching start
+                // time, do not claim cleanup or terminate the live process.
+                return false;
             }
 
             process.Kill(entireProcessTree: true);
@@ -1820,7 +1921,7 @@ internal static class ExcelBridgeSupport
         }
         if (ownedProcess.StartTime is null)
         {
-            return true;
+            return false;
         }
         try
         {
@@ -1834,8 +1935,15 @@ internal static class ExcelBridgeSupport
 
     internal static bool SameOwnedProcess(OwnedExcelProcess left, OwnedExcelProcess right)
     {
-        return left.ProcessId == right.ProcessId &&
-               (left.StartTime is null || right.StartTime is null || left.StartTime.Value == right.StartTime.Value);
+        if (left.ProcessId != right.ProcessId)
+        {
+            return false;
+        }
+        if (left.StartTime is not null && right.StartTime is not null)
+        {
+            return left.StartTime.Value == right.StartTime.Value;
+        }
+        return left.StartTime is null && right.StartTime is null;
     }
 
     internal static bool IsOracleOwnedProcess(OwnedExcelProcess candidate, IEnumerable<OwnedExcelProcess> ownedProcesses)

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/ExcelBridgeSupport.cs
@@ -179,6 +179,8 @@ internal sealed record ComFailureInfo(bool Fatal, string HResult, int Number, st
 internal static class ExcelBridgeSupport
 {
     private const int ObjIdNativeOm = unchecked((int)0xFFFFFFF0);
+    private static readonly TimeSpan OracleProcessExitBudget = TimeSpan.FromMilliseconds(11_500);
+    private static readonly TimeSpan OracleCleanupDrainBudget = TimeSpan.FromSeconds(45);
     private static readonly Guid DispatchGuid = new("00020400-0000-0000-C000-000000000046");
     internal static CultureInfo ComInvokeCulture => CultureInfo.CurrentCulture;
 
@@ -1627,8 +1629,10 @@ internal static class ExcelBridgeSupport
             ownedProcesses,
             baselineProcesses,
             CaptureOwnedExcelProcesses,
-            EnsureOwnedExcelProcessExited,
-            delay: duration => Thread.Sleep(duration));
+            EnsureOwnedExcelProcessExitedWithin,
+            ownershipPredicate: null,
+            delay: duration => Thread.Sleep(duration),
+            drainBudget: OracleCleanupDrainBudget);
     }
 
     // This overload keeps the process-state decision deterministic and
@@ -1641,6 +1645,28 @@ internal static class ExcelBridgeSupport
         Func<OwnedExcelProcess, bool> ensureExited,
         Action<TimeSpan>? delay = null)
     {
+        return ConfirmOracleProcessCleanup(
+            ownedProcesses,
+            baselineProcesses,
+            discoverProcesses,
+            (process, _) => ensureExited(process),
+            ownershipPredicate: null,
+            delay,
+            drainBudget: null);
+    }
+
+    internal static OracleCleanupDiagnostics ConfirmOracleProcessCleanup(
+        IList<OwnedExcelProcess> ownedProcesses,
+        IReadOnlyList<OwnedExcelProcess> baselineProcesses,
+        Func<IReadOnlyList<OwnedExcelProcess>> discoverProcesses,
+        Func<OwnedExcelProcess, TimeSpan, bool> ensureExited,
+        Func<OwnedExcelProcess, bool>? ownershipPredicate = null,
+        Action<TimeSpan>? delay = null,
+        TimeSpan? drainBudget = null)
+    {
+        ownershipPredicate ??= process => IsOracleOwnedProcess(process, ownedProcesses);
+        var maxDrainBudget = drainBudget.GetValueOrDefault(OracleCleanupDrainBudget);
+        var drainStopwatch = Stopwatch.StartNew();
         var diagnostics = new Dictionary<string, OracleCleanupProcessDiagnostic>(StringComparer.Ordinal);
         foreach (var process in ownedProcesses)
         {
@@ -1663,7 +1689,7 @@ internal static class ExcelBridgeSupport
             var unexpectedProcessesThisAttempt = 0;
             foreach (var process in discoverProcesses())
             {
-                if (IsOracleOwnedProcess(process, ownedProcesses))
+                if (ownershipPredicate(process))
                 {
                     if (!ownedProcesses.Any(existing => SameOwnedProcess(existing, process)))
                     {
@@ -1689,7 +1715,9 @@ internal static class ExcelBridgeSupport
             allOwnedExited = true;
             foreach (var ownedProcess in ownedProcesses)
             {
-                var exited = ensureExited(ownedProcess);
+                var remainingBudget = maxDrainBudget - drainStopwatch.Elapsed;
+                var exited = remainingBudget > TimeSpan.Zero &&
+                    ensureExited(ownedProcess, remainingBudget > OracleProcessExitBudget ? OracleProcessExitBudget : remainingBudget);
                 var key = ProcessDiagnosticKey(ownedProcess);
                 var prior = diagnostics.TryGetValue(key, out var existing)
                     ? existing
@@ -1702,16 +1730,20 @@ internal static class ExcelBridgeSupport
                 allOwnedExited &= exited;
             }
 
-            remainingProcesses = Math.Max(
-                remainingProcesses,
-                unexpectedProcessesThisAttempt + diagnostics.Values.Count(item => !item.ExitConfirmed));
+            remainingProcesses = unexpectedProcessesThisAttempt + diagnostics.Values.Count(item => !item.ExitConfirmed);
             if (!unexpectedProcessObserved && allOwnedExited && !discovered)
             {
                 break;
             }
             if (attempt < 2)
             {
-                delay?.Invoke(TimeSpan.FromMilliseconds(250));
+                var remainingBudget = maxDrainBudget - drainStopwatch.Elapsed;
+                if (remainingBudget > TimeSpan.Zero)
+                {
+                    delay?.Invoke(remainingBudget > TimeSpan.FromMilliseconds(250)
+                        ? TimeSpan.FromMilliseconds(250)
+                        : remainingBudget);
+                }
             }
         }
 
@@ -1832,15 +1864,21 @@ internal static class ExcelBridgeSupport
 
     private static bool EnsureOwnedExcelProcessExited(OwnedExcelProcess ownedProcess)
     {
-        if (ownedProcess.ProcessId <= 0)
+        return EnsureOwnedExcelProcessExitedWithin(ownedProcess, OracleProcessExitBudget);
+    }
+
+    private static bool EnsureOwnedExcelProcessExitedWithin(OwnedExcelProcess ownedProcess, TimeSpan budget)
+    {
+        if (ownedProcess.ProcessId <= 0 || budget <= TimeSpan.Zero)
         {
             return false;
         }
 
+        var stopwatch = Stopwatch.StartNew();
         try
         {
             using var process = Process.GetProcessById(ownedProcess.ProcessId);
-            if (process.WaitForExit(1500))
+            if (process.WaitForExit(ToWaitMilliseconds(budget, TimeSpan.FromMilliseconds(1500))))
             {
                 return true;
             }
@@ -1858,7 +1896,8 @@ internal static class ExcelBridgeSupport
             // ownership check bounded, but allow the dedicated process time
             // to acknowledge the termination before reporting infrastructure
             // failure.
-            return process.WaitForExit(10000);
+            var remaining = budget - stopwatch.Elapsed;
+            return process.WaitForExit(ToWaitMilliseconds(remaining, TimeSpan.FromSeconds(10)));
         }
         catch (ArgumentException)
         {
@@ -1869,6 +1908,12 @@ internal static class ExcelBridgeSupport
             // The process may already have exited, or Windows may refuse termination.
             return !IsExcelProcessRunning(ownedProcess.ProcessId);
         }
+    }
+
+    private static int ToWaitMilliseconds(TimeSpan value, TimeSpan maximum)
+    {
+        var milliseconds = (value < maximum ? value : maximum).TotalMilliseconds;
+        return (int)Math.Clamp(Math.Ceiling(Math.Max(0, milliseconds)), 0, int.MaxValue);
     }
 
     public static bool IsExcelProcessRunning(int processId)

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleService.cs
@@ -84,6 +84,8 @@ public sealed class VbeOracleService : IVbeOracleService
         var stage = "startup";
         var cleanupConfirmed = true;
         var tempCleanupConfirmed = true;
+        var remainingWindows = 0;
+        var cleanupDiagnostics = OracleCleanupDiagnostics.NotAttempted;
         IReadOnlyList<OwnedExcelProcess> baselineExcelProcesses = Array.Empty<OwnedExcelProcess>();
         var ownedExcelProcesses = new List<OwnedExcelProcess>();
         OracleObservation? observation = null;
@@ -180,6 +182,7 @@ public sealed class VbeOracleService : IVbeOracleService
                 var lingeringDialog = lingeringDialogs.Count == 0 ? null : lingeringDialogs[0];
                 if (lingeringDialog is not null)
                 {
+                    remainingWindows = 1;
                     observation = InfrastructureObservation(
                         "oracle_unknown_modal",
                         "A modal dialog remained after VBE Compile completed.",
@@ -215,11 +218,12 @@ public sealed class VbeOracleService : IVbeOracleService
                         ownedExcelProcesses.Add(process);
                     }
                 }
-                cleanupConfirmed = ExcelBridgeSupport.ReleaseOracleExcelAndConfirmExit(
+                cleanupDiagnostics = ExcelBridgeSupport.ReleaseOracleExcelAndGetDiagnostics(
                     workbook,
                     excel,
                     ownedExcelProcesses,
                     baselineExcelProcesses);
+                cleanupConfirmed = cleanupDiagnostics.Confirmed;
                 workbook = null;
                 excel = null;
             }
@@ -237,6 +241,11 @@ public sealed class VbeOracleService : IVbeOracleService
             }
         }
 
+        if (remainingWindows > 0)
+        {
+            cleanupDiagnostics = cleanupDiagnostics with { RemainingWindows = remainingWindows };
+        }
+
         observation ??= InfrastructureObservation(
             "oracle_worker_output_invalid",
             "The VBE oracle did not produce an observation.",
@@ -248,6 +257,13 @@ public sealed class VbeOracleService : IVbeOracleService
         // deliberately overrides an otherwise accepted or rejected result.
         if (!cleanupConfirmed || !tempCleanupConfirmed)
         {
+            cleanupDiagnostics = cleanupDiagnostics with
+            {
+                Confirmed = false,
+                FailureStage = !cleanupConfirmed
+                    ? cleanupDiagnostics.FailureStage ?? "process-exit-confirmation"
+                    : "temporary-directory",
+            };
             observation = InfrastructureObservation(
                 "oracle_cleanup_unconfirmed",
                 !cleanupConfirmed
@@ -258,7 +274,7 @@ public sealed class VbeOracleService : IVbeOracleService
                 excelMetadata);
         }
 
-        return BuildResponse(request, plan, observation, excelProcessId, cleanupConfirmed && tempCleanupConfirmed);
+        return BuildResponse(request, plan, observation, excelProcessId, cleanupConfirmed && tempCleanupConfirmed, cleanupDiagnostics);
     }
 
     private static OraclePlan DecodePlan(string planJson64)
@@ -511,7 +527,13 @@ public sealed class VbeOracleService : IVbeOracleService
         };
     }
 
-    private static BridgeResponse BuildResponse(BridgeRequest request, OraclePlan plan, OracleObservation observation, int processId, bool cleanupConfirmed)
+    private static BridgeResponse BuildResponse(
+        BridgeRequest request,
+        OraclePlan plan,
+        OracleObservation observation,
+        int processId,
+        bool cleanupConfirmed,
+        OracleCleanupDiagnostics cleanupDiagnostics)
     {
         var oracle = new Dictionary<string, object?>
         {
@@ -523,6 +545,7 @@ public sealed class VbeOracleService : IVbeOracleService
             ["duration_ms"] = Math.Max(0L, (long)observation.Duration.TotalMilliseconds),
             ["compile_invoked"] = observation.CompileInvoked,
             ["cleanup_confirmed"] = cleanupConfirmed,
+            ["cleanup"] = CleanupPayload(cleanupDiagnostics),
             ["excel_process_id"] = processId > 0 ? processId : null,
             ["excel"] = observation.Excel,
             ["metadata"] = new Dictionary<string, object?>
@@ -570,7 +593,32 @@ public sealed class VbeOracleService : IVbeOracleService
     private static BridgeResponse InfrastructureResponse(BridgeRequest request, OraclePlan plan, string code, string message, string stage, int processId, TimeSpan elapsed, Dictionary<string, object?> excel)
     {
         var observation = InfrastructureObservation(code, message, stage, elapsed, excel);
-        return BuildResponse(request, plan, observation, processId, cleanupConfirmed: false);
+        return BuildResponse(
+            request,
+            plan,
+            observation,
+            processId,
+            cleanupConfirmed: false,
+            OracleCleanupDiagnostics.NotAttempted with { Confirmed = false, FailureStage = stage });
+    }
+
+    private static Dictionary<string, object?> CleanupPayload(OracleCleanupDiagnostics cleanup)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["confirmed"] = cleanup.Confirmed,
+            ["owned_processes"] = cleanup.OwnedProcesses.Select(process => new Dictionary<string, object?>
+            {
+                ["pid"] = process.ProcessId,
+                ["start_time"] = process.StartTime?.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+                ["exit_confirmed"] = process.ExitConfirmed,
+                ["ownership_basis"] = process.OwnershipBasis,
+            }).ToArray(),
+            ["drain_attempts"] = cleanup.DrainAttempts,
+            ["remaining_windows"] = cleanup.RemainingWindows,
+            ["remaining_processes"] = cleanup.RemainingProcesses,
+            ["failure_stage"] = cleanup.FailureStage,
+        };
     }
 
     private static OracleObservation InfrastructureObservation(string code, string message, string stage, TimeSpan elapsed, IReadOnlyDictionary<string, object?> excel, DialogSnapshot? dialog = null)

--- a/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleService.cs
+++ b/bridge/dotnet/src/Xlflow.ExcelBridge/Services/VbeOracleService.cs
@@ -169,6 +169,11 @@ public sealed class VbeOracleService : IVbeOracleService
                 cancellationToken,
                 selectionLocator);
             observation = ClassifyInvocation(invocation, stopwatch.Elapsed, excelMetadata);
+            if (invocation.Dialog is not null &&
+                !string.Equals(invocation.Dialog.Kind, "compile", StringComparison.OrdinalIgnoreCase))
+            {
+                remainingWindows = 1;
+            }
             if (observation.Outcome == "accepted")
             {
                 var lingeringDialogs = new DialogWatcher().CaptureOracleDialogs(
@@ -599,7 +604,7 @@ public sealed class VbeOracleService : IVbeOracleService
             observation,
             processId,
             cleanupConfirmed: false,
-            OracleCleanupDiagnostics.NotAttempted with { Confirmed = false, FailureStage = stage });
+            cleanupDiagnostics: OracleCleanupDiagnostics.NotAttempted with { Confirmed = false, FailureStage = "not-attempted" });
     }
 
     private static Dictionary<string, object?> CleanupPayload(OracleCleanupDiagnostics cleanup)

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ExcelBridgeSupportTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ExcelBridgeSupportTests.cs
@@ -178,6 +178,59 @@ public sealed class ExcelBridgeSupportTests
         Assert.True(chart.PasteCalled);
     }
 
+    [Fact]
+    public void ConfirmOracleProcessCleanup_AllowsDelayedOwnedExit()
+    {
+        var owned = new OwnedExcelProcess(1234, new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc));
+        var discoverCalls = 0;
+        var exitCalls = 0;
+        var result = ExcelBridgeSupport.ConfirmOracleProcessCleanup(
+            new List<OwnedExcelProcess> { owned },
+            Array.Empty<OwnedExcelProcess>(),
+            () => ++discoverCalls == 1
+                ? new[] { owned }
+                : Array.Empty<OwnedExcelProcess>(),
+            _ => ++exitCalls >= 2,
+            _ => { });
+
+        Assert.True(result.Confirmed);
+        Assert.Equal(2, result.DrainAttempts);
+        Assert.Equal(2, exitCalls);
+        Assert.Single(result.OwnedProcesses);
+        Assert.True(result.OwnedProcesses[0].ExitConfirmed);
+        Assert.Null(result.FailureStage);
+    }
+
+    [Fact]
+    public void ConfirmOracleProcessCleanup_RemainsFailedAfterUnexpectedProcess()
+    {
+        var owned = new OwnedExcelProcess(1234, new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc));
+        var unrelated = new OwnedExcelProcess(5678, new DateTime(2026, 8, 6, 10, 1, 0, DateTimeKind.Utc));
+        var discoverCalls = 0;
+        var result = ExcelBridgeSupport.ConfirmOracleProcessCleanup(
+            new List<OwnedExcelProcess> { owned },
+            Array.Empty<OwnedExcelProcess>(),
+            () => ++discoverCalls == 1
+                ? new[] { owned, unrelated }
+                : Array.Empty<OwnedExcelProcess>(),
+            _ => true,
+            _ => { });
+
+        Assert.False(result.Confirmed);
+        Assert.Equal("unexpected-process", result.FailureStage);
+        Assert.Single(result.OwnedProcesses);
+        Assert.Equal(1, result.RemainingProcesses);
+    }
+
+    [Fact]
+    public void SameOwnedProcess_DoesNotMatchKnownStartTimeWithUnknownStartTime()
+    {
+        var known = new OwnedExcelProcess(1234, new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc));
+        var unknown = new OwnedExcelProcess(1234);
+
+        Assert.False(ExcelBridgeSupport.SameOwnedProcess(known, unknown));
+    }
+
     public sealed class FakeExcel
     {
         public FakeExcel(params FakeWorkbook[] workbooks)

--- a/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ExcelBridgeSupportTests.cs
+++ b/bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/ExcelBridgeSupportTests.cs
@@ -198,6 +198,7 @@ public sealed class ExcelBridgeSupportTests
         Assert.Equal(2, exitCalls);
         Assert.Single(result.OwnedProcesses);
         Assert.True(result.OwnedProcesses[0].ExitConfirmed);
+        Assert.Equal(0, result.RemainingProcesses);
         Assert.Null(result.FailureStage);
     }
 
@@ -213,13 +214,14 @@ public sealed class ExcelBridgeSupportTests
             () => ++discoverCalls == 1
                 ? new[] { owned, unrelated }
                 : Array.Empty<OwnedExcelProcess>(),
-            _ => true,
-            _ => { });
+            (_, _) => true,
+            ownershipPredicate: candidate => ExcelBridgeSupport.SameOwnedProcess(candidate, owned),
+            delay: _ => { });
 
         Assert.False(result.Confirmed);
         Assert.Equal("unexpected-process", result.FailureStage);
         Assert.Single(result.OwnedProcesses);
-        Assert.Equal(1, result.RemainingProcesses);
+        Assert.Equal(0, result.RemainingProcesses);
     }
 
     [Fact]

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -102,6 +102,12 @@ Task Manager for the recorded owned PID and any dialogs, confirm that no
 oracle-owned Excel remains, and rerun the controls. Do not remove lock files
 manually and do not promote fixtures from that report.
 
+`failure_stage` is `null` after confirmed cleanup. Infrastructure responses
+that did not start Excel use `not-attempted`; cleanup failures use
+`unexpected-process`, `process-exit-confirmation`, or `temporary-directory`.
+The execution stage for platform, startup, import, and compile failures is
+reported separately in `last_stage`.
+
 ## Fixture format
 
 The manifest has `schema_version: 1`, a `controls` object with `accept` and

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -18,6 +18,14 @@ The command only terminates the Excel process it created and recorded. If a run
 reports an unconfirmed cleanup or an infrastructure failure, inspect Task
 Manager before starting another run and do not promote a fixture.
 
+The oracle acquires a per-user Windows cross-process lock for the complete
+batch, including the known controls, selected cases, and any promotion. A
+second local oracle process fails immediately with the structured
+`oracle_already_running` infrastructure error. The lock is an OS-owned file
+lock, so normal process termination and crash termination release it without
+stale-lock cleanup or user confirmation. The lock does not participate in
+normal xlflow workbook coordination.
+
 Dialog detection is tied to the target Excel process/VBE owner chain through
 the existing Win32/UI Automation watcher. The oracle does not use
 `SendKeys` or keyboard-focus scripting.
@@ -50,6 +58,49 @@ To run the health controls explicitly in strict mode:
   --case known-compile-reject `
   --strict
 ```
+
+The per-case timeout applies to the VBE probe. The runner reserves an
+additional bounded cleanup margin for the bridge to close the disposable
+workbook, quit Excel, release COM/UI references, drain owned-process shutdown,
+and emit structured output before the outer process deadline.
+
+## Cleanup diagnostics and recovery
+
+Each bridge observation includes a `cleanup` object. It reports the owned
+Excel process identity, whether exit was confirmed for each owned process, the
+number of drain attempts, remaining dialog/process counts, and the failure
+stage. Unrelated Excel processes are not listed and are never terminated.
+
+For example:
+
+```json
+{
+  "cleanup": {
+    "confirmed": false,
+    "owned_processes": [
+      {
+        "pid": 1234,
+        "start_time": "2026-08-06T10:00:00.0000000Z",
+        "exit_confirmed": false,
+        "ownership_basis": "captured-process-pid"
+      }
+    ],
+    "drain_attempts": 3,
+    "remaining_windows": 0,
+    "remaining_processes": 1,
+    "failure_stage": "process-exit-confirmation"
+  }
+}
+```
+
+A `unexpected-process` failure means that a newly observed Excel process
+could not be proven to belong to the oracle. It is intentionally left alone;
+the run remains failed even if that process disappears during a later drain.
+A `process-exit-confirmation` failure means the captured process could not be
+proven to have exited within the bounded drain. After either failure, inspect
+Task Manager for the recorded owned PID and any dialogs, confirm that no
+oracle-owned Excel remains, and rerun the controls. Do not remove lock files
+manually and do not promote fixtures from that report.
 
 ## Fixture format
 

--- a/internal/oracle/lock.go
+++ b/internal/oracle/lock.go
@@ -1,0 +1,7 @@
+package oracle
+
+import "errors"
+
+const oracleAlreadyRunningMessage = "Another local VBE oracle process is already running"
+
+var errOracleAlreadyRunning = errors.New("another local VBE oracle process is already running")

--- a/internal/oracle/lock_other.go
+++ b/internal/oracle/lock_other.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package oracle
+
+import "context"
+
+type noopBatchLock struct{}
+
+func newBatchLock() (BatchLock, error) {
+	return noopBatchLock{}, nil
+}
+
+func (noopBatchLock) Acquire(ctx context.Context) (func(), error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return func() {}, nil
+}

--- a/internal/oracle/lock_windows.go
+++ b/internal/oracle/lock_windows.go
@@ -51,7 +51,7 @@ func (l fileBatchLock) Acquire(ctx context.Context) (func(), error) {
 	)
 	if err != nil {
 		_ = file.Close()
-		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
 			return nil, errOracleAlreadyRunning
 		}
 		return nil, fmt.Errorf("acquire VBE oracle lock: %w", err)

--- a/internal/oracle/lock_windows.go
+++ b/internal/oracle/lock_windows.go
@@ -1,0 +1,64 @@
+//go:build windows
+
+package oracle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+type fileBatchLock struct {
+	path string
+}
+
+func newBatchLock() (BatchLock, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("locate user cache directory for VBE oracle lock: %w", err)
+	}
+	stateDir := filepath.Join(cacheDir, "xlflow")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create VBE oracle lock directory: %w", err)
+	}
+	return fileBatchLock{path: filepath.Join(stateDir, "vbe-oracle.lock")}, nil
+}
+
+func (l fileBatchLock) Acquire(ctx context.Context) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	file, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open VBE oracle lock: %w", err)
+	}
+	overlapped := windows.Overlapped{}
+	err = windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+	if err != nil {
+		_ = file.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+			return nil, errOracleAlreadyRunning
+		}
+		return nil, fmt.Errorf("acquire VBE oracle lock: %w", err)
+	}
+
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+		_ = file.Close()
+	}, nil
+}

--- a/internal/oracle/lock_windows_test.go
+++ b/internal/oracle/lock_windows_test.go
@@ -9,12 +9,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 )
 
 func TestFileBatchLockRejectsConcurrentProcessAndReleasesAfterCrash(t *testing.T) {
-	lockPath := t.TempDir() + "\\vbe-oracle.lock"
+	lockPath := filepath.Join(t.TempDir(), "vbe-oracle.lock")
 	cmd := exec.Command(os.Args[0], "-test.run=^TestOracleBatchLockHelper$")
 	cmd.Env = append(os.Environ(),
 		"XLFLOW_ORACLE_LOCK_HELPER=1",
@@ -28,16 +29,10 @@ func TestFileBatchLockRejectsConcurrentProcessAndReleasesAfterCrash(t *testing.T
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
-	killed := false
-	defer func() {
-		if !killed && cmd.Process != nil {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-		}
-	}()
-
 	ready := make(chan string, 1)
+	scanDone := make(chan struct{})
 	go func() {
+		defer close(scanDone)
 		scanner := bufio.NewScanner(stdout)
 		if scanner.Scan() {
 			ready <- scanner.Text()
@@ -45,12 +40,26 @@ func TestFileBatchLockRejectsConcurrentProcessAndReleasesAfterCrash(t *testing.T
 		}
 		ready <- ""
 	}()
+	killed := false
+	stopHelper := func() {
+		if killed {
+			return
+		}
+		killed = true
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		<-scanDone
+		_ = cmd.Wait()
+	}
+	defer stopHelper()
 	select {
 	case line := <-ready:
 		if line != "READY" {
 			t.Fatalf("helper output = %q", line)
 		}
 	case <-time.After(10 * time.Second):
+		stopHelper()
 		t.Fatal("helper did not acquire oracle lock")
 	}
 
@@ -59,13 +68,10 @@ func TestFileBatchLockRejectsConcurrentProcessAndReleasesAfterCrash(t *testing.T
 		t.Fatalf("contention error = %v, want oracle_already_running", err)
 	}
 
-	if err := cmd.Process.Kill(); err != nil {
-		t.Fatalf("kill helper: %v", err)
-	}
-	if err := cmd.Wait(); err == nil {
+	stopHelper()
+	if cmd.ProcessState == nil || cmd.ProcessState.Success() {
 		t.Fatal("killed helper unexpectedly exited successfully")
 	}
-	killed = true
 
 	deadline := time.Now().Add(5 * time.Second)
 	for {

--- a/internal/oracle/lock_windows_test.go
+++ b/internal/oracle/lock_windows_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestFileBatchLockRejectsConcurrentProcessAndReleasesAfterCrash(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "vbe-oracle.lock")
-	cmd := exec.Command(os.Args[0], "-test.run=^TestOracleBatchLockHelper$")
+	cmd := exec.Command(os.Args[0], "-test.timeout=0", "-test.run=^TestOracleBatchLockHelper$")
 	cmd.Env = append(os.Environ(),
 		"XLFLOW_ORACLE_LOCK_HELPER=1",
 		"XLFLOW_ORACLE_LOCK_PATH="+lockPath,
@@ -99,5 +99,7 @@ func TestOracleBatchLockHelper(t *testing.T) {
 	}
 	defer release()
 	fmt.Println("READY")
-	select {}
+	timer := time.NewTimer(10 * time.Minute)
+	defer timer.Stop()
+	<-timer.C
 }

--- a/internal/oracle/lock_windows_test.go
+++ b/internal/oracle/lock_windows_test.go
@@ -1,0 +1,97 @@
+//go:build windows
+
+package oracle
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestFileBatchLockRejectsConcurrentProcessAndReleasesAfterCrash(t *testing.T) {
+	lockPath := t.TempDir() + "\\vbe-oracle.lock"
+	cmd := exec.Command(os.Args[0], "-test.run=^TestOracleBatchLockHelper$")
+	cmd.Env = append(os.Environ(),
+		"XLFLOW_ORACLE_LOCK_HELPER=1",
+		"XLFLOW_ORACLE_LOCK_PATH="+lockPath,
+	)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	killed := false
+	defer func() {
+		if !killed && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}()
+
+	ready := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		if scanner.Scan() {
+			ready <- scanner.Text()
+			return
+		}
+		ready <- ""
+	}()
+	select {
+	case line := <-ready:
+		if line != "READY" {
+			t.Fatalf("helper output = %q", line)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("helper did not acquire oracle lock")
+	}
+
+	lock := fileBatchLock{path: lockPath}
+	if _, err := lock.Acquire(context.Background()); !errors.Is(err, errOracleAlreadyRunning) {
+		t.Fatalf("contention error = %v, want oracle_already_running", err)
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill helper: %v", err)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("killed helper unexpectedly exited successfully")
+	}
+	killed = true
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		release, acquireErr := lock.Acquire(context.Background())
+		if acquireErr == nil {
+			release()
+			return
+		}
+		if !errors.Is(acquireErr, errOracleAlreadyRunning) || time.Now().After(deadline) {
+			t.Fatalf("acquire after crash: %v", acquireErr)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestOracleBatchLockHelper(t *testing.T) {
+	if os.Getenv("XLFLOW_ORACLE_LOCK_HELPER") != "1" {
+		t.Skip("subprocess helper")
+	}
+	lock := fileBatchLock{path: os.Getenv("XLFLOW_ORACLE_LOCK_PATH")}
+	release, err := lock.Acquire(context.Background())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	defer release()
+	fmt.Println("READY")
+	select {}
+}

--- a/internal/oracle/runner.go
+++ b/internal/oracle/runner.go
@@ -18,7 +18,7 @@ import (
 const (
 	CommandName                  = "vbe-oracle"
 	DefaultTimeout               = 5 * time.Minute
-	bridgeShutdownMargin         = 30 * time.Second
+	bridgeShutdownMargin         = 60 * time.Second
 	OutcomeAccepted              = "accepted"
 	OutcomeRejected              = "rejected"
 	OutcomeInfrastructureFailure = "infrastructure_failure"
@@ -26,6 +26,13 @@ const (
 
 type BridgeExecutor interface {
 	Execute(context.Context, excelbridge.Request) (excelbridge.Response, error)
+}
+
+// BatchLock serializes the complete local oracle batch. Excel/VBE state is a
+// single-user resource, so locking individual cases would still allow the
+// controls and selected cases from two runs to interleave.
+type BatchLock interface {
+	Acquire(context.Context) (func(), error)
 }
 
 type Options struct {
@@ -36,6 +43,7 @@ type Options struct {
 	DiagnosticMeaning map[string]string
 	Timeout           time.Duration
 	Executor          BridgeExecutor
+	Lock              BatchLock
 	Now               func() time.Time
 }
 
@@ -67,6 +75,7 @@ type CaseResult struct {
 	ExcelProcessID   int                  `json:"excel_process_id,omitempty"`
 	Metadata         VerificationMetadata `json:"metadata,omitempty"`
 	Error            string               `json:"error,omitempty"`
+	Cleanup          map[string]any       `json:"cleanup,omitempty"`
 }
 
 type ExitError struct {
@@ -109,6 +118,7 @@ type bridgeObservation struct {
 	ExcelProcessID   int                  `json:"excel_process_id,omitempty"`
 	Metadata         VerificationMetadata `json:"metadata,omitempty"`
 	Excel            map[string]any       `json:"excel,omitempty"`
+	Cleanup          map[string]any       `json:"cleanup,omitempty"`
 	Error            string               `json:"error,omitempty"`
 	ErrorCode        string               `json:"error_code,omitempty"`
 }
@@ -158,6 +168,24 @@ func runValidated(ctx context.Context, opts Options) (Report, error) {
 	if opts.PromoteObserved && len(opts.CaseIDs) == 0 {
 		return failReport(&report, 2, "--promote-observed requires one or more explicit --case values", "promotion_invalid")
 	}
+	if opts.Lock == nil {
+		lock, lockErr := newBatchLock()
+		if lockErr != nil {
+			return failReport(&report, 3, lockErr.Error(), "oracle_lock_failed")
+		}
+		opts.Lock = lock
+	}
+	release, lockErr := opts.Lock.Acquire(ctx)
+	if lockErr != nil {
+		kind := "oracle_lock_failed"
+		message := lockErr.Error()
+		if errors.Is(lockErr, errOracleAlreadyRunning) {
+			kind = "oracle_already_running"
+			message = oracleAlreadyRunningMessage
+		}
+		return failReport(&report, 3, message, kind)
+	}
+	defer release()
 	// Controls always run first, even when --case selects another fixture.
 	controlIDs := []string{manifest.Controls.Accept, manifest.Controls.Reject}
 	seen := map[string]bool{}
@@ -298,7 +326,7 @@ func runEntry(parent context.Context, root string, entry ManifestEntry, timeout 
 	if metadata.Locale == "" {
 		metadata.Locale = stringValue(obs.Excel, "locale")
 	}
-	result := CaseResult{ID: c.ID, Expected: c.VBE.Expected, Outcome: obs.Outcome, EvidencePhase: obs.EvidencePhase, LastStage: obs.LastStage, CompileInvoked: obs.CompileInvoked, CleanupConfirmed: obs.CleanupConfirmed, DurationMS: obs.DurationMS, Dialog: obs.Dialog, Location: obs.Location, ExcelProcessID: obs.ExcelProcessID, Metadata: metadata, Error: obs.Error}
+	result := CaseResult{ID: c.ID, Expected: c.VBE.Expected, Outcome: obs.Outcome, EvidencePhase: obs.EvidencePhase, LastStage: obs.LastStage, CompileInvoked: obs.CompileInvoked, CleanupConfirmed: obs.CleanupConfirmed, DurationMS: obs.DurationMS, Dialog: obs.Dialog, Location: obs.Location, ExcelProcessID: obs.ExcelProcessID, Metadata: metadata, Cleanup: obs.Cleanup, Error: obs.Error}
 	if result.DurationMS == 0 {
 		result.DurationMS = time.Since(started).Milliseconds()
 	}

--- a/internal/oracle/runner_test.go
+++ b/internal/oracle/runner_test.go
@@ -75,12 +75,30 @@ func (f *oracleFakeBridge) Execute(_ context.Context, req excelbridge.Request) (
 	return excelbridge.Response{Stdout: body}, nil
 }
 
+type oracleFakeBatchLock struct {
+	acquireErr error
+	acquired   bool
+	released   bool
+}
+
+func (f *oracleFakeBatchLock) Acquire(context.Context) (func(), error) {
+	if f.acquireErr != nil {
+		return nil, f.acquireErr
+	}
+	f.acquired = true
+	return func() { f.released = true }, nil
+}
+
 func TestRunControlsStrictAndPromotion(t *testing.T) {
 	manifestPath, _ := writeFixture(t, ExpectedObserve)
 	bridge := &oracleFakeBridge{}
-	report, err := runValidated(context.Background(), Options{ManifestPath: manifestPath, CaseIDs: []string{"sample"}, PromoteObserved: true, DiagnosticMeaning: map[string]string{"sample": MeaningSpecification}, Executor: bridge, Timeout: time.Second})
+	lock := &oracleFakeBatchLock{}
+	report, err := runValidated(context.Background(), Options{ManifestPath: manifestPath, CaseIDs: []string{"sample"}, PromoteObserved: true, DiagnosticMeaning: map[string]string{"sample": MeaningSpecification}, Executor: bridge, Lock: lock, Timeout: time.Second})
 	if err != nil {
 		t.Fatalf("run promotion failed: %v report=%+v", err, report)
+	}
+	if !lock.acquired || !lock.released {
+		t.Fatalf("lock lifecycle acquired=%v released=%v", lock.acquired, lock.released)
 	}
 	if len(bridge.calls) != 2 || bridge.calls[0] != "sample" || bridge.calls[1] != "sample-reject" {
 		t.Fatalf("calls=%v", bridge.calls)
@@ -92,6 +110,30 @@ func TestRunControlsStrictAndPromotion(t *testing.T) {
 	}
 	if c.VBE.Expected != ExpectedAccepted || c.Provenance.Status != "asserted" || c.Analysis.BindingStatus != BindingNotApplicable {
 		t.Fatalf("promotion=%+v", c)
+	}
+}
+
+func TestRunValidatedRejectsConcurrentOracleBatch(t *testing.T) {
+	manifestPath, _ := writeFixture(t, ExpectedObserve)
+	lock := &oracleFakeBatchLock{acquireErr: errOracleAlreadyRunning}
+	report, err := runValidated(context.Background(), Options{
+		ManifestPath: manifestPath,
+		Executor:     &oracleFakeBridge{},
+		Lock:         lock,
+		Timeout:      time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected concurrent oracle failure")
+	}
+	var exit *ExitError
+	if !errors.As(err, &exit) || exit.Code != 3 {
+		t.Fatalf("err=%v, want infrastructure exit code", err)
+	}
+	if report.Error == nil || report.Error.Code != "oracle_already_running" || report.Error.Message != oracleAlreadyRunningMessage {
+		t.Fatalf("report=%+v", report)
+	}
+	if lock.acquired || lock.released {
+		t.Fatalf("busy lock lifecycle acquired=%v released=%v", lock.acquired, lock.released)
 	}
 }
 

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -538,7 +538,9 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `operator_spacing`
 - `option_statement`
 - `optional_modifier`
+- `oracle_already_running`
 - `oracle_failure`
+- `oracle_lock_failed`
 - `original_error`
 - `original_workbook_path`
 - `output_file_exists`


### PR DESCRIPTION
## Summary

- Stabilize local VBE oracle cleanup by closing the disposable workbook, quitting Excel before COM release, and allowing delayed owned-process exit within a bounded drain.
- Preserve fail-closed ownership checks and return structured cleanup diagnostics for owned processes, drain attempts, remaining processes/windows, and failure stages.
- Serialize the complete local oracle batch with a crash-released Windows cross-process lock and reject concurrent runs with `oracle_already_running`.
- Update oracle documentation, changelog, and generated error-code inventory.

Fixes #526

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./...`
- `rtk dotnet test bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/Xlflow.ExcelBridge.Tests.csproj --no-restore`
- `rtk task lint`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/oracle -run TestFileBatchLock -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\test-vbe-oracle.ps1 --case known-compile-accept --case known-compile-reject --strict` (run twice; both controls passed with cleanup confirmed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-run protection for local VBE oracle batches, with clear `oracle_already_running` and lock-failure errors.
  * Added structured cleanup diagnostics covering owned processes, remaining resources, drain attempts, and failure stages.
* **Bug Fixes**
  * Improved Excel and workbook cleanup, including delayed process termination confirmation and fail-closed handling of uncertain process ownership.
  * Locks are released after process crashes, and cleanup time is preserved within per-case timeouts.
* **Documentation**
  * Documented locking behavior, cleanup diagnostics, recovery requirements, and new error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->