### PR TITLE
test(oracle): harden binding-state coverage semantics (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Clarified VBE oracle fixture binding/evidence roles and coverage reporting.
+  Compile-equivalent bindings now remain distinct from language, policy, and
+  maintainability observations; `sub-parenthesized-call` is unbound with a
+  maintainability role, `missing-set-object-assignment` records a policy role,
+  and `unknown-named-argument` remains partially bound and compile-equivalent.
 - Stabilized the local VBE oracle cleanup path by closing the disposable
   workbook before quitting Excel, allowing delayed owned-process exit within a
   bounded drain, preserving fail-closed behavior for unexpected Excel

--- a/docs/adr/ADR-0026-local-vbe-oracle-evidence.md
+++ b/docs/adr/ADR-0026-local-vbe-oracle-evidence.md
@@ -52,6 +52,18 @@ This keeps the relationship reviewable beside the source that needs the
 false-positive protection and makes rule-to-control coverage queryable without
 launching Excel.
 
+Binding completeness and evidence meaning are separate dimensions. `bound`
+means a compile-equivalent diagnostic contract is complete; `partially-bound`
+means that contract is intended but has a concrete incomplete piece; `unbound`
+means no compile-equivalent analyzer contract exists yet; and
+`not-applicable` is reserved for oracle harness controls. The orthogonal
+`evidence_role` classifies pending compile-equivalent evidence separately from
+language, policy, and maintainability observations. Policy or maintainability
+warnings therefore remain visible without being counted as incomplete compiler
+coverage, and an accepted VBE result cannot be used to erase those warnings.
+The Excel-free coverage test asserts the exact fixture IDs in every state so a
+state swap cannot hide behind unchanged aggregate counts.
+
 ## Consequences
 
 - Analyzer changes can cite empirical VBE compile evidence while normal tests
@@ -65,8 +77,8 @@ launching Excel.
 - VBE evidence must remain separate from policy and maintainability rule
   ownership; accepted VBA may still produce xlflow warnings.
 - Positive/negative coverage catches analyzer drift across future bindings while
-  preserving the Excel-free CI boundary; the trade-off is that a fixture must
-  remain `partially-bound` until every declared surface has an accepted control.
+  preserving the Excel-free CI boundary; exact fixture-state assertions add a
+  small reviewed migration cost when a binding is intentionally reclassified.
 
 ## Alternatives considered
 

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -142,34 +142,64 @@ Every fixture must also declare its diagnostic binding state under `analysis`:
 ```json
 {
   "analysis": {
-    "binding_status": "unbound"
+    "binding_status": "unbound",
+    "evidence_role": "language-observation"
   }
 }
 ```
 
 The supported states are:
 
-- `unbound`: VBE evidence exists, but no analyzer rule has been connected yet.
+- `unbound`: VBE evidence exists, but no analyzer rule contract is connected.
+  It cannot declare expected or forbidden diagnostics. Use an evidence role to
+  distinguish a pending compile-equivalent result from a language, policy, or
+  maintainability observation; a non-empty `binding_note` may explain the
+  missing contract.
 - `partially-bound`: at least one rule is connected, but coverage is incomplete;
-  `rule_codes` and a non-empty `binding_note` are required.
+  `evidence_role` must be `compile-equivalent`, and `rule_codes` plus a
+  non-empty `binding_note` are required.
 - `bound`: the fixture is fully connected to declared rules. It requires at
-  least one rule code, and every declared code must appear in the contract that
-  matches the VBE result (`expected` for rejected cases, `forbidden` for
-  accepted cases).
-- `not-applicable`: the fixture is intentionally a harness control or language
-  observation and cannot declare rule codes or diagnostic contracts.
+  least one rule code, `evidence_role` must be `compile-equivalent`, and every
+  declared code must appear in the contract that matches the VBE result
+  (`expected` for rejected cases, `forbidden` for accepted cases).
+- `not-applicable`: the fixture is a harness control. It must use the
+  `harness-control` evidence role and cannot declare rule codes or diagnostic
+  contracts. A language observation is `unbound`, not `not-applicable`.
+
+`analysis.evidence_role` records what the fixture can support independently of
+the VBE outcome and must not be used to rewrite `vbe.expected`,
+`vbe.evidence_phase`, `vbe.diagnostic_meaning`, or `provenance`:
+
+- `compile-equivalent`: the VBE result is relevant to a compile-equivalent
+  diagnostic. A bound or partially-bound fixture has a connected contract;
+  an unbound fixture records a pending compile-equivalent rule with no current
+  analyzer contract.
+- `language-observation`: an unbound fixture retaining VBE language behavior
+  for a rule that has no connected analyzer contract yet.
+- `policy-observation`: an unbound fixture where accepted VBA may still
+  receive a safety or policy warning, such as a missing-`Set` assignment.
+- `maintainability-observation`: an unbound fixture where accepted VBA may
+  still receive a maintainability warning, such as a parenthesized `Sub` call.
+- `harness-control`: a `not-applicable` known accept/reject control used to
+  verify the oracle itself.
+
+The validator requires `compile-equivalent` for `bound` and
+`partially-bound`, `harness-control` for `not-applicable`, and rejects
+`harness-control` on `unbound` fixtures. This keeps compile-equivalent binding
+coverage separate from accepted-language, policy, and maintainability
+observations.
 
 Every declared rule code is resolved against the authoritative static-analysis
 rule registry. The registry validates the canonical diagnostic ID, supported
 `lint`/`analyze`/`lsp` surfaces, and supported severities; fixture validation
 rejects unknown or non-canonical codes, unsupported surfaces, and unsupported
-severities. When a fixture declares rule codes, each code must be used by an
-expected or forbidden diagnostic contract. Bound fixtures also require every
-contract code to be listed in `rule_codes`, with rejected cases using the
-expected contract and accepted cases using the forbidden contract. Until a
-fixture is connected to an implemented rule, keep it `unbound` and do not alter
-the VBE expectation to satisfy an analyzer test. Binding notes must be omitted
-when unnecessary; an explicitly empty or whitespace-only note is invalid.
+severities. Bound and partially-bound fixtures require every contract code to
+be listed in `rule_codes`; bound fixtures additionally require every declared
+rule code to appear in the contract that matches the VBE result (`expected`
+for rejected cases, `forbidden` for accepted cases). Until a fixture is
+connected to an implemented rule, keep it `unbound` and do not alter the VBE
+expectation to satisfy an analyzer test. Binding notes must be omitted when
+unnecessary; an explicitly empty or whitespace-only note is invalid.
 
 ## Positive/negative binding pairs
 
@@ -180,6 +210,7 @@ from false positives:
 {
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VBAxxx"],
     "negative_controls": ["optional-argument-omitted", "known-named-argument"],
     "expected_diagnostics": [{ "code": "VBAxxx", "surfaces": ["analyze", "lsp"] }]
@@ -196,7 +227,7 @@ covers every surface in its positive contract. When a contract omits surfaces,
 the rule registry's supported surfaces are used for this comparison.
 
 The corpus validator also checks that every bound rule has rejected positive
-evidence and an accepted negative control. Existing historical `unbound` and
+evidence and an accepted negative control. Existing `unbound` and
 `partially-bound` fixtures remain visible in the report and do not fail CI by
 themselves; malformed relationships and incomplete `bound` rules do fail. A
 valid pair attached to a `partially-bound` rejected fixture is informational
@@ -212,11 +243,13 @@ rtk go test ./internal/oracle -run TestOracleBindingCoverage -v
 ```
 
 The test reports fixture state counts, complete and incomplete rule counts,
-sorted unbound/partially-bound fixture IDs, and sorted rule-to-case and
-surface coverage. The committed corpus currently reports 23 asserted fixtures,
-21 `unbound`, 2 `not-applicable`, and no bound rules. The report is emitted
-before a validation failure so missing positive/negative evidence remains
-visible in CI logs.
+sorted fixture IDs for every state (`bound`, `partially-bound`, `unbound`, and
+`not-applicable`), and sorted rule-to-case and surface coverage. The committed
+corpus currently reports 23 asserted fixtures: 9 `bound`, 1
+`partially-bound`, 11 `unbound`, and 2 `not-applicable`; the three bound rules
+have complete positive/negative coverage. The report is emitted before a
+validation failure so missing positive/negative evidence and state changes
+remain visible in CI logs.
 
 ## Outcomes and strict mode
 
@@ -283,9 +316,12 @@ LSP projections):
 7. Add `expected_diagnostics` to rejected fixtures.
 8. Add `forbidden_diagnostics` and `negative_controls` to accepted/rejected
    binding pairs, respectively.
-9. Mark fixtures `bound` only after all declared surfaces are covered; keep
-   incomplete work `partially-bound` with a note.
-10. Run Excel-free contracts and the coverage report, then record rule codes
+9. Assign `evidence_role`: use `compile-equivalent` only for compile-equivalent
+   bindings, and keep policy, maintainability, and language observations
+   unbound.
+10. Mark fixtures `bound` only after all declared surfaces are covered; keep
+    incomplete compile-equivalent work `partially-bound` with a note.
+11. Run Excel-free contracts and the coverage report, then record rule codes
     and all executed case IDs in the pull request.
 
 Oracle infrastructure failures are stop-the-line failures for agents and

--- a/docs/specs/vbe-oracle.md
+++ b/docs/specs/vbe-oracle.md
@@ -137,7 +137,8 @@ contract uses `analysis.expected_diagnostics` and
 optional source range, and (when needed) `surfaces` from `lint`, `analyze`, and
 `lsp`.
 
-Every fixture must also declare its diagnostic binding state under `analysis`:
+Every fixture must also declare its diagnostic binding state and a non-empty
+`evidence_role` under `analysis`:
 
 ```json
 {

--- a/internal/oracle/binding_coverage.go
+++ b/internal/oracle/binding_coverage.go
@@ -22,9 +22,11 @@ type BindingCoverage struct {
 	MissingNegativeRules int
 	MissingPositiveRules int
 
-	UnboundIDs []string
-	PartialIDs []string
-	Rules      []BindingRuleCoverage
+	BoundIDs         []string
+	PartialIDs       []string
+	UnboundIDs       []string
+	NotApplicableIDs []string
+	Rules            []BindingRuleCoverage
 }
 
 // BindingRuleCoverage describes positive and negative evidence for one
@@ -60,6 +62,7 @@ func ValidateBindingCoverage(cases []Case) (BindingCoverage, error) {
 		switch c.Analysis.BindingStatus {
 		case BindingBound:
 			report.BoundFixtures++
+			report.BoundIDs = append(report.BoundIDs, c.ID)
 		case BindingPartiallyBound:
 			report.PartialFixtures++
 			report.PartialIDs = append(report.PartialIDs, c.ID)
@@ -68,6 +71,7 @@ func ValidateBindingCoverage(cases []Case) (BindingCoverage, error) {
 			report.UnboundIDs = append(report.UnboundIDs, c.ID)
 		case BindingNotApplicable:
 			report.NotApplicable++
+			report.NotApplicableIDs = append(report.NotApplicableIDs, c.ID)
 		}
 		for _, code := range c.Analysis.RuleCodes {
 			if _, err := canonicalRuleMetadata(code); err != nil {
@@ -236,8 +240,10 @@ func ValidateBindingCoverage(cases []Case) (BindingCoverage, error) {
 		report.Rules = append(report.Rules, *coverage)
 	}
 	sort.Slice(report.Rules, func(i, j int) bool { return report.Rules[i].Code < report.Rules[j].Code })
-	sort.Strings(report.UnboundIDs)
+	sort.Strings(report.BoundIDs)
 	sort.Strings(report.PartialIDs)
+	sort.Strings(report.UnboundIDs)
+	sort.Strings(report.NotApplicableIDs)
 
 	validationErrors = append(validationErrors, coverageValidationErrors(report.Rules)...)
 	if len(validationErrors) > 0 {
@@ -385,18 +391,16 @@ func (r BindingCoverage) String() string {
 	fmt.Fprintf(&b, "Rules with complete positive/negative coverage: %d\n", r.CompleteRules)
 	fmt.Fprintf(&b, "Rules missing accepted controls: %d\n", r.MissingNegativeRules)
 	fmt.Fprintf(&b, "Rules missing rejected evidence: %d\n", r.MissingPositiveRules)
-	if len(r.UnboundIDs) > 0 {
-		fmt.Fprintln(&b, "\nUnbound fixtures:")
-		for _, id := range r.UnboundIDs {
+	writeFixtureIDs := func(label string, ids []string) {
+		fmt.Fprintf(&b, "\n%s\n", label)
+		for _, id := range ids {
 			fmt.Fprintf(&b, "- %s\n", id)
 		}
 	}
-	if len(r.PartialIDs) > 0 {
-		fmt.Fprintln(&b, "\nPartially-bound fixtures:")
-		for _, id := range r.PartialIDs {
-			fmt.Fprintf(&b, "- %s\n", id)
-		}
-	}
+	writeFixtureIDs("Bound fixtures:", r.BoundIDs)
+	writeFixtureIDs("Partially-bound fixtures:", r.PartialIDs)
+	writeFixtureIDs("Unbound fixtures:", r.UnboundIDs)
+	writeFixtureIDs("Not-applicable fixtures:", r.NotApplicableIDs)
 	if len(r.Rules) > 0 {
 		fmt.Fprintln(&b, "\nRules:")
 		for _, coverage := range r.Rules {

--- a/internal/oracle/binding_coverage_test.go
+++ b/internal/oracle/binding_coverage_test.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -210,5 +211,80 @@ func TestBindingCoverageStringIsDeterministic(t *testing.T) {
 	}
 	if !strings.Contains(output, "Rules with complete positive/negative coverage: 1") {
 		t.Fatalf("report missing complete rule count:\n%s", output)
+	}
+}
+
+func TestBindingCoverageReportsEveryFixtureState(t *testing.T) {
+	partial := coverageRejected("partial", "VBA101", []string{"accepted"}, nil)
+	partial.Analysis.BindingStatus = BindingPartiallyBound
+	cases := []Case{
+		coverageRejected("bound", "VBA101", []string{"accepted"}, nil),
+		partial,
+		{ID: "partial-z", VBE: VBEExpectation{Expected: ExpectedRejected}, Analysis: AnalysisExpectation{BindingStatus: BindingPartiallyBound}},
+		{ID: "partial-a", VBE: VBEExpectation{Expected: ExpectedRejected}, Analysis: AnalysisExpectation{BindingStatus: BindingPartiallyBound}},
+		coverageAccepted("accepted", "VBA101", nil),
+		{ID: "unbound-z", VBE: VBEExpectation{Expected: ExpectedAccepted}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}},
+		{ID: "unbound-a", VBE: VBEExpectation{Expected: ExpectedAccepted}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}},
+		{ID: "not-applicable-z", VBE: VBEExpectation{Expected: ExpectedAccepted}, Analysis: AnalysisExpectation{BindingStatus: BindingNotApplicable}},
+		{ID: "not-applicable-a", VBE: VBEExpectation{Expected: ExpectedAccepted}, Analysis: AnalysisExpectation{BindingStatus: BindingNotApplicable}},
+	}
+	report, err := ValidateBindingCoverage(cases)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := report.BoundIDs, []string{"accepted", "bound"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("bound IDs = %v, want %v", got, want)
+	}
+	if got, want := report.PartialIDs, []string{"partial", "partial-a", "partial-z"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial IDs = %v, want %v", got, want)
+	}
+	if got, want := report.UnboundIDs, []string{"unbound-a", "unbound-z"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unbound IDs = %v, want %v", got, want)
+	}
+	if got, want := report.NotApplicableIDs, []string{"not-applicable-a", "not-applicable-z"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("not-applicable IDs = %v, want %v", got, want)
+	}
+	output := report.String()
+	for _, label := range []string{
+		"Bound fixtures:",
+		"Partially-bound fixtures:",
+		"Unbound fixtures:",
+		"Not-applicable fixtures:",
+	} {
+		if !strings.Contains(output, label) {
+			t.Fatalf("report missing %q:\n%s", label, output)
+		}
+	}
+	assertBefore := func(first, second string) {
+		t.Helper()
+		if strings.Index(output, first) >= strings.Index(output, second) {
+			t.Fatalf("report order is not deterministic for %q before %q:\n%s", first, second, output)
+		}
+	}
+	assertBefore("- accepted\n", "- bound\n")
+	assertBefore("- partial-a\n", "- partial-z\n")
+	assertBefore("- unbound-a\n", "- unbound-z\n")
+	assertBefore("- not-applicable-a\n", "- not-applicable-z\n")
+}
+
+func TestBindingCoverageDetectsFixtureStateSwapWithEqualCounts(t *testing.T) {
+	makeReport := func(boundID, unboundID string) BindingCoverage {
+		report, err := ValidateBindingCoverage([]Case{
+			coverageRejected(boundID, "VBA101", []string{"accepted"}, nil),
+			coverageAccepted("accepted", "VBA101", nil),
+			{ID: unboundID, VBE: VBEExpectation{Expected: ExpectedAccepted}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return report
+	}
+	first := makeReport("fixture-a", "fixture-b")
+	swapped := makeReport("fixture-b", "fixture-a")
+	if first.BoundFixtures != swapped.BoundFixtures || first.UnboundFixtures != swapped.UnboundFixtures {
+		t.Fatalf("state swap changed aggregate counts: first=%+v swapped=%+v", first, swapped)
+	}
+	if reflect.DeepEqual(first.BoundIDs, swapped.BoundIDs) || reflect.DeepEqual(first.UnboundIDs, swapped.UnboundIDs) {
+		t.Fatalf("state swap was not visible in fixture IDs: first=%+v swapped=%+v", first, swapped)
 	}
 }

--- a/internal/oracle/fixture_contract_test.go
+++ b/internal/oracle/fixture_contract_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/analyze"
@@ -126,7 +127,39 @@ func TestOracleBindingCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.AssertedFixtures != 23 || report.BoundFixtures != 9 || report.PartialFixtures != 2 || report.UnboundFixtures != 10 || report.NotApplicable != 2 {
+	if report.AssertedFixtures != 23 || report.BoundFixtures != 9 || report.PartialFixtures != 1 || report.UnboundFixtures != 11 || report.NotApplicable != 2 {
 		t.Fatalf("unexpected current corpus coverage: %+v", report)
 	}
+	assertIDs := func(name string, got, want []string) {
+		t.Helper()
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s fixture IDs = %v, want %v", name, got, want)
+		}
+	}
+	assertIDs("bound", report.BoundIDs, []string{
+		"byref-bare-variable",
+		"byref-compatible",
+		"byref-incompatible",
+		"known-named-argument",
+		"missing-required-argument",
+		"optional-argument-omitted",
+		"scalar-assignment",
+		"set-object-target",
+		"set-scalar-target",
+	})
+	assertIDs("partially-bound", report.PartialIDs, []string{"unknown-named-argument"})
+	assertIDs("unbound", report.UnboundIDs, []string{
+		"byref-parenthesized-variable",
+		"duplicate-named-argument",
+		"function-bare-call",
+		"function-parenthesized-call",
+		"known-as-type",
+		"missing-set-object-assignment",
+		"object-to-object-parameter",
+		"scalar-to-object-parameter",
+		"sub-bare-call",
+		"sub-parenthesized-call",
+		"unknown-as-type",
+	})
+	assertIDs("not-applicable", report.NotApplicableIDs, []string{"known-compile-accept", "known-compile-reject"})
 }

--- a/internal/oracle/manifest.go
+++ b/internal/oracle/manifest.go
@@ -156,7 +156,7 @@ type VBEExpectation struct {
 
 type AnalysisExpectation struct {
 	BindingStatus        string                  `json:"binding_status"`
-	EvidenceRole         string                  `json:"evidence_role,omitempty"`
+	EvidenceRole         string                  `json:"evidence_role"`
 	RuleCodes            []string                `json:"rule_codes,omitempty"`
 	BindingNote          *string                 `json:"binding_note,omitempty"`
 	NegativeControls     []string                `json:"negative_controls,omitempty"`
@@ -506,8 +506,10 @@ func validateEvidenceRole(c Case) error {
 		return fmt.Errorf("oracle case %q has padded analysis.evidence_role %q", c.ID, c.Analysis.EvidenceRole)
 	}
 	switch role {
-	case "", EvidenceRoleCompileEquivalent, EvidenceRolePolicyObservation,
+	case EvidenceRoleCompileEquivalent, EvidenceRolePolicyObservation,
 		EvidenceRoleMaintainabilityObservation, EvidenceRoleLanguageObservation, EvidenceRoleHarnessControl:
+	case "":
+		return fmt.Errorf("oracle case %q: analysis.evidence_role is required", c.ID)
 	default:
 		return fmt.Errorf("oracle case %q has invalid analysis.evidence_role %q", c.ID, c.Analysis.EvidenceRole)
 	}

--- a/internal/oracle/manifest.go
+++ b/internal/oracle/manifest.go
@@ -38,6 +38,12 @@ const (
 	BindingPartiallyBound = "partially-bound"
 	BindingBound          = "bound"
 	BindingNotApplicable  = "not-applicable"
+
+	EvidenceRoleCompileEquivalent          = "compile-equivalent"
+	EvidenceRolePolicyObservation          = "policy-observation"
+	EvidenceRoleMaintainabilityObservation = "maintainability-observation"
+	EvidenceRoleLanguageObservation        = "language-observation"
+	EvidenceRoleHarnessControl             = "harness-control"
 )
 
 var caseIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -150,6 +156,7 @@ type VBEExpectation struct {
 
 type AnalysisExpectation struct {
 	BindingStatus        string                  `json:"binding_status"`
+	EvidenceRole         string                  `json:"evidence_role,omitempty"`
 	RuleCodes            []string                `json:"rule_codes,omitempty"`
 	BindingNote          *string                 `json:"binding_note,omitempty"`
 	NegativeControls     []string                `json:"negative_controls,omitempty"`
@@ -405,6 +412,9 @@ func validateAnalysisBinding(c Case) error {
 	default:
 		return fmt.Errorf("oracle case %q has invalid analysis.binding_status %q", c.ID, analysis.BindingStatus)
 	}
+	if err := validateEvidenceRole(c); err != nil {
+		return err
+	}
 
 	seenCodes := make(map[string]struct{}, len(analysis.RuleCodes))
 	for _, code := range analysis.RuleCodes {
@@ -485,6 +495,39 @@ func validateAnalysisBinding(c Case) error {
 				}
 				return fmt.Errorf("oracle case %q: partially-bound diagnostic code %q is not declared by analysis.rule_codes", c.ID, expectation.Code)
 			}
+		}
+	}
+	return nil
+}
+
+func validateEvidenceRole(c Case) error {
+	role := strings.TrimSpace(c.Analysis.EvidenceRole)
+	if role != c.Analysis.EvidenceRole {
+		return fmt.Errorf("oracle case %q has padded analysis.evidence_role %q", c.ID, c.Analysis.EvidenceRole)
+	}
+	switch role {
+	case "", EvidenceRoleCompileEquivalent, EvidenceRolePolicyObservation,
+		EvidenceRoleMaintainabilityObservation, EvidenceRoleLanguageObservation, EvidenceRoleHarnessControl:
+	default:
+		return fmt.Errorf("oracle case %q has invalid analysis.evidence_role %q", c.ID, c.Analysis.EvidenceRole)
+	}
+
+	switch c.Analysis.BindingStatus {
+	case BindingPartiallyBound:
+		if role != EvidenceRoleCompileEquivalent {
+			return fmt.Errorf("oracle case %q: partially-bound fixture requires evidence_role %q", c.ID, EvidenceRoleCompileEquivalent)
+		}
+	case BindingBound:
+		if role != EvidenceRoleCompileEquivalent {
+			return fmt.Errorf("oracle case %q: bound fixture requires evidence_role %q", c.ID, EvidenceRoleCompileEquivalent)
+		}
+	case BindingNotApplicable:
+		if role != EvidenceRoleHarnessControl {
+			return fmt.Errorf("oracle case %q: not-applicable fixture requires evidence_role %q", c.ID, EvidenceRoleHarnessControl)
+		}
+	case BindingUnbound:
+		if role == EvidenceRoleHarnessControl {
+			return fmt.Errorf("oracle case %q: unbound fixture cannot use evidence_role %q", c.ID, EvidenceRoleHarnessControl)
 		}
 	}
 	return nil

--- a/internal/oracle/manifest_test.go
+++ b/internal/oracle/manifest_test.go
@@ -19,7 +19,7 @@ func writeFixture(t *testing.T, expected string) (string, Manifest) {
 	if err := os.WriteFile(filepath.Join(caseDir, "Main.bas"), []byte(source), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	caseJSON := Case{SchemaVersion: SchemaVersion, ID: "sample", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas", Entry: true}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: expected, EvidencePhase: EvidenceUnknown, DiagnosticMeaning: MeaningObservation}, Analysis: AnalysisExpectation{BindingStatus: BindingNotApplicable}, Provenance: Provenance{Status: "pending"}}
+	caseJSON := Case{SchemaVersion: SchemaVersion, ID: "sample", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas", Entry: true}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: expected, EvidencePhase: EvidenceUnknown, DiagnosticMeaning: MeaningObservation}, Analysis: AnalysisExpectation{BindingStatus: BindingNotApplicable, EvidenceRole: EvidenceRoleHarnessControl}, Provenance: Provenance{Status: "pending"}}
 	body, _ := json.Marshal(caseJSON)
 	if err := os.WriteFile(filepath.Join(caseDir, "case.json"), body, 0o644); err != nil {
 		t.Fatal(err)
@@ -131,17 +131,20 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 		{name: "unbound", prepare: func(c *Case) {}},
 		{name: "partially-bound", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.BindingNote = analysisNote("positive contract is pending")
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 		}},
 		{name: "partially-bound pending contract", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.BindingNote = analysisNote("contract cannot be expressed yet")
 		}},
 		{name: "bound rejected", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101", Severity: "warning"}}
 		}},
@@ -149,6 +152,7 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 			c.VBE.Expected = ExpectedAccepted
 			c.VBE.DiagnosticMeaning = MeaningSpecification
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 		}},
@@ -156,6 +160,7 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 			c.VBE.Expected = ExpectedAccepted
 			c.VBE.DiagnosticMeaning = MeaningSpecification
 			c.Analysis.BindingStatus = BindingNotApplicable
+			c.Analysis.EvidenceRole = EvidenceRoleHarnessControl
 		}},
 		{name: "missing status", prepare: func(c *Case) { c.Analysis.BindingStatus = "" }, wantErr: true},
 		{name: "invalid status", prepare: func(c *Case) { c.Analysis.BindingStatus = "future" }, wantErr: true},
@@ -170,41 +175,49 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 		}, wantErr: true},
 		{name: "partially-bound needs rule code", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.BindingNote = analysisNote("pending")
 		}, wantErr: true},
 		{name: "partially-bound needs note", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 		}, wantErr: true},
 		{name: "bound needs rule code", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 		}, wantErr: true},
 		{name: "bound code needs contract", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VB002"}}
 		}, wantErr: true},
 		{name: "rejected bound code cannot be forbidden-only", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VB002"}}
 			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 		}, wantErr: true},
 		{name: "bound rejected needs expected", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 		}, wantErr: true},
 		{name: "bound accepted needs forbidden", prepare: func(c *Case) {
 			c.VBE.Expected = ExpectedAccepted
 			c.VBE.DiagnosticMeaning = MeaningSpecification
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 		}, wantErr: true},
 		{name: "accepted bound code cannot be expected-only", prepare: func(c *Case) {
 			c.VBE.Expected = ExpectedAccepted
 			c.VBE.DiagnosticMeaning = MeaningSpecification
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VB002"}}
@@ -215,19 +228,23 @@ func TestValidateCaseBindingMetadata(t *testing.T) {
 			c.VBE.DiagnosticMeaning = MeaningObservation
 			c.Provenance = Provenance{Status: "pending"}
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 		}, wantErr: true},
 		{name: "not-applicable rule code", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingNotApplicable
+			c.Analysis.EvidenceRole = EvidenceRoleHarnessControl
 			c.Analysis.RuleCodes = []string{"VBA101"}
 		}, wantErr: true},
 		{name: "not-applicable expected", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingNotApplicable
+			c.Analysis.EvidenceRole = EvidenceRoleHarnessControl
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 		}, wantErr: true},
 		{name: "not-applicable forbidden", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingNotApplicable
+			c.Analysis.EvidenceRole = EvidenceRoleHarnessControl
 			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 		}, wantErr: true},
 		{name: "empty rule code", prepare: func(c *Case) {
@@ -265,12 +282,14 @@ func TestValidateCaseRuleRegistryBindings(t *testing.T) {
 	}{
 		{name: "canonical registry diagnostic", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.BindingNote = analysisNote("registry validation test")
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101", Severity: "warning", Surfaces: []string{"analyze"}}}
 		}},
 		{name: "dynamic severity", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA214"}
 			c.Analysis.BindingNote = analysisNote("registry validation test")
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA214", Severity: "error"}}
@@ -292,12 +311,14 @@ func TestValidateCaseRuleRegistryBindings(t *testing.T) {
 		}, wantErr: true, errSubstr: "unsupported severity"},
 		{name: "partially-bound contract needs declared rule code", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.BindingNote = analysisNote("pending")
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VB002"}}
 		}, wantErr: true, errSubstr: "partially-bound diagnostic code"},
 		{name: "bound contract needs rule code", prepare: func(c *Case) {
 			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
 			c.Analysis.RuleCodes = []string{"VBA101"}
 			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
 			c.Analysis.ForbiddenDiagnostics = []DiagnosticExpectation{{Code: "VB002"}}
@@ -307,6 +328,63 @@ func TestValidateCaseRuleRegistryBindings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := validAssertedCase(ExpectedRejected)
+			tt.prepare(&c)
+			err := ValidateCase(c, c.ID, t.TempDir())
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateCase() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("ValidateCase() error = %q, want substring %q", err, tt.errSubstr)
+			}
+		})
+	}
+}
+
+func TestValidateCaseEvidenceRoleSemantics(t *testing.T) {
+	tests := []struct {
+		name      string
+		prepare   func(*Case)
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "valid compile-equivalent partial", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleCompileEquivalent
+			c.Analysis.RuleCodes = []string{"VBA101"}
+			c.Analysis.BindingNote = analysisNote("diagnostic identity is incomplete")
+			c.Analysis.NegativeControls = []string{"accepted"}
+		}},
+		{name: "policy observation cannot be partial", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingPartiallyBound
+			c.Analysis.EvidenceRole = EvidenceRoleMaintainabilityObservation
+			c.Analysis.RuleCodes = []string{"VB022"}
+			c.Analysis.BindingNote = analysisNote("VBE accepts the syntax")
+		}, wantErr: true, errSubstr: "partially-bound fixture requires evidence_role"},
+		{name: "policy observation cannot be bound", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingBound
+			c.Analysis.EvidenceRole = EvidenceRolePolicyObservation
+			c.Analysis.RuleCodes = []string{"VBA101"}
+			c.Analysis.ExpectedDiagnostics = []DiagnosticExpectation{{Code: "VBA101"}}
+		}, wantErr: true, errSubstr: "bound fixture requires evidence_role"},
+		{name: "harness control is explicit", prepare: func(c *Case) {
+			c.Analysis.BindingStatus = BindingNotApplicable
+			c.Analysis.EvidenceRole = EvidenceRoleHarnessControl
+		}},
+		{name: "invalid role", prepare: func(c *Case) {
+			c.Analysis.EvidenceRole = "compile-ish"
+		}, wantErr: true, errSubstr: "invalid analysis.evidence_role"},
+		{name: "padded role", prepare: func(c *Case) {
+			c.Analysis.EvidenceRole = " compile-equivalent"
+		}, wantErr: true, errSubstr: "padded analysis.evidence_role"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validAssertedCase(ExpectedRejected)
+			if tt.name == "harness control is explicit" {
+				c.VBE.Expected = ExpectedAccepted
+				c.VBE.DiagnosticMeaning = MeaningSpecification
+			}
 			tt.prepare(&c)
 			err := ValidateCase(c, c.ID, t.TempDir())
 			if (err != nil) != tt.wantErr {

--- a/internal/oracle/manifest_test.go
+++ b/internal/oracle/manifest_test.go
@@ -91,7 +91,7 @@ func TestValidateManifestRequiresCaseDirectoryAndEntryAgreement(t *testing.T) {
 }
 
 func TestValidateCaseRequiresAssertedProvenance(t *testing.T) {
-	c := Case{SchemaVersion: SchemaVersion, ID: "x", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas"}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: ExpectedAccepted, EvidencePhase: EvidenceCompile}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound}}
+	c := Case{SchemaVersion: SchemaVersion, ID: "x", Modules: []Module{{Name: "Main", Kind: "standard", Path: "Main.bas"}}, Probe: Probe{Mode: ProbeCompile}, VBE: VBEExpectation{Expected: ExpectedAccepted, EvidencePhase: EvidenceCompile}, Analysis: AnalysisExpectation{BindingStatus: BindingUnbound, EvidenceRole: EvidenceRoleCompileEquivalent}}
 	if err := ValidateCase(c, "x", t.TempDir()); err == nil {
 		t.Fatal("expected provenance validation error")
 	}
@@ -112,7 +112,7 @@ func validAssertedCase(expected string) Case {
 		Modules:       []Module{{Name: "Main", Kind: "standard", Path: "Main.bas"}},
 		Probe:         Probe{Mode: ProbeCompile},
 		VBE:           VBEExpectation{Expected: expected, EvidencePhase: EvidenceCompile, DiagnosticMeaning: meaning},
-		Analysis:      AnalysisExpectation{BindingStatus: BindingUnbound},
+		Analysis:      AnalysisExpectation{BindingStatus: BindingUnbound, EvidenceRole: EvidenceRoleCompileEquivalent},
 		Provenance: Provenance{
 			Status: "asserted",
 			VerifiedOn: []VerificationMetadata{{
@@ -373,6 +373,9 @@ func TestValidateCaseEvidenceRoleSemantics(t *testing.T) {
 		{name: "invalid role", prepare: func(c *Case) {
 			c.Analysis.EvidenceRole = "compile-ish"
 		}, wantErr: true, errSubstr: "invalid analysis.evidence_role"},
+		{name: "missing role", prepare: func(c *Case) {
+			c.Analysis.EvidenceRole = ""
+		}, wantErr: true, errSubstr: "analysis.evidence_role is required"},
 		{name: "padded role", prepare: func(c *Case) {
 			c.Analysis.EvidenceRole = " compile-equivalent"
 		}, wantErr: true, errSubstr: "padded analysis.evidence_role"},

--- a/testdata/vbe-oracle/cases/byref-bare-variable/case.json
+++ b/testdata/vbe-oracle/cases/byref-bare-variable/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VBA206"],
     "forbidden_diagnostics": [
       {

--- a/testdata/vbe-oracle/cases/byref-compatible/case.json
+++ b/testdata/vbe-oracle/cases/byref-compatible/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VBA206"],
     "forbidden_diagnostics": [
       {

--- a/testdata/vbe-oracle/cases/byref-incompatible/case.json
+++ b/testdata/vbe-oracle/cases/byref-incompatible/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VBA206"],
     "negative_controls": ["byref-compatible", "byref-bare-variable"],
     "expected_diagnostics": [

--- a/testdata/vbe-oracle/cases/byref-parenthesized-variable/case.json
+++ b/testdata/vbe-oracle/cases/byref-parenthesized-variable/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "policy-observation",
     "binding_note": "VBE accepts the parenthesized ByRef argument, while the existing VBA206 runtime-safety warning intentionally reports possible mutation loss; it cannot forbid VBA206."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/duplicate-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/duplicate-named-argument/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "language-observation",
     "binding_note": "VBE rejects duplicate named-argument assignment, but the current analyzer has no corresponding compile-error-equivalent diagnostic. The rejected fixture and its known-named-argument control are tracked in follow-up issue #520."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/function-bare-call/case.json
+++ b/testdata/vbe-oracle/cases/function-bare-call/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "language-observation",
     "binding_note": "VBE accepts the bare Function call in expression context and the current analyzer emits no compile-error-equivalent diagnostic for this accepted form. No binding contract is applicable in issue #511."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/function-parenthesized-call/case.json
+++ b/testdata/vbe-oracle/cases/function-parenthesized-call/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "language-observation",
     "binding_note": "VBE accepts the parenthesized Function call in expression context and the current analyzer emits no compile-error-equivalent diagnostic for this accepted form. No binding contract is applicable in issue #511."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/known-as-type/case.json
+++ b/testdata/vbe-oracle/cases/known-as-type/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "language-observation",
     "binding_note": "No production diagnostic currently covers local As <Type> declarations, so this accepted built-in-type control cannot yet forbid a corresponding rule. See follow-up issue #519."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/known-compile-accept/case.json
+++ b/testdata/vbe-oracle/cases/known-compile-accept/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "not-applicable"
+    "binding_status": "not-applicable",
+    "evidence_role": "harness-control"
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/known-compile-reject/case.json
+++ b/testdata/vbe-oracle/cases/known-compile-reject/case.json
@@ -19,7 +19,8 @@
     "diagnostic_meaning": "compile-error"
   },
   "analysis": {
-    "binding_status": "not-applicable"
+    "binding_status": "not-applicable",
+    "evidence_role": "harness-control"
   },
   "provenance": {
     "status": "asserted",

--- a/testdata/vbe-oracle/cases/known-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/known-named-argument/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VB030"],
     "forbidden_diagnostics": [
       {

--- a/testdata/vbe-oracle/cases/missing-required-argument/case.json
+++ b/testdata/vbe-oracle/cases/missing-required-argument/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VB030"],
     "negative_controls": ["optional-argument-omitted", "known-named-argument"],
     "expected_diagnostics": [

--- a/testdata/vbe-oracle/cases/missing-set-object-assignment/case.json
+++ b/testdata/vbe-oracle/cases/missing-set-object-assignment/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "policy-observation",
     "binding_note": "VBE accepts this policy-level missing-Set case; the existing VBA101 analyze warning is intentionally preserved and is not a compile-equivalent forbidden diagnostic."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/object-to-object-parameter/case.json
+++ b/testdata/vbe-oracle/cases/object-to-object-parameter/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "language-observation",
     "binding_note": "Accepted Object-to-Object parameter control retained for the missing scalar/Object compatibility rule; no existing diagnostic is bound yet."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/optional-argument-omitted/case.json
+++ b/testdata/vbe-oracle/cases/optional-argument-omitted/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VB030"],
     "forbidden_diagnostics": [
       {

--- a/testdata/vbe-oracle/cases/scalar-assignment/case.json
+++ b/testdata/vbe-oracle/cases/scalar-assignment/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VB037"],
     "forbidden_diagnostics": [
       {

--- a/testdata/vbe-oracle/cases/scalar-to-object-parameter/case.json
+++ b/testdata/vbe-oracle/cases/scalar-to-object-parameter/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "language-observation",
     "binding_note": "VBE rejects scalar-to-Object parameter compatibility, but no existing xlflow diagnostic covers this rule; track a focused follow-up."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/set-object-target/case.json
+++ b/testdata/vbe-oracle/cases/set-object-target/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VB037"],
     "forbidden_diagnostics": [
       {

--- a/testdata/vbe-oracle/cases/set-scalar-target/case.json
+++ b/testdata/vbe-oracle/cases/set-scalar-target/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VB037"],
     "negative_controls": ["set-object-target", "scalar-assignment"],
     "expected_diagnostics": [

--- a/testdata/vbe-oracle/cases/sub-bare-call/case.json
+++ b/testdata/vbe-oracle/cases/sub-bare-call/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "language-observation",
     "binding_note": "VBE accepts the bare Sub call and the current analyzer emits no compile-error-equivalent diagnostic for this accepted form. No binding contract is applicable in issue #511."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/sub-parenthesized-call/case.json
+++ b/testdata/vbe-oracle/cases/sub-parenthesized-call/case.json
@@ -19,8 +19,8 @@
     "diagnostic_meaning": "specification"
   },
   "analysis": {
-    "binding_status": "partially-bound",
-    "rule_codes": ["VB022"],
+    "binding_status": "unbound",
+    "evidence_role": "maintainability-observation",
     "binding_note": "VBE accepts this syntax. Current VB022 is an intentional maintainability warning on lint and LSP, not a compile-error-equivalent diagnostic, so this fixture has no expected or forbidden diagnostic contract in issue #511."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/unknown-as-type/case.json
+++ b/testdata/vbe-oracle/cases/unknown-as-type/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "unbound",
+    "evidence_role": "language-observation",
     "binding_note": "No production diagnostic currently covers unresolved local As <Type> declarations; VBA222 is limited to public API signatures and is not applicable. See follow-up issue #519."
   },
   "provenance": {

--- a/testdata/vbe-oracle/cases/unknown-named-argument/case.json
+++ b/testdata/vbe-oracle/cases/unknown-named-argument/case.json
@@ -20,6 +20,7 @@
   },
   "analysis": {
     "binding_status": "partially-bound",
+    "evidence_role": "compile-equivalent",
     "rule_codes": ["VB030"],
     "binding_note": "The current LSP emits two VB030 diagnostics for this call (excess argument and unknown named argument), while the Excel-free contract intentionally rejects duplicate same-code diagnostics. The incomplete binding is tracked in follow-up issue #520.",
     "negative_controls": ["known-named-argument"]

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -260,6 +260,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `event_declaration`
 - `event_statement`
 - `evidence_phase`
+- `evidence_role`
 - `example_cell`
 - `example_formula`
 - `exceeds_keep_last`


### PR DESCRIPTION
## Summary

- Harden VBE oracle binding-state semantics with explicit `evidence_role` validation.
- Report and assert exact fixture IDs for `bound`, `partially-bound`, `unbound`, and `not-applicable` states.
- Migrate policy/maintainability observations consistently while retaining `unknown-named-argument` as a compile-equivalent partial binding.
- Update the VBE oracle specification, ADR-0026, changelog, and all 23 fixture contracts.

Closes #524

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/oracle`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./...`
- `rtk task lint`
- `rtk pnpm format:check`
- `rtk pnpm docs:check`
- `rtk git diff --check`

The local Excel/VBE oracle was not run because this change preserves VBE expectations and provenance and only changes Excel-free binding metadata and coverage assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how oracle evidence is classified across compile-equivalent, language, policy, maintainability, and harness observations.
  * Documented binding states and their validation requirements.
  * Updated changelog and specifications with clearer coverage guidance.

* **Tests**
  * Improved coverage reporting to list deterministic fixture IDs for bound, partially bound, unbound, and not-applicable cases.
  * Added validation for evidence roles and their compatibility with binding states.
  * Refined several edge-case classifications and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->