### PR TITLE
feat: add native static-analysis corpus runner

### DIFF
--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -158,6 +158,17 @@ publish failure rollback. The synchronizer additionally rejects missing
 projects, symlink/reparse entries, and irregular files during staging. A
 second run from the real upstream pin must produce no corpus diff.
 
+Native runner regression tests cover discovery and stable project-ID selection,
+independent execution of each project root with its own configuration,
+separation of invalid-configuration, parser, and execution failures from
+ordinary diagnostics, deterministic diagnostic ordering across repeated runs,
+and preservation of partial results when another project fails. The real-world
+`self/gen-qrcode` test executes both lint and analyze through the production
+implementations, verifies repeatable diagnostics, and compares the project
+tree before and after execution to prove that corpus analysis is read-only.
+These tests protect the project-isolation and failure-boundary contracts that
+unit fixtures alone cannot establish.
+
 The corpus does not change static-analysis semantics, public CLI/API output,
 Excel/VBE oracle behavior, or Go dependency-inventory checks. Those suites
 remain separate from synchronization and may run fully offline.

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -125,15 +125,23 @@ removes stale files from a prior managed tree. Pin updates are explicit review
 changes to the manifest followed by a synchronization run; branch names and
 implicit "latest" updates are not accepted.
 
-## Future runner boundary
+## Runner boundary
 
-A future static-analysis runner may load this manifest, resolve each profile,
-and scan one project at a time. It must retain the project ID and profile in
-its test context and must not merge project roots unless a separate reviewed
-fixture explicitly requires that behavior. The runner consumes only the
-vendored tree and manifest; it does not invoke the synchronizer, fetch
-upstream, open Excel, or require COM/VBE. Runner-specific expectations belong
-in tests or a follow-up specification and must not change this sync contract.
+The native self-corpus runner discovers `example/*` directories that contain
+`xlflow.toml` and identifies them as `self/<directory>`. Callers may select a
+stable subset by project ID; the default is every discovered project in
+lexicographic order. Each project is loaded and analyzed from its own root
+through the production `config.Load`, lint, and analyze implementations. The
+runner never merges source trees, treats ordinary diagnostics as successful
+results, and reports invalid configuration, parser failures, and execution
+failures separately from normalized diagnostic records.
+
+The runner is test/developer infrastructure. It reads source files only and
+does not modify examples, invoke the corpus synchronizer, fetch upstream
+content, open Excel, or require COM/VBE. Third-party manifest profiles and
+vendored projects remain governed by the synchronization contract above; a
+third-party adapter, golden snapshots, and snapshot-delta reporting are
+follow-up work and must not change this sync contract.
 
 ## Verification requirements
 

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -42,6 +42,22 @@ type Finding struct {
 	DataFlow     *DataFlowContext `json:"data_flow,omitempty"`
 }
 
+// ParseError reports that tree-sitter could not produce a complete VBA
+// syntax tree for a source file. Callers that need to distinguish parser
+// failures from other analysis failures can use errors.As with this type.
+type ParseError struct {
+	Path       string
+	HasError   bool
+	HasMissing bool
+}
+
+func (e *ParseError) Error() string {
+	if e == nil {
+		return "VBA parser reported errors or missing nodes"
+	}
+	return fmt.Sprintf("parse %s: VBA parser reported errors or missing nodes", e.Path)
+}
+
 type Result struct {
 	Findings []Finding
 	Warnings []map[string]any
@@ -276,7 +292,7 @@ func (a Analyzer) RunResult() (Result, error) {
 		if ir.Parse.HasError || ir.Parse.HasMissing {
 			parsed.Close()
 			closeParsedFiles(parsedFiles)
-			return Result{}, fmt.Errorf("parse %s: VBA parser reported errors or missing nodes", file)
+			return Result{}, &ParseError{Path: file, HasError: ir.Parse.HasError, HasMissing: ir.Parse.HasMissing}
 		}
 		controlFlow := vbacfg.BuildDocument(ir)
 		var intelDocument intel.Document

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -698,6 +699,13 @@ End Function
 	}
 	if !strings.Contains(err.Error(), "VBA parser reported errors or missing nodes") {
 		t.Fatalf("unexpected parse error: %v", err)
+	}
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+	if parseErr.Path != filepath.Join(dir, "src", "modules", "Main.bas") || !parseErr.HasError && !parseErr.HasMissing {
+		t.Fatalf("unexpected ParseError: %+v", parseErr)
 	}
 }
 

--- a/internal/staticanalysis/corpus/runner.go
+++ b/internal/staticanalysis/corpus/runner.go
@@ -1,0 +1,289 @@
+package corpus
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/harumiWeb/xlflow/internal/analyze"
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/lint"
+)
+
+// NativeProject identifies a checked-in xlflow project under example/.
+// Native projects are deliberately separate from the third-party manifest's
+// Project type, whose Path and provenance fields have a different contract.
+type NativeProject struct {
+	ID   string
+	Root string
+}
+
+type Surface string
+
+const (
+	SurfaceConfig  Surface = "config"
+	SurfaceLint    Surface = "lint"
+	SurfaceAnalyze Surface = "analyze"
+)
+
+type FailureKind string
+
+const (
+	FailureInvalidProjectConfig FailureKind = "invalid_project_config"
+	FailureParser               FailureKind = "parser_failure"
+	FailureExecution            FailureKind = "execution_failure"
+)
+
+type Diagnostic struct {
+	Project  string  `json:"project"`
+	Surface  Surface `json:"surface"`
+	Code     string  `json:"code"`
+	Severity string  `json:"severity"`
+	File     string  `json:"file"`
+	Line     int     `json:"line"`
+	Column   int     `json:"column,omitempty"`
+}
+
+type Failure struct {
+	Project string      `json:"project"`
+	Surface Surface     `json:"surface"`
+	Kind    FailureKind `json:"kind"`
+	Err     error       `json:"-"`
+}
+
+type SurfaceResult struct {
+	Project     string       `json:"project"`
+	Surface     Surface      `json:"surface"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+	Failure     *Failure     `json:"failure,omitempty"`
+}
+
+type Report struct {
+	Surfaces    []SurfaceResult `json:"surfaces"`
+	Diagnostics []Diagnostic    `json:"diagnostics"`
+	Failures    []Failure       `json:"failures"`
+}
+
+// RunError reports project-level failures while preserving all successful and
+// partial results in the accompanying Report.
+type RunError struct {
+	Failures []Failure
+}
+
+func (e *RunError) Error() string {
+	if e == nil {
+		return "static-analysis corpus execution failed"
+	}
+	return fmt.Sprintf("static-analysis corpus execution failed for %d project surface(s)", len(e.Failures))
+}
+
+// DiscoverExampleProjects finds configured native projects without recursing
+// into their source trees. Results are identified and ordered deterministically.
+func DiscoverExampleProjects(repoRoot string) ([]NativeProject, error) {
+	root, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+	examplesRoot := filepath.Join(root, "example")
+	entries, err := os.ReadDir(examplesRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read example directory: %w", err)
+	}
+	projects := make([]NativeProject, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		projectRoot := filepath.Join(examplesRoot, entry.Name())
+		configPath := filepath.Join(projectRoot, config.FileName)
+		if _, err := os.Stat(configPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("inspect project %s: %w", entry.Name(), err)
+		}
+		projects = append(projects, NativeProject{
+			ID:   "self/" + entry.Name(),
+			Root: projectRoot,
+		})
+	}
+	sort.Slice(projects, func(i, j int) bool { return projects[i].ID < projects[j].ID })
+	return projects, nil
+}
+
+// SelectProjects filters projects by ID while retaining discovery order.
+// Empty ids selects every project.
+func SelectProjects(projects []NativeProject, ids []string) ([]NativeProject, error) {
+	if len(ids) == 0 {
+		return append([]NativeProject(nil), projects...), nil
+	}
+	known := make(map[string]NativeProject, len(projects))
+	for _, project := range projects {
+		if _, exists := known[project.ID]; exists {
+			return nil, fmt.Errorf("duplicate project ID %q", project.ID)
+		}
+		known[project.ID] = project
+	}
+	wanted := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, exists := wanted[id]; exists {
+			return nil, fmt.Errorf("duplicate selected project ID %q", id)
+		}
+		if _, exists := known[id]; !exists {
+			return nil, fmt.Errorf("unknown project ID %q", id)
+		}
+		wanted[id] = struct{}{}
+	}
+	selected := make([]NativeProject, 0, len(ids))
+	for _, project := range projects {
+		if _, ok := wanted[project.ID]; ok {
+			selected = append(selected, project)
+		}
+	}
+	return selected, nil
+}
+
+type executor struct {
+	loadConfig func(string) (config.Config, error)
+	runLint    func(string, config.Config) (lint.Result, error)
+	runAnalyze func(string, config.Config) (analyze.Result, error)
+}
+
+func productionExecutor() executor {
+	return executor{
+		loadConfig: config.Load,
+		runLint: func(root string, cfg config.Config) (lint.Result, error) {
+			return (lint.Linter{RootDir: root, Config: cfg}).RunResult()
+		},
+		runAnalyze: func(root string, cfg config.Config) (analyze.Result, error) {
+			return (analyze.Analyzer{RootDir: root, Config: cfg}).RunResult()
+		},
+	}
+}
+
+// RunProjects executes lint and analyze independently for each project. A
+// diagnostic is data, not a failure; only configuration or execution errors
+// populate the returned RunError.
+func RunProjects(projects []NativeProject) (Report, error) {
+	return runProjects(projects, productionExecutor())
+}
+
+func runProjects(projects []NativeProject, exec executor) (Report, error) {
+	report := Report{
+		Surfaces:    make([]SurfaceResult, 0, len(projects)*2),
+		Diagnostics: make([]Diagnostic, 0),
+		Failures:    make([]Failure, 0),
+	}
+	for _, project := range projects {
+		cfg, err := exec.loadConfig(project.Root)
+		if err != nil {
+			report.Failures = append(report.Failures, Failure{
+				Project: project.ID, Surface: SurfaceConfig, Kind: FailureInvalidProjectConfig, Err: err,
+			})
+			continue
+		}
+
+		lintResult, err := exec.runLint(project.Root, cfg)
+		lintSurface := SurfaceResult{Project: project.ID, Surface: SurfaceLint, Diagnostics: make([]Diagnostic, 0)}
+		if err != nil {
+			failure := Failure{Project: project.ID, Surface: SurfaceLint, Kind: classifyFailure(err), Err: err}
+			lintSurface.Failure = &failure
+			report.Failures = append(report.Failures, failure)
+		} else {
+			lintSurface.Diagnostics = normalizeLintDiagnostics(project.ID, lintResult.Issues)
+			report.Diagnostics = append(report.Diagnostics, lintSurface.Diagnostics...)
+		}
+		report.Surfaces = append(report.Surfaces, lintSurface)
+
+		analyzeResult, err := exec.runAnalyze(project.Root, cfg)
+		analyzeSurface := SurfaceResult{Project: project.ID, Surface: SurfaceAnalyze, Diagnostics: make([]Diagnostic, 0)}
+		if err != nil {
+			failure := Failure{Project: project.ID, Surface: SurfaceAnalyze, Kind: classifyFailure(err), Err: err}
+			analyzeSurface.Failure = &failure
+			report.Failures = append(report.Failures, failure)
+		} else {
+			analyzeSurface.Diagnostics = normalizeAnalyzeDiagnostics(project.ID, analyzeResult.Findings)
+			report.Diagnostics = append(report.Diagnostics, analyzeSurface.Diagnostics...)
+		}
+		report.Surfaces = append(report.Surfaces, analyzeSurface)
+	}
+	sortDiagnostics(report.Diagnostics)
+	sort.SliceStable(report.Failures, func(i, j int) bool {
+		a, b := report.Failures[i], report.Failures[j]
+		if a.Project != b.Project {
+			return a.Project < b.Project
+		}
+		if a.Surface != b.Surface {
+			return surfaceRank(a.Surface) < surfaceRank(b.Surface)
+		}
+		return a.Kind < b.Kind
+	})
+	if len(report.Failures) > 0 {
+		return report, &RunError{Failures: append([]Failure(nil), report.Failures...)}
+	}
+	return report, nil
+}
+
+func classifyFailure(err error) FailureKind {
+	var parseErr *analyze.ParseError
+	if errors.As(err, &parseErr) {
+		return FailureParser
+	}
+	return FailureExecution
+}
+
+func normalizeLintDiagnostics(project string, issues []lint.Issue) []Diagnostic {
+	result := make([]Diagnostic, 0, len(issues))
+	for _, issue := range issues {
+		result = append(result, Diagnostic{Project: project, Surface: SurfaceLint, Code: issue.Code, Severity: issue.Severity, File: filepath.ToSlash(filepath.Clean(issue.File)), Line: issue.Line, Column: issue.Column})
+	}
+	return result
+}
+
+func normalizeAnalyzeDiagnostics(project string, findings []analyze.Finding) []Diagnostic {
+	result := make([]Diagnostic, 0, len(findings))
+	for _, finding := range findings {
+		result = append(result, Diagnostic{Project: project, Surface: SurfaceAnalyze, Code: finding.Code, Severity: finding.Severity, File: filepath.ToSlash(filepath.Clean(finding.File)), Line: finding.Line, Column: finding.Column})
+	}
+	return result
+}
+
+func sortDiagnostics(diagnostics []Diagnostic) {
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		a, b := diagnostics[i], diagnostics[j]
+		if a.Project != b.Project {
+			return a.Project < b.Project
+		}
+		if a.Surface != b.Surface {
+			return surfaceRank(a.Surface) < surfaceRank(b.Surface)
+		}
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		if a.Column != b.Column {
+			return a.Column < b.Column
+		}
+		if a.Code != b.Code {
+			return a.Code < b.Code
+		}
+		return a.Severity < b.Severity
+	})
+}
+
+func surfaceRank(surface Surface) int {
+	switch surface {
+	case SurfaceConfig:
+		return 0
+	case SurfaceLint:
+		return 1
+	case SurfaceAnalyze:
+		return 2
+	default:
+		return 3
+	}
+}

--- a/internal/staticanalysis/corpus/runner_test.go
+++ b/internal/staticanalysis/corpus/runner_test.go
@@ -1,0 +1,218 @@
+package corpus
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/analyze"
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/lint"
+)
+
+func TestDiscoverExampleProjectsAndSelectByID(t *testing.T) {
+	repo := t.TempDir()
+	for _, name := range []string{"zeta", "alpha"} {
+		root := filepath.Join(repo, "example", name)
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, config.FileName), []byte("[project]\nentry = \"Main.Run\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "example", "not-a-project"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projects, err := DiscoverExampleProjects(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("discovered %d projects, want 2: %+v", len(projects), projects)
+	}
+	if got := []string{projects[0].ID, projects[1].ID}; !reflect.DeepEqual(got, []string{"self/alpha", "self/zeta"}) {
+		t.Fatalf("discovered IDs = %v", got)
+	}
+	selected, err := SelectProjects(projects, []string{"self/zeta"})
+	if err != nil || len(selected) != 1 || selected[0].ID != "self/zeta" {
+		t.Fatalf("selected = %+v, err = %v", selected, err)
+	}
+	if _, err := SelectProjects(projects, []string{"self/missing"}); err == nil {
+		t.Fatal("unknown project ID was accepted")
+	}
+	if _, err := SelectProjects(projects, []string{"self/alpha", "self/alpha"}); err == nil {
+		t.Fatal("duplicate selected project ID was accepted")
+	}
+}
+
+func TestRunProjectsClassifiesFailuresAndKeepsPartialResults(t *testing.T) {
+	projects := []NativeProject{
+		{ID: "self/config", Root: "config"},
+		{ID: "self/parser", Root: "parser"},
+		{ID: "self/execution", Root: "execution"},
+		{ID: "self/ok", Root: "ok"},
+	}
+	exec := executor{
+		loadConfig: func(root string) (config.Config, error) {
+			if root == "config" {
+				return config.Config{}, errors.New("invalid xlflow.toml")
+			}
+			return config.Default(), nil
+		},
+		runLint: func(root string, _ config.Config) (lint.Result, error) {
+			if root == "execution" {
+				return lint.Result{}, errors.New("lint filesystem failure")
+			}
+			return lint.Result{Issues: []lint.Issue{{Code: "VB001", Severity: "warning", File: "src/modules/Main.bas", Line: 2}}}, nil
+		},
+		runAnalyze: func(root string, _ config.Config) (analyze.Result, error) {
+			if root == "parser" {
+				return analyze.Result{}, &analyze.ParseError{Path: "src/modules/Main.bas", HasError: true}
+			}
+			return analyze.Result{Findings: []analyze.Finding{{Code: "VBA201", Severity: "warning", File: "src/modules/Main.bas", Line: 3}}}, nil
+		},
+	}
+	report, err := runProjects(projects, exec)
+	if err == nil {
+		t.Fatal("expected aggregate RunError")
+	}
+	var runErr *RunError
+	if !errors.As(err, &runErr) || len(runErr.Failures) != 3 {
+		t.Fatalf("aggregate error = %T %+v", err, err)
+	}
+	if len(report.Diagnostics) != 4 {
+		t.Fatalf("diagnostics = %+v", report.Diagnostics)
+	}
+	if len(report.Surfaces) != 6 {
+		t.Fatalf("surface results = %+v", report.Surfaces)
+	}
+	var parser, execution, configFailure bool
+	for _, failure := range report.Failures {
+		switch failure.Kind {
+		case FailureParser:
+			parser = true
+		case FailureExecution:
+			execution = true
+		case FailureInvalidProjectConfig:
+			configFailure = true
+		}
+	}
+	if !parser || !execution || !configFailure {
+		t.Fatalf("failure kinds = %+v", report.Failures)
+	}
+	if report.Diagnostics[0].Project != "self/execution" || report.Diagnostics[0].Surface != SurfaceAnalyze || report.Diagnostics[0].File != "src/modules/Main.bas" {
+		t.Fatalf("diagnostics are not normalized/sorted: %+v", report.Diagnostics)
+	}
+}
+
+func TestRunProjectsDiagnosticsAreDeterministic(t *testing.T) {
+	projects := []NativeProject{{ID: "self/sample", Root: "sample"}}
+	exec := executor{
+		loadConfig: func(string) (config.Config, error) { return config.Default(), nil },
+		runLint: func(string, config.Config) (lint.Result, error) {
+			return lint.Result{Issues: []lint.Issue{
+				{Code: "VB002", Severity: "warning", File: "b.bas", Line: 4},
+				{Code: "VB001", Severity: "warning", File: "a.bas", Line: 2},
+			}}, nil
+		},
+		runAnalyze: func(string, config.Config) (analyze.Result, error) {
+			return analyze.Result{Findings: []analyze.Finding{{Code: "VBA201", Severity: "warning", File: "a.bas", Line: 3}}}, nil
+		},
+	}
+	first, err := runProjects(projects, exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := runProjects(projects, exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first.Diagnostics, second.Diagnostics) {
+		t.Fatalf("diagnostics changed between runs:\n%+v\n%+v", first.Diagnostics, second.Diagnostics)
+	}
+	if first.Diagnostics[0].Surface != SurfaceLint || first.Diagnostics[0].File != "a.bas" || first.Diagnostics[2].Surface != SurfaceAnalyze {
+		t.Fatalf("unexpected deterministic order: %+v", first.Diagnostics)
+	}
+}
+
+func TestRunProjectsUsesEachProjectConfig(t *testing.T) {
+	root := t.TempDir()
+	projects := make([]NativeProject, 0, 2)
+	for _, name := range []string{"enabled", "disabled"} {
+		projectRoot := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Join(projectRoot, "src", "modules"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfg := config.Default()
+		if name == "disabled" {
+			cfg.Lint.DisabledRules = []string{"VB002"}
+		}
+		if err := config.Write(filepath.Join(projectRoot, config.FileName), cfg); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(projectRoot, "src", "modules", "Main.bas"), []byte("Attribute VB_Name = \"Main\"\nOption Explicit\nPublic Sub Run()\n  Range(\"A1\").Select\nEnd Sub\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		projects = append(projects, NativeProject{ID: "self/" + name, Root: projectRoot})
+	}
+	report, err := RunProjects(projects)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := map[string]int{}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Code == "VB002" {
+			counts[diagnostic.Project]++
+		}
+	}
+	if counts["self/enabled"] == 0 || counts["self/disabled"] != 0 {
+		t.Fatalf("per-project config was not respected: %+v", counts)
+	}
+}
+
+func TestRealWorldCorpusExampleGenQRCode(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projects, err := DiscoverExampleProjects(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected, err := SelectProjects(projects, []string{"self/gen-qrcode"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectTree := filepath.Join(repoRoot, "example", "gen-qrcode")
+	before, err := TreeDigest(projectTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := RunProjects(selected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := TreeDigest(projectTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before != after {
+		t.Fatal("corpus runner mutated example/gen-qrcode")
+	}
+	if len(first.Surfaces) != 2 || first.Surfaces[0].Surface != SurfaceLint || first.Surfaces[1].Surface != SurfaceAnalyze {
+		t.Fatalf("surfaces = %+v", first.Surfaces)
+	}
+	if len(first.Diagnostics) == 0 {
+		t.Fatal("expected real-world analyze diagnostics")
+	}
+	second, err := RunProjects(selected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first.Diagnostics, second.Diagnostics) {
+		t.Fatal("real-world diagnostics were not deterministic")
+	}
+}

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -280,6 +280,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `exceptional_exit`
 - `excluded_components`
 - `executable_path`
+- `execution_failure`
 - `existing_warning`
 - `exit_code`
 - `exit_do`
@@ -411,6 +412,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `invalid_entry`
 - `invalid_formula`
 - `invalid_metadata_json`
+- `invalid_project_config`
 - `invalid_range`
 - `invalid_reference`
 - `invalid_row_selector`
@@ -576,6 +578,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `parenthesized_expression`
 - `parse_status`
 - `parse_status_summary`
+- `parser_failure`
 - `parser_node`
 - `parser_recovery`
 - `parser_token`


### PR DESCRIPTION
## Summary

- Add a project-aware runner for the configured `example/*` xlflow workspaces.
- Normalize lint/analyze diagnostics by project and surface while keeping ordinary findings as successful results.
- Classify invalid configuration, parser, and execution failures separately.

Closes #532

## Implementation

- Discover native projects by `xlflow.toml` and select them by stable `self/<name>` IDs.
- Reuse the production `config.Load`, lint, and analyze implementations without adding a CLI command or changing the third-party corpus manifest.
- Add typed `analyze.ParseError` handling and update the static-analysis corpus specification.

## Tests

- `rtk task test`
- `rtk task lint`
- `rtk pnpm format:check`
- Real-world `self/gen-qrcode` corpus execution, determinism, and source non-mutation coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline runner for discovering, selecting, and analyzing example projects individually.
  * Linting and analysis now run independently, with project-specific configuration support.
  * Reports preserve partial results and distinguish configuration, parser, and execution failures from diagnostics.
  * Diagnostic results are normalized and deterministic.

* **Documentation**
  * Documented the native corpus runner contract and added inventory entries for new failure types.

* **Bug Fixes**
  * Parser failures now include the affected file and detailed error metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->