### PR TITLE
feat: add isolated third-party corpus workspaces

### DIFF
--- a/docs/adr/ADR-0030-third-party-corpus-workspaces.md
+++ b/docs/adr/ADR-0030-third-party-corpus-workspaces.md
@@ -1,0 +1,91 @@
+# ADR-0030: Isolated Third-Party Corpus Workspaces and Host Profiles
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #530 requires the real-world analyzer corpus to preserve project
+boundaries. The vendored projects selected by Issue #531 are ordinary VBA
+exports, not xlflow workspaces: their files may be nested, `.cls` can represent
+an Excel or Access document module, and the source tree must remain untouched.
+
+The production analyzer already has the correct project-scoped behavior, but
+it discovers files from configured xlflow source roots. A corpus-specific
+adapter is therefore needed. The corpus also contains Excel, generic VBA, and
+Access projects; reporting Excel object-model findings for a non-Excel project
+would make the regression evidence misleading.
+
+## Decision
+
+Materialize each enabled third-party manifest project into a unique temporary
+xlflow workspace and run the existing production `lint` and `analyze`
+implementations against that workspace. Preserve source bytes and relative
+paths, keep a complete workspace-to-project source map, and remove only the
+invocation-owned temporary child on every exit path.
+
+Use `.bas → standard`, `.cls → class`, and `.frm → form` as conservative
+defaults. Add exact, project-relative manifest classifications for document
+modules; do not infer document semantics from file names or `Attribute VB_*`
+metadata. Unsupported layouts, irregular files, collisions, missing
+classifications, and unmapped diagnostics are explicit workspace failures.
+
+Keep host-profile policy inside `internal/staticanalysis/corpus`. The `excel`
+profile uses the normal analyzer configuration. `generic-vba` and `access`
+remove Excel object-model diagnostics from corpus evidence, disabling
+configurable rules in generated configs and filtering the two always-on
+Excel-member rules at normalization. The shared rule registry and production
+Analyzer API remain unchanged.
+
+Normalized third-party diagnostics use `third_party/<manifest-id>` as the
+project identity and the original project-relative file path. Disabled
+projects require a manifest note and are reported as documented skips.
+
+## Consequences
+
+- Existing parser, symbol, CFG, and call-resolution semantics are reused
+  without rewriting vendored source or creating a merged synthetic project.
+- Temporary workspace creation and source mapping add a cleanup and failure
+  boundary that must be tested separately from analyzer diagnostics.
+- Exact classification entries require manifest maintenance when an upstream
+  project adds document modules, but they prevent unsafe host-specific guesses.
+- Profile filtering keeps non-Excel evidence useful while intentionally making
+  the policy corpus-specific; future host taxonomy work can extend this layer
+  without changing production rule metadata.
+
+## Alternatives Considered
+
+1. **Merge all third-party files into one workspace** - Rejected because
+   project-local symbols and host semantics would cross-contaminate results.
+2. **Modify vendored sources into committed xlflow layouts** - Rejected because
+   it breaks upstream byte preservation and makes refreshes harder to audit.
+3. **Infer document modules from names or VB attributes** - Rejected because
+   exported `.cls` conventions are not reliable across VBA hosts.
+4. **Add host metadata to the shared rule registry** - Rejected for v1 because
+   host selection is a corpus evidence concern and would expand production
+   API/registry compatibility scope.
+
+## Evidence
+
+- Issue #530 parent acceptance requirements and Issue #533 adapter scope.
+- `docs/specs/static-analysis-corpus.md`.
+- `internal/staticanalysis/corpus/manifest.go` and `runner.go`.
+- `testdata/static-analysis-corpus/manifest.json` classifications.
+- `docs/adr/ADR-0024-shared-static-analysis-rule-registry.md`.
+
+## Supersedes
+
+None.
+
+## Superseded by
+
+None.
+
+## Related
+
+- Issue #530
+- Issue #533
+- Issue #534
+- `docs/adr/ADR-0029-vendored-static-analysis-corpus.md`
+- `docs/specs/static-analysis-corpus.md`

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -52,15 +52,21 @@ The JSON document has exactly these top-level fields:
         "license": "MIT",
         "license_file": "LICENSE",
         "source_file": "SOURCE.md"
-      }
+      },
+      "classifications": [{ "path": "examples/analytics/AnalyticsSheet.cls", "kind": "document" }]
     }
   ]
 }
 ```
 
 `notes` is optional; when present it must contain non-whitespace text without
-leading or trailing padding. The allowed profiles are `excel`, `generic-vba`,
-and `access`. `source.origin` is
+leading or trailing padding. A disabled project must provide `notes` as its
+documented skip reason. `classifications` is an optional path-sorted list of
+exact project-relative source paths and module kinds (`standard`, `class`,
+`form`, or `document`). The default mapping is `.bas` to `standard`, `.cls` to
+`class`, and `.frm` to `form`; the adapter never infers document-module
+semantics from names or `Attribute VB_*` values. The allowed profiles are
+`excel`, `generic-vba`, and `access`. `source.origin` is
 currently only `tree-sitter-vba`. `provenance.license` is an SPDX identifier.
 The `license_file` and `source_file` values are required relative paths inside
 the destination project and must be present in the checked-in tree. `SOURCE.md`
@@ -70,9 +76,11 @@ normalization or file-removal performed during import.
 The loader uses strict JSON decoding. It rejects unknown fields, unsupported
 schema/profile/origin values, missing required values, duplicate IDs or
 destination/source paths, duplicate provenance paths, malformed repository
-names or commit hashes, overlapping project paths, and unsorted project
-entries. IDs are stable and lowercase; projects are ordered lexicographically by
-ID. All paths use `/`,
+names or commit hashes, overlapping project paths, and unsorted project or
+classification entries. It also rejects classification traversal, duplicate
+paths, unsupported extensions/kinds, and disabled projects without a reason.
+IDs are stable and lowercase; projects are ordered lexicographically by ID.
+All paths use `/`,
 are relative, contain no empty, `.` or `..` segment, do not name a drive/UNC
 root, and remain within the corpus or upstream checkout boundary. A project
 destination must remain under `projects/third_party`.
@@ -138,10 +146,35 @@ failures separately from normalized diagnostic records.
 
 The runner is test/developer infrastructure. It reads source files only and
 does not modify examples, invoke the corpus synchronizer, fetch upstream
-content, open Excel, or require COM/VBE. Third-party manifest profiles and
-vendored projects remain governed by the synchronization contract above; a
-third-party adapter, golden snapshots, and snapshot-delta reporting are
-follow-up work and must not change this sync contract.
+content, open Excel, or require COM/VBE.
+
+### Third-party workspace adapter
+
+Enabled manifest projects are analyzed independently. For each project the
+adapter creates an invocation-owned temporary child containing
+`src/modules`, `src/classes`, `src/forms`, `src/workbook`, and a generated
+`xlflow.toml`. Source files retain their project-relative subdirectories and
+bytes. The generated config applies the profile policy and uses `frm` as the
+UserForm code source. `.cls` document modules are placed under `src/workbook`
+only when an exact manifest classification says `document`.
+
+The result project ID is `third_party/<manifest-id>` and the diagnostic file is
+the stable project-relative source path. Temporary paths are never emitted in
+normalized diagnostics. Missing source-map entries, unsupported layouts,
+copy collisions, irregular files, and cleanup failures are reported as
+workspace failures; they do not silently fall back to temporary paths.
+Disabled projects are skipped with their manifest `notes` reason. Cleanup is
+performed after both analysis surfaces, including failure paths, and removes
+only the workspace child owned by that invocation.
+
+Profiles are selected in the corpus adapter, not in the shared static-analysis
+registry. `excel` keeps the normal rule set. `generic-vba` and `access` omit
+the Excel object-model rules `VB002`, `VB003`, `VB027`, `VBA104`, `VBA201`,
+`VBA203`, `VBA205`, `VBA211`, `VBA215`, `VBA216`, `VBA217`, `VBA218`, `VBA221`,
+`VBA225`, and `VBA226` from corpus evidence. Configurable rules are disabled
+in the generated project config; always-on `VBA104` and `VBA211` are filtered
+at normalization. This policy affects corpus evidence only and does not alter
+production analyzer semantics.
 
 ## Verification requirements
 
@@ -169,6 +202,14 @@ tree before and after execution to prove that corpus analysis is read-only.
 These tests protect the project-isolation and failure-boundary contracts that
 unit fixtures alone cannot establish.
 
+Third-party adapter tests cover manifest classifications, byte-preserving
+materialization of all three vendored projects, generated profile configs,
+document-module placement, source-map remapping, temporary-path exclusion,
+disabled-project skips, partial-result preservation, and cleanup after both
+success and failure. A representative third-party project is analyzed through
+the production lint/analyze implementations; the full golden snapshot and CI
+integration remain follow-up work.
+
 The corpus does not change static-analysis semantics, public CLI/API output,
 Excel/VBE oracle behavior, or Go dependency-inventory checks. Those suites
 remain separate from synchronization and may run fully offline.
@@ -176,6 +217,7 @@ remain separate from synchronization and may run fully offline.
 ## Related
 
 - `docs/adr/ADR-0029-vendored-static-analysis-corpus.md`
+- `docs/adr/ADR-0030-third-party-corpus-workspaces.md`
 - `docs/adr/ADR-0024-shared-static-analysis-rule-registry.md`
 - `docs/adr/ADR-0026-local-vbe-oracle-evidence.md`
 - Issue #530

--- a/internal/staticanalysis/corpus/manifest.go
+++ b/internal/staticanalysis/corpus/manifest.go
@@ -44,13 +44,14 @@ type Upstream struct {
 }
 
 type Project struct {
-	ID         string     `json:"id"`
-	Path       string     `json:"path"`
-	Profile    string     `json:"profile"`
-	Enabled    bool       `json:"enabled"`
-	Notes      string     `json:"notes,omitempty"`
-	Source     Source     `json:"source"`
-	Provenance Provenance `json:"provenance"`
+	ID              string           `json:"id"`
+	Path            string           `json:"path"`
+	Profile         string           `json:"profile"`
+	Enabled         bool             `json:"enabled"`
+	Notes           string           `json:"notes,omitempty"`
+	Source          Source           `json:"source"`
+	Provenance      Provenance       `json:"provenance"`
+	Classifications []Classification `json:"classifications,omitempty"`
 
 	// Presence flags are populated while decoding JSON.  They make it possible
 	// to distinguish a deliberately disabled project from a missing `enabled`
@@ -58,6 +59,22 @@ type Project struct {
 	enabledPresent bool
 	notesPresent   bool
 }
+
+// Classification overrides the default extension-to-module-kind mapping for
+// one source file. Paths are project-relative and deliberately exact; the
+// adapter never guesses document-module semantics from file names or VBA
+// attributes.
+type Classification struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+}
+
+const (
+	ModuleKindStandard = "standard"
+	ModuleKindClass    = "class"
+	ModuleKindForm     = "form"
+	ModuleKindDocument = "document"
+)
 
 type Source struct {
 	Origin string `json:"origin"`
@@ -186,6 +203,9 @@ func ValidateManifest(manifest Manifest) error {
 		if p.notesPresent && (p.Notes == "" || p.Notes != strings.TrimSpace(p.Notes)) {
 			return fmt.Errorf("project %q notes must be non-empty and unpadded", p.ID)
 		}
+		if !p.Enabled && strings.TrimSpace(p.Notes) == "" {
+			return fmt.Errorf("disabled project %q requires a non-empty notes reason", p.ID)
+		}
 		if err := validateSourcePath(p.Source.Path); err != nil {
 			return fmt.Errorf("project %q source.path: %w", p.ID, err)
 		}
@@ -200,6 +220,9 @@ func ValidateManifest(manifest Manifest) error {
 		if err := validateProvenance(p.Provenance); err != nil {
 			return fmt.Errorf("project %q provenance: %w", p.ID, err)
 		}
+		if err := validateClassifications(p.ID, p.Classifications); err != nil {
+			return err
+		}
 	}
 	// Source and destination paths may not overlap; otherwise one copy could
 	// consume or overwrite another project and boundaries would be ambiguous.
@@ -211,6 +234,35 @@ func ValidateManifest(manifest Manifest) error {
 			if pathOverlap(manifest.Projects[i].Path, manifest.Projects[j].Path) {
 				return fmt.Errorf("projects %q and %q have overlapping destination paths", manifest.Projects[i].ID, manifest.Projects[j].ID)
 			}
+		}
+	}
+	return nil
+}
+
+func validateClassifications(projectID string, classifications []Classification) error {
+	seen := make(map[string]struct{}, len(classifications))
+	for i, classification := range classifications {
+		if err := validateRelativePath(classification.Path); err != nil {
+			return fmt.Errorf("project %q classification %d path: %w", projectID, i, err)
+		}
+		ext := strings.ToLower(path.Ext(classification.Path))
+		switch ext {
+		case ".bas", ".cls", ".frm":
+		default:
+			return fmt.Errorf("project %q classification %q targets unsupported extension %q", projectID, classification.Path, ext)
+		}
+		switch classification.Kind {
+		case ModuleKindStandard, ModuleKindClass, ModuleKindForm, ModuleKindDocument:
+		default:
+			return fmt.Errorf("project %q classification %q has unsupported kind %q", projectID, classification.Path, classification.Kind)
+		}
+		key := strings.ToLower(classification.Path)
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("project %q has duplicate classification path %q", projectID, classification.Path)
+		}
+		seen[key] = struct{}{}
+		if i > 0 && classifications[i-1].Path >= classification.Path {
+			return fmt.Errorf("project %q classifications must be sorted by path: %q follows %q", projectID, classification.Path, classifications[i-1].Path)
 		}
 	}
 	return nil

--- a/internal/staticanalysis/corpus/manifest.go
+++ b/internal/staticanalysis/corpus/manifest.go
@@ -251,10 +251,19 @@ func validateClassifications(projectID string, classifications []Classification)
 		default:
 			return fmt.Errorf("project %q classification %q targets unsupported extension %q", projectID, classification.Path, ext)
 		}
-		switch classification.Kind {
-		case ModuleKindStandard, ModuleKindClass, ModuleKindForm, ModuleKindDocument:
-		default:
-			return fmt.Errorf("project %q classification %q has unsupported kind %q", projectID, classification.Path, classification.Kind)
+		switch ext {
+		case ".bas":
+			if classification.Kind != ModuleKindStandard {
+				return fmt.Errorf("project %q classification %q must use kind %q", projectID, classification.Path, ModuleKindStandard)
+			}
+		case ".frm":
+			if classification.Kind != ModuleKindForm {
+				return fmt.Errorf("project %q classification %q must use kind %q", projectID, classification.Path, ModuleKindForm)
+			}
+		case ".cls":
+			if classification.Kind != ModuleKindClass && classification.Kind != ModuleKindDocument {
+				return fmt.Errorf("project %q classification %q has unsupported kind %q", projectID, classification.Path, classification.Kind)
+			}
 		}
 		key := strings.ToLower(classification.Path)
 		if _, exists := seen[key]; exists {

--- a/internal/staticanalysis/corpus/manifest_test.go
+++ b/internal/staticanalysis/corpus/manifest_test.go
@@ -45,6 +45,9 @@ func TestLoadManifestRejectsMalformedDocuments(t *testing.T) {
 		{"path traversal", strings.Replace(valid, "projects/third_party/one", "projects/third_party/../one", 1), "non-canonical"},
 		{"unsupported profile", strings.Replace(valid, `"generic-vba"`, `"other"`, 1), "unsupported profile"},
 		{"empty notes", strings.Replace(valid, `"enabled":true`, `"enabled":true,"notes":"  "`, 1), "notes"},
+		{"disabled without reason", strings.Replace(valid, `"enabled":true`, `"enabled":false`, 1), "requires a non-empty notes reason"},
+		{"unsupported classification kind", strings.Replace(valid, `"source":{"origin"`, `"classifications":[{"path":"Main.bas","kind":"other"}],"source":{"origin"`, 1), "unsupported kind"},
+		{"classification traversal", strings.Replace(valid, `"source":{"origin"`, `"classifications":[{"path":"../Main.bas","kind":"standard"}],"source":{"origin"`, 1), "classification"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -57,6 +60,24 @@ func TestLoadManifestRejectsMalformedDocuments(t *testing.T) {
 				t.Fatalf("LoadManifest() error = %v, want substring %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestValidateManifestRejectsInvalidClassificationOrderingAndDuplicates(t *testing.T) {
+	manifest := fixtureManifest("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	manifest.Projects[0].Classifications = []Classification{
+		{Path: "z.cls", Kind: ModuleKindClass},
+		{Path: "a.cls", Kind: ModuleKindClass},
+	}
+	if err := ValidateManifest(manifest); err == nil || !strings.Contains(err.Error(), "sorted by path") {
+		t.Fatalf("unsorted classifications accepted: %v", err)
+	}
+	manifest.Projects[0].Classifications = []Classification{
+		{Path: "Main.cls", Kind: ModuleKindClass},
+		{Path: "main.cls", Kind: ModuleKindClass},
+	}
+	if err := ValidateManifest(manifest); err == nil || !strings.Contains(err.Error(), "duplicate classification") {
+		t.Fatalf("case-insensitive duplicate classifications accepted: %v", err)
 	}
 }
 
@@ -226,7 +247,7 @@ func fixtureManifest(commit string) Manifest {
 		Upstream:      Upstream{Repository: "harumiWeb/tree-sitter-vba", Commit: commit},
 		Projects: []Project{
 			{ID: "one", Path: "projects/third_party/one", Profile: ProfileGenericVBA, Enabled: true, Source: Source{Origin: OriginTreeSitterVBA, Path: "examples/third_party/one"}, Provenance: Provenance{Repository: "https://example.test/one", License: "MIT", LicenseFile: "LICENSE", SourceFile: "SOURCE.md"}},
-			{ID: "two", Path: "projects/third_party/two", Profile: ProfileExcel, Enabled: false, Source: Source{Origin: OriginTreeSitterVBA, Path: "examples/third_party/two"}, Provenance: Provenance{Repository: "https://example.test/two", License: "MIT", LicenseFile: "LICENSE", SourceFile: "SOURCE.md"}},
+			{ID: "two", Path: "projects/third_party/two", Profile: ProfileExcel, Enabled: false, Notes: "fixture disabled in this test", Source: Source{Origin: OriginTreeSitterVBA, Path: "examples/third_party/two"}, Provenance: Provenance{Repository: "https://example.test/two", License: "MIT", LicenseFile: "LICENSE", SourceFile: "SOURCE.md"}},
 		},
 	}
 }

--- a/internal/staticanalysis/corpus/manifest_test.go
+++ b/internal/staticanalysis/corpus/manifest_test.go
@@ -46,7 +46,7 @@ func TestLoadManifestRejectsMalformedDocuments(t *testing.T) {
 		{"unsupported profile", strings.Replace(valid, `"generic-vba"`, `"other"`, 1), "unsupported profile"},
 		{"empty notes", strings.Replace(valid, `"enabled":true`, `"enabled":true,"notes":"  "`, 1), "notes"},
 		{"disabled without reason", strings.Replace(valid, `"enabled":true`, `"enabled":false`, 1), "requires a non-empty notes reason"},
-		{"unsupported classification kind", strings.Replace(valid, `"source":{"origin"`, `"classifications":[{"path":"Main.bas","kind":"other"}],"source":{"origin"`, 1), "unsupported kind"},
+		{"unsupported classification kind", strings.Replace(valid, `"source":{"origin"`, `"classifications":[{"path":"Main.cls","kind":"other"}],"source":{"origin"`, 1), "unsupported kind"},
 		{"classification traversal", strings.Replace(valid, `"source":{"origin"`, `"classifications":[{"path":"../Main.bas","kind":"standard"}],"source":{"origin"`, 1), "classification"},
 	}
 	for _, test := range tests {
@@ -78,6 +78,24 @@ func TestValidateManifestRejectsInvalidClassificationOrderingAndDuplicates(t *te
 	}
 	if err := ValidateManifest(manifest); err == nil || !strings.Contains(err.Error(), "duplicate classification") {
 		t.Fatalf("case-insensitive duplicate classifications accepted: %v", err)
+	}
+}
+
+func TestValidateManifestRejectsInvalidClassificationKindPairs(t *testing.T) {
+	for _, test := range []struct {
+		name, path, kind, want string
+	}{
+		{"standard source as document", "Main.bas", ModuleKindDocument, "must use kind \"standard\""},
+		{"form source as class", "Dialog.frm", ModuleKindClass, "must use kind \"form\""},
+		{"class source as form", "Sheet.cls", ModuleKindForm, "unsupported kind"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			manifest := fixtureManifest("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+			manifest.Projects[0].Classifications = []Classification{{Path: test.path, Kind: test.kind}}
+			if err := ValidateManifest(manifest); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("invalid classification pair error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/staticanalysis/corpus/profile.go
+++ b/internal/staticanalysis/corpus/profile.go
@@ -1,0 +1,40 @@
+package corpus
+
+import (
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+)
+
+// These rules depend on the Excel object model. The policy intentionally
+// lives in the corpus adapter rather than the shared rule registry because it
+// describes evidence selection for third-party fixtures, not analyzer meaning.
+var nonExcelRuleIDs = map[string]struct{}{
+	"VB002": {}, "VB003": {}, "VB027": {},
+	"VBA104": {}, "VBA201": {}, "VBA203": {}, "VBA205": {},
+	"VBA211": {}, "VBA215": {}, "VBA216": {}, "VBA217": {},
+	"VBA218": {}, "VBA221": {}, "VBA225": {}, "VBA226": {},
+}
+
+var configurableNonExcelLintRuleIDs = []string{"VB002", "VB003", "VB027"}
+
+var configurableNonExcelAnalyzeRuleIDs = []string{
+	"VBA201", "VBA203", "VBA205", "VBA215", "VBA216", "VBA217",
+	"VBA218", "VBA221", "VBA225", "VBA226",
+}
+
+func applyProfilePolicy(cfg *config.Config, profile string) {
+	if strings.EqualFold(profile, ProfileExcel) {
+		return
+	}
+	cfg.Lint.DisabledRules = append([]string(nil), configurableNonExcelLintRuleIDs...)
+	cfg.Analyze.DisabledRules = append([]string(nil), configurableNonExcelAnalyzeRuleIDs...)
+}
+
+func profileExcludes(profile, code string) bool {
+	if strings.EqualFold(profile, ProfileExcel) {
+		return false
+	}
+	_, ok := nonExcelRuleIDs[strings.ToUpper(strings.TrimSpace(code))]
+	return ok
+}

--- a/internal/staticanalysis/corpus/runner.go
+++ b/internal/staticanalysis/corpus/runner.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/harumiWeb/xlflow/internal/analyze"
 	"github.com/harumiWeb/xlflow/internal/config"
@@ -34,6 +36,8 @@ const (
 	FailureInvalidProjectConfig FailureKind = "invalid_project_config"
 	FailureParser               FailureKind = "parser_failure"
 	FailureExecution            FailureKind = "execution_failure"
+	FailureWorkspace            FailureKind = "workspace_failure"
+	FailureUnsupportedLayout    FailureKind = "unsupported_project_layout"
 )
 
 type Diagnostic struct {
@@ -53,6 +57,11 @@ type Failure struct {
 	Err     error       `json:"-"`
 }
 
+type Skip struct {
+	Project string `json:"project"`
+	Reason  string `json:"reason"`
+}
+
 type SurfaceResult struct {
 	Project     string       `json:"project"`
 	Surface     Surface      `json:"surface"`
@@ -64,6 +73,7 @@ type Report struct {
 	Surfaces    []SurfaceResult `json:"surfaces"`
 	Diagnostics []Diagnostic    `json:"diagnostics"`
 	Failures    []Failure       `json:"failures"`
+	Skipped     []Skip          `json:"skipped,omitempty"`
 }
 
 // RunError reports project-level failures while preserving all successful and
@@ -170,6 +180,120 @@ func RunProjects(projects []NativeProject) (Report, error) {
 	return runProjects(projects, productionExecutor())
 }
 
+// SelectThirdPartyProjects filters manifest projects by their stable manifest
+// IDs. Empty ids selects every project in manifest order, including disabled
+// entries so callers can report their documented skip reasons.
+func SelectThirdPartyProjects(projects []Project, ids []string) ([]Project, error) {
+	if len(ids) == 0 {
+		return append([]Project(nil), projects...), nil
+	}
+	known := make(map[string]Project, len(projects))
+	for _, project := range projects {
+		if _, exists := known[project.ID]; exists {
+			return nil, fmt.Errorf("duplicate project ID %q", project.ID)
+		}
+		known[project.ID] = project
+	}
+	wanted := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, exists := wanted[id]; exists {
+			return nil, fmt.Errorf("duplicate selected project ID %q", id)
+		}
+		if _, exists := known[id]; !exists {
+			return nil, fmt.Errorf("unknown project ID %q", id)
+		}
+		wanted[id] = struct{}{}
+	}
+	selected := make([]Project, 0, len(ids))
+	for _, project := range projects {
+		if _, ok := wanted[project.ID]; ok {
+			selected = append(selected, project)
+		}
+	}
+	return selected, nil
+}
+
+// RunThirdPartyProjects materializes and analyzes each vendored project in an
+// isolated workspace. The caller supplies the manifest directory as
+// corpusRoot, not the project destination itself.
+func RunThirdPartyProjects(corpusRoot string, projects []Project, opts MaterializeOptions) (Report, error) {
+	return runThirdPartyProjects(corpusRoot, projects, opts, productionExecutor())
+}
+
+func runThirdPartyProjects(corpusRoot string, projects []Project, opts MaterializeOptions, exec executor) (Report, error) {
+	report := Report{
+		Surfaces:    make([]SurfaceResult, 0, len(projects)*2),
+		Diagnostics: make([]Diagnostic, 0),
+		Failures:    make([]Failure, 0),
+		Skipped:     make([]Skip, 0),
+	}
+	for _, project := range projects {
+		projectID := "third_party/" + project.ID
+		if !project.Enabled {
+			report.Skipped = append(report.Skipped, Skip{Project: projectID, Reason: project.Notes})
+			continue
+		}
+		workspace, err := MaterializeThirdPartyProject(corpusRoot, project, opts)
+		if err != nil {
+			failure := Failure{Project: projectID, Surface: SurfaceConfig, Kind: classifyThirdPartyFailure(err), Err: err}
+			report.Failures = append(report.Failures, failure)
+			continue
+		}
+		cfg, err := exec.loadConfig(workspace.Root)
+		if err != nil {
+			failure := Failure{Project: projectID, Surface: SurfaceConfig, Kind: FailureInvalidProjectConfig, Err: err}
+			report.Failures = append(report.Failures, failure)
+			if closeErr := workspace.Close(); closeErr != nil {
+				closeFailure := Failure{Project: projectID, Surface: SurfaceConfig, Kind: FailureWorkspace, Err: closeErr}
+				report.Failures = append(report.Failures, closeFailure)
+			}
+			continue
+		}
+
+		lintSurface := SurfaceResult{Project: projectID, Surface: SurfaceLint, Diagnostics: make([]Diagnostic, 0)}
+		lintResult, lintErr := exec.runLint(workspace.Root, cfg)
+		if lintErr != nil {
+			failure := Failure{Project: projectID, Surface: SurfaceLint, Kind: classifyFailure(lintErr), Err: lintErr}
+			lintSurface.Failure = &failure
+			report.Failures = append(report.Failures, failure)
+		} else if diagnostics, normalizeErr := normalizeThirdPartyLintDiagnostics(projectID, project.Profile, workspace.Mappings, lintResult.Issues); normalizeErr != nil {
+			failure := Failure{Project: projectID, Surface: SurfaceLint, Kind: FailureWorkspace, Err: normalizeErr}
+			lintSurface.Failure = &failure
+			report.Failures = append(report.Failures, failure)
+		} else {
+			lintSurface.Diagnostics = diagnostics
+			report.Diagnostics = append(report.Diagnostics, diagnostics...)
+		}
+		report.Surfaces = append(report.Surfaces, lintSurface)
+
+		analyzeSurface := SurfaceResult{Project: projectID, Surface: SurfaceAnalyze, Diagnostics: make([]Diagnostic, 0)}
+		analyzeResult, analyzeErr := exec.runAnalyze(workspace.Root, cfg)
+		if analyzeErr != nil {
+			failure := Failure{Project: projectID, Surface: SurfaceAnalyze, Kind: classifyFailure(analyzeErr), Err: analyzeErr}
+			analyzeSurface.Failure = &failure
+			report.Failures = append(report.Failures, failure)
+		} else if diagnostics, normalizeErr := normalizeThirdPartyAnalyzeDiagnostics(projectID, project.Profile, workspace.Mappings, analyzeResult.Findings); normalizeErr != nil {
+			failure := Failure{Project: projectID, Surface: SurfaceAnalyze, Kind: FailureWorkspace, Err: normalizeErr}
+			analyzeSurface.Failure = &failure
+			report.Failures = append(report.Failures, failure)
+		} else {
+			analyzeSurface.Diagnostics = diagnostics
+			report.Diagnostics = append(report.Diagnostics, diagnostics...)
+		}
+		report.Surfaces = append(report.Surfaces, analyzeSurface)
+		if closeErr := workspace.Close(); closeErr != nil {
+			failure := Failure{Project: projectID, Surface: SurfaceConfig, Kind: FailureWorkspace, Err: closeErr}
+			report.Failures = append(report.Failures, failure)
+		}
+	}
+	sortDiagnostics(report.Diagnostics)
+	sortThirdPartyFailuresAndSkips(&report)
+	if len(report.Failures) > 0 {
+		return report, &RunError{Failures: append([]Failure(nil), report.Failures...)}
+	}
+	return report, nil
+}
+
 func runProjects(projects []NativeProject, exec executor) (Report, error) {
 	report := Report{
 		Surfaces:    make([]SurfaceResult, 0, len(projects)*2),
@@ -234,6 +358,13 @@ func classifyFailure(err error) FailureKind {
 	return FailureExecution
 }
 
+func classifyThirdPartyFailure(err error) FailureKind {
+	if errors.Is(err, ErrUnsupportedProjectLayout) {
+		return FailureUnsupportedLayout
+	}
+	return FailureWorkspace
+}
+
 func normalizeLintDiagnostics(project string, issues []lint.Issue) []Diagnostic {
 	result := make([]Diagnostic, 0, len(issues))
 	for _, issue := range issues {
@@ -248,6 +379,63 @@ func normalizeAnalyzeDiagnostics(project string, findings []analyze.Finding) []D
 		result = append(result, Diagnostic{Project: project, Surface: SurfaceAnalyze, Code: finding.Code, Severity: finding.Severity, File: filepath.ToSlash(filepath.Clean(finding.File)), Line: finding.Line, Column: finding.Column})
 	}
 	return result
+}
+
+func normalizeThirdPartyLintDiagnostics(project, profile string, mappings map[string]string, issues []lint.Issue) ([]Diagnostic, error) {
+	result := make([]Diagnostic, 0, len(issues))
+	for _, issue := range issues {
+		if profileExcludes(profile, issue.Code) {
+			continue
+		}
+		file, err := remapThirdPartyPath(mappings, issue.File)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, Diagnostic{Project: project, Surface: SurfaceLint, Code: issue.Code, Severity: issue.Severity, File: file, Line: issue.Line, Column: issue.Column})
+	}
+	return result, nil
+}
+
+func normalizeThirdPartyAnalyzeDiagnostics(project, profile string, mappings map[string]string, findings []analyze.Finding) ([]Diagnostic, error) {
+	result := make([]Diagnostic, 0, len(findings))
+	for _, finding := range findings {
+		if profileExcludes(profile, finding.Code) {
+			continue
+		}
+		file, err := remapThirdPartyPath(mappings, finding.File)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, Diagnostic{Project: project, Surface: SurfaceAnalyze, Code: finding.Code, Severity: finding.Severity, File: file, Line: finding.Line, Column: finding.Column})
+	}
+	return result, nil
+}
+
+func remapThirdPartyPath(mappings map[string]string, file string) (string, error) {
+	key := path.Clean(filepath.ToSlash(strings.TrimSpace(file)))
+	if key == "." || key == "" {
+		return "", fmt.Errorf("third-party diagnostic has empty source path")
+	}
+	if source, ok := mappings[key]; ok {
+		return source, nil
+	}
+	return "", fmt.Errorf("third-party diagnostic path %q is not in the materialized source map", file)
+}
+
+func sortThirdPartyFailuresAndSkips(report *Report) {
+	sort.SliceStable(report.Failures, func(i, j int) bool {
+		a, b := report.Failures[i], report.Failures[j]
+		if a.Project != b.Project {
+			return a.Project < b.Project
+		}
+		if a.Surface != b.Surface {
+			return surfaceRank(a.Surface) < surfaceRank(b.Surface)
+		}
+		return a.Kind < b.Kind
+	})
+	sort.SliceStable(report.Skipped, func(i, j int) bool {
+		return report.Skipped[i].Project < report.Skipped[j].Project
+	})
 }
 
 func sortDiagnostics(diagnostics []Diagnostic) {

--- a/internal/staticanalysis/corpus/workspace.go
+++ b/internal/staticanalysis/corpus/workspace.go
@@ -1,0 +1,262 @@
+package corpus
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+)
+
+var ErrUnsupportedProjectLayout = errors.New("unsupported third-party project layout")
+
+// MaterializeOptions controls the temporary parent used by a third-party
+// workspace. TempRoot is useful for tests; the caller owns that directory and
+// the materializer only removes the unique child it creates.
+type MaterializeOptions struct {
+	TempRoot string
+}
+
+// MaterializedWorkspace is an isolated xlflow-compatible view of one
+// vendored project. Mappings use slash-separated paths relative to Root.
+type MaterializedWorkspace struct {
+	Root      string
+	ProjectID string
+	Profile   string
+	Mappings  map[string]string
+	closed    bool
+}
+
+// Close removes only this workspace. It is safe to call more than once.
+func (w *MaterializedWorkspace) Close() error {
+	if w == nil || w.Root == "" || w.closed {
+		return nil
+	}
+	if err := os.RemoveAll(w.Root); err != nil {
+		return fmt.Errorf("remove materialized workspace %q: %w", w.Root, err)
+	}
+	w.closed = true
+	return nil
+}
+
+// MaterializeThirdPartyProject copies one checked-in project into a temporary
+// xlflow workspace and generates a config that preserves the project's host
+// profile policy.
+func MaterializeThirdPartyProject(corpusRoot string, project Project, opts MaterializeOptions) (workspace MaterializedWorkspace, err error) {
+	if err := validateProjectForMaterialization(project); err != nil {
+		return workspace, err
+	}
+	root, err := filepath.Abs(corpusRoot)
+	if err != nil {
+		return workspace, fmt.Errorf("resolve corpus root: %w", err)
+	}
+	sourceRoot, err := containedPath(root, project.Path)
+	if err != nil {
+		return workspace, fmt.Errorf("project %q source: %w", project.ID, err)
+	}
+	if info, statErr := os.Lstat(sourceRoot); statErr != nil {
+		return workspace, fmt.Errorf("project %q source: %w", project.ID, statErr)
+	} else if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return workspace, fmt.Errorf("%w: project %q source is not a regular directory", ErrUnsupportedProjectLayout, project.ID)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return workspace, fmt.Errorf("resolve corpus root: %w", err)
+	}
+	resolvedSource, err := filepath.EvalSymlinks(sourceRoot)
+	if err != nil {
+		return workspace, fmt.Errorf("resolve project %q source: %w", project.ID, err)
+	}
+	if err := ensureContained(resolvedRoot, resolvedSource); err != nil {
+		return workspace, fmt.Errorf("project %q source: %w", project.ID, err)
+	}
+
+	tempParent := opts.TempRoot
+	if tempParent == "" {
+		tempParent = os.TempDir()
+	}
+	tempParent, err = filepath.Abs(tempParent)
+	if err != nil {
+		return workspace, fmt.Errorf("resolve workspace temp root: %w", err)
+	}
+	workspace.Root, err = os.MkdirTemp(tempParent, "xlflow-corpus-")
+	if err != nil {
+		return workspace, fmt.Errorf("create materialized workspace: %w", err)
+	}
+	workspace.ProjectID = "third_party/" + project.ID
+	workspace.Profile = project.Profile
+	workspace.Mappings = make(map[string]string)
+	defer func() {
+		if err != nil {
+			if closeErr := workspace.Close(); closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
+		}
+	}()
+
+	for _, dir := range []string{"src/modules", "src/classes", "src/forms", "src/workbook"} {
+		if err := os.MkdirAll(filepath.Join(workspace.Root, filepath.FromSlash(dir)), 0o755); err != nil {
+			return workspace, fmt.Errorf("create workspace source root %s: %w", dir, err)
+		}
+	}
+	overrides := make(map[string]string, len(project.Classifications))
+	for _, classification := range project.Classifications {
+		overrides[strings.ToLower(classification.Path)] = classification.Kind
+	}
+	seenOverrides := make(map[string]bool, len(overrides))
+	seenDestinations := make(map[string]string)
+	err = filepath.WalkDir(sourceRoot, func(sourcePath string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: source contains symlink or reparse point: %s", ErrUnsupportedProjectLayout, filepath.ToSlash(sourcePath))
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%w: source contains special file: %s", ErrUnsupportedProjectLayout, filepath.ToSlash(sourcePath))
+		}
+		rel, relErr := filepath.Rel(sourceRoot, sourcePath)
+		if relErr != nil {
+			return relErr
+		}
+		relSlash := filepath.ToSlash(rel)
+		ext := strings.ToLower(filepath.Ext(rel))
+		if ext != ".bas" && ext != ".cls" && ext != ".frm" {
+			return nil
+		}
+		kind := defaultModuleKind(ext)
+		if override, ok := overrides[strings.ToLower(relSlash)]; ok {
+			kind = override
+			seenOverrides[strings.ToLower(relSlash)] = true
+		}
+		destDir := moduleKindDirectory(kind)
+		destRel := path.Join(destDir, relSlash)
+		key := strings.ToLower(destRel)
+		if prior, exists := seenDestinations[key]; exists {
+			return fmt.Errorf("%w: source files %q and %q collide in workspace destination %q", ErrUnsupportedProjectLayout, prior, relSlash, destRel)
+		}
+		seenDestinations[key] = relSlash
+		destination := filepath.Join(workspace.Root, filepath.FromSlash(destRel))
+		if err := ensureContained(workspace.Root, destination); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+			return err
+		}
+		body, readErr := os.ReadFile(sourcePath)
+		if readErr != nil {
+			return readErr
+		}
+		if writeErr := os.WriteFile(destination, body, 0o644); writeErr != nil {
+			return writeErr
+		}
+		workspaceRel, relErr := filepath.Rel(workspace.Root, destination)
+		if relErr != nil {
+			return relErr
+		}
+		workspace.Mappings[filepath.ToSlash(workspaceRel)] = relSlash
+		return nil
+	})
+	if err != nil {
+		return workspace, fmt.Errorf("materialize project %q: %w", project.ID, err)
+	}
+	for overridePath := range overrides {
+		if !seenOverrides[overridePath] {
+			return workspace, fmt.Errorf("%w: project %q classification targets missing source %q", ErrUnsupportedProjectLayout, project.ID, overridePath)
+		}
+	}
+
+	cfg := config.Default()
+	cfg.Project.Name = project.ID
+	cfg.Project.Entry = "Corpus.Run"
+	cfg.UserForm.CodeSource = "frm"
+	applyProfilePolicy(&cfg, project.Profile)
+	if err := config.Write(filepath.Join(workspace.Root, config.FileName), cfg); err != nil {
+		return workspace, fmt.Errorf("write materialized project config: %w", err)
+	}
+	return workspace, nil
+}
+
+func validateProjectForMaterialization(project Project) error {
+	if !identifierPattern.MatchString(project.ID) {
+		return fmt.Errorf("invalid project id %q", project.ID)
+	}
+	if err := validateRelativePath(project.Path); err != nil {
+		return fmt.Errorf("invalid project path: %w", err)
+	}
+	if !strings.HasPrefix(project.Path, "projects/third_party/") || project.Path == "projects/third_party/" {
+		return fmt.Errorf("invalid project path %q: must be below projects/third_party", project.Path)
+	}
+	if err := validateClassifications(project.ID, project.Classifications); err != nil {
+		return err
+	}
+	return nil
+}
+
+func defaultModuleKind(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".bas":
+		return ModuleKindStandard
+	case ".cls":
+		return ModuleKindClass
+	case ".frm":
+		return ModuleKindForm
+	default:
+		return ""
+	}
+}
+
+func moduleKindDirectory(kind string) string {
+	switch kind {
+	case ModuleKindStandard:
+		return "src/modules"
+	case ModuleKindClass:
+		return "src/classes"
+	case ModuleKindForm:
+		return "src/forms"
+	case ModuleKindDocument:
+		return "src/workbook"
+	default:
+		return ""
+	}
+}
+
+func containedPath(root, relative string) (string, error) {
+	if err := validateRelativePath(relative); err != nil {
+		return "", err
+	}
+	candidate := filepath.Join(root, filepath.FromSlash(relative))
+	if err := ensureContained(root, candidate); err != nil {
+		return "", err
+	}
+	return candidate, nil
+}
+
+func ensureContained(root, candidate string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	candidateAbs, err := filepath.Abs(candidate)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(rootAbs, candidateAbs)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return errors.New("path escapes its root")
+	}
+	return nil
+}

--- a/internal/staticanalysis/corpus/workspace_test.go
+++ b/internal/staticanalysis/corpus/workspace_test.go
@@ -1,0 +1,262 @@
+package corpus
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/analyze"
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/lint"
+	"github.com/harumiWeb/xlflow/internal/vba/symbols"
+)
+
+func TestMaterializeThirdPartyProjectsPreservesSourcesAndClassifications(t *testing.T) {
+	manifest, corpusRoot, err := LoadManifest(filepath.Join("..", "..", "..", "testdata", "static-analysis-corpus", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempRoot := t.TempDir()
+	for _, project := range manifest.Projects {
+		if !project.Enabled {
+			continue
+		}
+		projectRoot := filepath.Join(corpusRoot, filepath.FromSlash(project.Path))
+		before, err := TreeDigest(projectRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		workspace, err := MaterializeThirdPartyProject(corpusRoot, project, MaterializeOptions{TempRoot: tempRoot})
+		if err != nil {
+			t.Fatalf("materialize %s: %v", project.ID, err)
+		}
+		loaded, err := config.Load(workspace.Root)
+		if err != nil {
+			t.Fatalf("load generated config for %s: %v", project.ID, err)
+		}
+		if loaded.UserForm.CodeSource != "frm" {
+			t.Fatalf("generated userform code source = %q", loaded.UserForm.CodeSource)
+		}
+		if project.Profile == ProfileExcel && len(loaded.Analyze.DisabledRules) != 0 {
+			t.Fatalf("excel profile unexpectedly disabled rules: %v", loaded.Analyze.DisabledRules)
+		}
+		if project.Profile != ProfileExcel && len(loaded.Analyze.DisabledRules) == 0 {
+			t.Fatalf("%s profile did not apply non-Excel policy", project.Profile)
+		}
+		if len(workspace.Mappings) == 0 {
+			t.Fatalf("project %s produced no source mappings", project.ID)
+		}
+		for workspacePath, sourcePath := range workspace.Mappings {
+			body, err := os.ReadFile(filepath.Join(workspace.Root, filepath.FromSlash(workspacePath)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			original, err := os.ReadFile(filepath.Join(projectRoot, filepath.FromSlash(sourcePath)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(body) != string(original) {
+				t.Fatalf("source bytes changed for %s: %s", project.ID, sourcePath)
+			}
+		}
+		if err := workspace.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(workspace.Root); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("workspace was not removed, stat error = %v", err)
+		}
+		after, err := TreeDigest(projectRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if before != after {
+			t.Fatalf("materialization changed source tree for %s", project.ID)
+		}
+	}
+	entries, err := os.ReadDir(tempRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("materializer left temporary children: %v", entries)
+	}
+}
+
+func TestMaterializeThirdPartyProjectUsesDocumentOverrides(t *testing.T) {
+	manifest, corpusRoot, err := LoadManifest(filepath.Join("..", "..", "..", "testdata", "static-analysis-corpus", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempRoot := t.TempDir()
+	for _, want := range []struct {
+		id, source, destination string
+	}{
+		{"access-examples", "Form_001_About_frm.cls", "src/workbook/Form_001_About_frm.cls"},
+		{"vba-web", "examples/analytics/AnalyticsSheet.cls", "src/workbook/examples/analytics/AnalyticsSheet.cls"},
+	} {
+		var project Project
+		for _, candidate := range manifest.Projects {
+			if candidate.ID == want.id {
+				project = candidate
+			}
+		}
+		workspace, err := MaterializeThirdPartyProject(corpusRoot, project, MaterializeOptions{TempRoot: tempRoot})
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for workspacePath, sourcePath := range workspace.Mappings {
+			if sourcePath == want.source {
+				found = workspacePath == want.destination
+			}
+		}
+		if !found {
+			t.Fatalf("%s was not mapped to %s: %v", want.source, want.destination, workspace.Mappings)
+		}
+		if err := workspace.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestMaterializeThirdPartyProjectRejectsMissingClassificationAndCleansUp(t *testing.T) {
+	manifest, corpusRoot, err := LoadManifest(filepath.Join("..", "..", "..", "testdata", "static-analysis-corpus", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := manifest.Projects[1]
+	project.Classifications = []Classification{{Path: "missing.cls", Kind: ModuleKindClass}}
+	tempRoot := t.TempDir()
+	if _, err := MaterializeThirdPartyProject(corpusRoot, project, MaterializeOptions{TempRoot: tempRoot}); err == nil || !errors.Is(err, ErrUnsupportedProjectLayout) {
+		t.Fatalf("missing classification error = %v", err)
+	}
+	entries, err := os.ReadDir(tempRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("failed materialization left temporary children: %v", entries)
+	}
+}
+
+func TestMaterializeThirdPartyProjectRejectsSymlinkSource(t *testing.T) {
+	corpusRoot := t.TempDir()
+	sourceRoot := filepath.Join(corpusRoot, "projects", "third_party", "fixture")
+	if err := os.MkdirAll(sourceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "Main.bas"), []byte("Option Explicit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(sourceRoot, "Main.bas"), filepath.Join(sourceRoot, "Link.bas")); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	project := Project{ID: "fixture", Path: "projects/third_party/fixture", Profile: ProfileGenericVBA, Enabled: true}
+	if _, err := MaterializeThirdPartyProject(corpusRoot, project, MaterializeOptions{TempRoot: t.TempDir()}); err == nil || !errors.Is(err, ErrUnsupportedProjectLayout) {
+		t.Fatalf("symlink source error = %v", err)
+	}
+}
+
+func TestThirdPartyProfileFilteringAndStableRemap(t *testing.T) {
+	mappings := map[string]string{"src/modules/Main.bas": "nested/Main.bas"}
+	lintDiagnostics, err := normalizeThirdPartyLintDiagnostics("third_party/access", ProfileAccess, mappings, []lint.Issue{
+		{Code: "VB002", Severity: "warning", File: "src/modules/Main.bas", Line: 1},
+		{Code: "VB001", Severity: "warning", File: "src/modules/Main.bas", Line: 2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lintDiagnostics) != 1 || lintDiagnostics[0].Code != "VB001" || lintDiagnostics[0].File != "nested/Main.bas" {
+		t.Fatalf("unexpected filtered lint diagnostics: %+v", lintDiagnostics)
+	}
+	analyzeDiagnostics, err := normalizeThirdPartyAnalyzeDiagnostics("third_party/access", ProfileAccess, mappings, []analyze.Finding{
+		{Code: "VBA104", Severity: "error", File: "src/modules/Main.bas", Line: 1},
+		{Code: "VBA219", Severity: "warning", File: "src/modules/Main.bas", Line: 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(analyzeDiagnostics) != 1 || analyzeDiagnostics[0].Code != "VBA219" {
+		t.Fatalf("unexpected filtered analyze diagnostics: %+v", analyzeDiagnostics)
+	}
+	if _, err := normalizeThirdPartyLintDiagnostics("third_party/access", ProfileAccess, mappings, []lint.Issue{{Code: "VB001", File: "temporary/path.bas"}}); err == nil || !strings.Contains(err.Error(), "not in the materialized source map") {
+		t.Fatalf("unmapped path error = %v", err)
+	}
+}
+
+func TestRunThirdPartyProjectsReportsSkipsAndRemapsDiagnostics(t *testing.T) {
+	manifest, corpusRoot, err := LoadManifest(filepath.Join("..", "..", "..", "testdata", "static-analysis-corpus", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projects := []Project{manifest.Projects[0], manifest.Projects[1]}
+	projects[0].Enabled = false
+	projects[0].Notes = "not included by this test"
+	report, err := RunThirdPartyProjects(corpusRoot, projects, MaterializeOptions{TempRoot: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Skipped) != 1 || report.Skipped[0].Project != "third_party/access-examples" {
+		t.Fatalf("unexpected skips: %+v", report.Skipped)
+	}
+	if len(report.Surfaces) != 2 {
+		t.Fatalf("surfaces = %+v", report.Surfaces)
+	}
+	for _, diagnostic := range report.Diagnostics {
+		if strings.Contains(diagnostic.File, "xlflow-corpus-") || filepath.IsAbs(filepath.FromSlash(diagnostic.File)) {
+			t.Fatalf("diagnostic leaked temporary path: %+v", diagnostic)
+		}
+	}
+}
+
+func TestRunThirdPartyProjectsPreservesPartialResultsAfterWorkspaceFailure(t *testing.T) {
+	manifest, corpusRoot, err := LoadManifest(filepath.Join("..", "..", "..", "testdata", "static-analysis-corpus", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	broken := manifest.Projects[1]
+	broken.ID = "broken"
+	broken.Path = "projects/third_party/missing"
+	report, err := RunThirdPartyProjects(corpusRoot, []Project{broken, manifest.Projects[1]}, MaterializeOptions{TempRoot: t.TempDir()})
+	if err == nil {
+		t.Fatal("expected workspace failure")
+	}
+	if len(report.Failures) != 1 || report.Failures[0].Kind != FailureWorkspace {
+		t.Fatalf("unexpected failures: %+v", report.Failures)
+	}
+	if len(report.Diagnostics) == 0 || len(report.Surfaces) != 2 {
+		t.Fatalf("successful project results were not preserved: %+v", report)
+	}
+}
+
+func TestMaterializedWorkspaceClassifiesFilesForProductionSymbols(t *testing.T) {
+	manifest, corpusRoot, err := LoadManifest(filepath.Join("..", "..", "..", "testdata", "static-analysis-corpus", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := manifest.Projects[1]
+	workspace, err := MaterializeThirdPartyProject(corpusRoot, project, MaterializeOptions{TempRoot: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := workspace.Close(); err != nil {
+			t.Errorf("close materialized workspace: %v", err)
+		}
+	}()
+	cfg, err := config.Load(workspace.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := symbols.DiscoverSourceFiles(symbols.Options{RootDir: workspace.Root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		if file.ModuleKind == "" {
+			t.Fatalf("source file has no module kind: %+v", file)
+		}
+	}
+}

--- a/testdata/static-analysis-corpus/manifest.json
+++ b/testdata/static-analysis-corpus/manifest.json
@@ -19,7 +19,30 @@
         "license": "MIT",
         "license_file": "LICENSE",
         "source_file": "SOURCE.md"
-      }
+      },
+      "classifications": [
+        { "path": "Form_001_About_frm.cls", "kind": "document" },
+        { "path": "Form_002_Splash_Screen_frm.cls", "kind": "document" },
+        { "path": "Form_003_Buttons_frm.cls", "kind": "document" },
+        { "path": "Form_004_DSN_Password_frm.cls", "kind": "document" },
+        { "path": "Form_005_Access_Security_frm.cls", "kind": "document" },
+        { "path": "Form_006_Dialogbox_Examples_frm.cls", "kind": "document" },
+        { "path": "Form_010_Date_Calendar_frm.cls", "kind": "document" },
+        { "path": "Form_301_Roulette_frm.cls", "kind": "document" },
+        { "path": "Form_700_Create_Filelist_frm.cls", "kind": "document" },
+        { "path": "Form_800_Link_Manager_frm.cls", "kind": "document" },
+        { "path": "Form_900_Check_Runtime_frm.cls", "kind": "document" },
+        { "path": "Form_950_Leszynski_Conventions_frm.cls", "kind": "document" },
+        { "path": "Form_980_Data_Dictionary_frm.cls", "kind": "document" },
+        { "path": "Report_001_Organization_Logo_srp.cls", "kind": "document" },
+        { "path": "Report_099_Object_Listing_Report_rpt.cls", "kind": "document" },
+        { "path": "Report_803_Object_Calendar_List_rpt.cls", "kind": "document" },
+        { "path": "Report_803a_Calendar_List_srp.cls", "kind": "document" },
+        { "path": "Report_804_Weekly_Report_rpt.cls", "kind": "document" },
+        { "path": "Report_805_Timeline_Report_rpt.cls", "kind": "document" },
+        { "path": "Report_950_Leszynski_Conventions_rpt.cls", "kind": "document" },
+        { "path": "Report_980_Data_Dictionary_rpt.cls", "kind": "document" }
+      ]
     },
     {
       "id": "vba-json",
@@ -51,7 +74,15 @@
         "license": "MIT",
         "license_file": "LICENSE",
         "source_file": "SOURCE.md"
-      }
+      },
+      "classifications": [
+        { "path": "examples/analytics/AnalyticsSheet.cls", "kind": "document" },
+        { "path": "examples/linkedin/LinkedInSheet.cls", "kind": "document" },
+        { "path": "examples/maps/MapsSheet.cls", "kind": "document" },
+        { "path": "examples/ops/OPSSheet.cls", "kind": "document" },
+        { "path": "examples/salesforce/SalesforceSheet.cls", "kind": "document" },
+        { "path": "examples/twitter/TwitterSheet.cls", "kind": "document" }
+      ]
     }
   ]
 }

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -838,6 +838,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `unsupported_inline_suppression_rule`
 - `unsupported_literal`
 - `unsupported_parameter_type`
+- `unsupported_project_layout`
 - `unsupported_property`
 - `unsupported_test_isolation`
 - `unsupported_test_rerun`
@@ -924,6 +925,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `worksheet_cell`
 - `worksheet_change`
 - `worksheet_selectionchange`
+- `workspace_failure`
 - `workspace_resolution_views`
 - `write_only`
 - `writes_cells`


### PR DESCRIPTION
## Summary

- Add an isolated temporary xlflow workspace adapter for each vendored third-party VBA project.
- Preserve source bytes and stable project-relative diagnostic paths through explicit source mappings.
- Add exact `.cls` document-module classifications for the Access and VBA-Web corpus projects.
- Apply corpus-local Excel, generic-VBA, and Access profile policies without changing the shared analyzer registry or production Analyzer API.
- Report documented skips and workspace/layout failures, and clean up invocation-owned temporary workspaces on success and failure paths.
- Add regression tests, ADR-0030, corpus specification updates, and generated error-code inventory entries.

Related to #530. Implements #533.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test .\internal\staticanalysis\corpus -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test .\... -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 vet .\...`
- `rtk pnpm format:check`
- `rtk git diff --check`

Excel/COM/VBE E2E is not applicable because this is a source-only corpus infrastructure change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for analyzing third-party VBA and Access projects in isolated workspaces.
  - Added source mapping, document classifications, profile-specific analysis rules, and stable diagnostic paths.
  - Added reporting for skipped projects, unsupported layouts, and workspace failures while preserving partial results.

- **Bug Fixes**
  - Improved validation for project manifests, file classifications, duplicates, ordering, and disabled-project reasons.
  - Added safeguards against unsafe file layouts and incomplete workspace cleanup.

- **Documentation**
  - Documented workspace behavior, manifest requirements, verification scenarios, and new error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->