### PR TITLE
test(corpus): integrate real-world corpus into deterministic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,19 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+      - name: Run deterministic static-analysis corpus
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          XLFLOW_UPDATE_CORPUS_SNAPSHOTS=0 \
+            /usr/bin/time -f 'corpus_elapsed_seconds=%e' \
+            go test ./internal/staticanalysis/corpus \
+              -run '^TestRealWorldCorpusSnapshots$' -count=1 -v
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Corpus verification modified the worktree"
+            git status --short
+            exit 1
+          fi
       - run: go build ./...
       - run: go test ./...
       - run: dotnet test bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/Xlflow.ExcelBridge.Tests.csproj

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -113,6 +113,16 @@ tasks:
       - cmd: rtk go test ./internal/staticanalysis/corpus -run '^TestRealWorldCorpusSnapshots$' -count=1
         platforms: [linux, darwin]
 
+  corpus:test:
+    desc: Run real-world corpus snapshot tests without updating snapshots
+    env:
+      XLFLOW_UPDATE_CORPUS_SNAPSHOTS: "0"
+    cmds:
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^TestRealWorldCorpusSnapshots$' -count=1 --test.v
+        platforms: [windows]
+      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^TestRealWorldCorpusSnapshots$' -count=1 -v
+        platforms: [linux, darwin]
+
   bench:lsp:
     desc: Run deterministic LSP performance benchmarks
     cmds:

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -267,6 +267,178 @@ empty files during an explicit update so that a reviewed no-diagnostic result
 remains a committed baseline. Updating a baseline is a reviewable change to
 test data, not an automatic acceptance of newly observed analyzer behavior.
 
+## Operational workflow
+
+The corpus has three deliberately separate evidence layers. Focused unit
+fixtures are small, deterministic source snippets owned by the rule tests. They
+prove one parser, diagnostic, severity, or LSP contract at a time and should
+remain the first place to reproduce a suspected regression. The real-world
+corpus runs the production runner against the pinned native and vendored
+projects; it exercises project isolation, source mapping, and interactions
+between rules that a focused fixture cannot model. The VBE oracle is a local,
+developer-only authority for whether a focused VBA case compiles in the real
+Excel/VBE environment. It is not a policy or maintainability oracle, and it is
+never a replacement for either unit fixtures or the real-world run.
+
+Run the Excel-free contracts before investigating a corpus change. On Windows
+use the repository Go wrapper (which selects the supported CGO toolchain); on
+other platforms the direct Go command is equivalent:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/... -count=1
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/oracle -run '^TestCommittedFixtureContractsWithoutExcel$' -count=1
+```
+
+For a rule-level change, narrow the focused fixture run to the owning
+diagnostic packages before running the corpus-wide checks:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/lint ./internal/analyze -run 'TestLinter|Test.*Analyze' -count=1
+```
+
+```bash
+rtk go test ./internal/staticanalysis/... -count=1
+rtk go test ./internal/oracle -run '^TestCommittedFixtureContractsWithoutExcel$' -count=1
+```
+
+```bash
+rtk go test ./internal/lint ./internal/analyze -run 'TestLinter|Test.*Analyze' -count=1
+```
+
+Then verify the checked-in observed behavior without writing files:
+
+```powershell
+rtk task corpus:test
+```
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^TestRealWorldCorpusSnapshots$' -count=1
+```
+
+```bash
+rtk go test ./internal/staticanalysis/corpus -run '^TestRealWorldCorpusSnapshots$' -count=1
+```
+
+Every snapshot row is an observation of the analyzer version and pinned source
+tree at the time it was reviewed. A row is not a claim that the diagnostic is
+a true positive, that the source is approved, or that the rule is correct. A
+new row therefore requires diagnosis; simply regenerating the file is not a
+false-positive fix.
+
+### Pin and vendor changes
+
+Upstream refreshes are explicit data changes. Review the complete manifest
+change (including the full 40-character commit, source path, profile,
+provenance, and `SOURCE.md`) before running the synchronizer. From the
+repository root, use the supported entry point:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\sync-static-analysis-corpus.ps1
+```
+
+When the exact pinned commit is already available locally, the same operation
+can avoid a network fetch:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\sync-static-analysis-corpus.ps1 -UpstreamCheckout C:\src\tree-sitter-vba
+```
+
+The checkout `HEAD` must equal the manifest pin. The synchronizer's clean-tree
+check, staging, byte-preserving copy, metadata validation, and atomic publish
+are the only supported vendor update path; do not copy files by hand or edit a
+snapshot to hide a vendor diff. Inspect the resulting tree and `SOURCE.md`,
+run the Excel-free contracts, and run the real-world snapshot verification
+before proposing any snapshot update. A pin change and its resulting snapshot
+change are separate review concerns and must be explained separately.
+
+### Reading a snapshot delta
+
+The delta report is grouped by diagnostic code and retains every `+` and `-`
+row, including duplicate identities. Read it in this order:
+
+1. Confirm that the project/file path and line mapping are stable. A path or
+   line movement caused by a vendor refresh is source churn, not automatically
+   an analyzer regression.
+2. Check the manifest pin and vendored tree digest. If the source did not
+   change, reproduce the delta with the focused unit fixture and inspect the
+   rule implementation or registry severity.
+3. Run the same verification twice. A changing result indicates an ordering,
+   parser recovery, temporary-workspace, or other determinism failure; do not
+   update the snapshot until it is fixed.
+4. For a deliberate analyzer change, land the focused fixture and its review
+   first, then perform one explicit snapshot update and include the delta in
+   the change description.
+
+An added diagnostic in a real-world project is not evidence that the project is
+wrong, and a removed diagnostic is not evidence that the rule is now correct.
+Message-only changes are intentionally absent from identity; if message prose
+is a contract, test it in the owning focused fixture instead of broadening the
+snapshot schema.
+
+### False-positive handling and VBE escalation
+
+When a delta looks like a false positive, first reduce it to a focused fixture
+and add an adjacent accepted control. For a compile-equivalent rule, run the
+known controls and the focused VBE case sequentially:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\test-vbe-oracle.ps1 --case known-compile-accept --case known-compile-reject --strict
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\test-vbe-oracle.ps1 --case <focused-case-id> --strict
+```
+
+Only a confirmed `accepted` or `rejected` result with confirmed Excel cleanup
+may be used to bind analyzer behavior. A timeout, unknown modal, failed
+Compile invocation, worker/COM failure, or unconfirmed cleanup is an
+infrastructure failure: stop, inspect the owned Excel process, and do not
+change the analyzer or promote a fixture. Accepted negative controls must
+forbid the bound rule on every declared surface; rejected fixtures should list
+those controls in `negative_controls` as described by the VBE oracle contract.
+Policy and maintainability observations remain unbound when VBE compilation
+cannot establish their meaning. Do not silence a suspected false positive by
+deleting a row or weakening the real-world snapshot comparison.
+
+### Explicit snapshot updates
+
+After the source, fixture, and (when applicable) VBE evidence are reviewed,
+generate snapshots explicitly:
+
+```powershell
+rtk task corpus:update-snapshots
+```
+
+```bash
+rtk go test ./internal/staticanalysis/corpus -run '^TestRealWorldCorpusSnapshots$' -count=1
+```
+
+The update command sets `XLFLOW_UPDATE_CORPUS_SNAPSHOTS=1`; it must complete
+every selected project and both surfaces before the atomic snapshot tree is
+published. Re-run the verify-only command afterwards. A failed update must
+leave the previous tree byte-for-byte unchanged, and a zero-byte successful
+surface remains a required reviewed artifact.
+
+### Execution-time reference
+
+The following are review observations, not CI thresholds; record actual elapsed
+times in a pull request when a run is unusually slow. A Windows run of the
+focused corpus test on 2026-08-08 completed in 41.168 s according to Go's
+package timer and 43.959 s wall-clock time. The Linux CI step emits the same
+project-ordered timing logs plus `corpus_elapsed_seconds` so future regressions
+remain visible. Do not treat this single workstation measurement as a fixed
+upper bound; record a new observation when analyzer or corpus changes make the
+run unusually slow. The VBE oracle is intentionally slower: its default
+per-case timeout is 5 min and a multi-case run can take several minutes because
+Excel startup and cleanup are serialized.
+
+Measure a local run when timing matters:
+
+```powershell
+rtk powershell -NoProfile -Command "Measure-Command { rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^TestRealWorldCorpusSnapshots$' -count=1 } | Select-Object TotalSeconds"
+```
+
+Do not parallelize VBE cases or infer a hang from the broad `go test ./...`
+duration; Excel/COM tests have a materially different runtime profile from
+the Excel-free corpus checks.
+
 ## Verification requirements
 
 Manifest tests cover valid v1 data and rejection of unknown fields, unsupported

--- a/internal/staticanalysis/corpus/snapshot_test.go
+++ b/internal/staticanalysis/corpus/snapshot_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/harumiWeb/xlflow/internal/lint"
 	"github.com/harumiWeb/xlflow/internal/typedb"
@@ -243,12 +244,41 @@ func TestWriteSnapshotSetDoesNotPublishInvalidUpdate(t *testing.T) {
 	}
 }
 
-func runRealWorldCorpus(repoRoot string) (Report, error) {
+func runRealWorldCorpus(repoRoot string, logf ...func(string, ...any)) (Report, error) {
+	var timingLogf func(string, ...any)
+	if len(logf) > 0 {
+		timingLogf = logf[0]
+	}
+	started := time.Now()
+	defer func() {
+		if timingLogf != nil {
+			timingLogf("corpus timing: total=%s", time.Since(started))
+		}
+	}()
+
 	nativeProjects, err := DiscoverExampleProjects(repoRoot)
 	if err != nil {
 		return Report{}, err
 	}
-	nativeReport, nativeErr := RunProjects(nativeProjects)
+	var nativeReport Report
+	nativeFailed := false
+	for _, project := range nativeProjects {
+		projectStarted := time.Now()
+		report, err := RunProjects([]NativeProject{project})
+		nativeReport.Surfaces = append(nativeReport.Surfaces, report.Surfaces...)
+		nativeReport.Diagnostics = append(nativeReport.Diagnostics, report.Diagnostics...)
+		nativeReport.Failures = append(nativeReport.Failures, report.Failures...)
+		if err != nil {
+			nativeFailed = true
+		}
+		if timingLogf != nil {
+			timingLogf("corpus timing: project=%s elapsed=%s", project.ID, time.Since(projectStarted))
+		}
+	}
+	var nativeErr error
+	if nativeFailed {
+		nativeErr = &RunError{Failures: append([]Failure(nil), nativeReport.Failures...)}
+	}
 	manifestPath := filepath.Join(repoRoot, "testdata", "static-analysis-corpus", "manifest.json")
 	manifest, corpusRoot, manifestErr := LoadManifest(manifestPath)
 	if manifestErr != nil {
@@ -258,13 +288,35 @@ func runRealWorldCorpus(repoRoot string) (Report, error) {
 	if selectErr != nil {
 		return nativeReport, errors.Join(nativeErr, selectErr)
 	}
-	thirdReport, thirdErr := RunThirdPartyProjects(corpusRoot, thirdProjects, MaterializeOptions{})
+	var thirdReport Report
+	thirdFailed := false
+	for _, project := range thirdProjects {
+		projectStarted := time.Now()
+		report, err := RunThirdPartyProjects(corpusRoot, []Project{project}, MaterializeOptions{})
+		thirdReport.Surfaces = append(thirdReport.Surfaces, report.Surfaces...)
+		thirdReport.Diagnostics = append(thirdReport.Diagnostics, report.Diagnostics...)
+		thirdReport.Failures = append(thirdReport.Failures, report.Failures...)
+		thirdReport.Skipped = append(thirdReport.Skipped, report.Skipped...)
+		if err != nil {
+			thirdFailed = true
+		}
+		if timingLogf != nil {
+			timingLogf("corpus timing: project=third_party/%s elapsed=%s", project.ID, time.Since(projectStarted))
+		}
+	}
+	var thirdErr error
+	if thirdFailed {
+		sortThirdPartyFailuresAndSkips(&thirdReport)
+		thirdErr = &RunError{Failures: append([]Failure(nil), thirdReport.Failures...)}
+	}
 	combined := Report{
 		Surfaces:    append(append([]SurfaceResult(nil), nativeReport.Surfaces...), thirdReport.Surfaces...),
 		Diagnostics: append(append([]Diagnostic(nil), nativeReport.Diagnostics...), thirdReport.Diagnostics...),
 		Failures:    append(append([]Failure(nil), nativeReport.Failures...), thirdReport.Failures...),
 		Skipped:     append(append([]Skip(nil), nativeReport.Skipped...), thirdReport.Skipped...),
 	}
+	sortDiagnostics(combined.Diagnostics)
+	sortThirdPartyFailuresAndSkips(&combined)
 	return combined, errors.Join(nativeErr, thirdErr)
 }
 
@@ -276,7 +328,7 @@ func TestRealWorldCorpusSnapshots(t *testing.T) {
 	// Snapshot identities must not depend on a developer's generated TypeLib
 	// database. Use only the embedded built-in database for every platform.
 	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
-	report, runErr := runRealWorldCorpus(repoRoot)
+	report, runErr := runRealWorldCorpus(repoRoot, t.Logf)
 	if runErr != nil {
 		t.Fatalf("real-world corpus execution failed: %v", runErr)
 	}


### PR DESCRIPTION
## Summary

- Add a verify-only `corpus:test` task with deterministic, sequential project timing logs.
- Run the real-world corpus explicitly in Ubuntu CI with a 10-minute timeout and a clean-worktree assertion.
- Document the focused-fixture, real-world corpus, and VBE-oracle responsibilities, plus snapshot update, delta, pin-sync, and false-positive workflows.

Related to #530.

Closes #536.

## Tests

- `rtk task corpus:test` — passed; all projects reported in stable order with timing output.
- `rtk task test` — passed.
- `rtk task lint` — passed.
- `rtk pnpm docs:check` — passed.
- `rtk pnpm format:check` — passed.
- `rtk actionlint .github/workflows/ci.yml` — passed.

The new GitHub Actions step itself was not executed locally; its workflow syntax was validated with actionlint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added deterministic static-analysis corpus verification to automated checks.
  * Added timing and per-project reporting to improve visibility into analysis performance.
  * Ensured corpus results, failures, skips, and diagnostics are reported consistently.

* **Documentation**
  * Added guidance for running corpus checks, interpreting snapshot changes, handling false positives, and updating snapshots safely.

* **Chores**
  * Added a convenient command for running corpus verification consistently across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->