### PR TITLE
Add context cancellation to procedure dataflow analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added context-aware cancellation to procedure-level `VBA224` dataflow
+  analysis and propagated explicit cancellation errors through batch and
+  real-time analyzer paths.
 - Defined reviewed static-analysis corpus evidence with exact expected and
   forbidden diagnostic contracts, durable false-positive records, and
   reviewed-only per-rule precision metrics. Added developer tasks for printing

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -249,6 +249,28 @@ func (a Analyzer) Run() ([]Finding, error) {
 }
 
 func (a Analyzer) RunResult() (Result, error) {
+	return a.RunResultContext(context.Background())
+}
+
+// RunContext is the cancellable variant of Run.
+func (a Analyzer) RunContext(ctx context.Context) ([]Finding, error) {
+	result, err := a.RunResultContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return result.Findings, nil
+}
+
+// RunResultContext is the cancellable variant of RunResult. Cancellation is
+// returned explicitly so callers can distinguish it from analysis findings or
+// a project-specific timeout policy.
+func (a Analyzer) RunResultContext(ctx context.Context) (Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
 	files, err := a.files()
 	if err != nil {
 		return Result{}, err
@@ -261,6 +283,9 @@ func (a Analyzer) RunResult() (Result, error) {
 	needsTypeDB := needsTypedExcelAnalysis || a.Config.Analyze.DetectPublicAPITypeSafety
 	parsedFiles := make([]parsedFile, 0, len(files))
 	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return Result{}, err
+		}
 		source, err := os.ReadFile(file)
 		if err != nil {
 			closeParsedFiles(parsedFiles)
@@ -315,7 +340,10 @@ func (a Analyzer) RunResult() (Result, error) {
 	defer closeParsedFiles(parsedFiles)
 
 	projectEffects := buildProjectEffects(parsedFiles)
-	ctx := a.buildContext(parsedFiles)
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	analysisCtx := a.buildContext(parsedFiles)
 	analysis := a
 	if analysis.Config.Analyze.DetectApplicationStateCallEffects {
 		analysis.applicationStateLeaks = buildApplicationStateLeakIndex(parsedFiles, projectEffects)
@@ -357,15 +385,28 @@ func (a Analyzer) RunResult() (Result, error) {
 		publicAPITypeIndex = buildAPITypeIndex(parsedFiles, analysis.typeDB)
 	}
 	for _, file := range parsedFiles {
+		if err := ctx.Err(); err != nil {
+			return Result{}, err
+		}
 		if err := file.Parsed.Read(func(view vbaast.ParsedView) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			file.Root = view.Root
-			findings = append(findings, analysis.analyzeParsedFile(file, ctx, projectEffects)...)
+			fileFindings, analyzeErr := analysis.analyzeParsedFileContext(ctx, analysisCtx, file, projectEffects)
+			if analyzeErr != nil {
+				return analyzeErr
+			}
+			findings = append(findings, fileFindings...)
 			if publicAPITypeIndex != nil {
 				findings = append(findings, analysis.publicAPITypeFindings(file, publicAPITypeIndex)...)
 			}
 			findings = append(findings, analysis.errorValueWrapperFindings(file)...)
 			return nil
 		}); err != nil {
+			return Result{}, err
+		}
+		if err := ctx.Err(); err != nil {
 			return Result{}, err
 		}
 		// The typed VBA215/VBA218 analysis uses the same snapshot-owned parsed
@@ -930,7 +971,11 @@ func (a Analyzer) sourceRealtimeProcedureFindingsContext(ctx context.Context, fi
 	if a.Config.Analyze.DetectErrorHandlerFallthrough {
 		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc)...)
 	}
-	findings = append(findings, a.dataFlowFindings(file, proc)...)
+	dataFlowFindings, err := a.dataFlowFindingsContext(ctx, file, proc)
+	if err != nil {
+		return nil, err
+	}
+	findings = append(findings, dataFlowFindings...)
 	if a.Config.Analyze.DetectResourceLeaks {
 		findings = append(findings, a.resourceLeakFindings(file, proc)...)
 	}
@@ -1025,27 +1070,47 @@ func (a Analyzer) buildContext(files []parsedFile) analysisContext {
 	return ctx
 }
 
-func (a Analyzer) analyzeParsedFile(file parsedFile, ctx analysisContext, projectEffects effects.ProjectSummary) []Finding {
+func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analysisContext, file parsedFile, projectEffects effects.ProjectSummary) ([]Finding, error) {
+	if err := cancelCtx.Err(); err != nil {
+		return nil, err
+	}
 	reportedMissingHelpers := map[string]bool{}
 	var findings []Finding
 	procedures := sourceProceduresWithEffects(file, projectEffects)
 	moduleDecls := moduleDeclarations(file.Lines, procedures)
 	findings = append(findings, a.hardcodedSecretFindings(file, procedures)...)
 	for _, proc := range procedures {
-		findings = append(findings, a.analyzeProcedure(file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers)...)
+		if err := cancelCtx.Err(); err != nil {
+			return nil, err
+		}
+		procedureFindings, err := a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, procedureFindings...)
 	}
 	if len(procedures) == 0 {
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		findings = append(findings, a.analyzeProcedure(file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers)...)
+		procedureFindings, err := a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, procedureFindings...)
 	}
 	if a.Config.Analyze.DetectNonShortCircuitObjectGuard {
-		guardFindings, _ := a.nonShortCircuitObjectGuardDocumentFindings(context.Background(), file, procedures, nil)
+		guardFindings, err := a.nonShortCircuitObjectGuardDocumentFindings(cancelCtx, file, procedures, nil)
+		if err != nil {
+			return nil, err
+		}
 		findings = append(findings, guardFindings...)
 	}
-	return findings
+	return findings, cancelCtx.Err()
 }
 
-func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary, reportedMissingHelpers map[string]bool) []Finding {
+func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary, reportedMissingHelpers map[string]bool) ([]Finding, error) {
+	if err := cancelCtx.Err(); err != nil {
+		return nil, err
+	}
 	decls := cloneDeclarations(moduleDecls)
 	for key, decl := range procedureDeclarations(file.Lines, proc) {
 		decls[key] = decl
@@ -1065,6 +1130,11 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 	}
 
 	for i := proc.StartLine - 1; i < proc.EndLine && i < len(file.Lines); i++ {
+		if i&0xff == 0 {
+			if err := cancelCtx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		lineNo := i + 1
 		stmt := normalizedCodeLine(file.Lines[i])
 		worksheetStmt, worksheetStatementStart := worksheetLogicalStatement(file.Lines, i, proc.EndLine-1)
@@ -1172,7 +1242,11 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 	if a.Config.Analyze.DetectEventHandlerReentry {
 		findings = append(findings, a.eventHandlerReentryFindings(file, proc, projectEffects)...)
 	}
-	findings = append(findings, a.dataFlowFindings(file, proc)...)
+	dataFlowFindings, err := a.dataFlowFindingsContext(cancelCtx, file, proc)
+	if err != nil {
+		return nil, err
+	}
+	findings = append(findings, dataFlowFindings...)
 	if a.Config.Analyze.DetectResourceLeaks {
 		findings = append(findings, a.resourceLeakFindings(file, proc)...)
 	}
@@ -1189,7 +1263,7 @@ func (a Analyzer) analyzeProcedure(file parsedFile, proc sourceProcedure, module
 		findings = append(findings, a.rangeValueShapeFindings(file, proc)...)
 	}
 	findings = append(findings, a.functionReturnPathFindings(file, proc)...)
-	return findings
+	return findings, cancelCtx.Err()
 }
 
 func sourceProceduresWithEffects(file parsedFile, project effects.ProjectSummary) []sourceProcedure {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -284,6 +284,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (Result, error) {
 	parsedFiles := make([]parsedFile, 0, len(files))
 	for _, file := range files {
 		if err := ctx.Err(); err != nil {
+			closeParsedFiles(parsedFiles)
 			return Result{}, err
 		}
 		source, err := os.ReadFile(file)

--- a/internal/analyze/dataflow.go
+++ b/internal/analyze/dataflow.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,17 +9,18 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
-// dataFlowFindings is the single adapter used by batch and realtime analysis.
-// The dataflow package remains independent from analyzer and LSP protocols.
-func (a Analyzer) dataFlowFindings(file parsedFile, proc sourceProcedure) []Finding {
+func (a Analyzer) dataFlowFindingsContext(ctx context.Context, file parsedFile, proc sourceProcedure) ([]Finding, error) {
 	if !a.Config.Analyze.DetectUntrustedDataFlow || proc.Graph == nil {
-		return nil
+		return nil, nil
 	}
 	ir, ok := procedureIRForSource(file.IR, proc)
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	result := vbadf.AnalyzeProcedure(ir, *proc.Graph, vbadf.Options{Conservative: true})
+	result, err := vbadf.AnalyzeProcedureContext(ctx, ir, *proc.Graph, vbadf.Options{Conservative: true})
+	if err != nil {
+		return nil, err
+	}
 	findings := make([]Finding, 0, len(result.Findings))
 	for _, flow := range result.Findings {
 		line := flow.Sink.Range.StartLine
@@ -48,7 +50,7 @@ func (a Analyzer) dataFlowFindings(file parsedFile, proc sourceProcedure) []Find
 		}
 		findings = append(findings, finding)
 	}
-	return findings
+	return findings, nil
 }
 
 func procedureIRForSource(document procedureir.DocumentIR, proc sourceProcedure) (procedureir.ProcedureIR, bool) {

--- a/internal/analyze/vba224_dataflow_test.go
+++ b/internal/analyze/vba224_dataflow_test.go
@@ -21,6 +21,37 @@ func TestAnalyzerRunResultContextReturnsCancellation(t *testing.T) {
 	}
 }
 
+func TestAnalyzerRunResultContextReturnsCancellationDuringFileLoop(t *testing.T) {
+	dir := t.TempDir()
+	for _, module := range []string{"First", "Second", "Third"} {
+		writeModule(t, dir, module+".bas", `Attribute VB_Name = "`+module+`"
+Option Explicit
+
+Public Sub Run()
+End Sub
+`)
+	}
+
+	ctx := &cancelAfterChecksContext{Context: context.Background(), remaining: 2}
+	_, err := (Analyzer{RootDir: dir, Config: config.Default()}).RunResultContext(ctx)
+	if err != context.Canceled {
+		t.Fatalf("RunResultContext error = %v, want context.Canceled", err)
+	}
+}
+
+type cancelAfterChecksContext struct {
+	context.Context
+	remaining int
+}
+
+func (c *cancelAfterChecksContext) Err() error {
+	if c.remaining <= 0 {
+		return context.Canceled
+	}
+	c.remaining--
+	return nil
+}
+
 func TestVBA224DetectsDirectAliasAndConcatenation(t *testing.T) {
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"

--- a/internal/analyze/vba224_dataflow_test.go
+++ b/internal/analyze/vba224_dataflow_test.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"sort"
@@ -9,6 +10,16 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/config"
 )
+
+func TestAnalyzerRunResultContextReturnsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := (Analyzer{RootDir: t.TempDir(), Config: config.Default()}).RunResultContext(ctx)
+	if err != context.Canceled {
+		t.Fatalf("RunResultContext error = %v, want context.Canceled", err)
+	}
+}
 
 func TestVBA224DetectsDirectAliasAndConcatenation(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7343,7 +7343,7 @@ func (a *app) analyzeCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			analyzeResult, err := analyze.Analyzer{RootDir: a.cwd, Config: cfg}.RunResult()
+			analyzeResult, err := analyze.Analyzer{RootDir: a.cwd, Config: cfg}.RunResultContext(cmd.Context())
 			if err != nil {
 				return a.writeFailure("analyze", output.ExitEnvironment, "analyze_failed", err)
 			}
@@ -7381,7 +7381,7 @@ func (a *app) checkCommand() *cobra.Command {
 			}
 			issues := lintResult.Issues
 			check["lint"] = map[string]any{"status": statusForCount(len(issues)), "count": len(issues)}
-			analyzeResult, err := analyze.Analyzer{RootDir: a.cwd, Config: cfg}.RunResult()
+			analyzeResult, err := analyze.Analyzer{RootDir: a.cwd, Config: cfg}.RunResultContext(cmd.Context())
 			if err != nil {
 				return a.writeFailure("check", output.ExitEnvironment, "analyze_failed", err)
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
@@ -303,7 +304,9 @@ func isGeneratedCobraCommand(cmd *cobra.Command) bool {
 }
 
 func (a *app) executeRoot(root *cobra.Command) error {
-	err := root.Execute()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	err := root.ExecuteContext(ctx)
 	if err == nil {
 		return nil
 	}
@@ -1183,7 +1186,7 @@ func (a *app) formBuildCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := a.runFormWritePreflight("form build", cfg, opts); err != nil {
+			if err := a.runFormWritePreflight(cmd.Context(), "form build", cfg, opts); err != nil {
 				return err
 			}
 			var env output.Envelope
@@ -1235,7 +1238,7 @@ func (a *app) formApplyCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := a.runFormWritePreflight("form apply", cfg, opts); err != nil {
+			if err := a.runFormWritePreflight(cmd.Context(), "form apply", cfg, opts); err != nil {
 				return err
 			}
 			var env output.Envelope
@@ -1672,7 +1675,7 @@ func (a *app) initCommand() *cobra.Command {
 					if err != nil {
 						return a.writeFailure("init", output.ExitConfig, "module_install_failed", err)
 					}
-					pushEnv, pushCode, pushErr := a.pushSource("init", cfg, excel.PushOptions{
+					pushEnv, pushCode, pushErr := a.pushSource(cmd.Context(), "init", cfg, excel.PushOptions{
 						BackupMode: "always",
 						Keepalive:  runOpts,
 						SourceRoot: project.ResolveModuleRoot(a.cwd, cfg.Src),
@@ -2383,7 +2386,7 @@ func (a *app) pushCommand() *cobra.Command {
 			if err != nil {
 				return a.writeFailure("push", output.ExitConfig, "push_args_invalid", err)
 			}
-			env, code, err := a.pushSource("push", cfg, pushOpts, "Importing VBA source")
+			env, code, err := a.pushSource(cmd.Context(), "push", cfg, pushOpts, "Importing VBA source")
 			if err != nil {
 				return err
 			}
@@ -2584,7 +2587,7 @@ func (a *app) moduleInstallCommand() *cobra.Command {
 				return a.write(env, output.ExitSuccess)
 			}
 			commandOpts := buildCommandOptions(a.stderrWriter())
-			pushEnv, pushCode, pushErr := a.pushSource("module install", cfg, excel.PushOptions{
+			pushEnv, pushCode, pushErr := a.pushSource(cmd.Context(), "module install", cfg, excel.PushOptions{
 				BackupMode: "always",
 				Keepalive:  commandOpts,
 				SourceRoot: project.ResolveModuleRoot(a.cwd, cfg.Src),
@@ -2628,14 +2631,14 @@ func buildPushOptions(backupMode string, fast bool, changedOnly bool, session bo
 	}, nil
 }
 
-func (a *app) pushSource(command string, cfg config.Config, pushOpts excel.PushOptions, progressLabel string) (output.Envelope, int, error) {
+func (a *app) pushSource(ctx context.Context, command string, cfg config.Config, pushOpts excel.PushOptions, progressLabel string) (output.Envelope, int, error) {
 	if err := a.runUserFormCodeSourcePreflight(command, cfg, nil); err != nil {
 		return output.Envelope{}, 0, err
 	}
 	if err := a.runUserFormArtifactPreflight(command, cfg, nil); err != nil {
 		return output.Envelope{}, 0, err
 	}
-	if err := a.runSourcePreflight(command, cfg, "pushing to Excel", nil, nil); err != nil {
+	if err := a.runSourcePreflight(ctx, command, cfg, "pushing to Excel", nil, nil); err != nil {
 		return output.Envelope{}, 0, err
 	}
 	var env output.Envelope
@@ -4128,7 +4131,7 @@ func (a *app) runCommand() *cobra.Command {
 				if err != nil {
 					return a.writeFailure("run", output.ExitConfig, "run_args_invalid", err)
 				}
-				pushEnv, pushCode, pushErr := a.pushSource("run", cfg, pushOpts, "Importing VBA source")
+				pushEnv, pushCode, pushErr := a.pushSource(cmd.Context(), "run", cfg, pushOpts, "Importing VBA source")
 				if pushErr != nil {
 					return pushErr
 				}
@@ -4137,7 +4140,7 @@ func (a *app) runCommand() *cobra.Command {
 				}
 			}
 			if a.shouldRunSourcePreflight(cfg, opts) {
-				if err := a.runSourcePreflight("run", cfg, "running macros", nil, nil); err != nil {
+				if err := a.runSourcePreflight(cmd.Context(), "run", cfg, "running macros", nil, nil); err != nil {
 					return err
 				}
 			}
@@ -7563,7 +7566,7 @@ func (a *app) buildRunDiagnostic(cfg config.Config, env output.Envelope) map[str
 	return diag
 }
 
-func (a *app) runSourcePreflight(command string, cfg config.Config, action string, ignoredAnalysisCodes map[string]bool, pathFilter func(string) bool) error {
+func (a *app) runSourcePreflight(ctx context.Context, command string, cfg config.Config, action string, ignoredAnalysisCodes map[string]bool, pathFilter func(string) bool) error {
 	lintResult, err := lint.Linter{RootDir: a.cwd, Config: cfg, PathFilter: pathFilter}.RunResult()
 	if err != nil {
 		return a.writeFailure(command, output.ExitEnvironment, "lint_failed", err)
@@ -7581,7 +7584,7 @@ func (a *app) runSourcePreflight(command string, cfg config.Config, action strin
 		env.Logs = []string{"blocked before Excel automation to avoid a VBA editor dialog"}
 		return a.write(env, output.ExitValidation)
 	}
-	analyzeResult, err := analyze.Analyzer{RootDir: a.cwd, Config: cfg, PathFilter: pathFilter}.RunResult()
+	analyzeResult, err := analyze.Analyzer{RootDir: a.cwd, Config: cfg, PathFilter: pathFilter}.RunResultContext(ctx)
 	if err != nil {
 		exitCode := output.ExitEnvironment
 		if strings.HasPrefix(err.Error(), "parse ") {
@@ -7740,13 +7743,13 @@ func (a *app) runUserFormArtifactPreflight(command string, cfg config.Config, ta
 	return a.write(env, output.ExitValidation)
 }
 
-func (a *app) runFormWritePreflight(command string, cfg config.Config, opts formWriteCommandOptions) error {
+func (a *app) runFormWritePreflight(ctx context.Context, command string, cfg config.Config, opts formWriteCommandOptions) error {
 	targetForms := map[string]bool{opts.Spec.Form.Name: true}
 	if err := a.runUserFormCodeSourcePreflight(command, cfg, targetForms); err != nil {
 		return err
 	}
 	if cfg.UserForm.CodeSource == "sidecar" {
-		if err := a.runSourcePreflight(command, cfg, "writing workbook forms", nil, buildUserFormSourcePathFilter(a.cwd, cfg, targetForms)); err != nil {
+		if err := a.runSourcePreflight(ctx, command, cfg, "writing workbook forms", nil, buildUserFormSourcePathFilter(a.cwd, cfg, targetForms)); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7751,6 +7751,12 @@ func (a *app) runUserFormArtifactPreflight(command string, cfg config.Config, ta
 }
 
 func (a *app) runFormWritePreflight(ctx context.Context, command string, cfg config.Config, opts formWriteCommandOptions) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	targetForms := map[string]bool{opts.Spec.Form.Name: true}
 	if err := a.runUserFormCodeSourcePreflight(command, cfg, targetForms); err != nil {
 		return err

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -4880,15 +4880,27 @@ code_source = "sidecar"
 			Form: forms.FormSpecForm{Name: "UserForm1"},
 		},
 	}
-	if err := a.runFormWritePreflight(context.Background(), "form apply", cfg, opts); err != nil {
-		t.Fatalf("runFormWritePreflight() error = %v, exit = %d", err, output.ExitCode(err))
+	frmPath := filepath.Join(dir, "src", "forms", "UserForm1.frm")
+	beforeCanceled, err := os.ReadFile(frmPath)
+	if err != nil {
+		t.Fatal(err)
 	}
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
 	if err := a.runFormWritePreflight(canceled, "form apply", cfg, opts); !errors.Is(err, context.Canceled) {
 		t.Fatalf("canceled runFormWritePreflight() error = %v, want context.Canceled", err)
 	}
-	rewritten, err := os.ReadFile(filepath.Join(dir, "src", "forms", "UserForm1.frm"))
+	afterCanceled, err := os.ReadFile(frmPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(afterCanceled, beforeCanceled) {
+		t.Fatalf("canceled runFormWritePreflight() modified %s", frmPath)
+	}
+	if err := a.runFormWritePreflight(context.Background(), "form apply", cfg, opts); err != nil {
+		t.Fatalf("runFormWritePreflight() error = %v, exit = %d", err, output.ExitCode(err))
+	}
+	rewritten, err := os.ReadFile(frmPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -4880,7 +4880,7 @@ code_source = "sidecar"
 			Form: forms.FormSpecForm{Name: "UserForm1"},
 		},
 	}
-	if err := a.runFormWritePreflight("form apply", cfg, opts); err != nil {
+	if err := a.runFormWritePreflight(context.Background(), "form apply", cfg, opts); err != nil {
 		t.Fatalf("runFormWritePreflight() error = %v, exit = %d", err, output.ExitCode(err))
 	}
 	rewritten, err := os.ReadFile(filepath.Join(dir, "src", "forms", "UserForm1.frm"))

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -153,7 +153,10 @@ func (l Linter) RunResultContext(ctx context.Context) (Result, error) {
 	}
 	issues, suppressionWarnings := applyInlineSuppressions(issues, directives)
 	warnings = append(warnings, suppressionWarnings...)
-	return Result{Issues: issues, Warnings: warnings}, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	return Result{Issues: issues, Warnings: warnings}, nil
 }
 
 func (l Linter) filesContext(ctx context.Context) ([]string, error) {

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -30,6 +30,20 @@ func TestLinterRunResultContextReturnsCancellation(t *testing.T) {
 	}
 }
 
+func TestLinterRunResultContextReturnsZeroResultWhenCanceledDuringFinalization(t *testing.T) {
+	ctx := &lintCheckpointContext{cancelAt: 13}
+	result, err := (Linter{RootDir: t.TempDir(), Config: config.Default()}).RunResultContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunResultContext error = %v, want context.Canceled", err)
+	}
+	if !reflect.DeepEqual(result, Result{}) {
+		t.Fatalf("canceled result = %#v, want zero result", result)
+	}
+	if ctx.checks != ctx.cancelAt {
+		t.Fatalf("cancellation checks = %d, want finalization check %d", ctx.checks, ctx.cancelAt)
+	}
+}
+
 func TestLintParsedContextReturnsCancellationWithoutPartialIssues(t *testing.T) {
 	doc, err := vbaast.ParseDocument("Main.bas", []byte("Sub Main()\nEnd Sub\n"))
 	if err != nil {

--- a/internal/vba/dataflow/analysis.go
+++ b/internal/vba/dataflow/analysis.go
@@ -2,6 +2,7 @@ package dataflow
 
 import (
 	"container/heap"
+	"context"
 	"fmt"
 	"regexp"
 	"sort"
@@ -16,11 +17,33 @@ import (
 // may-analysis. A supplied graph is used as-is; when it is empty a graph is
 // built from the procedure so small protocol adapters can use the API safely.
 func AnalyzeProcedure(procedure procedureir.ProcedureIR, graph cfg.Graph, options Options) Result {
-	if len(graph.Blocks) == 0 {
-		graph = cfg.Build(procedure)
+	result, _ := AnalyzeProcedureContext(context.Background(), procedure, graph, options)
+	return result
+}
+
+// AnalyzeProcedureContext performs the same analysis as AnalyzeProcedure but
+// observes ctx and returns its cancellation or deadline error explicitly.
+// Cancellation never produces a partial Result: callers must handle the
+// returned error before using any findings.
+func AnalyzeProcedureContext(ctx context.Context, procedure procedureir.ProcedureIR, graph cfg.Graph, options Options) (Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	a := newProcedureAnalyzer(procedure, graph, options)
-	return a.run()
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	if len(graph.Blocks) == 0 {
+		var err error
+		graph, err = cfg.BuildContext(ctx, procedure)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	a, err := newProcedureAnalyzerContext(ctx, procedure, graph, options)
+	if err != nil {
+		return Result{}, err
+	}
+	return a.runContext()
 }
 
 type provenance struct {
@@ -52,6 +75,7 @@ type procedureAnalyzer struct {
 	findings          map[string]Finding
 	blocksByID        map[cfg.BlockID]cfg.Block
 	outgoingEdges     map[cfg.BlockID][]cfg.Edge
+	ctx               context.Context
 }
 
 type analysisStats struct {
@@ -59,6 +83,17 @@ type analysisStats struct {
 }
 
 func newProcedureAnalyzer(procedure procedureir.ProcedureIR, graph cfg.Graph, options Options) *procedureAnalyzer {
+	a, _ := newProcedureAnalyzerContext(context.Background(), procedure, graph, options)
+	return a
+}
+
+func newProcedureAnalyzerContext(ctx context.Context, procedure procedureir.ProcedureIR, graph cfg.Graph, options Options) (*procedureAnalyzer, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	a := &procedureAnalyzer{
 		procedure:         procedure,
 		graph:             graph,
@@ -73,14 +108,28 @@ func newProcedureAnalyzer(procedure procedureir.ProcedureIR, graph cfg.Graph, op
 		findings:          map[string]Finding{},
 		blocksByID:        map[cfg.BlockID]cfg.Block{},
 		outgoingEdges:     map[cfg.BlockID][]cfg.Edge{},
+		ctx:               ctx,
 	}
-	for _, block := range graph.Blocks {
+	for i, block := range graph.Blocks {
+		if i&0xff == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		a.blocksByID[block.ID] = block
 	}
-	for _, edge := range graph.Edges {
+	for i, edge := range graph.Edges {
+		if i&0xff == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		a.outgoingEdges[edge.From] = append(a.outgoingEdges[edge.From], edge)
 	}
 	for from := range a.outgoingEdges {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		sort.SliceStable(a.outgoingEdges[from], func(i, j int) bool {
 			left, right := a.outgoingEdges[from][i], a.outgoingEdges[from][j]
 			if left.To != right.To {
@@ -89,25 +138,55 @@ func newProcedureAnalyzer(procedure procedureir.ProcedureIR, graph cfg.Graph, op
 			return left.ID < right.ID
 		})
 	}
-	for _, statement := range procedure.Statements {
+	for i, statement := range procedure.Statements {
+		if i&0xff == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		a.statements[statement.ID] = statement
 	}
-	for _, declaration := range procedure.Declarations {
+	for i, declaration := range procedure.Declarations {
+		if i&0xff == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		a.declaredNames[canonicalName(declaration.Name)] = true
 	}
-	for _, parameter := range procedure.Symbol.Parameters {
+	for i, parameter := range procedure.Symbol.Parameters {
+		if i&0xff == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		a.declaredNames[canonicalName(parameter.Name)] = true
 	}
-	for _, expression := range procedure.Expressions {
+	for i, expression := range procedure.Expressions {
+		if i&0xff == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		a.expressions[expression.ID] = expression
 	}
-	for _, call := range procedure.Calls {
+	for i, call := range procedure.Calls {
+		if i&0xff == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		if call.ExpressionID != 0 {
 			a.callsByExpression[call.ExpressionID] = call
 		}
 		a.callsByStatement[call.StatementID] = append(a.callsByStatement[call.StatementID], call)
 	}
-	for _, statement := range procedure.Statements {
+	for i, statement := range procedure.Statements {
+		if i&0xff == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		if statement.Kind != procedureir.StatementSelect {
 			continue
 		}
@@ -116,22 +195,43 @@ func newProcedureAnalyzer(procedure procedureir.ProcedureIR, graph cfg.Graph, op
 		}
 	}
 	a.scanKnownShellObjects()
-	return a
-}
-
-func (a *procedureAnalyzer) run() Result {
-	result, _ := a.runWithStats()
-	return result
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return a, nil
 }
 
 func (a *procedureAnalyzer) runWithStats() (Result, analysisStats) {
-	return a.runWithStatsAndRank(nil)
+	result, stats, _ := a.runWithStatsContext()
+	return result, stats
 }
 
 func (a *procedureAnalyzer) runWithStatsAndRank(worklistRank map[cfg.BlockID]int) (Result, analysisStats) {
+	result, stats, _ := a.runWithStatsAndRankContext(worklistRank)
+	return result, stats
+}
+
+func (a *procedureAnalyzer) runContext() (Result, error) {
+	result, _, err := a.runWithStatsContext()
+	return result, err
+}
+
+func (a *procedureAnalyzer) runWithStatsContext() (Result, analysisStats, error) {
+	return a.runWithStatsAndRankContext(nil)
+}
+
+func (a *procedureAnalyzer) runWithStatsAndRankContext(worklistRank map[cfg.BlockID]int) (Result, analysisStats, error) {
 	stats := analysisStats{}
+	if err := a.contextErr(); err != nil {
+		return Result{}, stats, err
+	}
 	entry := abstractState{vars: map[string]value{}}
-	for _, parameter := range a.procedure.Symbol.Parameters {
+	for i, parameter := range a.procedure.Symbol.Parameters {
+		if i&0xff == 0 {
+			if err := a.contextErr(); err != nil {
+				return Result{}, stats, err
+			}
+		}
 		entry.vars[canonicalName(parameter.Name)] = valueFromSource(Source{
 			Kind:        SourceParameter,
 			Label:       parameter.Name,
@@ -140,21 +240,27 @@ func (a *procedureAnalyzer) runWithStatsAndRank(worklistRank map[cfg.BlockID]int
 		}, PathStep{Kind: "source", Label: parameter.Name, Range: parameter.Range})
 	}
 
-	reachable := map[cfg.BlockID]bool{}
-	for _, id := range a.graph.Reachable(cfg.EdgeFilter{}) {
-		reachable[id] = true
+	reachable, err := a.reachableContext()
+	if err != nil {
+		return Result{}, stats, err
 	}
 	if len(reachable) == 0 {
-		return Result{Findings: nil, States: nil}, stats
+		return Result{Findings: nil, States: nil}, stats, nil
 	}
 	inStates := map[cfg.BlockID]abstractState{a.graph.Entry: entry}
 	if worklistRank == nil {
-		worklistRank = a.reversePostOrderRank(reachable)
+		worklistRank, err = a.reversePostOrderRankContext(reachable)
+		if err != nil {
+			return Result{}, stats, err
+		}
 	}
 	queue := rankedWorklist{{id: a.graph.Entry, rank: worklistRank[a.graph.Entry]}}
 	heap.Init(&queue)
 	inQueue := map[cfg.BlockID]bool{a.graph.Entry: true}
 	for len(queue) > 0 {
+		if err := a.contextErr(); err != nil {
+			return Result{}, stats, err
+		}
 		id := heap.Pop(&queue).(rankedBlock).id
 		inQueue[id] = false
 		state, ok := inStates[id]
@@ -162,8 +268,14 @@ func (a *procedureAnalyzer) runWithStatsAndRank(worklistRank map[cfg.BlockID]int
 			continue
 		}
 		out := a.transfer(id, state, false)
+		if err := a.contextErr(); err != nil {
+			return Result{}, stats, err
+		}
 		stats.transfers++
 		for _, edge := range a.outgoing(id) {
+			if err := a.contextErr(); err != nil {
+				return Result{}, stats, err
+			}
 			if !reachable[edge.To] {
 				continue
 			}
@@ -187,15 +299,24 @@ func (a *procedureAnalyzer) runWithStatsAndRank(worklistRank map[cfg.BlockID]int
 	a.findings = map[string]Finding{}
 	blockIDs := make([]cfg.BlockID, 0, len(reachable))
 	for id := range reachable {
+		if err := a.contextErr(); err != nil {
+			return Result{}, stats, err
+		}
 		blockIDs = append(blockIDs, id)
 	}
 	sort.Slice(blockIDs, func(i, j int) bool { return blockIDs[i] < blockIDs[j] })
 	for _, id := range blockIDs {
+		if err := a.contextErr(); err != nil {
+			return Result{}, stats, err
+		}
 		state, ok := inStates[id]
 		if !ok {
 			continue
 		}
 		a.transfer(id, state, true)
+		if err := a.contextErr(); err != nil {
+			return Result{}, stats, err
+		}
 	}
 
 	findings := make([]Finding, 0, len(a.findings))
@@ -213,15 +334,21 @@ func (a *procedureAnalyzer) runWithStatsAndRank(worklistRank map[cfg.BlockID]int
 	})
 	states := map[cfg.BlockID]map[string]State{}
 	for id, state := range inStates {
+		if err := a.contextErr(); err != nil {
+			return Result{}, stats, err
+		}
 		states[id] = map[string]State{}
 		for name, variable := range state.vars {
 			states[id][name] = variableState(variable)
 		}
 	}
-	return Result{Findings: findings, States: states}, stats
+	return Result{Findings: findings, States: states}, stats, nil
 }
 
 func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collectFindings bool) abstractState {
+	if a.contextErr() != nil {
+		return abstractState{}
+	}
 	state := cloneState(input)
 	block, ok := a.blocksByID[id]
 	if !ok || block.Statement == nil {
@@ -240,6 +367,9 @@ func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collec
 		state.vars[target] = assigned
 	}
 	for _, call := range a.callsByStatement[statement.ID] {
+		if a.contextErr() != nil {
+			return abstractState{}
+		}
 		a.applySourceWrite(call, state)
 		if collectFindings {
 			a.inspectSink(call, state)
@@ -256,6 +386,9 @@ func (a *procedureAnalyzer) applySourceWrite(call procedureir.CallSite, state ab
 	// VBA's Input/Line Input/Get statements write their last argument(s),
 	// whereas function-style reads are handled by evalCall on the assignment.
 	for _, expressionID := range call.Arguments.ExpressionIDs[1:] {
+		if a.contextErr() != nil {
+			return
+		}
 		expression, exists := a.expressions[expressionID]
 		if !exists || expression.Kind != procedureir.ExpressionIdentifier {
 			continue
@@ -267,6 +400,9 @@ func (a *procedureAnalyzer) applySourceWrite(call procedureir.CallSite, state ab
 }
 
 func (a *procedureAnalyzer) evalExpression(expression procedureir.Expression, state abstractState) value {
+	if a.contextErr() != nil {
+		return value{}
+	}
 	if canonical, ok := a.expressions[expression.ID]; ok {
 		expression = canonical
 	}
@@ -326,6 +462,9 @@ func (a *procedureAnalyzer) evalMemberChildren(expression procedureir.Expression
 	}
 	var values []value
 	for _, id := range expression.Children {
+		if a.contextErr() != nil {
+			return value{}
+		}
 		child, ok := a.expressions[id]
 		if !ok {
 			continue
@@ -380,6 +519,9 @@ func (a *procedureAnalyzer) evalCall(expression procedureir.Expression, state ab
 func (a *procedureAnalyzer) evalChildren(ids []int, state abstractState) value {
 	var values []value
 	for _, id := range ids {
+		if a.contextErr() != nil {
+			return value{}
+		}
 		if expression, ok := a.expressions[id]; ok {
 			values = append(values, a.evalExpression(expression, state))
 		}
@@ -390,6 +532,9 @@ func (a *procedureAnalyzer) evalChildren(ids []int, state abstractState) value {
 func (a *procedureAnalyzer) callArguments(call procedureir.CallSite, state abstractState) []value {
 	args := make([]value, 0, len(call.Arguments.ExpressionIDs))
 	for _, id := range call.Arguments.ExpressionIDs {
+		if a.contextErr() != nil {
+			return args
+		}
 		if expression, ok := a.expressions[id]; ok {
 			args = append(args, a.evalExpression(expression, state))
 		}
@@ -410,10 +555,16 @@ func (a *procedureAnalyzer) inspectSink(call procedureir.CallSite, state abstrac
 		origins := args[target.argument].origins
 		keys := make([]string, 0, len(origins))
 		for key := range origins {
+			if a.contextErr() != nil {
+				return
+			}
 			keys = append(keys, key)
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
+			if a.contextErr() != nil {
+				return
+			}
 			origin := origins[key]
 			if origin.safe[target.kind] || (origin.state != StateTainted && origin.state != StateUnknown) {
 				continue
@@ -607,6 +758,9 @@ func looksHTTPReceiver(receiver, full string) bool {
 func (a *procedureAnalyzer) scanKnownShellObjects() {
 	assign := regexp.MustCompile(`(?i)\b(?:set\s+)?([a-z_][a-z0-9_]*)\s*=\s*(?:createobject\s*\(\s*"wscript\.shell"|new\s+wscript\.shell)`)
 	for _, statement := range a.procedure.Statements {
+		if a.contextErr() != nil {
+			return
+		}
 		if match := assign.FindStringSubmatch(statement.Text); len(match) > 1 {
 			a.knownShellObjects[canonicalName(match[1])] = true
 		}
@@ -733,6 +887,11 @@ func (a *procedureAnalyzer) outgoing(from cfg.BlockID) []cfg.Edge {
 }
 
 func (a *procedureAnalyzer) reversePostOrderRank(reachable map[cfg.BlockID]bool) map[cfg.BlockID]int {
+	rank, _ := a.reversePostOrderRankContext(reachable)
+	return rank
+}
+
+func (a *procedureAnalyzer) reversePostOrderRankContext(reachable map[cfg.BlockID]bool) (map[cfg.BlockID]int, error) {
 	visited := map[cfg.BlockID]bool{}
 	postorder := make([]cfg.BlockID, 0, len(reachable))
 	type frame struct {
@@ -742,12 +901,18 @@ func (a *procedureAnalyzer) reversePostOrderRank(reachable map[cfg.BlockID]bool)
 	visited[a.graph.Entry] = true
 	stack := []frame{{id: a.graph.Entry}}
 	for len(stack) > 0 {
+		if err := a.contextErr(); err != nil {
+			return nil, err
+		}
 		current := &stack[len(stack)-1]
 		edges := a.outgoing(current.id)
 		if current.next < len(edges) {
 			target := edges[current.next].To
 			current.next++
 			if reachable[target] && !visited[target] {
+				if err := a.contextErr(); err != nil {
+					return nil, err
+				}
 				visited[target] = true
 				stack = append(stack, frame{id: target})
 			}
@@ -758,9 +923,96 @@ func (a *procedureAnalyzer) reversePostOrderRank(reachable map[cfg.BlockID]bool)
 	}
 	rank := make(map[cfg.BlockID]int, len(postorder))
 	for index := len(postorder) - 1; index >= 0; index-- {
+		if index&0xff == 0 {
+			if err := a.contextErr(); err != nil {
+				return nil, err
+			}
+		}
 		rank[postorder[index]] = len(postorder) - 1 - index
 	}
-	return rank
+	return rank, nil
+}
+
+func (a *procedureAnalyzer) reachableContext() (map[cfg.BlockID]bool, error) {
+	seen := map[cfg.BlockID]bool{}
+	if err := a.contextErr(); err != nil {
+		return nil, err
+	}
+	seen[a.graph.Entry] = true
+	queue := []cfg.BlockID{a.graph.Entry}
+	for len(queue) > 0 {
+		if err := a.contextErr(); err != nil {
+			return nil, err
+		}
+		current := queue[0]
+		queue = queue[1:]
+		for _, edge := range a.outgoing(current) {
+			if err := a.contextErr(); err != nil {
+				return nil, err
+			}
+			if seen[edge.To] {
+				continue
+			}
+			seen[edge.To] = true
+			queue = append(queue, edge.To)
+		}
+	}
+	unknownReached := false
+	for _, source := range a.graph.UnknownFlowSources {
+		if err := a.contextErr(); err != nil {
+			return nil, err
+		}
+		if seen[source] {
+			unknownReached = true
+			break
+		}
+	}
+	if unknownReached {
+		for _, block := range a.graph.Blocks {
+			if err := a.contextErr(); err != nil {
+				return nil, err
+			}
+			if block.Kind == cfg.BlockStatement {
+				seen[block.ID] = true
+			}
+		}
+		seen[a.graph.UnknownExit] = true
+		queue = queue[:0]
+		for id := range seen {
+			queue = append(queue, id)
+		}
+		for len(queue) > 0 {
+			if err := a.contextErr(); err != nil {
+				return nil, err
+			}
+			current := queue[0]
+			queue = queue[1:]
+			for _, edge := range a.outgoing(current) {
+				if a.contextErr() != nil {
+					return nil, a.contextErr()
+				}
+				if seen[edge.To] {
+					continue
+				}
+				seen[edge.To] = true
+				queue = append(queue, edge.To)
+			}
+		}
+	}
+	reachable := make(map[cfg.BlockID]bool, len(seen))
+	for _, block := range a.graph.Blocks {
+		if seen[block.ID] {
+			reachable[block.ID] = true
+		}
+	}
+	return reachable, nil
+}
+
+func (a *procedureAnalyzer) contextErr() error {
+	if a == nil || a.ctx == nil {
+		return nil
+	}
+	return a.ctx.Err()
 }
 
 type rankedBlock struct {

--- a/internal/vba/dataflow/analysis.go
+++ b/internal/vba/dataflow/analysis.go
@@ -267,8 +267,8 @@ func (a *procedureAnalyzer) runWithStatsAndRankContext(worklistRank map[cfg.Bloc
 		if !ok {
 			continue
 		}
-		out := a.transfer(id, state, false)
-		if err := a.contextErr(); err != nil {
+		out, err := a.transfer(id, state, false)
+		if err != nil {
 			return Result{}, stats, err
 		}
 		stats.transfers++
@@ -313,8 +313,7 @@ func (a *procedureAnalyzer) runWithStatsAndRankContext(worklistRank map[cfg.Bloc
 		if !ok {
 			continue
 		}
-		a.transfer(id, state, true)
-		if err := a.contextErr(); err != nil {
+		if _, err := a.transfer(id, state, true); err != nil {
 			return Result{}, stats, err
 		}
 	}
@@ -345,14 +344,14 @@ func (a *procedureAnalyzer) runWithStatsAndRankContext(worklistRank map[cfg.Bloc
 	return Result{Findings: findings, States: states}, stats, nil
 }
 
-func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collectFindings bool) abstractState {
-	if a.contextErr() != nil {
-		return abstractState{}
+func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collectFindings bool) (abstractState, error) {
+	if err := a.contextErr(); err != nil {
+		return abstractState{}, err
 	}
 	state := cloneState(input)
 	block, ok := a.blocksByID[id]
 	if !ok || block.Statement == nil {
-		return state
+		return state, nil
 	}
 	statement := *block.Statement
 	recovered := statement.Recovered || statement.Kind == procedureir.StatementRecovered
@@ -363,19 +362,25 @@ func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collec
 	}
 	if target := assignmentTarget(statement); !recovered && target != "" && statement.Value != nil {
 		assigned := a.evalExpression(*statement.Value, state)
+		if err := a.contextErr(); err != nil {
+			return abstractState{}, err
+		}
 		assigned = appendPath(assigned, PathStep{Kind: "assignment", Label: statement.Text, Range: statement.Range, StatementID: statement.ID})
 		state.vars[target] = assigned
 	}
 	for _, call := range a.callsByStatement[statement.ID] {
-		if a.contextErr() != nil {
-			return abstractState{}
+		if err := a.contextErr(); err != nil {
+			return abstractState{}, err
 		}
 		a.applySourceWrite(call, state)
 		if collectFindings {
 			a.inspectSink(call, state)
 		}
 	}
-	return state
+	if err := a.contextErr(); err != nil {
+		return abstractState{}, err
+	}
+	return state, nil
 }
 
 func (a *procedureAnalyzer) applySourceWrite(call procedureir.CallSite, state abstractState) {
@@ -910,9 +915,6 @@ func (a *procedureAnalyzer) reversePostOrderRankContext(reachable map[cfg.BlockI
 			target := edges[current.next].To
 			current.next++
 			if reachable[target] && !visited[target] {
-				if err := a.contextErr(); err != nil {
-					return nil, err
-				}
 				visited[target] = true
 				stack = append(stack, frame{id: target})
 			}
@@ -988,8 +990,8 @@ func (a *procedureAnalyzer) reachableContext() (map[cfg.BlockID]bool, error) {
 			current := queue[0]
 			queue = queue[1:]
 			for _, edge := range a.outgoing(current) {
-				if a.contextErr() != nil {
-					return nil, a.contextErr()
+				if err := a.contextErr(); err != nil {
+					return nil, err
 				}
 				if seen[edge.To] {
 					continue

--- a/internal/vba/dataflow/analysis_test.go
+++ b/internal/vba/dataflow/analysis_test.go
@@ -1,6 +1,7 @@
 package dataflow
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -8,6 +9,53 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
+
+func TestAnalyzeProcedureContextReturnsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := AnalyzeProcedureContext(ctx, procedureir.ProcedureIR{}, cfg.Graph{}, Options{})
+	if err != context.Canceled {
+		t.Fatalf("AnalyzeProcedureContext error = %v, want context.Canceled", err)
+	}
+	if !reflect.DeepEqual(result, Result{}) {
+		t.Fatalf("canceled result = %#v, want zero result", result)
+	}
+}
+
+func TestAnalyzeProcedureContextCancelsDuringLargeCFGTraversal(t *testing.T) {
+	const blockCount = 20000
+	blocks := make([]cfg.Block, 0, blockCount)
+	edges := make([]cfg.Edge, 0, blockCount-1)
+	for id := 1; id <= blockCount; id++ {
+		blocks = append(blocks, cfg.Block{ID: cfg.BlockID(id)})
+		if id > 1 {
+			edges = append(edges, cfg.Edge{ID: cfg.EdgeID(id - 1), From: cfg.BlockID(id - 1), To: cfg.BlockID(id)})
+		}
+	}
+
+	ctx := &cancelAfterChecksContext{remaining: 1000}
+	result, err := AnalyzeProcedureContext(ctx, procedureir.ProcedureIR{}, cfg.Graph{Blocks: blocks, Edges: edges, Entry: 1}, Options{})
+	if err != context.Canceled {
+		t.Fatalf("large CFG error = %v, want context.Canceled", err)
+	}
+	if !reflect.DeepEqual(result, Result{}) {
+		t.Fatalf("large CFG canceled result = %#v, want zero result", result)
+	}
+}
+
+type cancelAfterChecksContext struct {
+	context.Context
+	remaining int
+}
+
+func (c *cancelAfterChecksContext) Err() error {
+	if c.remaining <= 0 {
+		return context.Canceled
+	}
+	c.remaining--
+	return nil
+}
 
 func TestAnalyzeProcedureFindingsDoNotDependOnWorklistRank(t *testing.T) {
 	document, err := procedureir.BuildSource(procedureir.BuildOptions{Path: "Main.bas", ModuleKind: "standard"}, []byte(`Option Explicit

--- a/internal/vba/dataflow/analysis_test.go
+++ b/internal/vba/dataflow/analysis_test.go
@@ -34,7 +34,7 @@ func TestAnalyzeProcedureContextCancelsDuringLargeCFGTraversal(t *testing.T) {
 		}
 	}
 
-	ctx := &cancelAfterChecksContext{remaining: 1000}
+	ctx := &cancelAfterChecksContext{Context: context.Background(), remaining: 1000}
 	result, err := AnalyzeProcedureContext(ctx, procedureir.ProcedureIR{}, cfg.Graph{Blocks: blocks, Edges: edges, Entry: 1}, Options{})
 	if err != context.Canceled {
 		t.Fatalf("large CFG error = %v, want context.Canceled", err)


### PR DESCRIPTION
## Summary

Closes #550.

Adds cooperative context cancellation to procedure-level VBA dataflow analysis and propagates cancellation through batch and realtime analyzer paths.

## What changed

- Added `AnalyzeProcedureContext`, returning explicit `context.Canceled` or `context.DeadlineExceeded` errors.
- Added cancellation checks during CFG construction, analyzer indexing, reachability, reverse-postorder ranking, worklist processing, sink inspection, and expression evaluation.
- Added `Analyzer.RunContext` / `RunResultContext` for batch analysis.
- Wired realtime dataflow analysis to its existing request context.
- Wired `xlflow analyze` and `xlflow check` to Cobra command contexts.
- Added immediate-cancellation and large-CFG regression coverage.
- Updated the Unreleased changelog.

## Behavior

Uncanceled analysis keeps the existing findings, path witnesses, source mappings, and deterministic ordering. Canceled analysis returns the context error explicitly and does not expose partial findings as a successful result.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./... -count=1`
- `golangci-lint run`
- `pnpm format:check`
- `pnpm lint`
- `pnpm docs:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cancellation and deadline support across analysis, linting, preflight checks, and diagnostics.
  - Commands now respond promptly to interruption and return clear cancellation errors.
  - Extended cancellation support to `VBA224` dataflow analysis.

- **Bug Fixes**
  - Prevents incomplete findings from being reported after cancellation.
  - Improved error reporting across project, file, procedure, and real-time analysis workflows.

- **Documentation**
  - Documented context-aware cancellation behavior for analysis operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->