### PR TITLE
perf: optimize real-world corpus hotspots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Reduced conservative data-flow analysis allocation pressure by comparing
+  deterministic propagation paths without repeatedly serializing them, and
+  indexed effect-summary candidate lookup so matching one call no longer
+  clones the complete project summary. Added developer-only real-world corpus
+  benchmarks and profiling commands for the `std-vba` and `ronecone` analyzer
+  hotspots.
 - Added context-aware cancellation to procedure-level `VBA224` dataflow
   analysis and propagated explicit cancellation errors through batch and
   real-time analyzer paths.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,6 +152,14 @@ tasks:
       - cmd: go test ./internal/lspserver -run '^TestLSPBenchmarkFixture$' -bench '^BenchmarkLSP' -benchmem -benchtime=1x -count 5
         platforms: [linux, darwin]
 
+  bench:corpus:
+    desc: Benchmark the analyzer stage for the slowest real-world corpus projects
+    cmds:
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only$' -benchmem -benchtime=1x -count 2
+        platforms: [windows]
+      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only$' -benchmem -benchtime=1x -count 2
+        platforms: [linux, darwin]
+
   verify:security:
     desc: Run vulnerability and third-party licence inventory checks
     cmds:

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -652,6 +652,80 @@ Measure a local run when timing matters:
 rtk powershell -NoProfile -Command '$env:XLFLOW_RUN_REALWORLD_CORPUS="1"; Measure-Command { & ".\scripts\dev\go.ps1" test ./internal/staticanalysis/corpus -run "^TestRealWorldCorpusSnapshots$" -count=1 } | Select-Object TotalSeconds'
 ```
 
+### Developer-only corpus profiling
+
+The slowest projects have a focused benchmark that is separate from snapshot
+and review evaluation. It materializes each selected project in its own
+temporary workspace and offers two stages: `full-pipeline` runs materialization,
+configuration, lint, analyze, normalization, and cleanup; `analyze-only`
+materializes and loads configuration outside the timer, then measures the
+production analyzer. Benchmarks are opt-in Go test binaries: ordinary tests,
+the production CLI/API, corpus CI, and the Excel/VBE oracle never invoke them.
+
+Run the analyzer-only measurement twice for both hotspot projects:
+
+```powershell
+rtk task bench:corpus
+```
+
+Use a leaf benchmark name to isolate one project and stage. `-count=2` is the
+minimum timing run for variability; profiles use `-count=1` so output files are
+not overwritten by repeated test processes:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -Command '$cpu = Join-Path $env:TEMP "xlflow-std-vba.cpu.pprof"; $mem = Join-Path $env:TEMP "xlflow-std-vba.mem.pprof"; $bin = Join-Path $env:TEMP "xlflow-std-vba-corpus.test.exe"; $args = @("test", "./internal/staticanalysis/corpus", "-run", "^$", "-bench", "^BenchmarkRealWorldCorpus/std-vba/analyze-only$", "-benchtime=1x", "-count=1", "-cpuprofile=$cpu", "-memprofile=$mem", "-o=$bin"); & ".\scripts\dev\go.ps1" @args'
+rtk powershell -NoProfile -ExecutionPolicy Bypass -Command '$cpu = Join-Path $env:TEMP "xlflow-ronecone.cpu.pprof"; $mem = Join-Path $env:TEMP "xlflow-ronecone.mem.pprof"; $bin = Join-Path $env:TEMP "xlflow-ronecone-corpus.test.exe"; $args = @("test", "./internal/staticanalysis/corpus", "-run", "^$", "-bench", "^BenchmarkRealWorldCorpus/ronecone/analyze-only$", "-benchtime=1x", "-count=1", "-cpuprofile=$cpu", "-memprofile=$mem", "-o=$bin"); & ".\scripts\dev\go.ps1" @args'
+```
+
+The 2026-08-08 Windows CPU profile attributed 112.24 s cumulative CPU to
+procedure data-flow analysis, including 102.96 s in state joins. Repeated
+serialization of propagation paths accounted for 82.45 s in `pathKey`, with
+41.42 s below `fmt.Fprintf` and 23.77 s below `strings.ToLower`; GC draining
+accounted for 133.68 s across the full profiled corpus. The optimized comparator
+streams the exact former canonical byte sequence, retains lowercase label and
+decimal lexical ordering, and allocates nothing for ASCII path comparisons.
+This preserves representative paths and diagnostic behavior while removing the
+dominant temporary strings.
+
+The project-specific heap profiles also separated the two slow projects. After
+the path comparison change, `ronecone` still allocated 20.89 GB through
+`ProjectSummary.All` while resolving call candidates: every lookup defensively
+cloned every procedure and evidence slice before selecting one summary. The
+replacement maintains a declaration-line index, rechecks the original
+slash-normalized `EqualFold` file/name/kind and exact-line contract, preserves
+the first deterministic match, and defensively clones only that match.
+
+The focused `LibJSON.ParseChars` benchmark set a target of at least 20% lower
+median runtime and 50% lower allocated bytes per operation. On the same
+Windows machine, the pre-change five-run baseline was 1.190-1.266 s,
+1,003.4-1,003.8 MB, and 20.681-20.682 million allocations per operation. Three
+post-change runs were 0.919-0.934 s, 447.6-448.1 MB, and 5.576 million
+allocations per operation. Median runtime fell from 1.197 s to 0.924 s (22.8%),
+allocated bytes fell by approximately 55.3%, and allocation count fell by
+approximately 73.0%, meeting the recorded target.
+
+The final project-isolated `analyze-only` benchmark produced two post-change
+samples of 62.869 s and 62.980 s for `std-vba` (0.2% spread), 19.741 GB
+allocated per operation, and 2,792 stable findings. For `ronecone`, the
+candidate-lookup baseline was 46.014 s and
+47.769 s with 43.214 GB allocated per operation; post-index samples were
+36.156 s and 36.664 s (1.4% spread), 20.617 GB per operation, and the same 808
+findings. Its two-sample midpoint runtime fell by 22.4% and allocated bytes by
+52.3%. These numbers are developer observations rather than fixed thresholds;
+compare future changes using the same command, machine, power state, and Go
+toolchain.
+
+After rebasing onto the context-cancellation analyzer change, two consecutive
+final verify-only corpus runs completed in 171.5 s and 170.2 s wall-clock time
+with no snapshot, diagnostic, severity, range, multiplicity, or ordering delta.
+Compared with the earlier same-machine 196.764-201.156 s reference, the
+midpoint fell by approximately 14.1%. `std-vba` completed in 68.276 s and
+68.474 s, down 16.9% from the earlier 82.250 s observation; `ronecone`
+completed in 38.558 s and 38.635 s, down approximately 16.1% from the roughly
+46 s issue baseline. The focused benchmark target remains the hardware-local
+optimization guard because it isolates this change from independent analyzer
+instrumentation overhead.
+
 Do not parallelize VBE cases or infer a hang from the broad `go test ./...`
 duration; Excel/COM tests have a materially different runtime profile from
 the Excel-free corpus checks.

--- a/internal/analyze/event_reentry.go
+++ b/internal/analyze/event_reentry.go
@@ -1,7 +1,6 @@
 package analyze
 
 import (
-	"path/filepath"
 	"strings"
 
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
@@ -200,14 +199,7 @@ func eventSafeProcedures(files []parsedFile, project effects.ProjectSummary) map
 }
 
 func summaryForCandidate(project effects.ProjectSummary, candidate procedureir.Candidate) (effects.ProcedureSummary, bool) {
-	for _, summary := range project.All() {
-		id := summary.Identity
-		if strings.EqualFold(filepath.ToSlash(id.File), filepath.ToSlash(candidate.File)) && strings.EqualFold(id.QualifiedName, candidate.QualifiedName) &&
-			strings.EqualFold(string(id.Kind), candidate.Kind) && id.DeclarationLine == candidate.Line {
-			return summary, true
-		}
-	}
-	return effects.ProcedureSummary{}, false
+	return project.LookupCandidate(candidate)
 }
 
 // eventGuardedAt accepts a guard only when its False assignment dominates the

--- a/internal/staticanalysis/corpus/benchmark_test.go
+++ b/internal/staticanalysis/corpus/benchmark_test.go
@@ -1,0 +1,107 @@
+package corpus
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/typedb"
+)
+
+var realWorldCorpusBenchmarkProjectIDs = []string{"std-vba", "ronecone"}
+
+// BenchmarkRealWorldCorpus provides an opt-in, developer-only profiling path
+// for the slowest checked-in third-party projects. The benchmark deliberately
+// bypasses snapshot and review evaluation; invoke it with -bench and use a
+// project/stage sub-benchmark name to keep profiles focused.
+func BenchmarkRealWorldCorpus(b *testing.B) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		b.Fatal(err)
+	}
+	manifestPath := filepath.Join(repoRoot, "testdata", "static-analysis-corpus", "manifest.json")
+	manifest, corpusRoot, err := LoadManifest(manifestPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	projects, err := SelectThirdPartyProjects(manifest.Projects, realWorldCorpusBenchmarkProjectIDs)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if len(projects) != len(realWorldCorpusBenchmarkProjectIDs) {
+		b.Fatalf("selected %d benchmark projects, want %d", len(projects), len(realWorldCorpusBenchmarkProjectIDs))
+	}
+
+	// Results must not depend on a developer-generated TypeLib database.
+	b.Setenv(typedb.EnvDir, filepath.Join(b.TempDir(), "typelib"))
+	for _, project := range projects {
+		project := project
+		if !project.Enabled {
+			b.Fatalf("benchmark project %q is disabled", project.ID)
+		}
+		b.Run(project.ID, func(b *testing.B) {
+			b.Run("full-pipeline", func(b *testing.B) {
+				benchmarkRealWorldCorpusFullPipeline(b, corpusRoot, project)
+			})
+			b.Run("analyze-only", func(b *testing.B) {
+				benchmarkRealWorldCorpusAnalyzeOnly(b, corpusRoot, project)
+			})
+		})
+	}
+}
+
+func benchmarkRealWorldCorpusFullPipeline(b *testing.B, corpusRoot string, project Project) {
+	tempRoot := b.TempDir()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var diagnostics, surfaces int
+	for i := 0; i < b.N; i++ {
+		report, err := RunThirdPartyProjects(corpusRoot, []Project{project}, MaterializeOptions{TempRoot: tempRoot})
+		if err != nil {
+			b.Fatalf("full pipeline for %q failed: %v", project.ID, err)
+		}
+		if len(report.Failures) != 0 {
+			b.Fatalf("full pipeline for %q reported %d failure(s)", project.ID, len(report.Failures))
+		}
+		if len(report.Skipped) != 0 {
+			b.Fatalf("full pipeline for %q unexpectedly skipped", project.ID)
+		}
+		diagnostics += len(report.Diagnostics)
+		surfaces += len(report.Surfaces)
+	}
+	b.ReportMetric(float64(diagnostics)/float64(b.N), "diagnostics/op")
+	b.ReportMetric(float64(project.SourceCounts.Total()), "source-files/op")
+	b.ReportMetric(float64(surfaces)/float64(b.N), "surfaces/op")
+}
+
+func benchmarkRealWorldCorpusAnalyzeOnly(b *testing.B, corpusRoot string, project Project) {
+	workspace, err := MaterializeThirdPartyProject(corpusRoot, project, MaterializeOptions{TempRoot: b.TempDir()})
+	if err != nil {
+		b.Fatalf("materialize %q: %v", project.ID, err)
+	}
+	b.Cleanup(func() {
+		if err := workspace.Close(); err != nil {
+			b.Errorf("cleanup %q: %v", project.ID, err)
+		}
+	})
+	exec := productionExecutor()
+	cfg, err := exec.loadConfig(workspace.Root)
+	if err != nil {
+		b.Fatalf("load config for %q: %v", project.ID, err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var findings, warnings int
+	for i := 0; i < b.N; i++ {
+		result, err := exec.runAnalyze(workspace.Root, cfg)
+		if err != nil {
+			b.Fatalf("analyze %q: %v", project.ID, err)
+		}
+		findings += len(result.Findings)
+		warnings += len(result.Warnings)
+	}
+	b.ReportMetric(float64(findings)/float64(b.N), "findings/op")
+	b.ReportMetric(float64(project.SourceCounts.Total()), "source-files/op")
+	b.ReportMetric(float64(warnings)/float64(b.N), "warnings/op")
+}

--- a/internal/vba/dataflow/analysis.go
+++ b/internal/vba/dataflow/analysis.go
@@ -1198,7 +1198,7 @@ func joinStateValue(a, b State) State {
 func isEmptyValue(input value) bool { return len(input.origins) == 0 }
 
 func sameProvenance(a, b provenance) bool {
-	return a.state == b.state && sourceKey(a.source) == sourceKey(b.source) && pathKey(a.path) == pathKey(b.path) && sameSafe(a.safe, b.safe)
+	return a.state == b.state && sourceKey(a.source) == sourceKey(b.source) && comparePathKeys(a.path, b.path) == 0 && sameSafe(a.safe, b.safe)
 }
 
 func sameSafe(a, b map[SinkKind]bool) bool {
@@ -1230,7 +1230,7 @@ func betterPath(a, b []PathStep) bool {
 	if len(a) != len(b) {
 		return len(a) < len(b)
 	}
-	return pathKey(a) < pathKey(b)
+	return comparePathKeys(a, b) < 0
 }
 
 func betterPathValue(a, b []PathStep) []PathStep {

--- a/internal/vba/dataflow/parsechars_regression_test.go
+++ b/internal/vba/dataflow/parsechars_regression_test.go
@@ -10,38 +10,55 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
-func TestAnalyzeProcedureParseCharsConvergesWithBoundedTransfers(t *testing.T) {
+func parseCharsProcedure(tb testing.TB) (procedureir.ProcedureIR, cfg.Graph) {
+	tb.Helper()
 	path := filepath.Join("..", "..", "..", "testdata", "static-analysis-corpus", "projects", "third_party", "vba-fast-json", "src", "LibJSON.bas")
 	source, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	document, err := procedureir.BuildSource(procedureir.BuildOptions{Path: path, ModuleKind: "standard"}, source)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	for _, procedure := range document.Procedures {
-		if procedure.Symbol.Name != "ParseChars" {
-			continue
+		if procedure.Symbol.Name == "ParseChars" {
+			return procedure, cfg.Build(procedure)
 		}
-		graph := cfg.Build(procedure)
-		analyzer := newProcedureAnalyzer(procedure, graph, Options{})
-		result, stats := analyzer.runWithStats()
-		reachableBlocks := len(graph.Reachable(cfg.EdgeFilter{}))
-		if stats.transfers > 5*reachableBlocks {
-			t.Fatalf("worklist transfers = %d for %d reachable blocks, want at most five transfers per block", stats.transfers, reachableBlocks)
-		}
-		if len(result.States) != reachableBlocks {
-			t.Fatalf("analyzed states = %d, want one for each of %d reachable blocks", len(result.States), reachableBlocks)
-		}
-		repeated := newProcedureAnalyzer(procedure, graph, Options{})
-		repeatedResult, repeatedStats := repeated.runWithStats()
-		if repeatedStats.transfers != stats.transfers || !reflect.DeepEqual(repeatedResult, result) {
-			t.Fatalf("repeated analysis was not deterministic: transfers %d then %d", stats.transfers, repeatedStats.transfers)
-		}
-		return
 	}
-	t.Fatal("ParseChars procedure not found")
+	tb.Fatal("ParseChars procedure not found")
+	return procedureir.ProcedureIR{}, cfg.Graph{}
+}
+
+func TestAnalyzeProcedureParseCharsConvergesWithBoundedTransfers(t *testing.T) {
+	procedure, graph := parseCharsProcedure(t)
+	analyzer := newProcedureAnalyzer(procedure, graph, Options{})
+	result, stats := analyzer.runWithStats()
+	reachableBlocks := len(graph.Reachable(cfg.EdgeFilter{}))
+	if stats.transfers > 5*reachableBlocks {
+		t.Fatalf("worklist transfers = %d for %d reachable blocks, want at most five transfers per block", stats.transfers, reachableBlocks)
+	}
+	if len(result.States) != reachableBlocks {
+		t.Fatalf("analyzed states = %d, want one for each of %d reachable blocks", len(result.States), reachableBlocks)
+	}
+	repeated := newProcedureAnalyzer(procedure, graph, Options{})
+	repeatedResult, repeatedStats := repeated.runWithStats()
+	if repeatedStats.transfers != stats.transfers || !reflect.DeepEqual(repeatedResult, result) {
+		t.Fatalf("repeated analysis was not deterministic: transfers %d then %d", stats.transfers, repeatedStats.transfers)
+	}
+}
+
+func BenchmarkAnalyzeProcedureParseChars(b *testing.B) {
+	procedure, graph := parseCharsProcedure(b)
+	reachableBlocks := len(graph.Reachable(cfg.EdgeFilter{}))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		result, stats := newProcedureAnalyzer(procedure, graph, Options{}).runWithStats()
+		if stats.transfers > 5*reachableBlocks || len(result.States) != reachableBlocks {
+			b.Fatalf("analysis changed during benchmark: transfers=%d states=%d reachable=%d", stats.transfers, len(result.States), reachableBlocks)
+		}
+	}
 }
 
 func TestRankedWorklistHandlesDeepWideGraphDeterministically(t *testing.T) {

--- a/internal/vba/dataflow/path_compare_test.go
+++ b/internal/vba/dataflow/path_compare_test.go
@@ -1,0 +1,58 @@
+package dataflow
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+)
+
+func TestComparePathKeysMatchesSerializedKeyOrdering(t *testing.T) {
+	paths := [][]PathStep{
+		nil,
+		{},
+		{{Kind: "assignment", Label: "Alpha", Range: vbaast.Range{StartByte: 1, EndByte: 2, StartLine: 3}, StatementID: 4}},
+		{{Kind: "assignment", Label: "alpha", Range: vbaast.Range{StartByte: 1, EndByte: 2, StartLine: 3}, StatementID: 4}},
+		{{Kind: "assignment", Label: "ALPHA", Range: vbaast.Range{StartByte: 1, EndByte: 2, StartLine: 3}, StatementID: 4}},
+		{{Kind: "assignment", Label: "ÄPFEL", Range: vbaast.Range{StartByte: 1, EndByte: 2, StartLine: 3}, StatementID: 4}},
+		{{Kind: "assignment", Label: "äpfel", Range: vbaast.Range{StartByte: 1, EndByte: 2, StartLine: 3}, StatementID: 4}},
+		{{Kind: "a\x00z", Label: "control\x01label", Range: vbaast.Range{StartByte: -10, EndByte: -2, StartLine: -1}, StatementID: -20}},
+		{{Kind: "a", Label: "z\x00control", Range: vbaast.Range{StartByte: -2, EndByte: 10, StartLine: 11}, StatementID: 100}},
+		{{Kind: "assignment", Label: "decimal", Range: vbaast.Range{StartByte: 1, EndByte: 10, StartLine: 100}, StatementID: 2}},
+		{{Kind: "assignment", Label: "decimal", Range: vbaast.Range{StartByte: 10, EndByte: 1, StartLine: 2}, StatementID: 100}},
+		{
+			{Kind: "source", Label: "First", Range: vbaast.Range{StartByte: 1}, StatementID: 1},
+			{Kind: "assignment", Label: "Second", Range: vbaast.Range{StartByte: 2}, StatementID: 2},
+		},
+	}
+
+	for leftIndex, left := range paths {
+		for rightIndex, right := range paths {
+			want := strings.Compare(serializedPathKey(left), serializedPathKey(right))
+			if got := comparePathKeys(left, right); got != want {
+				t.Errorf("comparePathKeys(paths[%d], paths[%d]) = %d, want %d", leftIndex, rightIndex, got, want)
+			}
+		}
+	}
+}
+
+func TestComparePathKeysASCIIAllocations(t *testing.T) {
+	left := []PathStep{{Kind: "assignment", Label: "CustomerInput", Range: vbaast.Range{StartByte: 10, EndByte: 24, StartLine: 3}, StatementID: 7}}
+	right := []PathStep{{Kind: "assignment", Label: "customerOutput", Range: vbaast.Range{StartByte: 10, EndByte: 25, StartLine: 3}, StatementID: 8}}
+	if allocations := testing.AllocsPerRun(1000, func() {
+		if comparePathKeys(left, right) >= 0 {
+			t.Fatal("unexpected path ordering")
+		}
+	}); allocations != 0 {
+		t.Fatalf("comparePathKeys allocated %.2f times for ASCII paths, want zero", allocations)
+	}
+}
+
+func serializedPathKey(path []PathStep) string {
+	var builder strings.Builder
+	for _, step := range path {
+		fmt.Fprintf(&builder, "%s\x00%s\x00%d\x00%d\x00%d\x00%d\x01", step.Kind, strings.ToLower(step.Label), step.Range.StartByte, step.Range.EndByte, step.Range.StartLine, step.StatementID)
+	}
+	return builder.String()
+}

--- a/internal/vba/dataflow/types.go
+++ b/internal/vba/dataflow/types.go
@@ -4,6 +4,7 @@ package dataflow
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
@@ -161,10 +162,131 @@ func sourceKey(source Source) string {
 	return fmt.Sprintf("%s\x00%s\x00%d\x00%d\x00%d\x00%d", source.Kind, strings.ToLower(source.Label), source.Range.StartByte, source.Range.EndByte, source.Range.StartLine, source.StatementID)
 }
 
-func pathKey(path []PathStep) string {
-	var b strings.Builder
-	for _, step := range path {
-		fmt.Fprintf(&b, "%s\x00%s\x00%d\x00%d\x00%d\x00%d\x01", step.Kind, strings.ToLower(step.Label), step.Range.StartByte, step.Range.EndByte, step.Range.StartLine, step.StatementID)
+// comparePathKeys compares the byte sequences formerly produced by pathKey
+// without materializing those sequences. Labels use the allocation-free ASCII
+// case fold on the common path and fall back to strings.ToLower for Unicode.
+func comparePathKeys(left, right []PathStep) int {
+	leftKey := pathKeyIterator{path: left}
+	rightKey := pathKeyIterator{path: right}
+	for {
+		leftByte, leftOK := leftKey.next()
+		rightByte, rightOK := rightKey.next()
+		switch {
+		case !leftOK && !rightOK:
+			return 0
+		case !leftOK:
+			return -1
+		case !rightOK:
+			return 1
+		case leftByte < rightByte:
+			return -1
+		case leftByte > rightByte:
+			return 1
+		}
 	}
-	return b.String()
+}
+
+type pathKeyIterator struct {
+	path []PathStep
+
+	step  int
+	field int
+	index int
+
+	labelReady  bool
+	labelASCII  bool
+	foldedLabel string
+
+	decimalReady  bool
+	decimalLength int
+	decimal       [32]byte
+}
+
+func (it *pathKeyIterator) next() (byte, bool) {
+	for it.step < len(it.path) {
+		step := &it.path[it.step]
+		switch it.field {
+		case 0:
+			if it.index < len(step.Kind) {
+				value := step.Kind[it.index]
+				it.index++
+				return value, true
+			}
+			it.advanceField()
+		case 1, 3, 5, 7, 9:
+			it.advanceField()
+			return 0, true
+		case 2:
+			if !it.labelReady {
+				it.prepareLabel(step.Label)
+			}
+			label := step.Label
+			if !it.labelASCII {
+				label = it.foldedLabel
+			}
+			if it.index < len(label) {
+				value := label[it.index]
+				if it.labelASCII && value >= 'A' && value <= 'Z' {
+					value += 'a' - 'A'
+				}
+				it.index++
+				return value, true
+			}
+			it.advanceField()
+		case 4, 6, 8, 10:
+			if !it.decimalReady {
+				it.prepareDecimal(step)
+			}
+			if it.index < it.decimalLength {
+				value := it.decimal[it.index]
+				it.index++
+				return value, true
+			}
+			it.advanceField()
+		case 11:
+			it.step++
+			it.field = 0
+			it.index = 0
+			return 1, true
+		}
+	}
+	return 0, false
+}
+
+func (it *pathKeyIterator) advanceField() {
+	it.field++
+	it.index = 0
+	it.labelReady = false
+	it.foldedLabel = ""
+	it.decimalReady = false
+	it.decimalLength = 0
+}
+
+func (it *pathKeyIterator) prepareLabel(label string) {
+	it.labelReady = true
+	it.labelASCII = true
+	for index := 0; index < len(label); index++ {
+		if label[index] >= 0x80 {
+			it.labelASCII = false
+			it.foldedLabel = strings.ToLower(label)
+			return
+		}
+	}
+}
+
+func (it *pathKeyIterator) prepareDecimal(step *PathStep) {
+	value := 0
+	switch it.field {
+	case 4:
+		value = step.Range.StartByte
+	case 6:
+		value = step.Range.EndByte
+	case 8:
+		value = step.Range.StartLine
+	case 10:
+		value = step.StatementID
+	}
+	formatted := strconv.AppendInt(it.decimal[:0], int64(value), 10)
+	it.decimalLength = len(formatted)
+	it.decimalReady = true
 }

--- a/internal/vba/effects/build.go
+++ b/internal/vba/effects/build.go
@@ -104,13 +104,18 @@ func Build(documents []Document) ProjectSummary {
 		return edges[i].to < edges[j].to
 	})
 	propagate(summaries, edges)
-	out := ProjectSummary{byKey: map[string]int{}}
+	out := ProjectSummary{
+		byKey:           map[string]int{},
+		byCandidateLine: map[int][]int{},
+	}
 	for _, summary := range summaries {
 		out.procedures = append(out.procedures, *summary)
 	}
 	sortSummaries(out.procedures)
 	for i := range out.procedures {
 		out.byKey[out.procedures[i].Identity.Key()] = i
+		line := out.procedures[i].Identity.DeclarationLine
+		out.byCandidateLine[line] = append(out.byCandidateLine[line], i)
 	}
 	return out
 }

--- a/internal/vba/effects/effects_test.go
+++ b/internal/vba/effects/effects_test.go
@@ -1,7 +1,9 @@
 package effects
 
 import (
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
@@ -311,6 +313,83 @@ func TestProjectSummaryReturnsDefensiveCopies(t *testing.T) {
 	second, ok := project.Lookup(id)
 	if !ok || second.Identity.Name != "Run" || second.Direct[0].Target == "mutated" || second.Direct[0].Target == "mutated again" {
 		t.Fatalf("project summary was mutated through a returned value: %#v", second)
+	}
+}
+
+func TestProjectSummaryLookupCandidateMatchesResolverIdentity(t *testing.T) {
+	path := filepath.Join("Dir", "State.bas")
+	project := buildSources(t, sourceFile{path, "State", "Public Sub Run()\n Application.EnableEvents = False\nEnd Sub\n"})
+	candidate := procedureir.Candidate{
+		File:          filepath.FromSlash("DIR/STATE.BAS"),
+		QualifiedName: "state.run",
+		Kind:          "SUB",
+		Line:          1,
+	}
+
+	first, ok := project.LookupCandidate(candidate)
+	if !ok {
+		t.Fatal("case-insensitive, slash-normalized candidate did not match")
+	}
+	first.Direct[0].Target = "mutated"
+	second, ok := project.LookupCandidate(candidate)
+	if !ok || second.Direct[0].Target == "mutated" {
+		t.Fatalf("candidate lookup did not return a defensive copy: %#v", second)
+	}
+}
+
+func TestProjectSummaryLookupCandidateRequiresCompleteIdentity(t *testing.T) {
+	project := buildSources(t, sourceFile{"State.bas", "State", "Public Sub Run()\nEnd Sub\n"})
+	matching := procedureir.Candidate{File: "State.bas", QualifiedName: "State.Run", Kind: "sub", Line: 1}
+	tests := map[string]procedureir.Candidate{
+		"file":           {File: "Other.bas", QualifiedName: matching.QualifiedName, Kind: matching.Kind, Line: matching.Line},
+		"qualified name": {File: matching.File, QualifiedName: "State.Other", Kind: matching.Kind, Line: matching.Line},
+		"kind":           {File: matching.File, QualifiedName: matching.QualifiedName, Kind: "function", Line: matching.Line},
+		"line":           {File: matching.File, QualifiedName: matching.QualifiedName, Kind: matching.Kind, Line: 2},
+	}
+	for name, candidate := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := project.LookupCandidate(candidate); ok {
+				t.Fatalf("mismatched candidate unexpectedly resolved: %#v", candidate)
+			}
+		})
+	}
+}
+
+func TestProjectSummaryLookupCandidatePreservesUnicodeCaseFolding(t *testing.T) {
+	doc := procedureir.DocumentIR{
+		Path:       "Σ.bas",
+		ModuleName: "Σ",
+		Procedures: []procedureir.ProcedureIR{{Symbol: procedureir.ProcedureSymbol{
+			Name: "Run", QualifiedName: "Σ.Run", Kind: procedureir.ProcedureSub,
+			DeclarationRange: rangeAt(1),
+		}}},
+	}
+	project := Build([]Document{{IR: doc}})
+	candidate := procedureir.Candidate{File: "ς.BAS", QualifiedName: "ς.run", Kind: "SUB", Line: 1}
+	if _, ok := project.LookupCandidate(candidate); !ok {
+		t.Fatal("candidate lookup lost strings.EqualFold Unicode semantics")
+	}
+}
+
+func TestProjectSummaryLookupCandidateUsesFirstDeterministicDuplicate(t *testing.T) {
+	procedure := func(module string) procedureir.ProcedureIR {
+		return procedureir.ProcedureIR{Symbol: procedureir.ProcedureSymbol{
+			Name: "Run", QualifiedName: "Shared.Run", Kind: procedureir.ProcedureSub,
+			DeclarationRange: rangeAt(1),
+		}}
+	}
+	documents := func(first, second string) []Document {
+		return []Document{
+			{IR: procedureir.DocumentIR{Path: "Shared.bas", ModuleName: first, Procedures: []procedureir.ProcedureIR{procedure(first)}}},
+			{IR: procedureir.DocumentIR{Path: "Shared.bas", ModuleName: second, Procedures: []procedureir.ProcedureIR{procedure(second)}}},
+		}
+	}
+	candidate := procedureir.Candidate{File: "Shared.bas", QualifiedName: "Shared.Run", Kind: "sub", Line: 1}
+	for _, project := range []ProjectSummary{Build(documents("Z", "A")), Build(documents("A", "Z"))} {
+		got, ok := project.LookupCandidate(candidate)
+		if !ok || !strings.EqualFold(got.Identity.Module, "A") {
+			t.Fatalf("duplicate candidate selected %q, want deterministic first module A", got.Identity.Module)
+		}
 	}
 }
 

--- a/internal/vba/effects/types.go
+++ b/internal/vba/effects/types.go
@@ -108,8 +108,9 @@ func (s ProcedureSummary) Has(kind EffectKind) bool {
 }
 
 type ProjectSummary struct {
-	procedures []ProcedureSummary
-	byKey      map[string]int
+	procedures      []ProcedureSummary
+	byKey           map[string]int
+	byCandidateLine map[int][]int
 }
 
 func (p ProjectSummary) Lookup(id ProcedureIdentity) (ProcedureSummary, bool) {
@@ -118,6 +119,24 @@ func (p ProjectSummary) Lookup(id ProcedureIdentity) (ProcedureSummary, bool) {
 		return ProcedureSummary{}, false
 	}
 	return cloneProcedureSummary(p.procedures[i]), true
+}
+
+// LookupCandidate returns the first summary in deterministic procedure order
+// that matches the resolver candidate. The line index narrows the search while
+// the final comparisons preserve the resolver's case-insensitive matching
+// contract, including Unicode case folding.
+func (p ProjectSummary) LookupCandidate(candidate procedureir.Candidate) (ProcedureSummary, bool) {
+	candidateFile := filepath.ToSlash(candidate.File)
+	for _, i := range p.byCandidateLine[candidate.Line] {
+		id := p.procedures[i].Identity
+		if strings.EqualFold(filepath.ToSlash(id.File), candidateFile) &&
+			strings.EqualFold(id.QualifiedName, candidate.QualifiedName) &&
+			strings.EqualFold(string(id.Kind), candidate.Kind) &&
+			id.DeclarationLine == candidate.Line {
+			return cloneProcedureSummary(p.procedures[i]), true
+		}
+	}
+	return ProcedureSummary{}, false
 }
 
 // All returns a defensive copy in deterministic procedure order.


### PR DESCRIPTION
## Summary

- Add developer-only, project-isolated corpus benchmarks and CPU/heap profiling commands for `std-vba` and `ronecone`.
- Replace repeated propagation-path serialization with an allocation-free ASCII comparator that preserves the former canonical byte ordering and Unicode fallback behavior.
- Index effect-summary candidate lookup so resolving one call clones only the matched summary instead of the complete project summary.
- Document the profiler evidence, before/after measurements, variability, optimization target, and final verify-only corpus timings.

## Impact

- The focused `LibJSON.ParseChars` benchmark reduced median runtime by 22.8%, allocated bytes by 55.3%, and allocation count by 73.0%.
- After rebasing onto the context-cancellation analyzer change, two full verify-only corpus runs completed in 171.5 s and 170.2 s with no diagnostic or snapshot delta.
- Diagnostic ranges, severities, multiplicity, ordering, project isolation, production CLI/API behavior, and Excel/VBE oracle behavior are unchanged.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -Command '$testArgs = @("test", "./internal/vba/dataflow", "./internal/vba/effects", "./internal/analyze", "./internal/staticanalysis/...", "-count=1"); & ".\scripts\dev\go.ps1" @testArgs'`
- `rtk task corpus:test` (twice after rebasing onto `origin/main`)
- `rtk task corpus:metrics`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/oracle -run "^TestCommittedFixtureContractsWithoutExcel$" -count=1`
- `rtk golangci-lint run ./internal/staticanalysis/... ./internal/analyze/... ./internal/vba/dataflow/... ./internal/vba/effects/...`
- `rtk pnpm docs:check`
- `rtk pnpm format:check`
- `rtk git diff --check`

Closes #554


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory allocations during data-flow path comparisons, improving analysis efficiency.
  * Accelerated procedure and effect-summary lookups, particularly in larger projects.

* **Reliability**
  * Improved consistency when matching procedures across file paths, names, kinds, and declaration locations.
  * Strengthened handling of case differences, Unicode names, duplicate declarations, and complex analysis paths.

* **Documentation**
  * Added developer documentation and benchmark tooling for evaluating analysis performance on real-world VBA projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->