### PR TITLE
Improve Go test execution time with safe intra-package parallelization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,10 @@ The fast verification path currently runs non-COM test coverage via:
 go test ./...
 ```
 
+The repository's rules for safe intra-package test parallelization, corpus
+worker limits, and timing measurements are documented in
+[`docs/specs/go-test-parallelization.md`](docs/specs/go-test-parallelization.md).
+
 Run vulnerability and third-party licence inventory checks with:
 
 ```bash

--- a/docs/specs/go-test-parallelization.md
+++ b/docs/specs/go-test-parallelization.md
@@ -1,0 +1,71 @@
+# Go Test Parallelization Policy
+
+This repository uses Go package-level parallelism by default and adds
+intra-package parallelism only where test isolation is explicit. The purpose is
+to improve throughput without making process-wide state or timing-sensitive
+tests order-dependent.
+
+## Safety policy
+
+Tests may use `t.Parallel()` when they only perform pure computation, read
+immutable fixtures, use an independent `t.TempDir()` workspace, run an
+isolated analyzer/linter invocation, or verify read-only deterministic
+snapshots.
+
+Tests remain serial when they use `t.Setenv`/`t.Chdir`, mutate package or
+process-wide state, use fixed shared paths, coordinate locks or child
+processes, depend on timing or execution order, invoke Excel/COM/VBE or the
+local oracle, or publish/update snapshots. A `t.Parallel()` test must not call
+an API that changes process-wide environment or working-directory state.
+
+The `analyze`, `lint`, and pure VBA data-flow fixtures follow the safe policy.
+The existing `cfg` and `procedureir` parallel tests are retained. CLI, LSP,
+Excel/COM, coordination, process-sensitive, and environment-mutating tests
+are intentionally outside the initial parallelization scope.
+
+## Real-world corpus
+
+Each corpus project is analyzed in its own temporary workspace. Native and
+third-party projects run as named parallel subtests, with a fixed maximum of
+two active projects. Results are stored by input index and merged in manifest
+order before the existing deterministic diagnostic and failure sorting. This
+keeps output stable while limiting peak memory and GC pressure on smaller CI
+runners.
+
+Diagnostic normalization happens inside each isolated worker. Snapshot set
+construction, review evaluation, verification, and publication happen only
+after all project workers complete. Snapshot updates retain the existing
+all-or-nothing contract: workers never publish individual files, and
+`WriteSnapshotSet` replaces the complete tree once, after successful analysis.
+
+## Timing reference
+
+These are observations from the Windows development workstation on 2026-08-08
+using Go 1.26.5, `-count=1`, and the repository's
+`scripts/dev/go.ps1` wrapper. They are comparison points, not CI thresholds.
+
+| Run                           |    Before |                After |
+| ----------------------------- | --------: | -------------------: |
+| `go test ./...` (uncached)    |  59.198 s | 50.951 s median of 3 |
+| real-world corpus verify-only | 171.054 s | 86.584 s median of 2 |
+
+Repeat timing measurements with the same toolchain and machine before drawing
+performance conclusions. Use `go test -json` to retain package/test timing, and
+run the corpus through `task corpus:test` so the opt-in environment and
+verify-only snapshot mode are explicit.
+
+## Verification commands
+
+On Windows, invoke Go through `scripts/dev/go.ps1`:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -count=1 -json ./...
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./...
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -shuffle=on -count=10 ./...
+task corpus:test
+```
+
+The opt-in corpus suite should also be exercised with race detection and
+shuffled repetition during development. Snapshot update runs must be followed
+by a worktree check; normal verification must never modify committed snapshot
+files.

--- a/docs/specs/go-test-parallelization.md
+++ b/docs/specs/go-test-parallelization.md
@@ -50,8 +50,8 @@ using Go 1.26.5, `-count=1`, and the repository's
 | real-world corpus verify-only | 171.054 s | 86.584 s median of 2 |
 
 Repeat timing measurements with the same toolchain and machine before drawing
-performance conclusions. Use `go test -json` to retain package/test timing, and
-run the corpus through `task corpus:test` so the opt-in environment and
+performance conclusions. Use `-json` test output to retain package/test timing,
+and run the corpus through `rtk task corpus:test` so the opt-in environment and
 verify-only snapshot mode are explicit.
 
 ## Verification commands
@@ -59,10 +59,10 @@ verify-only snapshot mode are explicit.
 On Windows, invoke Go through `scripts/dev/go.ps1`:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -count=1 -json ./...
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./...
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -shuffle=on -count=10 ./...
-task corpus:test
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -count=1 -json ./...
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./...
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -shuffle=on -count=10 ./...
+rtk task corpus:test
 ```
 
 The opt-in corpus suite should also be exercised with race detection and

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestSourceRealtimeRuleIDsMatchRegistry(t *testing.T) {
+	t.Parallel()
 	var registryIDs []string
 	for _, rule := range staticrules.ByFamily(staticrules.FamilyAnalyze) {
 		if rule.Realtime {
@@ -39,6 +40,7 @@ func TestSourceRealtimeRuleIDsMatchRegistry(t *testing.T) {
 }
 
 func TestProcedureEffectIdentityCanonicalizesPath(t *testing.T) {
+	t.Parallel()
 	document := procedureir.DocumentIR{
 		Path:       filepath.Join("modules", "..", "modules", "Main.bas"),
 		ModuleName: "Main",
@@ -60,6 +62,7 @@ func TestProcedureEffectIdentityCanonicalizesPath(t *testing.T) {
 }
 
 func TestVBA225DetectsIndexedCellReadsWritesAndFormatting(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -88,6 +91,7 @@ End Sub
 }
 
 func TestVBA225NestedSeverityAndSmallLoopExemption(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -114,6 +118,7 @@ End Sub
 }
 
 func TestVBA225UsesNearestNonSmallLoop(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -137,6 +142,7 @@ End Sub
 }
 
 func TestVBA225IgnoresStringAndCommentText(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -157,6 +163,7 @@ End Sub
 }
 
 func TestVBA225SupportsForEachOffsetWorksheetFunctionsAndBorders(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -186,6 +193,7 @@ End Sub
 }
 
 func TestVBA225SupportsDoAndWhileLoops(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -211,6 +219,7 @@ End Sub
 }
 
 func TestVBA225BulkOperationsAndSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "src", "modules", "Main.bas")
 	writeModule(t, dir, "Main.bas", `Option Explicit
@@ -259,6 +268,7 @@ End Sub
 }
 
 func TestVBA225TracksUniqueAndTransitiveHelpers(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Helpers.bas", `Option Explicit
 Public Sub ReadCell(ByVal rng As Range, ByVal i As Long)
@@ -316,6 +326,7 @@ End Sub
 }
 
 func TestVBA225SkipsAmbiguousHelpers(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "First.bas", `Option Explicit
 Public Sub ReadCell(ByVal rng As Range, ByVal i As Long)
@@ -347,6 +358,7 @@ End Sub
 }
 
 func TestAnalyzerDetectsProcedureLocalResourceLeaks(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Resources.bas", `Option Explicit
 
@@ -525,6 +537,7 @@ End Sub
 }
 
 func TestResourceLeakDoesNotTrustRecoveredRelease(t *testing.T) {
+	t.Parallel()
 	acquisition := procedureir.Statement{ID: 1, Kind: procedureir.StatementSet, Text: `Set wb = Workbooks.Open(path)`}
 	recoveredClose := procedureir.Statement{ID: 2, Kind: procedureir.StatementCall, Text: `wb.Close`, Recovered: true}
 	graph := vbacfg.Graph{
@@ -548,6 +561,7 @@ func TestResourceLeakDoesNotTrustRecoveredRelease(t *testing.T) {
 }
 
 func TestSourceRealtimeFindingsParsedMatchesSource(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Main.bas")
 	source := []byte("Option Explicit\nPublic Sub Run()\n  Dim found As Range\n  Set found = Range(\"A1\").Find(What:=\"x\")\n  Debug.Print found.Value\nEnd Sub\n")
@@ -571,6 +585,7 @@ func TestSourceRealtimeFindingsParsedMatchesSource(t *testing.T) {
 }
 
 func TestAnalyzerFindsMissingSetForObjectVariable(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -587,6 +602,7 @@ End Sub
 }
 
 func TestAnalyzerFindsMissingSetForModuleLevelObjectVariable(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private ws As Worksheet
@@ -603,6 +619,7 @@ End Sub
 }
 
 func TestAnalyzerFindsMissingSetForObjectReturningFunction(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function FindRange() As Range
@@ -622,6 +639,7 @@ End Sub
 }
 
 func TestAnalyzerFindsMissingSetInObjectReturningFunction(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function GetSheet() As Worksheet
@@ -641,6 +659,7 @@ End Function
 }
 
 func TestAnalyzerIgnoresScalarAndSetAssignments(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function FindRange() As Range
@@ -664,6 +683,7 @@ End Sub
 }
 
 func TestAnalyzerDoesNotReportObjectFunctionAssignmentToScalar(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function FindRange() As Range
@@ -687,6 +707,7 @@ End Sub
 }
 
 func TestAnalyzerFailsOnParserRecovery(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function Broken(ByVal value As String
@@ -710,6 +731,7 @@ End Function
 }
 
 func TestAnalyzerFindsWorksheetMemberAssignedOnVariable(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -727,6 +749,7 @@ End Sub
 }
 
 func TestAnalyzerFindsWorksheetMemberOnModuleLevelVariable(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private ws As Worksheet
@@ -744,6 +767,7 @@ End Sub
 }
 
 func TestAnalyzerFindsWorksheetMemberAssignedInsideWithBlock(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -763,6 +787,7 @@ End Sub
 }
 
 func TestAnalyzerFindsMissingXlflowLogHelperSource(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -782,6 +807,7 @@ End Sub
 }
 
 func TestAnalyzerFindsMissingXlflowSetTraceFileHelperSource(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -801,6 +827,7 @@ End Sub
 }
 
 func TestAnalyzerStillFlagsLegacyTraceHelpersWhenHelperSourceExists(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -824,6 +851,7 @@ End Sub
 }
 
 func TestAnalyzerSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	formsDir := filepath.Join(dir, "src", "forms")
 	if err := os.MkdirAll(filepath.Join(formsDir, "code"), 0o755); err != nil {
@@ -858,6 +886,7 @@ func TestAnalyzerSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
 }
 
 func TestAnalyzerFindsDefaultRuntimeRiskRules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -895,6 +924,7 @@ End Sub
 }
 
 func TestAnalyzerDetectsAmbiguousExcelScopeRoots(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub InteractiveEntry()
@@ -957,6 +987,7 @@ End Sub
 }
 
 func TestAnalyzerAcceptsExplicitExcelScopeReferences(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal wb As Workbook, ByVal ws As Worksheet)
@@ -982,6 +1013,7 @@ End Sub
 }
 
 func TestAnalyzerDetectsAmbiguousExcelScopeRootsInWithHeaders(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1017,6 +1049,7 @@ End Sub
 }
 
 func TestAnalyzerDetectsApplicationScopedAmbiguousRoots(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1053,6 +1086,7 @@ End Sub
 }
 
 func TestAnalyzerDetectsAllNumericPositionalWorkbookAndWindowIndices(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1081,6 +1115,7 @@ End Sub
 }
 
 func TestAnalyzerClassifiesEachWorkbooksOpenCaptureIndependently(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal useA As Boolean)
@@ -1103,6 +1138,7 @@ End Sub
 }
 
 func TestAnalyzerAddInSheetCollectionSuggestsCallerWorkbook(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "AddInEntry.bas", `Option Explicit
 Public Sub Run()
@@ -1128,6 +1164,7 @@ End Sub
 }
 
 func TestAnalyzerReportsThisWorkbookOnlyForAddInStandardModules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "AddInEntry.bas", `Option Explicit
 Public Sub Run()
@@ -1159,6 +1196,7 @@ End Sub
 }
 
 func TestAnalyzerReportsActiveSheetDependenciesInPrivateHelpers(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1184,6 +1222,7 @@ End Sub
 }
 
 func TestAnalyzerVBA205IgnoresCommentsAndStringLiterals(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1202,6 +1241,7 @@ End Sub
 }
 
 func TestAnalyzerHonorsDisabledRuleIDs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1239,6 +1279,7 @@ disabled_rules = ["VBA205"]
 }
 
 func TestAnalyzerSupportsInlineSuppressions(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1258,6 +1299,7 @@ End Sub
 }
 
 func TestAnalyzerReportsUnknownAndUnusedInlineSuppressionsAsWarnings(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1284,6 +1326,7 @@ End Sub
 }
 
 func TestAnalyzerDoesNotSuppressPreflightBlockingDiagnostics(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1307,6 +1350,7 @@ End Sub
 }
 
 func TestAnalyzerDoesNotSuppressVBA216(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeWorkbookModule(t, dir, "Sheet1.bas")
 	writeWorkbookModule(t, dir, "Sheet2.bas")
@@ -1331,6 +1375,7 @@ End Sub
 }
 
 func TestAnalyzerRuntimeRiskRulesAllowGuardedPatterns(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function Build() As Range
@@ -1363,6 +1408,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateAllowsPushPopRestorePattern(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private fastModeDepth As Long
@@ -1414,6 +1460,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateAllowsEitherSameModuleRestoreAlias(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1439,6 +1486,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateRejectsPopThatDisablesEvents(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1458,6 +1506,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateStillFlagsUnpairedPushPattern(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1473,6 +1522,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateAllowsPropagatedRestoreEffect(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1504,6 +1554,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateAllowsUniqueProjectVisibleRestorePair(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1530,6 +1581,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateRejectsAmbiguousProjectRestorePair(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1552,6 +1604,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateRejectsCrossModuleClassMethodPair(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1572,6 +1625,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateRejectsRestorePropagatedFromBareClassMethod(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1597,6 +1651,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateRejectsRestorePropagatedFromBareUserFormMethod(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1622,6 +1677,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStatePreservesInlineSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub PushFastMode()
@@ -1640,6 +1696,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateChecksEveryConfiguredProperty(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub UnsafeAllProperties()
@@ -1679,6 +1736,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateRecognizesWithApplicationSharedCleanupAndCopies(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub SafeCleanup(ByVal invalidInput As Boolean)
@@ -1713,6 +1771,7 @@ End Sub
 }
 
 func TestAnalyzerApplicationStateReportsEarlyExitAndErrorHandlerPaths(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub UnsafeExitSub(ByVal invalidInput As Boolean)
@@ -1796,6 +1855,7 @@ End Property
 }
 
 func TestAnalyzerApplicationStateRejectsInvalidOrConditionalSavedValue(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub ReassignedSavedValue()
@@ -1837,6 +1897,7 @@ End Sub
 }
 
 func TestVBA221ReportsImmediateCallerAndUncertainCalleeOncePerProperty(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Main()
@@ -1875,6 +1936,7 @@ End Sub
 }
 
 func TestVBA221DoesNotRepeatTransitiveLeakAtAncestorOrRealtime(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	source := `Option Explicit
 Public Sub Main()
@@ -1908,6 +1970,7 @@ End Sub
 }
 
 func TestVBA221IgnoresUnreachableCallerPaths(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Main()
@@ -1931,6 +1994,7 @@ End Sub
 }
 
 func TestVBA221HonorsConfigAndInlineSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Main()
@@ -1978,6 +2042,7 @@ End Sub
 }
 
 func TestAnalyzerErrorHandlerFallthroughSuggestsConcreteExitStatement(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1998,6 +2063,7 @@ End Sub
 }
 
 func TestAnalyzerIRVBA204PreservesPropertyExitAndCleanupSemantics(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Property Get SafeValue() As Long
@@ -2036,6 +2102,7 @@ End Sub
 }
 
 func TestAnalyzerIRVBA204PreservesInlineSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2055,6 +2122,7 @@ End Sub
 }
 
 func TestAnalyzerIRVBA204DoesNotTreatNestedExitAsUnconditional(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal stopEarly As Boolean)
@@ -2076,6 +2144,7 @@ End Sub
 }
 
 func TestAnalyzerIRVBA204DoesNotNestHandlerAfterSingleLineIf(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal stopEarly As Boolean)
@@ -2095,6 +2164,7 @@ End Sub
 }
 
 func TestAnalyzerCFGVBA204DoesNotReportHandlerSkippedByGoto(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2117,6 +2187,7 @@ End Sub
 }
 
 func TestAnalyzerCFGVBA204DoesNotTreatGotoHandlerAsFallthrough(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2138,6 +2209,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214AllowsNarrowCompatibilityProbes(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub DirectProbe()
@@ -2178,6 +2250,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214ReportsScopeBoundsAndEarlyExits(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub BroadScope()
@@ -2219,6 +2292,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214ReportsContinuationAfterObjectProbeBeforeRestore(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub UsesFailedProbe()
@@ -2241,6 +2315,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214DoesNotTreatStringLiteralsAsErrProbes(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2262,6 +2337,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214ElevatesResolvedProjectCallsAndWarnsUnresolvedCalls(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Helper()
@@ -2312,6 +2388,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214TracksNestedBranchAndHandlerScopes(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub BranchLeak(ByVal stopEarly As Boolean)
@@ -2354,6 +2431,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214DoesNotFollowMergedDisabledErrorMode(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2376,6 +2454,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214ReportsAllProcedureExitKindsAndHandlerReplacement(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function FunctionExit() As Long
@@ -2419,6 +2498,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214ReportsUnknownGotoExit(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2438,6 +2518,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214ElevatesProjectCallsInControlConditions(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function ProjectPredicate() As Boolean
@@ -2464,6 +2545,7 @@ End Sub
 }
 
 func TestAnalyzerVBA214HonorsInlineAndConfigSuppressionIndependentlyOfVB004(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub InlineSuppressed()
@@ -2510,6 +2592,7 @@ End Sub
 }
 
 func TestSourceRealtimeAnalysisExcludesBatchOnlyVBA214(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Main.bas")
 	source := []byte(`Option Explicit
@@ -2530,6 +2613,7 @@ End Sub
 }
 
 func TestVBA215MatchesBatchAndRealtimeAnalysisAndHonorsSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2575,6 +2659,7 @@ End Sub
 }
 
 func TestBatchTypedExcelRulesReusePreparedParsedDocument(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Main.bas")
 	source := []byte(`Option Explicit
@@ -2617,6 +2702,7 @@ End Sub
 }
 
 func TestVBA218MatchesBatchAndRealtimeAnalysisAndHonorsFailureContracts(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Main.bas")
 	source := `Option Explicit
@@ -2669,6 +2755,7 @@ End Sub
 }
 
 func TestVBA218RecognizesLocalIsErrorGuardAndCVErrWrapper(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Function IsLookupError(ByVal value As Variant) As Boolean
@@ -2704,6 +2791,7 @@ End Sub
 }
 
 func TestVBA218UsesUniqueCrossModuleIsErrorGuardOnlyInBatch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Guards.bas", `Option Explicit
 Public Function IsLookupFailure(ByVal value As Variant) As Boolean
@@ -2737,6 +2825,7 @@ End Sub
 }
 
 func TestVBA218RejectsNonDominatingAndUninspectedGuards(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Function IsLookupError(ByVal value As Variant) As Boolean
@@ -2769,6 +2858,7 @@ End Sub
 }
 
 func TestVBA218TracksCVErrWrapperResultAtCaller(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Function TryVisible(ByVal rng As Range) As Variant
@@ -2796,6 +2886,7 @@ End Sub
 }
 
 func TestVBA218SuppressesDisabledCVErrWrapperFindingsInBatchAndRealtime(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Main.bas")
 	source := `Option Explicit
@@ -2829,6 +2920,7 @@ End Sub
 }
 
 func TestVBA218RecognizesLocalGuardAliasInRealtimeWrapperChecks(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Main.bas")
 	source := `Option Explicit
@@ -2859,6 +2951,7 @@ End Sub
 }
 
 func TestVBA218StopsVariantTrackingAfterImmediateReassignment(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal values As Range)
@@ -2878,6 +2971,7 @@ End Sub
 }
 
 func TestVBA218RecognizesMultilineIsErrorExitGuard(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal values As Range)
@@ -2899,6 +2993,7 @@ End Sub
 }
 
 func TestVBA218TracksUniqueCrossModuleCVErrWrapperOnlyInBatch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Guards.bas", `Option Explicit
 Public Function TryVisible(ByVal rng As Range) As Variant
@@ -2933,6 +3028,7 @@ End Sub
 }
 
 func TestWorksheetRootFindingsAppearInRealtimeAnalysis(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "src", "modules", "Main.bas")
 	source := []byte(`Option Explicit
@@ -2960,6 +3056,7 @@ End Sub
 }
 
 func TestWorksheetRootRealtimeAnalysisUsesWorkbookCodenames(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeWorkbookModule(t, dir, "InputSheet.bas")
 	writeWorkbookModule(t, dir, "OutputSheet.bas")
@@ -2981,6 +3078,7 @@ End Sub
 }
 
 func TestWorksheetRootRealtimeAnalysisHandlesContinuationsAndWithHeaders(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeWorkbookModule(t, dir, "InputSheet.bas")
 	writeWorkbookModule(t, dir, "OutputSheet.bas")
@@ -3007,6 +3105,7 @@ End Sub
 }
 
 func TestAnalyzerChecksObjectUseOnSetAssignmentRHS(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3024,6 +3123,7 @@ End Sub
 }
 
 func TestAnalyzerDoesNotTreatAnyObjectMentionAsInitialization(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3041,6 +3141,7 @@ End Sub
 }
 
 func TestAnalyzerAllowsKnownByRefObjectInitializer(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Sub InitSheet(ByRef target As Worksheet)
@@ -3063,6 +3164,7 @@ End Sub
 }
 
 func TestAnalyzerRuntimeRiskRules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub NeedsLong(ByRef value As Long)
@@ -3090,6 +3192,7 @@ End Sub
 }
 
 func TestAnalyzerVBA210UsesCFGReturnPaths(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Function MissingReturn() As Long
@@ -3267,6 +3370,7 @@ End Sub
 }
 
 func TestAnalyzerByRefMismatchHandlesLowercaseCallKeyword(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub NeedsLong(ByRef value As Long)
@@ -3283,6 +3387,7 @@ End Sub
 }
 
 func TestAnalyzerCompileEquivalentByRefMismatchIgnoresVBA206Disable(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub NeedsLong(ByRef value As Long)
@@ -3308,6 +3413,7 @@ End Sub
 }
 
 func TestAnalyzerByRefUsesProjectLocalNamedSignatures(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Receiver.bas", `Option Explicit
 Public Sub ReplaceText(ByRef target As String, Optional ByVal suffix As String = "")
@@ -3331,6 +3437,7 @@ End Sub
 }
 
 func TestAnalyzerByRefSkipsAmbiguousCallsAndHonorsSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "First.bas", `Option Explicit
 Public Sub TakeText(ByRef target As String)
@@ -3360,6 +3467,7 @@ End Sub
 }
 
 func TestAnalyzerArrayComparisonUsesIdentifierBoundaries(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3382,6 +3490,7 @@ End Sub
 }
 
 func TestAnalyzerArrayComparisonIgnoresFunctionReturnAssignment(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Function CopyValues() As Variant
@@ -3408,6 +3517,7 @@ End Sub
 }
 
 func TestAnalyzerArrayComparisonFindingsHaveStableOrder(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3431,6 +3541,7 @@ End Sub
 }
 
 func TestAnalyzerArrayLifecycleAndDimensionSafety(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Function BuildValues() As Variant
@@ -3491,6 +3602,7 @@ End Sub
 }
 
 func TestAnalyzerArrayLifecycleIsDeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal chooseFirst As Boolean)
@@ -3527,6 +3639,7 @@ End Sub
 }
 
 func TestAnalyzerArrayLifecycleSuppressesRangeValueDuplicates(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3545,6 +3658,7 @@ End Sub
 }
 
 func TestAnalyzerArrayLifecycleUsesConservativeBranchAndVariantStates(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal shouldAllocate As Boolean)
@@ -3569,6 +3683,7 @@ End Sub
 }
 
 func TestAnalyzerArrayLifecyclePreservesMatchingShapesAndMultiTargetTransitions(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal shouldAllocate As Boolean)
@@ -3617,6 +3732,7 @@ End Sub
 }
 
 func TestAnalyzerArrayLifecycleAcceptsReDimTypeSuffixAndUnknownDimension(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal dimension As Long)
@@ -3637,6 +3753,7 @@ End Sub
 }
 
 func TestAnalyzerArrayLifecycleQualifiedReDimAndUnknownArrayAssignment(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3661,6 +3778,7 @@ End Sub
 }
 
 func TestAnalyzerArrayLifecycleKeepsAlwaysEnabledObjectArrayFindings(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3684,6 +3802,7 @@ End Sub
 }
 
 func TestAnalyzerArrayReturnSummariesRequireDefiniteAllocation(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Function MaybeValues(ByVal shouldAllocate As Boolean) As Variant
@@ -3725,6 +3844,7 @@ End Sub
 }
 
 func TestAnalyzerArrayReturnSummaryDeduplicatesLoopVisits(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Function LoopValues() As Variant
@@ -3754,6 +3874,7 @@ End Sub
 }
 
 func TestAnalyzerArrayReturnSummaryExcludesScalarRangeValue(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private Function ReadScalar() As Variant
@@ -3778,6 +3899,7 @@ End Sub
 }
 
 func TestVBA227RealtimeArrayReturnSummariesAreDocumentLocal(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Helper.bas", `Option Explicit
 Public Function BuildValues() As Variant
@@ -3805,6 +3927,7 @@ End Sub
 }
 
 func TestVBA227BatchAndRealtimeResultsMatch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	source := `Option Explicit
 Public Sub Run()
@@ -3834,6 +3957,7 @@ End Sub
 }
 
 func TestAnalyzerArrayComparisonIgnoresElementsAndProcedureHeaders(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Private fastModeDepth As Long
@@ -3873,6 +3997,7 @@ End Sub
 }
 
 func TestAnalyzerExpandedExcelMemberMismatch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3890,6 +4015,7 @@ End Sub
 }
 
 func TestAnalyzerDetectsNonShortCircuitObjectGuards(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3920,6 +4046,7 @@ End Sub
 }
 
 func TestAnalyzerNonShortCircuitObjectGuardAllowsSeparateAndDifferentObjects(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3943,6 +4070,7 @@ End Sub
 }
 
 func TestAnalyzerNonShortCircuitObjectGuardCanBeDisabled(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -3976,6 +4104,7 @@ disabled_rules = ["VBA212"]
 }
 
 func TestAnalyzerNonShortCircuitObjectGuardDedupesMultilineExpression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4006,6 +4135,7 @@ End Sub
 }
 
 func TestAnalyzerNonShortCircuitObjectGuardSupportsInlineSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4025,6 +4155,7 @@ End Sub
 }
 
 func TestAnalyzerDictionaryIterationValueUsageFindsKnownAndInferredDictionaries(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4064,6 +4195,7 @@ End Sub
 }
 
 func TestAnalyzerDictionaryIterationValueUsageFindsObjectAssignmentAndIgnoresKeyUsage(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4100,6 +4232,7 @@ End Sub
 }
 
 func TestAnalyzerDictionaryIterationValueUsageIsOptInAndInvalidatesInference(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4122,6 +4255,7 @@ End Sub
 }
 
 func TestAnalyzerDictionaryIterationValueUsageRecognizesWithAndAllowsReboundValues(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4151,6 +4285,7 @@ End Sub
 }
 
 func TestAnalyzerRuntimeRiskRulesIgnoreCommentsAndStrings(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4173,6 +4308,7 @@ End Sub
 }
 
 func TestAnalyzerVBA216DetectsDistinctWorksheetRoots(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	tracker := newWorksheetRootTracker(nil)
 	tracker.observeSetAssignment(`Set inputSheet = ThisWorkbook.Worksheets("Input")`)
@@ -4235,6 +4371,7 @@ End Sub
 }
 
 func TestAnalyzerVBA216OnlyComparesProvableRootIdentities(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeWorkbookModule(t, dir, "InputSheet.bas")
 	writeWorkbookModule(t, dir, "OutputSheet.bas")
@@ -4264,6 +4401,7 @@ End Sub
 }
 
 func TestAnalyzerVBA216AnalyzesContinuationsAndWithHeaders(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeWorkbookModule(t, dir, "InputSheet.bas")
 	writeWorkbookModule(t, dir, "OutputSheet.bas")
@@ -4289,6 +4427,7 @@ End Sub
 }
 
 func TestAnalyzerVBA217AnalyzesContinuationStatements(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4309,6 +4448,7 @@ End Sub
 }
 
 func TestWorksheetRootMemberOffsetsPreserveUTF8(t *testing.T) {
+	t.Parallel()
 	tracker := newWorksheetRootTracker(map[string]string{"inputsheet": "InputSheet", "outputsheet": "OutputSheet"})
 	accesses := worksheetMemberAccesses(`lastRow = Len("İ") + InputSheet.Cells(OutputSheet.Rows.Count, 1).End(xlUp).Row`, tracker)
 	if len(accesses) != 2 || accesses[0].root.identity != "codename:inputsheet" || accesses[1].root.identity != "codename:outputsheet" {
@@ -4317,6 +4457,7 @@ func TestWorksheetRootMemberOffsetsPreserveUTF8(t *testing.T) {
 }
 
 func TestAnalyzerVBA216AcceptsSameWorksheetRootsAndUnknowns(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub SameRoot()
@@ -4342,6 +4483,7 @@ End Sub
 }
 
 func TestAnalyzerVBA217ReportsOnlyUnstableLastRowPatterns(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4376,6 +4518,7 @@ End Sub
 }
 
 func TestAnalyzerVBA217HonorsDisableAndInlineSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub InlineSuppressed()
@@ -4405,6 +4548,7 @@ End Sub
 }
 
 func TestAnalyzerWorksheetRootRulesIgnoreStringLiterals(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -4436,6 +4580,7 @@ func writeModule(t *testing.T, dir, name, body string) {
 }
 
 func TestVBA220DetectsEventReentryAndHonorsSafeEventCleanup(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "src", "workbook")
 	if err := os.MkdirAll(workbook, 0o755); err != nil {
@@ -4504,6 +4649,7 @@ End Sub
 }
 
 func TestVBA220ReportsUserFormControlReentryWithoutEnableEventsExemption(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeFormSidecar(t, dir, "Dialog.bas", `Option Explicit
 Private Sub TextBox1_Change()
@@ -4523,6 +4669,7 @@ End Sub
 }
 
 func TestVBA220AcceptsDelegatedWorkCoveredBySafeEventCleanup(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "src", "workbook")
 	if err := os.MkdirAll(workbook, 0o755); err != nil {
@@ -4561,6 +4708,7 @@ End Sub
 }
 
 func TestVBA220ReportsAmbiguousCallsAsUncertainty(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	workbook := filepath.Join(dir, "src", "workbook")
 	if err := os.MkdirAll(workbook, 0o755); err != nil {
@@ -4674,6 +4822,7 @@ func containsAll(text string, parts ...string) bool {
 }
 
 func TestAnalyzerVBA229IsBlockingAndUnsuppressible(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Probe()
@@ -4695,6 +4844,7 @@ End Sub
 }
 
 func TestAnalyzerVBA229AcceptsQualifiedProjectType(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Types.bas", `Option Explicit
 Public Type Payload

--- a/internal/analyze/hardcoded_secrets_test.go
+++ b/internal/analyze/hardcoded_secrets_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestVBA223DetectsStructuredCredentialsAndRedactsOutput(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	apiKey := "g" + "h" + "p_" + strings.Repeat("a", 24)
 	awsAccessKey := "A" + "KIA" + strings.Repeat("A", 16)
@@ -94,6 +95,7 @@ End Sub
 }
 
 func TestVBA223IgnoresPlaceholdersCommentsAndEnvironmentReferences(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 ' password = "comment-secret"
@@ -118,6 +120,7 @@ End Sub
 }
 
 func TestVBA223DetectsModuleOnlyDeclarationsInBatchAndRealtime(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	secret := "module-only-secret"
 	source := `Option Explicit
@@ -147,6 +150,7 @@ Private Const ApiKey As String = "__SECRET__"
 }
 
 func TestVBA223DetectsCredentialContainingPercent(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	secret := "pa%ssword-value"
 	source := `Option Explicit
@@ -168,6 +172,7 @@ End Sub
 }
 
 func TestVBA223RedactsRemCommentsInNearbyCode(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	commentSecret := "adjacent-comment-secret"
 	source := `Option Explicit
@@ -198,6 +203,7 @@ End Sub
 }
 
 func TestVBA223HonorsDisabledRulesAndInlineSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	source := `Option Explicit
 Public Sub Run()

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestVBA226DetectsOneDimensionalRangeValueUse(t *testing.T) {
+	t.Parallel()
 	for _, member := range []string{"Value", "Value2"} {
 		t.Run(member, func(t *testing.T) {
 			dir := t.TempDir()
@@ -41,6 +42,7 @@ End Sub
 }
 
 func TestVBA226AcceptsSafeTwoDimensionalAccessAndPassThrough(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -61,6 +63,7 @@ End Sub
 }
 
 func TestVBA226DetectsSingleCellAndDynamicShapesButAcceptsGuardedArrayAccess(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal lastCell As String)
@@ -94,6 +97,7 @@ End Sub
 }
 
 func TestVBA226DetectsIncompatibleDestinationShape(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -114,6 +118,7 @@ End Sub
 }
 
 func TestVBA226DetectsHorizontalAndRectangularIndexOrder(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -150,6 +155,7 @@ End Sub
 }
 
 func TestVBA226RecognizesArrayGuardAndConservativeBranchMerge(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal useArray As Boolean)
@@ -193,6 +199,7 @@ End Sub
 }
 
 func TestVBA226ClearsArrayGuardAfterReassignment(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run(ByVal lastCell As String)
@@ -215,6 +222,7 @@ End Sub
 }
 
 func TestVBA226HonorsConfigurationAndInlineSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -245,6 +253,7 @@ End Sub
 }
 
 func TestVBA226BatchAndRealtimeResultsMatch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	source := `Option Explicit
 Public Sub Run()

--- a/internal/analyze/vba212_single_pass_test.go
+++ b/internal/analyze/vba212_single_pass_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestVBA212ScannerTraversesRootOnceAndPreservesProcedureOwnership(t *testing.T) {
+	t.Parallel()
 	source := []byte(`Option Explicit
 Public Sub First()
   Dim one As Collection
@@ -65,6 +66,7 @@ End Property
 }
 
 func TestVBA212ScannerCancellationStopsAtCheckpoint(t *testing.T) {
+	t.Parallel()
 	var source strings.Builder
 	source.WriteString("Option Explicit\nPublic Sub Run()\n  Dim item As Collection\n")
 	for i := 0; i < 600; i++ {

--- a/internal/analyze/vba224_dataflow_test.go
+++ b/internal/analyze/vba224_dataflow_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAnalyzerRunResultContextReturnsCancellation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -22,6 +23,7 @@ func TestAnalyzerRunResultContextReturnsCancellation(t *testing.T) {
 }
 
 func TestAnalyzerRunResultContextReturnsCancellationDuringFileLoop(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	for _, module := range []string{"First", "Second", "Third"} {
 		writeModule(t, dir, module+".bas", `Attribute VB_Name = "`+module+`"
@@ -53,6 +55,7 @@ func (c *cancelAfterChecksContext) Err() error {
 }
 
 func TestVBA224DetectsDirectAliasAndConcatenation(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -102,6 +105,7 @@ End Sub
 }
 
 func TestVBA224AcceptsConstantsAndExplicitURLSanitization(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -127,6 +131,7 @@ End Sub
 }
 
 func TestVBA224KeepsUnknownTransformationsAndHonorsDisable(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -158,6 +163,7 @@ End Sub
 }
 
 func TestVBA224AcceptsOnlyTheValidatedAllowlistBranch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	source := `Attribute VB_Name = "Main"
 Option Explicit
@@ -182,6 +188,7 @@ End Sub
 }
 
 func TestVBA224DetectsProcedureParameter(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -199,6 +206,7 @@ End Sub
 }
 
 func TestVBA224HonorsInlineSuppression(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -217,6 +225,7 @@ End Sub
 }
 
 func TestVBA224AcceptsOnlyTheValidatedSelectCaseBranch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	source := `Attribute VB_Name = "Main"
 Option Explicit
@@ -240,6 +249,7 @@ End Sub
 }
 
 func TestVBA224RecognizesInitialSourceAndSinkCatalogMembers(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	source := `Attribute VB_Name = "Main"
 Option Explicit
@@ -311,6 +321,7 @@ func sameStrings(got, want []string) bool {
 }
 
 func TestVBA224DoesNotMatchUnrelatedMembersOrUnreachableCode(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit

--- a/internal/lint/linter_test.go
+++ b/internal/lint/linter_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestLinterRunResultContextReturnsCancellation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -31,6 +32,7 @@ func TestLinterRunResultContextReturnsCancellation(t *testing.T) {
 }
 
 func TestLinterRunResultContextReturnsZeroResultWhenCanceledDuringFinalization(t *testing.T) {
+	t.Parallel()
 	ctx := &lintCheckpointContext{cancelAt: 13}
 	result, err := (Linter{RootDir: t.TempDir(), Config: config.Default()}).RunResultContext(ctx)
 	if !errors.Is(err, context.Canceled) {
@@ -45,6 +47,7 @@ func TestLinterRunResultContextReturnsZeroResultWhenCanceledDuringFinalization(t
 }
 
 func TestLintParsedContextReturnsCancellationWithoutPartialIssues(t *testing.T) {
+	t.Parallel()
 	doc, err := vbaast.ParseDocument("Main.bas", []byte("Sub Main()\nEnd Sub\n"))
 	if err != nil {
 		t.Fatal(err)
@@ -110,6 +113,7 @@ func (c *lintCheckpointContext) Err() error {
 }
 
 func TestLinterFindsMVPRules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -206,6 +210,7 @@ End Sub
 }
 
 func TestLinterAllowsSelectCase(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -233,6 +238,7 @@ End Sub
 }
 
 func TestLinterHonorsDisabledRuleIDs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -269,6 +275,7 @@ disabled_rules = ["VB002"]
 }
 
 func TestLinterSupportsInlineSuppressions(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -288,6 +295,7 @@ End Sub
 }
 
 func TestLinterSupportsMultipleInlineSuppressionIDs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -309,6 +317,7 @@ End Sub
 }
 
 func TestLinterInlineSuppressionKeepsUnrelatedSameLineDiagnostic(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -330,6 +339,7 @@ End Sub
 }
 
 func TestLinterReportsUnknownAndUnusedInlineSuppressionsAsWarnings(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -357,6 +367,7 @@ End Sub
 }
 
 func TestLinterDoesNotSuppressPreflightBlockingDiagnostics(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", "Option Explicit\nPublic Sub Run()\n  ' xlflow:disable-next-line VB008\n  Debug.Print “bad quote”\nEnd Sub\n")
 
@@ -373,6 +384,7 @@ func TestLinterDoesNotSuppressPreflightBlockingDiagnostics(t *testing.T) {
 }
 
 func TestLinterConfigDisabledRulesComposeWithInlineSuppressions(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -401,6 +413,7 @@ End Sub
 }
 
 func TestLinterUsesASTForDeclaratorsAndColumns(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -445,6 +458,7 @@ End Sub
 }
 
 func TestLinterASTIgnoresCommentsAndStringsForKeywordRules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -473,6 +487,7 @@ End Sub
 }
 
 func TestLinterASTDetectsMemberAccessAndOnError(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -514,6 +529,7 @@ End Sub
 }
 
 func TestLinterAcceptsBoundedErrNumberProbes(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -545,6 +561,7 @@ End Sub
 }
 
 func TestLinterReportsUnobservedOnErrorCleanupScopes(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -576,6 +593,7 @@ End Sub
 }
 
 func TestConfusingParenthesizedCallIgnoresFunctionArguments(t *testing.T) {
+	t.Parallel()
 	if name, ok := confusingParenthesizedCall("Mid$(alphabet, (block \\ 64) + 1, 1)"); ok || name != "" {
 		t.Fatalf("Mid$ argument expression = (%q, %t), want no VB022", name, ok)
 	}
@@ -585,6 +603,7 @@ func TestConfusingParenthesizedCallIgnoresFunctionArguments(t *testing.T) {
 }
 
 func TestLinterReportsParserRecovery(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -637,6 +656,7 @@ End Sub
 }
 
 func TestLinterReportsMissingParserRecoveryContext(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "src", "modules", "Main.bas")
 	source := []byte(`Option Explicit
@@ -664,6 +684,7 @@ End Sub
 }
 
 func TestLinterReportsLikelyUnclosedBlocks(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	tests := []struct {
 		name         string
@@ -727,6 +748,7 @@ func TestLinterReportsLikelyUnclosedBlocks(t *testing.T) {
 }
 
 func TestLinterLocatesNestedUnclosedBlockAtParentCloser(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	source := []byte("Option Explicit\nSub Main()\n  If outerReady Then\n    If innerReady Then\n      Debug.Print \"x\"\n  End If\nEnd Sub\n")
 	issues, err := (Linter{RootDir: filepath.Dir(filepath.Dir(filepath.Dir(path))), Config: config.Default()}).LintSource(path, source)
@@ -747,6 +769,7 @@ func TestLinterLocatesNestedUnclosedBlockAtParentCloser(t *testing.T) {
 }
 
 func TestLinterPreservesContinuationTailLocationForUnclosedBlock(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	source := []byte("Sub Main()\n  result = _\n    1: If ready Then\n      Debug.Print \"x\"\nEnd Sub\n")
 	issues, err := (Linter{RootDir: filepath.Dir(filepath.Dir(filepath.Dir(path))), Config: config.Default()}).LintSource(path, source)
@@ -764,6 +787,7 @@ func TestLinterPreservesContinuationTailLocationForUnclosedBlock(t *testing.T) {
 }
 
 func TestUnmatchedBlockCandidatesStayConservative(t *testing.T) {
+	t.Parallel()
 	valid := "Sub Main()\n  If ready Then\n    For Each item In items\n      Debug.Print item\n    Next item\n  End If\nEnd Sub\n"
 	if candidates, reliable := unmatchedBlockCandidates(valid); !reliable || len(candidates) != 0 {
 		t.Fatalf("valid source candidates = %+v, reliable=%t", candidates, reliable)
@@ -834,6 +858,7 @@ func TestUnmatchedBlockCandidatesStayConservative(t *testing.T) {
 }
 
 func TestLinterAcceptsNextPrefixedIdentifiersWithoutParserRecovery(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "classes", "Example.cls")
 	source := []byte("Option Explicit\nPrivate Sub ReadNext()\n  Dim nextChar As String\n  Dim nextSlot As Long\n  nextChar = Mid$(text, position, 1)\n  nextSlot = (slot + 1) And mask\nEnd Sub\nPrivate Function NextHashCapacity() As Long\n  NextHashCapacity = 1\nEnd Function\n")
 	issues, err := (Linter{RootDir: filepath.Dir(filepath.Dir(filepath.Dir(path))), Config: config.Default()}).LintSource(path, source)
@@ -846,6 +871,7 @@ func TestLinterAcceptsNextPrefixedIdentifiersWithoutParserRecovery(t *testing.T)
 }
 
 func TestLinterFallsBackToGenericRecoveryForConditionalCompilation(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	source := []byte("Option Explicit\nSub Main()\n#If VBA7 Then\n  If ready Then\n    Debug.Print \"x\"\n#End If\nEnd Sub\n")
 	issues, err := (Linter{RootDir: filepath.Dir(filepath.Dir(filepath.Dir(path))), Config: config.Default()}).LintSource(path, source)
@@ -863,6 +889,7 @@ func TestLinterFallsBackToGenericRecoveryForConditionalCompilation(t *testing.T)
 }
 
 func TestConditionalIfBalanceAcrossCompilationBranches(t *testing.T) {
+	t.Parallel()
 	balanced := "Sub Main()\n#If Win64 Then\n  If a Then\n#Else\n  If b Then\n#End If\n    Debug.Print \"x\"\n  Else\n    Debug.Print \"y\"\n  End If\nEnd Sub\n"
 	if conditionalIfBalanceInvalid(balanced) {
 		t.Fatal("equivalent conditional If headers should merge into one balanced shared block")
@@ -875,6 +902,7 @@ func TestConditionalIfBalanceAcrossCompilationBranches(t *testing.T) {
 }
 
 func TestLinterAcceptsConditionalCompilationSplitIfWithFlatCST(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	source := []byte("Option Explicit\nSub Main()\n#If Win64 Then\n  If a Then\n#Else\n  If b Then\n#End If\n    Debug.Print \"x\"\n  Else\n    Debug.Print \"y\"\n  End If\nEnd Sub\n")
 
@@ -888,6 +916,7 @@ func TestLinterAcceptsConditionalCompilationSplitIfWithFlatCST(t *testing.T) {
 }
 
 func TestLinterFlagsUnbalancedConditionalCompilationSplitIfWithFlatCST(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	source := []byte("Option Explicit\nSub Main()\n#If Win64 Then\n  If a Then\n#End If\n    Debug.Print \"x\"\nEnd Sub\n")
 
@@ -901,6 +930,7 @@ func TestLinterFlagsUnbalancedConditionalCompilationSplitIfWithFlatCST(t *testin
 }
 
 func TestLinterAcceptsContinuedIfWithConditionalCompilation(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	source := []byte("Option Explicit\nSub Main()\n#If Win64 Then\n  Debug.Print \"64\"\n#Else\n  Debug.Print \"32\"\n#End If\n  If ready _\n    And enabled Then\n    Debug.Print \"x\"\n  End If\nEnd Sub\n")
 
@@ -914,6 +944,7 @@ func TestLinterAcceptsContinuedIfWithConditionalCompilation(t *testing.T) {
 }
 
 func TestLinterRejectsInvalidFlatIfBranchOwnership(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	tests := map[string]string{
 		"orphan Else":   "Option Explicit\nSub Main()\n  Else\n    Debug.Print \"x\"\nEnd Sub\n",
@@ -937,6 +968,7 @@ func TestLinterRejectsInvalidFlatIfBranchOwnership(t *testing.T) {
 }
 
 func TestLinterFallsBackToGenericRecoveryForAmbiguousBlocks(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "src", "modules", "Main.bas")
 	tests := []struct {
 		name   string
@@ -974,6 +1006,7 @@ func TestLinterFallsBackToGenericRecoveryForAmbiguousBlocks(t *testing.T) {
 }
 
 func TestParserRecoveryDetailsForBlocksAssociateOnlyMatchingRecovery(t *testing.T) {
+	t.Parallel()
 	blocks := []unclosedBlockCandidate{
 		{openingLine: 2, expectedLine: 9},
 		{openingLine: 4, expectedLine: 6},
@@ -993,6 +1026,7 @@ func TestParserRecoveryDetailsForBlocksAssociateOnlyMatchingRecovery(t *testing.
 }
 
 func TestParserRecoveryDetailBoundsUnicodeText(t *testing.T) {
+	t.Parallel()
 	text := strings.Repeat("あ", maxParserRecoveryContextRunes+1)
 	got := truncateParserRecoveryText(text, maxParserRecoveryContextRunes)
 	if utf8.RuneCountInString(got) != maxParserRecoveryContextRunes || !strings.HasSuffix(got, "…") {
@@ -1001,6 +1035,7 @@ func TestParserRecoveryDetailBoundsUnicodeText(t *testing.T) {
 }
 
 func TestLinterHandlesImplicitVariantsInsideUDTs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1054,6 +1089,7 @@ End Sub
 }
 
 func TestLinterIgnoresConditionalCompilationDirectivesInsideUDTs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1097,6 +1133,7 @@ End Type
 }
 
 func TestLinterAllowsInteractiveInputWhenDisabled(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1125,6 +1162,7 @@ End Sub
 }
 
 func TestLinterIgnoresXlflowUIWrappers(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1160,6 +1198,7 @@ End Sub
 }
 
 func TestLinterBlocksBareDialogsWhenXlflowUIIsPresent(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1220,6 +1259,7 @@ End Sub
 }
 
 func TestLinterVB028UsesStatementCallContext(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1265,6 +1305,7 @@ End Function
 }
 
 func TestLinterAllowsBareDialogsWithoutXlflowUI(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1284,6 +1325,7 @@ End Sub
 }
 
 func TestLinterFindsTypographicQuotesThatTriggerVBECompileDialogs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1307,6 +1349,7 @@ func TestLinterFindsTypographicQuotesThatTriggerVBECompileDialogs(t *testing.T) 
 }
 
 func TestLinterFindsLikelyCStyleQuoteEscapesThatTriggerVBECompileDialogs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1330,6 +1373,7 @@ func TestLinterFindsLikelyCStyleQuoteEscapesThatTriggerVBECompileDialogs(t *test
 }
 
 func TestLinterKeepsEarlierCStyleQuoteEscapeWhenLaterQuoteExists(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", "Option Explicit\nPublic Sub Run()\n  s = \"\\\"\": Debug.Print \"x\"\nEnd Sub\n")
 	issues, err := Linter{RootDir: dir, Config: config.Default()}.Run()
@@ -1346,6 +1390,7 @@ func TestLinterKeepsEarlierCStyleQuoteEscapeWhenLaterQuoteExists(t *testing.T) {
 }
 
 func TestLinterAllowsVBAJSONEscapedQuoteStrings(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "JsonConverter.bas", `Attribute VB_Name = "JsonConverter"
 Option Explicit
@@ -1371,6 +1416,7 @@ End Function
 }
 
 func TestLinterAllowsValidProcedureBoundaries(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1409,6 +1455,7 @@ Public Declare PtrSafe Function GetTickCount Lib "kernel32" () As Long
 }
 
 func TestLinterFindsProcedureBoundarySyntaxErrors(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1437,6 +1484,7 @@ End Property
 }
 
 func TestLinterFindsUnterminatedProcedureAtStartLine(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1461,6 +1509,7 @@ Public Function MissingClose() As String
 }
 
 func TestLinterProcedureScannerIgnoresCommentsStringsAndDesignerEnd(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	formsDir := filepath.Join(dir, "src", "forms")
 	if err := os.MkdirAll(formsDir, 0o755); err != nil {
@@ -1493,6 +1542,7 @@ End Sub
 }
 
 func TestLinterHandlesContinuedProcedureDeclaration(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1518,6 +1568,7 @@ End Sub
 }
 
 func TestLinterFindsMissingWhitespaceBeforeLineContinuation(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1551,6 +1602,7 @@ End Sub
 }
 
 func TestLinterFindsVBAContinuationLineOverflow(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		body          string
@@ -1621,6 +1673,7 @@ func TestLinterFindsVBAContinuationLineOverflow(t *testing.T) {
 }
 
 func TestLinterAllowsVBAContinuationLineLimitAndIgnoresStringsAndComments(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	body := "Attribute VB_Name = \"Main\"\nOption Explicit\nPublic Sub Run()\n" +
 		continuedLogicalLine("    result = a0 +", "        arg +", "        finalArg\n", 24) +
@@ -1639,6 +1692,7 @@ func TestLinterAllowsVBAContinuationLineLimitAndIgnoresStringsAndComments(t *tes
 }
 
 func TestLinterFindsRepeatedQuestionShorthand(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1687,6 +1741,7 @@ End Sub
 }
 
 func TestLinterAllowsIdentifiersEndingWithUnderscore(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1714,6 +1769,7 @@ End Sub
 }
 
 func TestLinterHandlesOneLineProcedureStatements(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src", "modules")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -1739,6 +1795,7 @@ Property Get Name() As String: Name = "x": End Property
 }
 
 func TestLinterSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	formsDir := filepath.Join(dir, "src", "forms")
 	if err := os.MkdirAll(filepath.Join(formsDir, "code"), 0o755); err != nil {
@@ -1773,6 +1830,7 @@ func TestLinterSidecarModeSkipsGeneratedFRMCodeDiagnostics(t *testing.T) {
 }
 
 func TestLinterFindsDefaultASTBackedRules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1788,6 +1846,7 @@ End Sub
 }
 
 func TestLinterAllowsQualifiedExcelAccessAndNarrowResumeNext(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -1815,6 +1874,7 @@ End Sub
 }
 
 func TestLinterOptInProcedureLocalRules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Private moduleValue As Long
@@ -1862,6 +1922,7 @@ End Sub
 }
 
 func TestLinterVB021UsesRootedReachabilityAndClusters(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Private Sub Used()
@@ -1938,6 +1999,7 @@ End Sub
 }
 
 func TestLinterVB021KeepsInlineSuppressionLineBased(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 ' xlflow:disable-next-line VB021
@@ -1967,6 +2029,7 @@ End Sub
 }
 
 func TestLinterVB021RecognizesTestProceduresAsRoots(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Tests.bas", `Option Explicit
 Public Sub TestWorkflow(ByVal input As Long)
@@ -1994,6 +2057,7 @@ End Sub
 }
 
 func TestLinterVB021HandlesDynamicReachabilityConservatively(t *testing.T) {
+	t.Parallel()
 	t.Run("known target from reachable caller", func(t *testing.T) {
 		dir := t.TempDir()
 		writeLintModule(t, dir, "Main.bas", `Option Explicit
@@ -2056,6 +2120,7 @@ End Sub
 }
 
 func TestLinterVB021TreatsPublicStandardModuleAPIsAsPossibleRoots(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Api.bas", `Option Explicit
 Public Function PublicApi(ByVal value As String) As String
@@ -2083,6 +2148,7 @@ End Sub
 }
 
 func TestLinterVB021RecognizesEventsAndWithEventsHandlers(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	cfg := config.Default()
 	cfg.Project.Entry = "Missing.Run"
@@ -2193,6 +2259,7 @@ End Sub
 }
 
 func TestLinterUnusedLocalVariableUsesProcedureBounds(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2214,6 +2281,7 @@ End Sub
 }
 
 func TestLinterUnusedLocalVariableCountsEarlierConstOnSameLine(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2234,6 +2302,7 @@ End Sub
 }
 
 func TestLinterUnusedLocalVariableIgnoresWriteOnlyAssignments(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2259,6 +2328,7 @@ End Sub
 }
 
 func TestLinterUnusedLocalVariableTreatsOneLineConditionalAssignmentsAsWrites(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2282,6 +2352,7 @@ End Sub
 }
 
 func TestLinterDetectsNestedWithAmbiguityWhenEnabled(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2302,6 +2373,7 @@ End Sub
 }
 
 func TestLinterNewASTRulesIgnoreCommentsAndStrings(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -2321,6 +2393,7 @@ End Sub
 }
 
 func TestLinterSortsIssuesStably(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "B.bas", "Sub B()\nRange(\"A1\").Value = 1\nEnd Sub\n")
 	writeLintModule(t, dir, "A.bas", "Sub A()\nRange(\"A1\").Value = 1\nEnd Sub\n")
@@ -2344,6 +2417,7 @@ func TestLinterSortsIssuesStably(t *testing.T) {
 }
 
 func TestLinterLintSourceUsesUnsavedContent(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "src", "modules", "Main.bas")
 	source := []byte("Sub Run()\n    Range(\"A1\").Select\n    Dim value\nEnd Sub\n")
@@ -2359,6 +2433,7 @@ func TestLinterLintSourceUsesUnsavedContent(t *testing.T) {
 }
 
 func TestLinterLintParsedMatchesLintSource(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "src", "modules", "Main.bas")
 	source := []byte("Option Explicit\nPublic Sub Run()\n    Dim value\n    Range(\"A1\").Select\nEnd Sub\n")
@@ -2382,6 +2457,7 @@ func TestLinterLintParsedMatchesLintSource(t *testing.T) {
 }
 
 func TestLinterLintSourceAppliesInlineSuppressions(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "src", "modules", "Main.bas")
 	source := []byte(`Option Explicit
@@ -2401,6 +2477,7 @@ End Sub
 }
 
 func TestLinterReportsUndeclaredAssignmentsWithOptionExplicit(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Private moduleValue As Long
@@ -2437,6 +2514,7 @@ End Function
 }
 
 func TestLinterDoesNotTreatMultilineComparisonArgumentsAsAssignments(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -2458,6 +2536,7 @@ End Function
 }
 
 func TestLinterAllowsModuleVariablesDeclaredInsideConditionalCompilationBlocks(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -2511,6 +2590,7 @@ End Sub
 }
 
 func TestLinterUndeclaredAssignmentsRequireOptionExplicit(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Public Sub Run()
   missingValue = 1
@@ -2527,6 +2607,7 @@ End Sub
 }
 
 func TestLinterRequiresVBNameAttributeForStandardModules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Option Explicit
 Public Sub Run()
@@ -2549,6 +2630,7 @@ End Sub
 }
 
 func TestLinterAcceptsVBNameAttributeForStandardModules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
 Option Explicit
@@ -2566,6 +2648,7 @@ End Sub
 }
 
 func TestLinterRejectsEmptyVBNameAttributeForStandardModules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeLintModule(t, dir, "Main.bas", `Attribute VB_Name = ""
 Option Explicit
@@ -2583,6 +2666,7 @@ End Sub
 }
 
 func TestLinterVBNameAttributeOnlyAppliesToStandardModules(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	cfg := config.Default()
 	classes := filepath.Join(dir, "src", "classes")
@@ -2655,6 +2739,7 @@ func hasWarning(warnings []map[string]any, code string, rule string) bool {
 }
 
 func TestLinterProcedureNameConstantRule(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	cfg := config.Default()
 	cfg.Lint.ProcedureNameConstant = config.ProcedureNameConstantConfig{Enabled: true, ConstantName: "procedure_name"}
@@ -2719,6 +2804,7 @@ End Property
 }
 
 func TestLinterProcedureNameConstantRuleScansModuleKinds(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	cfg := config.Default()
 	cfg.UserForm.CodeSource = "frm"

--- a/internal/staticanalysis/corpus/snapshot_test.go
+++ b/internal/staticanalysis/corpus/snapshot_test.go
@@ -2,11 +2,14 @@ package corpus
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,8 +18,9 @@ import (
 )
 
 const (
-	runRealWorldCorpusEnv    = "XLFLOW_RUN_REALWORLD_CORPUS"
-	updateCorpusSnapshotsEnv = "XLFLOW_UPDATE_CORPUS_SNAPSHOTS"
+	runRealWorldCorpusEnv     = "XLFLOW_RUN_REALWORLD_CORPUS"
+	updateCorpusSnapshotsEnv  = "XLFLOW_UPDATE_CORPUS_SNAPSHOTS"
+	maxParallelCorpusProjects = 2
 )
 
 func realWorldCorpusMode() (run, update bool) {
@@ -280,7 +284,44 @@ func TestWriteSnapshotSetDoesNotPublishInvalidUpdate(t *testing.T) {
 	}
 }
 
-func runRealWorldCorpus(repoRoot string, logf ...func(string, ...any)) (Report, error) {
+type corpusProjectResult struct {
+	report  Report
+	err     error
+	elapsed time.Duration
+}
+
+func runParallelCorpusProjects(t *testing.T, group string, names []string, run func(int) (Report, error)) []corpusProjectResult {
+	t.Helper()
+	results := make([]corpusProjectResult, len(names))
+	limiter := make(chan struct{}, maxParallelCorpusProjects)
+	t.Run(group, func(t *testing.T) {
+		for i, name := range names {
+			i, name := i, name
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				limiter <- struct{}{}
+				defer func() { <-limiter }()
+				started := time.Now()
+				report, err := run(i)
+				results[i] = corpusProjectResult{
+					report:  report,
+					err:     err,
+					elapsed: time.Since(started),
+				}
+			})
+		}
+	})
+	return results
+}
+
+func appendCorpusReport(dst *Report, src Report) {
+	dst.Surfaces = append(dst.Surfaces, src.Surfaces...)
+	dst.Diagnostics = append(dst.Diagnostics, src.Diagnostics...)
+	dst.Failures = append(dst.Failures, src.Failures...)
+	dst.Skipped = append(dst.Skipped, src.Skipped...)
+}
+
+func runRealWorldCorpus(t *testing.T, repoRoot string, logf ...func(string, ...any)) (Report, error) {
 	var timingLogf func(string, ...any)
 	if len(logf) > 0 {
 		timingLogf = logf[0]
@@ -298,17 +339,20 @@ func runRealWorldCorpus(repoRoot string, logf ...func(string, ...any)) (Report, 
 	}
 	var nativeReport Report
 	nativeFailed := false
-	for _, project := range nativeProjects {
-		projectStarted := time.Now()
-		report, err := RunProjects([]NativeProject{project})
-		nativeReport.Surfaces = append(nativeReport.Surfaces, report.Surfaces...)
-		nativeReport.Diagnostics = append(nativeReport.Diagnostics, report.Diagnostics...)
-		nativeReport.Failures = append(nativeReport.Failures, report.Failures...)
-		if err != nil {
+	nativeNames := make([]string, len(nativeProjects))
+	for i, project := range nativeProjects {
+		nativeNames[i] = project.ID
+	}
+	nativeResults := runParallelCorpusProjects(t, "native", nativeNames, func(i int) (Report, error) {
+		return RunProjects([]NativeProject{nativeProjects[i]})
+	})
+	for i, result := range nativeResults {
+		appendCorpusReport(&nativeReport, result.report)
+		if result.err != nil {
 			nativeFailed = true
 		}
 		if timingLogf != nil {
-			timingLogf("corpus timing: project=%s elapsed=%s", project.ID, time.Since(projectStarted))
+			timingLogf("corpus timing: project=%s elapsed=%s", nativeProjects[i].ID, result.elapsed)
 		}
 	}
 	var nativeErr error
@@ -337,18 +381,20 @@ func runRealWorldCorpus(repoRoot string, logf ...func(string, ...any)) (Report, 
 	}
 	var thirdReport Report
 	thirdFailed := false
-	for _, project := range thirdProjects {
-		projectStarted := time.Now()
-		report, err := RunThirdPartyProjects(corpusRoot, []Project{project}, MaterializeOptions{})
-		thirdReport.Surfaces = append(thirdReport.Surfaces, report.Surfaces...)
-		thirdReport.Diagnostics = append(thirdReport.Diagnostics, report.Diagnostics...)
-		thirdReport.Failures = append(thirdReport.Failures, report.Failures...)
-		thirdReport.Skipped = append(thirdReport.Skipped, report.Skipped...)
-		if err != nil {
+	thirdNames := make([]string, len(thirdProjects))
+	for i, project := range thirdProjects {
+		thirdNames[i] = project.ID
+	}
+	thirdResults := runParallelCorpusProjects(t, "third_party", thirdNames, func(i int) (Report, error) {
+		return RunThirdPartyProjects(corpusRoot, []Project{thirdProjects[i]}, MaterializeOptions{})
+	})
+	for i, result := range thirdResults {
+		appendCorpusReport(&thirdReport, result.report)
+		if result.err != nil {
 			thirdFailed = true
 		}
 		if timingLogf != nil {
-			timingLogf("corpus timing: project=third_party/%s elapsed=%s", project.ID, time.Since(projectStarted))
+			timingLogf("corpus timing: project=third_party/%s elapsed=%s", thirdProjects[i].ID, result.elapsed)
 		}
 	}
 	var thirdErr error
@@ -371,6 +417,87 @@ func runRealWorldCorpus(repoRoot string, logf ...func(string, ...any)) (Report, 
 	return combined, errors.Join(nativeErr, thirdErr)
 }
 
+func TestParallelCorpusProjectsPreserveOrderAndFailures(t *testing.T) {
+	names := []string{"first", "second", "third"}
+	wantPeak := maxParallelCorpusProjects
+	if parallelFlag := flag.Lookup("test.parallel"); parallelFlag != nil {
+		if parallel, err := strconv.Atoi(parallelFlag.Value.String()); err == nil && parallel < wantPeak {
+			wantPeak = parallel
+		}
+	}
+	admitted := make(chan struct{}, len(names))
+	completed := make(chan int, len(names))
+	release := make(chan struct{})
+	var active atomic.Int32
+	var peak atomic.Int32
+	go func() {
+		for i := 0; i < wantPeak; i++ {
+			<-admitted
+		}
+		close(release)
+	}()
+	results := runParallelCorpusProjects(t, "synthetic", names, func(i int) (Report, error) {
+		current := active.Add(1)
+		for {
+			previous := peak.Load()
+			if current <= previous || peak.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		admitted <- struct{}{}
+		<-release
+		active.Add(-1)
+		completed <- i
+		report := Report{
+			Diagnostics: []Diagnostic{{
+				Project: names[i], Surface: SurfaceAnalyze, Code: fmt.Sprintf("VBA%d", i),
+			}},
+		}
+		if i != 1 {
+			return report, nil
+		}
+		failure := Failure{Project: names[i], Surface: SurfaceAnalyze, Kind: FailureExecution, Err: errors.New("synthetic worker failure")}
+		report.Failures = []Failure{failure}
+		return report, &RunError{Failures: []Failure{failure}}
+	})
+
+	if len(results) != len(names) {
+		t.Fatalf("result count = %d, want %d", len(results), len(names))
+	}
+	if got := peak.Load(); got != int32(wantPeak) {
+		t.Fatalf("peak corpus project concurrency = %d, want %d", got, wantPeak)
+	}
+	seen := make(map[int]bool, len(names))
+	var combined Report
+	var failures []Failure
+	for i, result := range results {
+		if len(result.report.Diagnostics) != 1 || result.report.Diagnostics[0].Project != names[i] {
+			t.Fatalf("result[%d] project = %#v, want %q", i, result.report.Diagnostics, names[i])
+		}
+		appendCorpusReport(&combined, result.report)
+		if result.err == nil {
+			continue
+		}
+		var runErr *RunError
+		if !errors.As(result.err, &runErr) {
+			t.Fatalf("result[%d] error = %T, want *RunError", i, result.err)
+		}
+		failures = append(failures, runErr.Failures...)
+	}
+	for len(seen) < len(names) {
+		seen[<-completed] = true
+	}
+	if len(combined.Diagnostics) != len(names) {
+		t.Fatalf("combined diagnostics = %d, want %d", len(combined.Diagnostics), len(names))
+	}
+	if len(combined.Failures) != 1 || len(failures) != 1 || failures[0].Project != names[1] {
+		t.Fatalf("combined failures = %#v, worker failures = %#v", combined.Failures, failures)
+	}
+	if got := (&RunError{Failures: failures}).Error(); got != "static-analysis corpus execution failed for 1 project surface(s)" {
+		t.Fatalf("RunError summary = %q", got)
+	}
+}
+
 func TestRealWorldCorpusSnapshots(t *testing.T) {
 	shouldRun, update := realWorldCorpusMode()
 	if !shouldRun {
@@ -383,7 +510,7 @@ func TestRealWorldCorpusSnapshots(t *testing.T) {
 	// Snapshot identities must not depend on a developer's generated TypeLib
 	// database. Use only the embedded built-in database for every platform.
 	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
-	report, runErr := runRealWorldCorpus(repoRoot, t.Logf)
+	report, runErr := runRealWorldCorpus(t, repoRoot, t.Logf)
 	if runErr != nil {
 		t.Fatalf("real-world corpus execution failed: %v", runErr)
 	}

--- a/internal/vba/dataflow/analysis_test.go
+++ b/internal/vba/dataflow/analysis_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAnalyzeProcedureContextReturnsCancellation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -24,6 +25,7 @@ func TestAnalyzeProcedureContextReturnsCancellation(t *testing.T) {
 }
 
 func TestAnalyzeProcedureContextCancelsDuringLargeCFGTraversal(t *testing.T) {
+	t.Parallel()
 	const blockCount = 20000
 	blocks := make([]cfg.Block, 0, blockCount)
 	edges := make([]cfg.Edge, 0, blockCount-1)
@@ -58,6 +60,7 @@ func (c *cancelAfterChecksContext) Err() error {
 }
 
 func TestAnalyzeProcedureFindingsDoNotDependOnWorklistRank(t *testing.T) {
+	t.Parallel()
 	document, err := procedureir.BuildSource(procedureir.BuildOptions{Path: "Main.bas", ModuleKind: "standard"}, []byte(`Option Explicit
 Sub Run(ByVal raw As String)
     Dim command As String
@@ -104,6 +107,7 @@ End Sub
 }
 
 func TestAnalyzeProcedureTracksParameterAliasAndConcatenation(t *testing.T) {
+	t.Parallel()
 	procedure := procedureir.ProcedureIR{
 		Symbol: procedureir.ProcedureSymbol{
 			Name:             "Run",
@@ -150,6 +154,7 @@ func hasPathKind(path []PathStep, kind string) bool {
 }
 
 func TestAnalyzeProcedureChoosesDeterministicRepresentativeAndUnknown(t *testing.T) {
+	t.Parallel()
 	procedure := procedureir.ProcedureIR{
 		Symbol: procedureir.ProcedureSymbol{Name: "Run", Kind: procedureir.ProcedureSub, DeclarationRange: lineRange(1), BodyRange: lineRange(6)},
 		Statements: []procedureir.Statement{
@@ -181,6 +186,7 @@ func TestAnalyzeProcedureChoosesDeterministicRepresentativeAndUnknown(t *testing
 }
 
 func TestJoinStateUsesConservativeStateAndShortestPath(t *testing.T) {
+	t.Parallel()
 	source := Source{Kind: SourceInputBox, Label: "InputBox", Range: lineRange(2)}
 	long := value{origins: map[string]provenance{sourceKey(source): {
 		source: source, state: StateTainted,
@@ -200,6 +206,7 @@ func TestJoinStateUsesConservativeStateAndShortestPath(t *testing.T) {
 }
 
 func TestRecoveredAssignmentDoesNotRestoreACleanValue(t *testing.T) {
+	t.Parallel()
 	procedure := procedureir.ProcedureIR{
 		Symbol: procedureir.ProcedureSymbol{Name: "Run", Kind: procedureir.ProcedureSub, DeclarationRange: lineRange(1), BodyRange: lineRange(5)},
 		Statements: []procedureir.Statement{
@@ -224,6 +231,7 @@ func TestRecoveredAssignmentDoesNotRestoreACleanValue(t *testing.T) {
 }
 
 func TestJoinStateDoesNotReportChangeForEquivalentMissingValue(t *testing.T) {
+	t.Parallel()
 	state := abstractState{vars: map[string]value{"raw": unknownStandaloneValue()}}
 	_, changed := joinState(state, abstractState{}, true)
 	if changed {
@@ -232,6 +240,7 @@ func TestJoinStateDoesNotReportChangeForEquivalentMissingValue(t *testing.T) {
 }
 
 func TestLooksDatabaseReceiverUsesIdentifierBoundaries(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		receiver string
 		full     string

--- a/internal/vba/dataflow/parsechars_regression_test.go
+++ b/internal/vba/dataflow/parsechars_regression_test.go
@@ -31,6 +31,7 @@ func parseCharsProcedure(tb testing.TB) (procedureir.ProcedureIR, cfg.Graph) {
 }
 
 func TestAnalyzeProcedureParseCharsConvergesWithBoundedTransfers(t *testing.T) {
+	t.Parallel()
 	procedure, graph := parseCharsProcedure(t)
 	analyzer := newProcedureAnalyzer(procedure, graph, Options{})
 	result, stats := analyzer.runWithStats()
@@ -62,6 +63,7 @@ func BenchmarkAnalyzeProcedureParseChars(b *testing.B) {
 }
 
 func TestRankedWorklistHandlesDeepWideGraphDeterministically(t *testing.T) {
+	t.Parallel()
 	const (
 		depth = 8000
 		width = 4000

--- a/internal/vba/dataflow/path_compare_test.go
+++ b/internal/vba/dataflow/path_compare_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestComparePathKeysMatchesSerializedKeyOrdering(t *testing.T) {
+	t.Parallel()
 	paths := [][]PathStep{
 		nil,
 		{},


### PR DESCRIPTION
## Summary

- add safe `t.Parallel()` coverage to isolated analyzer, linter, and VBA data-flow tests while keeping environment- and timing-sensitive tests serial
- run real-world corpus projects as named parallel subtests with a fixed concurrency limit of two and deterministic input-order aggregation
- keep snapshot verification and all-or-nothing publication after every worker completes, with regression coverage for concurrency, ordering, and failure retention
- document the repository's parallel-safety policy and timing reference

## Performance

- uncached `go test ./...`: 59.198 s before, 50.951 s after (median of three)
- real-world corpus verify-only: 171.054 s before, 86.584 s after (median of two)

## Tests

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -count=1 ./...`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -shuffle=on -count=10 ./internal/analyze ./internal/lint ./internal/vba/dataflow`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./...`
- opt-in real-world corpus race run with `-timeout=30m` (925.583 s)
- opt-in real-world corpus `-shuffle=on -count=3`
- `task corpus:test`
- `task corpus:update-snapshots` (no tracked snapshot diff)
- `pnpm docs:check`

Closes #544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved automated test execution speed through safe parallel processing.
  - Added bounded parallel analysis for real-world code corpora while preserving deterministic ordering and complete result reporting.
  - Strengthened validation of failure handling, isolated workspaces, timing data, and snapshot integrity.

- **Documentation**
  - Added guidance covering test parallelization, corpus workload limits, timing measurements, platform verification, and snapshot requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->