### PR TITLE
feat(corpus): improve static-analysis review tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added developer-only corpus review commands for exact diagnostic ranges,
+  schema-valid ledger drafts, and read-only project/rule-focused verification;
+  added an extensible machine-checked rule-contract marker inventory to prevent
+  protected specification metadata from drifting from the registry.
 - Fixed `VBA219` false positives for `Workbooks.Open` assignments to
   non-Workbook locals or return slots and for direct ownership transfer through
   a Workbook-valued Function return.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -148,18 +148,18 @@ tasks:
     desc: "Run selected corpus projects and print exact review ranges (usage: rtk proxy task corpus:review-details -- --rule VBA225 [--limit 20] [--project third_party/std-vba])"
     silent: true
     cmds:
-      - cmd: rtk proxy powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' run ./cmd/xlflow-static-analysis-corpus review-details {{.CLI_ARGS}}
+      - cmd: powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' run ./cmd/xlflow-static-analysis-corpus review-details {{.CLI_ARGS}}
         platforms: [windows]
-      - cmd: rtk proxy go run ./cmd/xlflow-static-analysis-corpus review-details {{.CLI_ARGS}}
+      - cmd: go run ./cmd/xlflow-static-analysis-corpus review-details {{.CLI_ARGS}}
         platforms: [linux, darwin]
 
   corpus:review-draft:
     desc: "Print schema-valid review JSONL without editing the ledger (invoke through rtk proxy task to preserve complete output)"
     silent: true
     cmds:
-      - cmd: rtk proxy powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' run ./cmd/xlflow-static-analysis-corpus review-draft {{.CLI_ARGS}}
+      - cmd: powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' run ./cmd/xlflow-static-analysis-corpus review-draft {{.CLI_ARGS}}
         platforms: [windows]
-      - cmd: rtk proxy go run ./cmd/xlflow-static-analysis-corpus review-draft {{.CLI_ARGS}}
+      - cmd: go run ./cmd/xlflow-static-analysis-corpus review-draft {{.CLI_ARGS}}
         platforms: [linux, darwin]
 
   corpus:test-focused:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,6 +144,32 @@ tasks:
       - cmd: rtk go test ./internal/staticanalysis/corpus -run '^TestCommittedCorpusReviewCandidates$' -count=1 -v
         platforms: [linux, darwin]
 
+  corpus:review-details:
+    desc: "Run selected corpus projects and print exact review ranges (usage: rtk proxy task corpus:review-details -- --rule VBA225 [--limit 20] [--project third_party/std-vba])"
+    silent: true
+    cmds:
+      - cmd: rtk proxy powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' run ./cmd/xlflow-static-analysis-corpus review-details {{.CLI_ARGS}}
+        platforms: [windows]
+      - cmd: rtk proxy go run ./cmd/xlflow-static-analysis-corpus review-details {{.CLI_ARGS}}
+        platforms: [linux, darwin]
+
+  corpus:review-draft:
+    desc: "Print schema-valid review JSONL without editing the ledger (invoke through rtk proxy task to preserve complete output)"
+    silent: true
+    cmds:
+      - cmd: rtk proxy powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' run ./cmd/xlflow-static-analysis-corpus review-draft {{.CLI_ARGS}}
+        platforms: [windows]
+      - cmd: rtk proxy go run ./cmd/xlflow-static-analysis-corpus review-draft {{.CLI_ARGS}}
+        platforms: [linux, darwin]
+
+  corpus:test-focused:
+    desc: "Read-only focused corpus verification (usage: task corpus:test-focused -- --project third_party/std-vba --rule VBA225)"
+    cmds:
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' run ./cmd/xlflow-static-analysis-corpus verify {{.CLI_ARGS}}
+        platforms: [windows]
+      - cmd: rtk go run ./cmd/xlflow-static-analysis-corpus verify {{.CLI_ARGS}}
+        platforms: [linux, darwin]
+
   bench:lsp:
     desc: Run deterministic LSP performance benchmarks
     cmds:

--- a/cmd/xlflow-static-analysis-corpus/main.go
+++ b/cmd/xlflow-static-analysis-corpus/main.go
@@ -17,7 +17,13 @@ import (
 )
 
 func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx := context.Background()
+	stop := func() {}
+	// Sync owns cancellable cleanup. Analysis commands keep the default
+	// interrupt behavior so Ctrl+C terminates their non-context-aware runners.
+	if len(os.Args) > 1 && os.Args[1] == "sync" {
+		ctx, stop = signal.NotifyContext(ctx, os.Interrupt)
+	}
 	defer stop()
 	os.Exit(run(ctx, os.Args[1:], os.Stdout, os.Stderr))
 }
@@ -132,7 +138,11 @@ func parseReviewOptions(name string, args []string, stderr io.Writer, draft bool
 }
 
 func runReviewDetails(args []string, stdout, stderr io.Writer, draft bool) error {
-	opts, err := parseReviewOptions(map[bool]string{false: "review-details", true: "review-draft"}[draft], args, stderr, draft)
+	name := "review-details"
+	if draft {
+		name = "review-draft"
+	}
+	opts, err := parseReviewOptions(name, args, stderr, draft)
 	if err != nil {
 		return err
 	}
@@ -183,7 +193,7 @@ func collectReviewDetails(opts reviewOptions) ([]corpus.ReviewDetail, error) {
 		snapshots = filterSnapshotProject(snapshots, opts.project)
 		reviews = corpus.FilterReviews(reviews, []string{opts.project}, "")
 		if len(snapshots) == 0 {
-			return nil, fmt.Errorf("unknown corpus project %q", opts.project)
+			return nil, fmt.Errorf("corpus snapshot project %q has no committed snapshots", opts.project)
 		}
 	}
 	candidates, err := corpus.FindSnapshotReviewCandidates(reviews, snapshots, opts.rule, opts.limit)

--- a/cmd/xlflow-static-analysis-corpus/main.go
+++ b/cmd/xlflow-static-analysis-corpus/main.go
@@ -2,35 +2,308 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/harumiWeb/xlflow/internal/staticanalysis/corpus"
+	"github.com/harumiWeb/xlflow/internal/staticanalysis/rules"
 )
 
 func main() {
-	if len(os.Args) < 2 || os.Args[1] != "sync" {
-		fmt.Fprintln(os.Stderr, "usage: xlflow-static-analysis-corpus sync [--manifest path] [--corpus-root path] [--upstream-checkout path]")
-		os.Exit(2)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	os.Exit(run(ctx, os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		usage(stderr)
+		return 2
 	}
+	var err error
+	switch args[0] {
+	case "sync":
+		err = runSync(ctx, args[1:], stderr)
+	case "review-details":
+		err = runReviewDetails(args[1:], stdout, stderr, false)
+	case "review-draft":
+		err = runReviewDetails(args[1:], stdout, stderr, true)
+	case "verify":
+		err = runVerify(args[1:], stdout, stderr)
+	default:
+		usage(stderr)
+		return 2
+	}
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func usage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "usage: xlflow-static-analysis-corpus <sync|review-details|review-draft|verify> [options]")
+}
+
+func runSync(ctx context.Context, args []string, stderr io.Writer) error {
 	flags := flag.NewFlagSet("sync", flag.ContinueOnError)
-	flags.SetOutput(os.Stderr)
+	flags.SetOutput(stderr)
 	manifest := flags.String("manifest", "testdata/static-analysis-corpus/manifest.json", "corpus manifest")
 	corpusRoot := flags.String("corpus-root", "testdata/static-analysis-corpus", "corpus root")
 	checkout := flags.String("upstream-checkout", "", "local checkout at the pinned upstream commit")
-	if err := flags.Parse(os.Args[2:]); err != nil {
-		os.Exit(2)
+	if err := flags.Parse(args); err != nil {
+		return err
 	}
 	if flags.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "sync does not accept positional arguments")
-		os.Exit(2)
+		return fmt.Errorf("sync does not accept positional arguments")
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer stop()
-	if err := corpus.Sync(ctx, corpus.SyncOptions{ManifestPath: *manifest, CorpusRoot: *corpusRoot, UpstreamCheckout: *checkout}); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+	return corpus.Sync(ctx, corpus.SyncOptions{ManifestPath: *manifest, CorpusRoot: *corpusRoot, UpstreamCheckout: *checkout})
+}
+
+type reviewOptions struct {
+	repoRoot            string
+	rule                string
+	project             string
+	limit               int
+	jsonOutput          bool
+	classification      string
+	rationale           string
+	regressionTest      string
+	regressionException string
+}
+
+func parseReviewOptions(name string, args []string, stderr io.Writer, draft bool) (reviewOptions, error) {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var opts reviewOptions
+	flags.StringVar(&opts.repoRoot, "repo-root", ".", "repository root")
+	flags.StringVar(&opts.rule, "rule", "", "diagnostic rule ID")
+	flags.StringVar(&opts.project, "project", "", "stable corpus project ID")
+	flags.IntVar(&opts.limit, "limit", 20, "maximum candidate occurrences")
+	flags.BoolVar(&opts.jsonOutput, "json", false, "emit JSON instead of TSV")
+	if draft {
+		flags.StringVar(&opts.classification, "classification", "", "true-positive or false-positive")
+		flags.StringVar(&opts.rationale, "rationale", "", "human review rationale")
+		flags.StringVar(&opts.regressionTest, "regression-test", "", "FP regression test path and name")
+		flags.StringVar(&opts.regressionException, "regression-exception", "", "FP regression exception")
 	}
+	if err := flags.Parse(args); err != nil {
+		return opts, err
+	}
+	if flags.NArg() != 0 {
+		return opts, fmt.Errorf("%s does not accept positional arguments", name)
+	}
+	if opts.rule == "" {
+		return opts, fmt.Errorf("--rule is required")
+	}
+	metadata, ok := rules.Lookup(opts.rule)
+	if !ok {
+		return opts, fmt.Errorf("unknown diagnostic rule %q", opts.rule)
+	}
+	opts.rule = metadata.ID
+	if draft && opts.classification == "" {
+		return opts, fmt.Errorf("--classification is required")
+	}
+	if draft {
+		classification := corpus.ReviewClassification(opts.classification)
+		if classification != corpus.ReviewTruePositive && classification != corpus.ReviewFalsePositive {
+			return opts, fmt.Errorf("unsupported classification %q", opts.classification)
+		}
+		if strings.TrimSpace(opts.rationale) == "" {
+			return opts, fmt.Errorf("--rationale is required")
+		}
+		hasTest := strings.TrimSpace(opts.regressionTest) != ""
+		hasException := strings.TrimSpace(opts.regressionException) != ""
+		if classification == corpus.ReviewFalsePositive && hasTest == hasException {
+			return opts, fmt.Errorf("false-positive draft requires exactly one of --regression-test or --regression-exception")
+		}
+		if classification == corpus.ReviewTruePositive && (hasTest || hasException) {
+			return opts, fmt.Errorf("true-positive draft does not accept regression evidence")
+		}
+	}
+	return opts, nil
+}
+
+func runReviewDetails(args []string, stdout, stderr io.Writer, draft bool) error {
+	opts, err := parseReviewOptions(map[bool]string{false: "review-details", true: "review-draft"}[draft], args, stderr, draft)
+	if err != nil {
+		return err
+	}
+	details, err := collectReviewDetails(opts)
+	if err != nil {
+		return err
+	}
+	if !draft {
+		if opts.jsonOutput {
+			encoder := json.NewEncoder(stdout)
+			encoder.SetIndent("", "  ")
+			return encoder.Encode(details)
+		}
+		_, err = io.WriteString(stdout, corpus.FormatReviewDetails(details))
+		return err
+	}
+	drafts, err := corpus.BuildReviewDrafts(details, corpus.ReviewClassification(opts.classification), opts.rationale, opts.regressionTest, opts.regressionException)
+	if err != nil {
+		return err
+	}
+	encoded, err := corpus.EncodeReviewDrafts(drafts)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(encoded)
+	return err
+}
+
+func collectReviewDetails(opts reviewOptions) ([]corpus.ReviewDetail, error) {
+	repoRoot, err := filepath.Abs(opts.repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	corpusRoot := filepath.Join(repoRoot, "testdata", "static-analysis-corpus")
+	ids, err := corpus.DiscoverSnapshotIDs(filepath.Join(corpusRoot, "snapshots"))
+	if err != nil {
+		return nil, err
+	}
+	snapshots, err := corpus.LoadSnapshotSubset(filepath.Join(corpusRoot, "snapshots"), ids)
+	if err != nil {
+		return nil, err
+	}
+	reviews, err := corpus.LoadDiagnosticReviews(filepath.Join(corpusRoot, "reviews", "diagnostics.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	if opts.project != "" {
+		snapshots = filterSnapshotProject(snapshots, opts.project)
+		reviews = corpus.FilterReviews(reviews, []string{opts.project}, "")
+		if len(snapshots) == 0 {
+			return nil, fmt.Errorf("unknown corpus project %q", opts.project)
+		}
+	}
+	candidates, err := corpus.FindSnapshotReviewCandidates(reviews, snapshots, opts.rule, opts.limit)
+	if err != nil {
+		return nil, err
+	}
+	projects := uniqueCandidateProjects(candidates.Rows)
+	if len(projects) == 0 {
+		return []corpus.ReviewDetail{}, nil
+	}
+	report, err := corpus.RunSelectedCorpus(repoRoot, projects)
+	if err != nil {
+		return nil, err
+	}
+	return corpus.ResolveReviewDetails(candidates, report)
+}
+
+func filterSnapshotProject(set corpus.SnapshotSet, project string) corpus.SnapshotSet {
+	filtered := make(corpus.SnapshotSet)
+	for id, rows := range set {
+		if id.Project == project {
+			filtered[id] = rows
+		}
+	}
+	return filtered
+}
+
+func uniqueCandidateProjects(rows []corpus.SnapshotDiagnostic) []string {
+	seen := make(map[string]struct{})
+	for _, row := range rows {
+		seen[row.Project] = struct{}{}
+	}
+	result := make([]string, 0, len(seen))
+	for project := range seen {
+		result = append(result, project)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func runVerify(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("verify", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	repoRootFlag := flags.String("repo-root", ".", "repository root")
+	project := flags.String("project", "", "stable corpus project ID")
+	rule := flags.String("rule", "", "diagnostic rule ID")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("verify does not accept positional arguments")
+	}
+	if *project == "" && *rule == "" {
+		return fmt.Errorf("focused verify requires --project, --rule, or both; use corpus:test for the full gate")
+	}
+	if *rule != "" {
+		metadata, ok := rules.Lookup(*rule)
+		if !ok {
+			return fmt.Errorf("unknown diagnostic rule %q", *rule)
+		}
+		*rule = metadata.ID
+	}
+	repoRoot, err := filepath.Abs(*repoRootFlag)
+	if err != nil {
+		return err
+	}
+	projects := []string(nil)
+	if *project != "" {
+		projects = []string{*project}
+	}
+	report, err := corpus.RunSelectedCorpus(repoRoot, projects)
+	if err != nil {
+		return err
+	}
+	report = corpus.FilterReport(report, *rule)
+	actual, err := corpus.SnapshotSetFromReport(report)
+	if err != nil {
+		return err
+	}
+	snapshotRoot := filepath.Join(repoRoot, "testdata", "static-analysis-corpus", "snapshots")
+	committedIDs, err := corpus.DiscoverSnapshotIDs(snapshotRoot)
+	if err != nil {
+		return err
+	}
+	expectedIDs := selectSnapshotIDs(committedIDs, *project)
+	want, err := corpus.LoadSnapshotSubset(snapshotRoot, expectedIDs)
+	if err != nil {
+		return err
+	}
+	for _, id := range actual.IDs() {
+		if _, exists := want[id]; !exists {
+			want[id] = []corpus.SnapshotDiagnostic{}
+		}
+	}
+	want = corpus.FilterSnapshots(want, *rule)
+	if diff := corpus.CompareSnapshotSets(want, actual); !diff.Empty() {
+		return fmt.Errorf("%s", strings.TrimSpace(corpus.FormatSnapshotDiff(diff)))
+	}
+	reviews, err := corpus.LoadDiagnosticReviews(filepath.Join(repoRoot, "testdata", "static-analysis-corpus", "reviews", "diagnostics.jsonl"))
+	if err != nil {
+		return err
+	}
+	reviews = corpus.FilterReviews(reviews, projects, *rule)
+	metrics, err := corpus.EvaluateDiagnosticReviews(reviews, report)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(stdout, corpus.FormatReviewMetrics(metrics))
+	return err
+}
+
+func selectSnapshotIDs(ids []corpus.SnapshotID, project string) []corpus.SnapshotID {
+	if project == "" {
+		return append([]corpus.SnapshotID(nil), ids...)
+	}
+	selected := make([]corpus.SnapshotID, 0, 2)
+	for _, id := range ids {
+		if id.Project == project {
+			selected = append(selected, id)
+		}
+	}
+	return selected
 }

--- a/cmd/xlflow-static-analysis-corpus/main_test.go
+++ b/cmd/xlflow-static-analysis-corpus/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/staticanalysis/corpus"
+)
+
+func TestRunRejectsUnsafeOrIncompleteDeveloperCommands(t *testing.T) {
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{args: nil, want: "usage:"},
+		{args: []string{"review-details"}, want: "--rule is required"},
+		{args: []string{"review-draft", "--rule", "VBA225"}, want: "--classification is required"},
+		{args: []string{"review-draft", "--rule", "VBA225", "--classification", "true-positive"}, want: "--rationale is required"},
+		{args: []string{"review-draft", "--rule", "VBA225", "--classification", "false-positive", "--rationale", "reviewed"}, want: "requires exactly one"},
+		{args: []string{"verify"}, want: "focused verify requires"},
+		{args: []string{"verify", "--rule", "VBA999"}, want: "unknown diagnostic rule"},
+	}
+	for _, test := range tests {
+		var stdout, stderr bytes.Buffer
+		if code := run(context.Background(), test.args, &stdout, &stderr); code == 0 {
+			t.Fatalf("run(%q) succeeded", test.args)
+		}
+		if !strings.Contains(stderr.String(), test.want) {
+			t.Fatalf("run(%q) stderr = %q, want %q", test.args, stderr.String(), test.want)
+		}
+	}
+}
+
+func TestSelectSnapshotIDsUsesCommittedSelectionRatherThanActualResults(t *testing.T) {
+	ids := []corpus.SnapshotID{
+		{Project: "self/selected", Surface: corpus.SurfaceLint},
+		{Project: "self/selected", Surface: corpus.SurfaceAnalyze},
+		{Project: "self/other", Surface: corpus.SurfaceAnalyze},
+	}
+	selected := selectSnapshotIDs(ids, "self/selected")
+	if len(selected) != 2 || selected[0].Project != "self/selected" || selected[1].Project != "self/selected" {
+		t.Fatalf("selected IDs = %#v", selected)
+	}
+	if all := selectSnapshotIDs(ids, ""); len(all) != len(ids) {
+		t.Fatalf("all IDs = %#v", all)
+	}
+	want := corpus.SnapshotSet{
+		selected[0]: {{Project: selected[0].Project, Surface: selected[0].Surface, File: "src/Main.bas", Code: "VBA225", Severity: "warning", Line: 1}},
+		selected[1]: {},
+	}
+	actual := corpus.SnapshotSet{selected[1]: {}}
+	if diff := corpus.CompareSnapshotSets(want, actual); len(diff.Removed) != 1 {
+		t.Fatalf("missing committed surface was not detected: %#v", diff)
+	}
+}

--- a/docs/adr/ADR-0025-excel-loop-performance-analysis.md
+++ b/docs/adr/ADR-0025-excel-loop-performance-analysis.md
@@ -14,11 +14,11 @@ tell whether the receiver is an Excel object, whether a statement is inside a
 reachable loop, or whether a range operation is already a bulk transfer.
 
 Issue #452 requires a diagnostic that covers indexed and `For Each` loops,
-distinguishes reads, writes, formulas, and formatting, increases severity for
-nested loops, explains the COM cost, suggests array or bulk-range operations,
-and avoids clearly trivial fixed-size loops. The rule must also account for
-uniquely resolved local helpers without turning ambiguous or late-bound VBA
-into false certainty.
+distinguishes reads, writes, formulas, and formatting, retains nested-loop
+depth as explanatory context, explains the COM cost, suggests array or
+bulk-range operations, and avoids clearly trivial fixed-size loops. The rule
+must also account for uniquely resolved local helpers without turning
+ambiguous or late-bound VBA into false certainty.
 
 ## Decision
 

--- a/docs/specs/excel-loop-performance-analysis.md
+++ b/docs/specs/excel-loop-performance-analysis.md
@@ -7,6 +7,8 @@ design rationale and boundaries.
 
 ## Scope and public contract
 
+<!-- xlflow-rule-contract: {"id":"VBA225","family":"analyze","category":"performance","default_severity":"warning","scope":"interprocedural","realtime":true,"configuration_key":"detect_excel_cell_access_in_loops","inline_suppressible":true,"preflight_blocking":false} -->
+
 `VBA225` is a default-enabled `analyze` warning in batch analysis and the
 shared real-time editor path. It is interprocedural when a uniquely resolved
 project-local helper contributes the Excel access, remains non-blocking for
@@ -27,19 +29,18 @@ The rule adds no fields to the `analysis` finding object. It uses the existing
 `code`, `severity`, `file`, `module`, `procedure`, `line`, `message`, `reason`,
 `suggestion`, and `nearby_code` fields. The message and reason identify the
 access kind and explain that each iteration can add an Excel COM round trip.
-Nested-loop findings use `error` severity, but remain advisory and do not
-change the source-preflight policy.
+Nested-loop findings retain `warning` severity and remain advisory.
 
 ## Loop boundaries and reachability
 
 The analyzer consumes the normalized procedure IR and conservative CFG. It
 recognizes `For`, `For Each`, `While`, and `Do` loops, including pre-test and
 post-test forms, and considers only reachable loop-body statements. The loop
-depth at the access site is retained for severity and remediation text:
+depth at the access site is retained for remediation text:
 
-- depth one produces a `warning`; and
-- depth two or greater produces an `error` because the nested loop multiplies
-  the possible number of COM calls.
+- every depth produces a `warning`; and
+- depth two or greater adds context explaining that nesting multiplies the
+  possible number of COM calls, without escalating severity.
 
 One finding is emitted for each loop with confirmed hot-loop evidence. It is
 located at the loop header, with deterministic source ordering. Additional

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -511,6 +511,43 @@ aid, not a ledger-row generator or an exact forbidden-contract check; obtain
 the full normalized range from the analyzer before committing semantic
 evidence, and use `task corpus:test` for exact TP/FP verification.
 
+To execute only the projects represented by a bounded candidate set and print
+the analyzer's complete normalized ranges, use the developer-only detail task:
+
+```powershell
+rtk proxy task corpus:review-details -- --rule VBA225 --limit 20
+rtk proxy task corpus:review-details -- --rule VBA225 --project third_party/std-vba
+```
+
+`corpus:review-details` joins the start-only committed candidates to a fresh
+run and retains duplicate occurrences. It does not classify diagnostics or
+write the review ledger. After inspecting the source, a reviewer may request
+schema-valid, canonically sorted JSONL on stdout:
+
+```powershell
+rtk proxy task corpus:review-draft -- --rule VBA225 --classification false-positive --rationale "Receiver resolution is incorrect." --regression-test "internal/analyze/analyzer_test.go::TestName"
+```
+
+True-positive drafts require `--classification true-positive` and a rationale.
+False-positive drafts additionally require exactly one of `--regression-test`
+or `--regression-exception`. The task never edits
+`reviews/diagnostics.jsonl`; the reviewer must inspect and merge its stdout.
+The outer `rtk proxy` is required for the detail and draft tasks because their
+TSV/JSONL stdout is an artifact and must not be summarized or truncated.
+
+During implementation, a read-only focused comparison can select a stable
+project ID, a rule ID, or both:
+
+```powershell
+rtk task corpus:test-focused -- --project third_party/std-vba --rule VBA225
+rtk task corpus:test-focused -- --rule VBA225
+```
+
+Rule-only verification still executes every project so a new diagnostic in a
+previously empty project cannot be hidden. Focused verification checks the
+selected snapshot and exact TP/FP contracts, cannot update snapshots, and is
+only a fast development loop. `corpus:test` remains the required full gate.
+
 Then verify the checked-in observed behavior without writing files:
 
 ```powershell

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -517,10 +517,12 @@ the analyzer's complete normalized ranges, use the developer-only detail task:
 ```powershell
 rtk proxy task corpus:review-details -- --rule VBA225 --limit 20
 rtk proxy task corpus:review-details -- --rule VBA225 --project third_party/std-vba
+rtk proxy task corpus:review-details -- --rule VBA225 --limit 20 --json
 ```
 
 `corpus:review-details` joins the start-only committed candidates to a fresh
-run and retains duplicate occurrences. It does not classify diagnostics or
+run and retains duplicate occurrences. Its default output is TSV; `--json`
+switches the output to indented JSON. It does not classify diagnostics or
 write the review ledger. After inspecting the source, a reviewer may request
 schema-valid, canonically sorted JSONL on stdout:
 
@@ -533,7 +535,7 @@ False-positive drafts additionally require exactly one of `--regression-test`
 or `--regression-exception`. The task never edits
 `reviews/diagnostics.jsonl`; the reviewer must inspect and merge its stdout.
 The outer `rtk proxy` is required for the detail and draft tasks because their
-TSV/JSONL stdout is an artifact and must not be summarized or truncated.
+TSV/JSON/JSONL stdout is an artifact and must not be summarized or truncated.
 
 During implementation, a read-only focused comparison can select a stable
 project ID, a rule ID, or both:

--- a/internal/staticanalysis/corpus/candidates_test.go
+++ b/internal/staticanalysis/corpus/candidates_test.go
@@ -116,7 +116,7 @@ func TestCommittedCorpusReviewCandidates(t *testing.T) {
 		t.Fatal(err)
 	}
 	snapshotRoot := filepath.Join(corpusRoot, "snapshots")
-	ids, err := discoverCommittedSnapshotIDs(snapshotRoot)
+	ids, err := DiscoverSnapshotIDs(snapshotRoot)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/staticanalysis/corpus/developer.go
+++ b/internal/staticanalysis/corpus/developer.go
@@ -1,0 +1,292 @@
+package corpus
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ReviewDetail is the full normalized diagnostic identity used to prepare
+// exact review-ledger evidence. Unlike snapshots, it retains the end position.
+type ReviewDetail struct {
+	Project   string  `json:"project"`
+	File      string  `json:"file"`
+	Surface   Surface `json:"surface"`
+	Code      string  `json:"code"`
+	Severity  string  `json:"severity"`
+	Line      int     `json:"start_line"`
+	Column    int     `json:"start_column"`
+	EndLine   int     `json:"end_line"`
+	EndColumn int     `json:"end_column"`
+}
+
+// DiscoverSnapshotIDs returns every committed project/surface snapshot ID.
+func DiscoverSnapshotIDs(root string) ([]SnapshotID, error) {
+	ids := make([]SnapshotID, 0)
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".jsonl" {
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		parts := strings.SplitN(filepath.ToSlash(relative), "/", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid snapshot path %q", relative)
+		}
+		id := SnapshotID{Project: strings.TrimSuffix(parts[1], ".jsonl"), Surface: Surface(parts[0])}
+		if err := validateSnapshotID(id); err != nil {
+			return fmt.Errorf("snapshot path %q: %w", relative, err)
+		}
+		ids = append(ids, id)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(ids, func(i, j int) bool { return snapshotIDLess(ids[i], ids[j]) })
+	return ids, nil
+}
+
+// LoadSnapshotSubset loads only the requested files. It intentionally does
+// not reject unrelated committed snapshots, which makes focused verification
+// read-only and independent of the rest of the corpus.
+func LoadSnapshotSubset(root string, ids []SnapshotID) (SnapshotSet, error) {
+	set := make(SnapshotSet, len(ids))
+	for _, id := range ids {
+		if _, exists := set[id]; exists {
+			return nil, fmt.Errorf("duplicate expected snapshot %s/%s", id.Project, id.Surface)
+		}
+		path, err := snapshotPath(root, id)
+		if err != nil {
+			return nil, err
+		}
+		rows, err := loadSnapshotFile(path, id)
+		if err != nil {
+			return nil, fmt.Errorf("load snapshot %s/%s: %w", id.Project, id.Surface, err)
+		}
+		set[id] = rows
+	}
+	return set, nil
+}
+
+// RunSelectedCorpus executes all corpus projects, or only the named stable
+// project IDs. The returned report retains the ordinary production adapters.
+func RunSelectedCorpus(repoRoot string, projectIDs []string) (Report, error) {
+	native, err := DiscoverExampleProjects(repoRoot)
+	if err != nil {
+		return Report{}, err
+	}
+	manifestPath := filepath.Join(repoRoot, "testdata", "static-analysis-corpus", "manifest.json")
+	manifest, corpusRoot, err := LoadManifest(manifestPath)
+	if err != nil {
+		return Report{}, err
+	}
+	if _, err := ValidateInventory(corpusRoot, manifest); err != nil {
+		return Report{}, err
+	}
+
+	nativeIDs, thirdIDs := splitProjectIDs(projectIDs)
+	selectedNative, nativeErr := SelectProjects(native, nativeIDs)
+	thirdManifestIDs := make([]string, len(thirdIDs))
+	for i, id := range thirdIDs {
+		thirdManifestIDs[i] = strings.TrimPrefix(id, "third_party/")
+	}
+	selectedThird, thirdErr := SelectThirdPartyProjects(manifest.Projects, thirdManifestIDs)
+	if len(projectIDs) > 0 && len(nativeIDs) == 0 {
+		selectedNative = nil
+	}
+	if len(projectIDs) > 0 && len(thirdIDs) == 0 {
+		selectedThird = nil
+	}
+	if nativeErr != nil || thirdErr != nil {
+		return Report{}, errors.Join(nativeErr, thirdErr)
+	}
+
+	nativeReport, nativeRunErr := RunProjects(selectedNative)
+	thirdReport, thirdRunErr := RunThirdPartyProjects(corpusRoot, selectedThird, MaterializeOptions{})
+	combined := Report{}
+	appendReport(&combined, nativeReport)
+	appendReport(&combined, thirdReport)
+	sortDiagnostics(combined.Diagnostics)
+	sortThirdPartyFailuresAndSkips(&combined)
+	return combined, errors.Join(nativeRunErr, thirdRunErr)
+}
+
+func splitProjectIDs(ids []string) (native, third []string) {
+	for _, id := range ids {
+		if strings.HasPrefix(id, "third_party/") {
+			third = append(third, id)
+		} else {
+			native = append(native, id)
+		}
+	}
+	return native, third
+}
+
+func appendReport(dst *Report, src Report) {
+	dst.Surfaces = append(dst.Surfaces, src.Surfaces...)
+	dst.Diagnostics = append(dst.Diagnostics, src.Diagnostics...)
+	dst.Failures = append(dst.Failures, src.Failures...)
+	dst.Skipped = append(dst.Skipped, src.Skipped...)
+}
+
+// FilterReport and FilterSnapshots retain only the selected rule. Project
+// selection is performed before execution, so filtering by project here is
+// unnecessary and cannot conceal an unexpected project result.
+func FilterReport(report Report, rule string) Report {
+	if rule == "" {
+		return report
+	}
+	filtered := Report{Failures: report.Failures, Skipped: report.Skipped}
+	for _, surface := range report.Surfaces {
+		copySurface := surface
+		copySurface.Diagnostics = filterDiagnostics(surface.Diagnostics, rule)
+		filtered.Surfaces = append(filtered.Surfaces, copySurface)
+		filtered.Diagnostics = append(filtered.Diagnostics, copySurface.Diagnostics...)
+	}
+	return filtered
+}
+
+func filterDiagnostics(rows []Diagnostic, rule string) []Diagnostic {
+	result := make([]Diagnostic, 0)
+	for _, row := range rows {
+		if row.Code == rule {
+			result = append(result, row)
+		}
+	}
+	return result
+}
+
+func FilterSnapshots(set SnapshotSet, rule string) SnapshotSet {
+	if rule == "" {
+		return set
+	}
+	filtered := make(SnapshotSet, len(set))
+	for id, rows := range set {
+		for _, row := range rows {
+			if row.Code == rule {
+				filtered[id] = append(filtered[id], row)
+			}
+		}
+		if filtered[id] == nil {
+			filtered[id] = []SnapshotDiagnostic{}
+		}
+	}
+	return filtered
+}
+
+func FilterReviews(reviews []DiagnosticReview, projects []string, rule string) []DiagnosticReview {
+	wanted := make(map[string]struct{}, len(projects))
+	for _, project := range projects {
+		wanted[project] = struct{}{}
+	}
+	result := make([]DiagnosticReview, 0)
+	for _, review := range reviews {
+		if len(wanted) > 0 {
+			if _, ok := wanted[review.Project]; !ok {
+				continue
+			}
+		}
+		if rule != "" && review.Diagnostic.Code != rule {
+			continue
+		}
+		result = append(result, review)
+	}
+	return result
+}
+
+// ResolveReviewDetails joins start-only committed candidates with a fresh
+// analyzer run and returns exact ranges while retaining multiplicity.
+func ResolveReviewDetails(candidates SnapshotReviewCandidateReport, report Report) ([]ReviewDetail, error) {
+	available := make(map[string][]Diagnostic)
+	for _, diagnostic := range report.Diagnostics {
+		available[startIdentity(diagnostic)] = append(available[startIdentity(diagnostic)], diagnostic)
+	}
+	details := make([]ReviewDetail, 0, len(candidates.Rows))
+	for _, candidate := range candidates.Rows {
+		key := snapshotStartIdentity(candidate)
+		matches := available[key]
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("fresh corpus run did not reproduce %s/%s:%d:%d [%s]", candidate.Project, candidate.File, candidate.Line, candidate.Column, candidate.Code)
+		}
+		diagnostic := matches[0]
+		available[key] = matches[1:]
+		details = append(details, ReviewDetail{Project: diagnostic.Project, File: diagnostic.File, Surface: diagnostic.Surface, Code: diagnostic.Code, Severity: diagnostic.Severity, Line: diagnostic.Line, Column: diagnostic.Column, EndLine: diagnostic.EndLine, EndColumn: diagnostic.EndColumn})
+	}
+	return details, nil
+}
+
+func startIdentity(d Diagnostic) string {
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s\x00%d\x00%d", d.Project, d.File, d.Surface, d.Code, d.Severity, d.Line, d.Column)
+}
+
+func snapshotStartIdentity(d SnapshotDiagnostic) string {
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s\x00%d\x00%d", d.Project, d.File, d.Surface, d.Code, d.Severity, d.Line, d.Column)
+}
+
+func FormatReviewDetails(details []ReviewDetail) string {
+	var builder strings.Builder
+	builder.WriteString("project\tfile\tsurface\tcode\tseverity\trange\n")
+	for _, detail := range details {
+		fmt.Fprintf(&builder, "%s\t%s\t%s\t%s\t%s\t%d:%d-%d:%d\n", detail.Project, detail.File, detail.Surface, detail.Code, detail.Severity, detail.Line, detail.Column, detail.EndLine, detail.EndColumn)
+	}
+	return builder.String()
+}
+
+// BuildReviewDrafts creates canonical ledger rows but never writes the ledger.
+func BuildReviewDrafts(details []ReviewDetail, classification ReviewClassification, rationale, regressionTest, regressionException string) ([]DiagnosticReview, error) {
+	grouped := make(map[string]DiagnosticReview)
+	for _, detail := range details {
+		review := DiagnosticReview{SchemaVersion: ReviewSchemaVersion, Project: detail.Project, File: detail.File, Classification: classification, Diagnostic: ReviewedDiagnostic{Code: detail.Code, Severity: detail.Severity, Surface: string(detail.Surface), Range: &ReviewedRange{StartLine: detail.Line, StartColumn: detail.Column, EndLine: detail.EndLine, EndColumn: detail.EndColumn}, Count: 1}, Rationale: rationale, RegressionTest: regressionTest, RegressionException: regressionException}
+		key := diagnosticReviewIdentity(review)
+		if existing, ok := grouped[key]; ok {
+			existing.Diagnostic.Count++
+			grouped[key] = existing
+		} else {
+			grouped[key] = review
+		}
+	}
+	result := make([]DiagnosticReview, 0, len(grouped))
+	for _, review := range grouped {
+		if err := validateDiagnosticReview(review); err != nil {
+			return nil, err
+		}
+		result = append(result, review)
+	}
+	sort.Slice(result, func(i, j int) bool { return diagnosticReviewSortKey(result[i]) < diagnosticReviewSortKey(result[j]) })
+	return result, nil
+}
+
+func EncodeReviewDrafts(reviews []DiagnosticReview) ([]byte, error) {
+	reviews = append([]DiagnosticReview(nil), reviews...)
+	sort.Slice(reviews, func(i, j int) bool { return diagnosticReviewSortKey(reviews[i]) < diagnosticReviewSortKey(reviews[j]) })
+	var output bytes.Buffer
+	previousIdentity := ""
+	for index, review := range reviews {
+		if err := validateDiagnosticReview(review); err != nil {
+			return nil, err
+		}
+		identity := diagnosticReviewIdentity(review)
+		if index > 0 && identity == previousIdentity {
+			return nil, fmt.Errorf("review draft repeats diagnostic identity %q", identity)
+		}
+		previousIdentity = identity
+		row, err := json.Marshal(review)
+		if err != nil {
+			return nil, err
+		}
+		output.Write(row)
+		output.WriteByte('\n')
+	}
+	return output.Bytes(), nil
+}

--- a/internal/staticanalysis/corpus/developer_test.go
+++ b/internal/staticanalysis/corpus/developer_test.go
@@ -1,0 +1,77 @@
+package corpus
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadSnapshotSubsetIgnoresUnselectedCommittedFiles(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "snapshots")
+	first := SnapshotID{Project: "self/first", Surface: SurfaceAnalyze}
+	second := SnapshotID{Project: "self/second", Surface: SurfaceLint}
+	set := SnapshotSet{
+		first:  {{Project: first.Project, Surface: first.Surface, File: "src/Main.bas", Code: "VBA225", Severity: "warning", Line: 3}},
+		second: {},
+	}
+	if err := WriteSnapshotSet(root, set); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadSnapshotSubset(root, []SnapshotID{first})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || len(got[first]) != 1 {
+		t.Fatalf("subset = %#v", got)
+	}
+}
+
+func TestResolveReviewDetailsRetainsRangesAndMultiplicity(t *testing.T) {
+	row := SnapshotDiagnostic{Project: "self/sample", Surface: SurfaceAnalyze, File: "src/Main.bas", Code: "VBA225", Severity: "warning", Line: 3, Column: 2}
+	candidates := SnapshotReviewCandidateReport{Rule: "VBA225", Rows: []SnapshotDiagnostic{row, row}}
+	report := Report{Diagnostics: []Diagnostic{
+		{Project: row.Project, Surface: row.Surface, File: row.File, Code: row.Code, Severity: row.Severity, Line: 3, Column: 2, EndLine: 3, EndColumn: 8},
+		{Project: row.Project, Surface: row.Surface, File: row.File, Code: row.Code, Severity: row.Severity, Line: 3, Column: 2, EndLine: 4, EndColumn: 1},
+	}}
+	details, err := ResolveReviewDetails(candidates, report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(details) != 2 || details[0].EndColumn != 8 || details[1].EndLine != 4 {
+		t.Fatalf("details = %#v", details)
+	}
+}
+
+func TestBuildReviewDraftsIsCanonicalAndRequiresHumanClassificationFields(t *testing.T) {
+	detail := ReviewDetail{Project: "self/sample", File: "src/Main.bas", Surface: SurfaceAnalyze, Code: "VBA225", Severity: "warning", Line: 3, EndLine: 3}
+	drafts, err := BuildReviewDrafts([]ReviewDetail{detail, detail}, ReviewFalsePositive, "Receiver resolution was incorrect.", "internal/analyze/analyzer_test.go::TestFocused", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drafts) != 1 || drafts[0].Diagnostic.Count != 2 {
+		t.Fatalf("drafts = %#v", drafts)
+	}
+	encoded, err := EncodeReviewDrafts(drafts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"count":2`) || !strings.HasSuffix(string(encoded), "\n") {
+		t.Fatalf("encoded = %q", encoded)
+	}
+	if _, err := BuildReviewDrafts([]ReviewDetail{detail}, ReviewFalsePositive, "reason", "", ""); err == nil {
+		t.Fatal("false-positive draft without regression evidence succeeded")
+	}
+}
+
+func TestFilterReportAndSnapshotsKeepEmptySurfaces(t *testing.T) {
+	id := SnapshotID{Project: "self/sample", Surface: SurfaceAnalyze}
+	report := Report{Surfaces: []SurfaceResult{{Project: id.Project, Surface: id.Surface, Diagnostics: []Diagnostic{{Project: id.Project, Surface: id.Surface, Code: "VBA224"}}}}}
+	filteredReport := FilterReport(report, "VBA225")
+	if len(filteredReport.Surfaces) != 1 || len(filteredReport.Surfaces[0].Diagnostics) != 0 {
+		t.Fatalf("report = %#v", filteredReport)
+	}
+	filteredSnapshots := FilterSnapshots(SnapshotSet{id: {{Project: id.Project, Surface: id.Surface, File: "src/Main.bas", Code: "VBA224", Severity: "warning", Line: 1}}}, "VBA225")
+	if rows, ok := filteredSnapshots[id]; !ok || len(rows) != 0 {
+		t.Fatalf("snapshots = %#v", filteredSnapshots)
+	}
+}

--- a/internal/staticanalysis/corpus/developer_test.go
+++ b/internal/staticanalysis/corpus/developer_test.go
@@ -61,6 +61,15 @@ func TestBuildReviewDraftsIsCanonicalAndRequiresHumanClassificationFields(t *tes
 	if _, err := BuildReviewDrafts([]ReviewDetail{detail}, ReviewFalsePositive, "reason", "", ""); err == nil {
 		t.Fatal("false-positive draft without regression evidence succeeded")
 	}
+	distinctRange := detail
+	distinctRange.EndLine = 4
+	drafts, err = BuildReviewDrafts([]ReviewDetail{detail, distinctRange}, ReviewTruePositive, "Reviewed against the rule contract.", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drafts) != 2 {
+		t.Fatalf("distinct ranges were grouped together: %#v", drafts)
+	}
 }
 
 func TestFilterReportAndSnapshotsKeepEmptySurfaces(t *testing.T) {

--- a/internal/staticanalysis/corpus/review_test.go
+++ b/internal/staticanalysis/corpus/review_test.go
@@ -142,7 +142,7 @@ func TestCommittedCorpusReviewMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 	snapshotRoot := filepath.Join(corpusRoot, "snapshots")
-	ids, err := discoverCommittedSnapshotIDs(snapshotRoot)
+	ids, err := DiscoverSnapshotIDs(snapshotRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,29 +158,6 @@ func TestCommittedCorpusReviewMetrics(t *testing.T) {
 		t.Fatalf("committed review metrics = %#v", metrics)
 	}
 	t.Log(FormatReviewMetrics(metrics))
-}
-
-func discoverCommittedSnapshotIDs(root string) ([]SnapshotID, error) {
-	ids := make([]SnapshotID, 0)
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() || filepath.Ext(path) != ".jsonl" {
-			return nil
-		}
-		relative, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		parts := strings.SplitN(filepath.ToSlash(relative), "/", 2)
-		if len(parts) != 2 {
-			return nil
-		}
-		ids = append(ids, SnapshotID{Project: strings.TrimSuffix(parts[1], ".jsonl"), Surface: Surface(parts[0])})
-		return nil
-	})
-	return ids, err
 }
 
 func TestEvaluateDiagnosticReviewsEnforcesTrueAndFalsePositiveContracts(t *testing.T) {

--- a/internal/staticanalysis/rules/spec_contract_test.go
+++ b/internal/staticanalysis/rules/spec_contract_test.go
@@ -43,6 +43,10 @@ func TestSpecificationRuleContractsMatchRegistry(t *testing.T) {
 		for _, match := range specContractPattern.FindAllSubmatch(body, -1) {
 			markers++
 			var contract specRuleContract
+			if !json.Valid(match[1]) {
+				t.Errorf("%s: rule contract is not one complete JSON value", path)
+				continue
+			}
 			decoder := json.NewDecoder(bytes.NewReader(match[1]))
 			decoder.DisallowUnknownFields()
 			if err := decoder.Decode(&contract); err != nil {

--- a/internal/staticanalysis/rules/spec_contract_test.go
+++ b/internal/staticanalysis/rules/spec_contract_test.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+var specContractPattern = regexp.MustCompile(`<!-- xlflow-rule-contract: (\{[^\n]+\}) -->`)
+
+var requiredSpecContracts = map[string]string{
+	"VBA225": "excel-loop-performance-analysis.md",
+}
+
+type specRuleContract struct {
+	ID                 string       `json:"id"`
+	Family             RuleFamily   `json:"family"`
+	Category           RuleCategory `json:"category"`
+	DefaultSeverity    RuleSeverity `json:"default_severity"`
+	Scope              RuleScope    `json:"scope"`
+	Realtime           bool         `json:"realtime"`
+	ConfigurationKey   string       `json:"configuration_key"`
+	InlineSuppressible bool         `json:"inline_suppressible"`
+	PreflightBlocking  bool         `json:"preflight_blocking"`
+}
+
+func TestSpecificationRuleContractsMatchRegistry(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "docs", "specs")
+	seen := make(map[string]string)
+	markers := 0
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() || filepath.Ext(path) != ".md" {
+			return walkErr
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, match := range specContractPattern.FindAllSubmatch(body, -1) {
+			markers++
+			var contract specRuleContract
+			decoder := json.NewDecoder(bytes.NewReader(match[1]))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&contract); err != nil {
+				t.Errorf("%s: decode rule contract: %v", path, err)
+				continue
+			}
+			if previous, ok := seen[contract.ID]; ok {
+				t.Errorf("%s: duplicate contract for %s (already in %s)", path, contract.ID, previous)
+				continue
+			}
+			seen[contract.ID] = path
+			metadata, ok := Lookup(contract.ID)
+			if !ok {
+				t.Errorf("%s: unknown rule %q", path, contract.ID)
+				continue
+			}
+			want := specRuleContract{ID: metadata.ID, Family: metadata.Family, Category: metadata.Category, DefaultSeverity: metadata.DefaultSeverity, Scope: metadata.Scope, Realtime: metadata.Realtime, ConfigurationKey: metadata.ConfigurationKey, InlineSuppressible: metadata.InlineSuppressible, PreflightBlocking: metadata.PreflightBlocking}
+			if contract != want {
+				t.Errorf("%s: contract = %#v, registry = %#v", path, contract, want)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if markers == 0 {
+		t.Fatal("no xlflow-rule-contract markers found")
+	}
+	for id, filename := range requiredSpecContracts {
+		path, ok := seen[id]
+		if !ok {
+			t.Errorf("required specification contract %s is missing from %s", id, filename)
+			continue
+		}
+		if filepath.Base(path) != filename {
+			t.Errorf("specification contract %s is in %s, want %s", id, path, filename)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add developer-only corpus commands that resolve start-only candidates to exact normalized ranges and emit canonically sorted review-ledger drafts without modifying committed evidence.
- Add read-only project/rule-focused corpus verification while retaining committed project/surface baselines, so missing surfaces and newly introduced diagnostics remain visible.
- Add an extensible specification/registry contract-marker check and correct the stale VBA225 nested-loop severity documentation to match the existing warning-level implementation.
- Preserve the committed review inventory and reviewed-only metrics as durable evidence contracts.

## Motivation

Corpus investigations previously required manually recovering full diagnostic ranges, hand-authoring canonical JSONL, and rerunning the complete corpus for every implementation iteration. That made review work slower and increased the risk of malformed evidence or incomplete focused comparisons.

The new commands keep classification decisions human-controlled and never update snapshots or `reviews/diagnostics.jsonl`. The existing full `corpus:test` remains the required final gate.

## Tests

- `rtk task lint`
- `rtk task test`
- `rtk task corpus:test` (two successful verify-only runs)
- `rtk task corpus:metrics`
- `rtk task corpus:test-focused -- --project self/gen-qrcode --rule VBA225`
- `rtk task corpus:test-focused -- --rule VBA225`
- `rtk proxy task corpus:review-details -- --rule VBA225 --project self/gen-qrcode --limit 3`
- `rtk proxy task corpus:review-draft -- --rule VBA225 --project self/gen-qrcode --limit 1 --classification true-positive --rationale "Reviewed against source and the VBA225 contract."`
- `rtk git diff --check`

VBE oracle and Excel E2E were not run because this change does not alter analyzer or Excel/VBE semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added corpus review workflows for inspecting diagnostics, generating review drafts, and running focused verification.
  - Added project and rule filtering, snapshot comparison, and diagnostic range validation.
  - Added machine-checked validation for rule specification contracts.

- **Documentation**
  - Documented corpus review workflows and draft requirements.
  - Clarified Excel loop performance guidance: nested-loop depth remains explanatory context, findings retain warning severity, and bulk operations are recommended where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->