### PR TITLE
fix(deps): update js-yaml to 4.3.1

### DIFF
--- a/editors/vscode/pnpm-lock.yaml
+++ b/editors/vscode/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   brace-expansion: 5.0.9
   fast-uri: 3.1.5
   undici: 7.29.0
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   linkify-it: 5.0.2
 
 importers:
@@ -958,8 +958,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -1859,7 +1859,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -2436,7 +2436,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2736,7 +2736,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:

--- a/editors/vscode/pnpm-workspace.yaml
+++ b/editors/vscode/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ overrides:
   brace-expansion: 5.0.9
   fast-uri: 3.1.5
   undici: 7.29.0
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   linkify-it: 5.0.2
 
 minimumReleaseAge: 1440


### PR DESCRIPTION
## Summary

- Update the VS Code extension workspace override from `js-yaml` 4.3.0 to 4.3.1.
- Refresh the pnpm lockfile to resolve Dependabot alert #37 (`GHSA-5p4m-2wfm-xmqj`).
- Keep a single patched `js-yaml` version across the Secretlint and `@vscode/vsce` dependency tree.

## Tests

- `pnpm --dir editors/vscode install --frozen-lockfile`
- `pnpm --dir editors/vscode run check`
- `pnpm --dir editors/vscode run lint`
- `pnpm --dir editors/vscode run compile`
- `pnpm --dir editors/vscode run test`
- `pnpm --dir editors/vscode why js-yaml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the YAML parsing library to version 4.3.1 for improved reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->