### PR TITLE
Add procedure complexity metrics command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added source-only `xlflow metrics` procedure complexity reporting with a
+  versioned JSON schema (`metrics.schema_version = 1`) and deterministic values
+  for cyclomatic complexity, nesting, statements, source lines, branches,
+  loops, `GoTo`, exits, parameters, `ByRef` parameters, locals, and call
+  fan-out. Optional `[metrics.thresholds]` settings emit metrics-specific
+  `MX001` warnings and exit `1` while retaining the complete metrics payload;
+  exclusions are configured independently through `[metrics].exclude`.
+
 - Added default-enabled, compile-equivalent `VB050` module declaration-context
   diagnostics and `VB051` invalid-`Me` diagnostics. Checks use canonical
   standard/class/document/UserForm metadata across lint, LSP, and source

--- a/docs/adr/ADR-0036-procedure-complexity-metrics.md
+++ b/docs/adr/ADR-0036-procedure-complexity-metrics.md
@@ -1,0 +1,171 @@
+# ADR-0036: Procedure Complexity Metrics
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #460 needs maintainability measurements for VBA procedures. The existing
+`lint` and `analyze` surfaces are diagnostic surfaces: their findings are
+rule-owned, configurable through the analyzer registry, and may change as
+runtime-risk analysis evolves. Putting subjective complexity thresholds into
+those surfaces would make a measurement useful only when a particular finding
+is enabled and would couple consumers to diagnostic rule ownership. Existing
+`analysis_metrics.module_state` is likewise an analyzer-owned projection and
+must retain its compatibility contract.
+
+Consumers instead need a deterministic, source-only procedure inventory that
+can be stored, compared, and used by future reports without opening Excel or
+parsing diagnostic prose. The calculation must also have one interpretation of
+single-line, colon-separated, continued, property, label, and generated
+UserForm syntax.
+
+## Decision
+
+Add a source-only `xlflow metrics` command. It reuses the parsed procedure IR,
+control-flow graph, and uniquely resolved project-local call edges, but has its
+own collector and threshold evaluator. It does not run `lint`, `analyze`,
+`check`, LSP diagnostics, preflight rules, or Excel/COM operations. The command
+scans configured VBA source roots and `tests`; generated build state and
+sidecar-generated `.frm` code are not scanned. In UserForm `sidecar` mode the
+sidecar code file is the procedure source. A separate `[metrics].exclude`
+glob list is applied after normal source discovery and is not inherited from
+`[build].exclude` or `[analyze].disabled_rules`.
+
+The command's machine-readable result is a versioned `metrics` object with
+`schema_version: 1` and a `procedures` array. Each procedure carries its
+project-relative slash-separated file, module and module kind, procedure name
+and kind, and a `declaration_range` object with one-based `startLine` and
+`endLine` (plus the parser's column/byte offsets), and these twelve integer
+metrics:
+
+- `cyclomatic_complexity`
+- `max_nesting_depth`
+- `statement_count`
+- `source_line_count`
+- `branch_count`
+- `loop_count`
+- `goto_count`
+- `exit_point_count`
+- `parameter_count`
+- `byref_parameter_count`
+- `local_variable_count`
+- `call_fan_out`
+
+The counting rules are permanent and are defined in
+`docs/specs/vba-procedure-complexity-metrics.md`. In particular, cyclomatic
+complexity is `1 + branch_count + loop_count`; unknown CFG edges, Boolean
+operators, and `GoTo` do not add branches. `call_fan_out` contains only unique,
+resolved project-local callees. Source line and statement counts deliberately
+have different units: physical lines include comments, blanks, and
+continuations between the procedure header and matching `End`, while
+statements use normalized source-backed IR (colon-separated statements are
+separate and a continuation is one statement).
+
+Thresholds are opt-in and independent of diagnostics:
+
+```toml
+[metrics]
+exclude = []
+
+[metrics.thresholds]
+cyclomatic_complexity = 0
+max_nesting_depth = 0
+statement_count = 0
+source_line_count = 0
+branch_count = 0
+loop_count = 0
+goto_count = 0
+exit_point_count = 0
+parameter_count = 0
+byref_parameter_count = 0
+local_variable_count = 0
+call_fan_out = 0
+```
+
+An omitted or zero threshold is disabled. A positive threshold reports only
+when the metric is greater than the threshold; negative values and invalid
+types are configuration errors. Threshold evaluation emits metrics-specific
+`MX001` warning entries, one entry for each exceeded procedure/metric pair.
+`MX001` is not registered as a lint/analyze rule, cannot be inline-suppressed,
+and is not affected by analyzer rule configuration. Without an enabled
+threshold the command exits `0`. With one or more threshold findings it keeps
+the complete metrics result, sets the failure error code to
+`metrics_threshold_exceeded`, and exits `1`.
+
+The v1 JSON contract is additive: consumers must ignore unknown fields and
+additional metrics, while removal or a meaning change requires a new schema
+version. Procedure arrays are sorted by normalized file, declaration start
+position, module, name, and kind. Threshold diagnostics follow that procedure
+order and the fixed metric order above. Paths, exclusion patterns, warnings, and JSON
+serialization use normalized separators and stable ordering, so repeated runs
+over the same source produce the same metrics and JSON bytes.
+
+Parse recovery does not yield guessed or partial measurements. An unreadable
+source, malformed exclusion pattern, or unrecoverable parse returns a metrics
+operation error; an unmatched valid exclusion pattern is retained as a stable
+warning. No generated file is silently counted twice.
+
+## Consequences
+
+- Metrics can be consumed by reports, baselines, and editor integrations
+  without depending on diagnostic enablement or message wording.
+- Threshold policy is explicit and can fail CI only when a project opts in;
+  raw measurement collection remains useful with all thresholds disabled.
+- The schema and ordering are stable across operating systems and source
+  enumeration order, but consumers must honor `schema_version` before relying
+  on field meaning.
+- IR/CFG and call-resolution limitations remain visible: unresolved or
+  ambiguous calls do not inflate fan-out, and unrecoverable syntax fails closed
+  rather than producing misleading values.
+- This first version reports procedures only. Module/project aggregates,
+  historical trends, recommended thresholds, and LSP projections remain future
+  work.
+
+## Alternatives Considered
+
+1. **Add complexity findings to `analyze`** - Rejected because diagnostics and
+   measurements have different ownership, enablement, and compatibility needs;
+   subjective thresholds would also affect existing `analyze` exit behavior.
+2. **Reuse `analysis_metrics.module_state`** - Rejected because it is an
+   analyzer-specific projection and does not contain the procedure structure,
+   source-line semantics, or call fan-out required here.
+3. **Compute metrics from diagnostic counts or formatted text** - Rejected
+   because diagnostics are configurable and prose is not a deterministic
+   source contract.
+4. **Count unresolved and external calls as fan-out** - Rejected because an
+   uncertainty is not evidence of a project-local dependency.
+5. **Apply `[build].exclude` and analyzer rule settings automatically** -
+   Rejected because release artifact selection and finding suppression are
+   separate policies from maintainability measurement.
+
+## Evidence
+
+- Issue #460 acceptance criteria for deterministic metrics, configurable
+  thresholds, JSON, exclusions, and syntax coverage.
+- Procedure IR and source-backed declaration facts:
+  `docs/specs/vba-analysis-ir.md` and ADR-0021.
+- Conservative control-flow semantics:
+  `docs/specs/vba-control-flow-graph.md` and ADR-0022.
+- Existing project-local call resolution and deterministic ordering:
+  `docs/specs/vba-call-graph-reachability.md`,
+  `docs/specs/vba-procedure-call-cycles.md`, and ADR-0035.
+- Public command and JSON envelope contract:
+  `docs/specs/cli-contract.md` and `vitepress/reference/json-output.md`.
+- Procedure metric definitions and threshold behavior:
+  `docs/specs/vba-procedure-complexity-metrics.md`.
+
+## Supersedes
+
+None.
+
+## Superseded by
+
+None.
+
+## Related
+
+- Issue #460
+- ADR-0021, ADR-0022, ADR-0035
+- `docs/specs/vba-procedure-complexity-metrics.md`

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -65,6 +65,7 @@ xlflow [--json] lint
 xlflow lsp (--stdio | --check | --version) [--log-file <path>] [--performance-log]
 xlflow [--json] fmt [--write|--check|--diff] [--line-numbers <preserve|add|remove|renumber>] [--stdin] [<path>...]
 xlflow [--json] analyze
+xlflow [--json] metrics
 xlflow [--json] check
 xlflow [--json] generate test <module-name>
 xlflow [--json] module new <name> --type standard|class
@@ -86,7 +87,7 @@ Unknown top-level commands fail loudly before any workbook or project configurat
 
 `--bridge` is also a persistent global flag for Excel bridge-backed commands. Supported values are `auto` and `dotnet`. Resolution order is `--bridge`, then `XLFLOW_EXCEL_BRIDGE`, then `[excel].bridge`, then the default `auto`. On Windows, `auto` selects the `.NET` bridge. Explicit `--bridge dotnet` is strict. The removed value `powershell` is rejected with a bridge-mode/configuration error.
 
-Under WSL, Excel-related top-level commands are delegated to Windows `xlflow.exe`: `new`, `init`, `doctor`, `attach`, `list`, `form`, `pull`, `push`, `rollback`, `session`, `save`, `status`, `recovery`, `runner`, `run`, `export-image`, `edit`, `macros`, `ui`, `test`, `inspect`, `diff`, `check`, and `process`. Source-oriented commands remain in WSL: `backup`, `impact`, `graph`, `inspect-gui`, `lint`, `lsp`, `fmt`, `analyze`, `rules`, `generate`, `module`, `skill`, `version`, `update`, and completion/help. Source-only subcommands under delegated groups also remain local when explicitly documented, currently `test list` and `form new`. Delegation preserves stdin, stdout, stderr, JSON envelopes, Windows-side recovery state, and the Windows process exit code.
+Under WSL, Excel-related top-level commands are delegated to Windows `xlflow.exe`: `new`, `init`, `doctor`, `attach`, `list`, `form`, `pull`, `push`, `rollback`, `session`, `save`, `status`, `recovery`, `runner`, `run`, `export-image`, `edit`, `macros`, `ui`, `test`, `inspect`, `diff`, `check`, and `process`. Source-oriented commands remain in WSL: `backup`, `impact`, `graph`, `inspect-gui`, `lint`, `lsp`, `fmt`, `analyze`, `metrics`, `rules`, `generate`, `module`, `skill`, `version`, `update`, and completion/help. Source-only subcommands under delegated groups also remain local when explicitly documented, currently `test list` and `form new`. Delegation preserves stdin, stdout, stderr, JSON envelopes, Windows-side recovery state, and the Windows process exit code.
 
 Delegated projects must be located under a Windows-mounted drive such as `/mnt/c/...`. The WSL working directory and absolute workbook, source/spec, input, save, and output path arguments are translated with `wslpath -w`; relative paths remain relative to the shared project directory. WSL-only absolute paths such as `/home/user/project` fail before Windows starts. Windows xlflow resolution uses `XLFLOW_WINDOWS_EXE` first and then `xlflow.exe` from the interoperable PATH. The override accepts either a Windows absolute path or a WSL path to an `.exe`.
 
@@ -266,6 +267,23 @@ or another explicit recovery path rather than saving the uncertain workbook.
 
 `check` runs `lint`, `analyze`, then `doctor`. It continues after lint/analyze findings so source issues and environment status are returned together. JSON output includes top-level `check`, `issues`, `analysis`, optional `analysis_metrics`, and doctor diagnostics. Lint/analyze findings return exit code `1`; doctor/environment failure returns exit code `3`.
 
+`metrics` is an independent source-only procedure measurement command. It
+scans configured source roots and `tests`, applies `[metrics].exclude`, and
+returns a versioned `metrics.schema_version = 1` procedure array containing
+the twelve complexity and maintainability metrics defined in
+`docs/specs/vba-procedure-complexity-metrics.md`. It does not invoke
+`analyze`, add to `analysis_metrics.module_state`, or depend on diagnostic
+enablement. Thresholds are opt-in under `[metrics.thresholds]`; each positive
+threshold uses a strict `value > threshold` comparison and zero/omitted values
+are disabled. Exceeded thresholds produce metrics-specific `MX001` warning
+diagnostics, retain the complete metrics payload, return
+`error.code = "metrics_threshold_exceeded"`, and exit `1`. With all thresholds
+disabled, the command exits `0`. Invalid thresholds or exclusion patterns are
+configuration errors and exit `2`; an unrecoverable source parse fails without
+publishing partial metrics. Procedure and diagnostic ordering, path
+normalization, sidecar/generated-file exclusions, and all counting rules are
+specified by [VBA Procedure Complexity Metrics](vba-procedure-complexity-metrics.md).
+
 `VBA229` is a default-enabled, realtime and batch compile-equivalent error for an unresolved type identifier in a procedure-local `Dim` or `Static ... As <Type>` declaration. It uses the production built-in/host/TypeLib and project symbol resolver, including embedded enum groups and class, UserForm, and document-module types, points at the type identifier, cannot be suppressed, and blocks source preflight. A missing, malformed, empty, or partially materialized generated TypeLib manifest leaves absence resolution incomplete: embedded types may still resolve positively, but a lookup miss does not emit `VBA229`. Parameters, return types, and module-level declarations remain outside this rule's v1 scope.
 
 `macros` opens the configured workbook and discovers VBA entrypoints without executing user code. JSON output includes top-level `macros`, where each entry contains `module`, `name`, `qualified_name`, `kind` when available, and `args` when available. `macros --session` reads from the workbook opened by `session start`. Agents should use this command before guessing a `run` target.
@@ -365,6 +383,23 @@ disabled_rules = []
 
 [analyze]
 disabled_rules = []
+
+[metrics]
+exclude = []
+
+[metrics.thresholds]
+cyclomatic_complexity = 0
+max_nesting_depth = 0
+statement_count = 0
+source_line_count = 0
+branch_count = 0
+loop_count = 0
+goto_count = 0
+exit_point_count = 0
+parameter_count = 0
+byref_parameter_count = 0
+local_variable_count = 0
+call_fan_out = 0
 ```
 
 `[build].exclude` defines the source filtering policy used only by the Excel-backed `build` command; it never changes `push` or `pack` source selection. Each entry is a project-root-relative `doublestar` glob. Paths and patterns are normalized to `/`, so Windows and WSL separators match identically; absolute paths and patterns that traverse outside the project root are invalid. Matching is component-level: standard, class, and document components match their source file, while a UserForm matches its `.frm` and any associated `.frx`, sidecar code, or persisted spec path. A matching UserForm artifact excludes the whole form component. The resolver reports unmatched patterns as stable `build_exclude_unmatched` warnings, but malformed patterns, unreadable configured source roots or files, incomplete UserForm artifacts, duplicate included VBA component names (case-insensitive across component types), and equal resolved base/output paths are errors before Excel is opened. Included and excluded lists are sorted by normalized source path.
@@ -380,6 +415,23 @@ After a successful non-dry artifact publication, xlflow attempts to publish the 
 Cleanup of the bridge-owned staging directory runs after publication. If it alone fails, the command remains successful, retains the published output, reports `output.temporary_cleanup.status="failed"`, and adds warning `build_temporary_cleanup_failed` with the residual staging path when available. Pre-publication cleanup outcomes are retained in structured error details. `build_output_directory_failed`, `build_output_busy`, `build_temporary_artifact_missing` (including an unreadable staged artifact), and `build_output_replace_failed` are operational failures that preserve an existing output. Uncertain Excel cleanup still publishes workbook recovery quarantine.
 
 `[backup.retention]` controls automatic pruning after successful backup-producing operations. It is disabled by default. `max_count <= 0`, `max_age_days <= 0`, and `max_total_size_mb <= 0` disable their respective limits. `min_keep` must be zero or greater and always protects the newest valid backups when automatic pruning is enabled. Negative values are configuration errors, and `min_keep > max_count` is invalid when `max_count > 0`. If all limits are disabled, automatic pruning performs no deletion, though invalid or legacy entries may still be reported as skipped.
+
+`[metrics]` controls only `xlflow metrics`. `exclude` is a project-root-relative
+`doublestar` glob list applied after source discovery; it is normalized to `/`,
+deduplicated, and sorted. Absolute patterns and patterns that traverse outside
+the project root are invalid. A valid pattern that matches no source emits a
+stable `metrics_exclude_unmatched` warning. The setting does not alter
+`build`, `push`, `pack`, `lint`, or `analyze` source selection.
+
+`[metrics.thresholds]` accepts the twelve metric names defined in
+`docs/specs/vba-procedure-complexity-metrics.md`. Omitted and zero values
+disable a threshold; positive values report only `value > threshold`. Negative
+values, non-integers, unknown keys, and malformed tables are configuration
+errors. Thresholds are evaluated after all metrics are collected and do not
+change the raw values. They emit `MX001` warning diagnostics only when
+explicitly enabled, so `metrics` does not produce subjective diagnostics by
+default. `MX001` is not an analyzer rule and cannot be configured through
+`[analyze].disabled_rules` or inline suppression.
 
 ## JSON Envelope
 
@@ -550,6 +602,8 @@ Command-specific fields are added at the top level:
 - `inspect` for `inspect`
 - `issues` for `lint`
 - `analysis` for `analyze` and `check`
+- `metrics` for `metrics`, with optional metrics-specific `diagnostics` and
+  `warnings`
 - `check` for `check`
 - `capabilities` for command coordination and safety metadata
 - `run_diagnostic` for enriched `run` failures
@@ -783,8 +837,8 @@ the corresponding marker. Cleanup results add `recovery.cleared[]` and
 ## Exit Codes
 
 - `0`: success
-- `1`: user-code or validation failure, including lint findings, analysis findings, GUI boundary preflight failures, macro failure, macro timeout, VBE compile failure, missing macro target, removed-helper findings, missing UI sheets or buttons, VBA test failure, no tests found, missing or ambiguous filter targets, active workbook mismatches, duplicate test names within one module, invalid exported ranges, existing output files, unsupported export-image formats, unsupported form export-image formats, missing UserForms, `form_already_exists`, `unsupported_form_control`, `designer_write_failed`, capture window lookup failures, image capture failures, `edit` session requirements, invalid workbook edit selectors, invalid edit colors, `invalid_sheet_name`, `sheet_exists`, `fmt_check_failed` (unformatted files in `--check` mode), and workbook event-handler failures returned by the bridge
-- `2`: CLI argument or configuration error, including invalid `push`, `run`, `session`, `save`, `runner`, `export-image`, `form new`, `form build`, `form export-image`, `module new`, `edit`, and `process` option combinations, invalid `fmt` mode combinations, plus `process_args_invalid` and `process_not_found` errors from the bridge
+- `1`: user-code or validation failure, including lint findings, analysis findings, metrics threshold findings (`metrics_threshold_exceeded`), GUI boundary preflight failures, macro failure, macro timeout, VBE compile failure, missing macro target, removed-helper findings, missing UI sheets or buttons, VBA test failure, no tests found, missing or ambiguous filter targets, active workbook mismatches, duplicate test names within one module, invalid exported ranges, existing output files, unsupported export-image formats, unsupported form export-image formats, missing UserForms, `form_already_exists`, `unsupported_form_control`, `designer_write_failed`, capture window lookup failures, image capture failures, `edit` session requirements, invalid workbook edit selectors, invalid edit colors, `invalid_sheet_name`, `sheet_exists`, `fmt_check_failed` (unformatted files in `--check` mode), and workbook event-handler failures returned by the bridge
+- `2`: CLI argument or configuration error, including invalid `push`, `run`, `session`, `save`, `runner`, `export-image`, `form new`, `form build`, `form export-image`, `module new`, `edit`, and `process` option combinations, invalid `fmt` mode combinations, invalid metrics thresholds or exclusion patterns, plus `process_args_invalid` and `process_not_found` errors from the bridge
 - `3`: environment or operational failure, including workbook lock contention
   (`workbook_busy`, `workbook_busy_timeout`, `workbook_busy_cancelled`),
   workbook recovery (`workbook_recovery_required`,

--- a/docs/specs/vba-procedure-complexity-metrics.md
+++ b/docs/specs/vba-procedure-complexity-metrics.md
@@ -1,0 +1,232 @@
+# VBA Procedure Complexity Metrics
+
+This specification defines the source-only `xlflow metrics` command and its
+procedure metric schema. ADR-0036 records why metrics have an independent
+surface and why thresholds are not analyzer rules.
+
+## Scope and command
+
+```text
+xlflow [--json] metrics
+```
+
+`metrics` reads source and project configuration only. It never opens Excel,
+uses the bridge, attaches to an Excel session, runs VBA, or invokes `lint`,
+`analyze`, `check`, LSP diagnostics, or preflight findings. The command has no
+command-local options in v1; `--json` is the persistent global output flag.
+Human output is a stable procedure table containing all twelve metrics. Machine
+consumers must use the JSON contract below rather than parse the table.
+
+The source scan includes files under configured `[src]` roots (`modules`,
+`classes`, `forms`, and `workbook`) and `tests`. The normal source resolver
+decides whether a file is a standard module, class, document module, or
+UserForm. In `[userform].code_source = "sidecar"` mode, a matching
+`src/forms/code/<FormName>.bas` is the authoritative UserForm procedure source
+and the generated `.frm` code is skipped. In `frm` mode, embedded `.frm` code
+is scanned once. `.frx`, build artifacts, `.xlflow` state, and other generated
+files are never procedure inputs.
+
+After source discovery, `[metrics].exclude` is applied to source files. These
+patterns are project-root-relative `doublestar` globs, normalized to `/`,
+deduplicated, and sorted. Absolute patterns and patterns containing `..` that
+would escape the project root are invalid. An unmatched valid pattern produces
+one `metrics_exclude_unmatched` warning; it is not an error. Metrics exclusions
+are independent from `[build].exclude`, `[lint].disabled_rules`, and
+`[analyze].disabled_rules`.
+
+If a source cannot be read or parsed without recovery, the command fails closed
+and does not publish partial procedure metrics. A failed source scan is not
+converted to a threshold diagnostic.
+
+## Metric schema
+
+The successful result uses the normal xlflow envelope and adds:
+
+```json
+{
+  "status": "ok",
+  "command": "metrics",
+  "metrics": {
+    "schema_version": 1,
+    "procedures": [
+      {
+        "file": "src/modules/Main.bas",
+        "module": "Main",
+        "module_kind": "standard",
+        "name": "Run",
+        "kind": "sub",
+        "declaration_range": {
+          "startLine": 1,
+          "startColumn": 1,
+          "endLine": 18,
+          "endColumn": 7,
+          "startByte": 0,
+          "endByte": 256
+        },
+        "cyclomatic_complexity": 3,
+        "max_nesting_depth": 2,
+        "statement_count": 12,
+        "source_line_count": 18,
+        "branch_count": 1,
+        "loop_count": 1,
+        "goto_count": 0,
+        "exit_point_count": 2,
+        "parameter_count": 1,
+        "byref_parameter_count": 1,
+        "local_variable_count": 2,
+        "call_fan_out": 2
+      }
+    ]
+  },
+  "diagnostics": [],
+  "warnings": [],
+  "logs": []
+}
+```
+
+`file` is project-relative and uses `/` on every host. `module_kind` is the
+resolved source module kind (`standard`, `class`, `document`, or `form`).
+`kind` identifies the procedure declaration (`sub`, `function`,
+`property_get`, `property_let`, or `property_set`). `declaration_range` is the
+parser range with one-based physical `startLine`/`endLine` and
+`startColumn`/`endColumn`, plus zero-based byte offsets, as exposed by the
+shared AST range type. Procedure entries are
+sorted by normalized `file`, declaration start position, `module`, `name`, and
+`kind`; source enumeration order must not affect the result.
+
+`schema_version` is `1` for this contract. New optional fields and additive
+metrics do not change the version. Removing a field or changing the meaning or
+units of an existing field requires a new version. Consumers must ignore
+unknown fields and reject or quarantine unsupported schema versions rather than
+guessing their meaning.
+
+## Counting rules
+
+All twelve values are non-negative integers. The collector consumes normalized,
+source-backed procedure IR and its conservative CFG. It does not infer facts
+from diagnostic findings.
+
+| Metric                  | Definition                                                                                                                                                                                                                                                                                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cyclomatic_complexity` | `1 + branch_count + loop_count`. Unknown CFG edges, Boolean `And`/`Or`, exceptions, and `GoTo` do not add complexity.                                                                                                                                                                     |
+| `max_nesting_depth`     | Maximum simultaneous nesting of `If`, `Select`, any loop, and `With`. `Else`, `ElseIf`, and `Case` stay within their parent structure. A single-line `If` contributes its control structure once.                                                                                         |
+| `statement_count`       | Count source-backed normalized IR statements. Colon-separated statements count separately; a continued physical statement counts once. Labels, declarations, control headers, and `Exit` statements count. The internal `do_condition` node of a `Do ... Loop` is not counted separately. |
+| `source_line_count`     | Physical line count from the procedure header through its matching `End Sub`, `End Function`, or `End Property`, inclusive. Blank lines, comments, and continuation lines count. A terminal newline does not create an extra line.                                                        |
+| `branch_count`          | One for every `If`, one for every `ElseIf`, and one for every `Case` other than `Case Else`. `Select Case`, `Else`, and `Case Else` themselves do not add a branch. Single-line and multiline forms use the same rule.                                                                    |
+| `loop_count`            | One for each `For`, `For Each`, `While`/`Wend`, and `Do`/`Loop` construct. A `Do While` or `Do Until` condition is part of that `Do`; it is not a second loop.                                                                                                                            |
+| `goto_count`            | Explicit `GoTo <label>` statements only. `On Error GoTo <label>`, `Resume`, `GoSub`, and numeric labels are excluded.                                                                                                                                                                     |
+| `exit_point_count`      | One implicit normal procedure-tail exit plus each explicit `Exit Sub`, `Exit Function`, or `Exit Property`, and each standalone `End`. `Exit For` and `Exit Do` are not procedure exits.                                                                                                  |
+| `parameter_count`       | Every declared procedure parameter, including `ParamArray` and the accessor `value` parameter of a Property Let/Set declaration.                                                                                                                                                          |
+| `byref_parameter_count` | Parameters whose effective passing mode is `ByRef`, including parameters where `ByRef` is omitted (VBA's default). `ByVal` is excluded; a `ParamArray` follows its effective `ByRef` passing mode.                                                                                        |
+| `local_variable_count`  | Each local declarator in `Dim`, `Static`, and `Const`, including multiple declarators in one declaration. Parameters, module fields, and a synthesized Function/Property return slot are excluded.                                                                                        |
+| `call_fan_out`          | Number of unique, resolved project-local callee procedures referenced by the procedure. Repeated calls to one callee count once. Ambiguous, unresolved, external, member, and built-in calls are excluded.                                                                                |
+
+The declaration, statement, and CFG facts must be normalized so equivalent
+single-line and multiline syntax has identical structural metrics. Physical
+source line count intentionally remains different when the source occupies a
+different number of lines. CRLF and LF line endings represent the same physical
+line count.
+
+`Property Get`, `Property Let`, and `Property Set` are separate procedures and
+are identified by `kind`; same-name accessors are not merged. Their parameters
+and local declarations are counted independently. Labels do not increase
+nesting or complexity; a label is only a statement when the normalized IR
+represents it as a source-backed statement.
+
+## Thresholds and `MX001`
+
+Threshold configuration is separate from diagnostics:
+
+```toml
+[metrics]
+exclude = []
+
+[metrics.thresholds]
+cyclomatic_complexity = 0
+max_nesting_depth = 0
+statement_count = 0
+source_line_count = 0
+branch_count = 0
+loop_count = 0
+goto_count = 0
+exit_point_count = 0
+parameter_count = 0
+byref_parameter_count = 0
+local_variable_count = 0
+call_fan_out = 0
+```
+
+Every threshold key is an integer. Omitted keys and `0` disable that metric's
+threshold. A positive threshold emits a finding only when `value > threshold`;
+equal values are accepted. Negative values, non-integers, unknown threshold
+keys, malformed tables, and invalid `exclude` patterns are configuration
+errors (exit `2`).
+
+When one or more enabled thresholds are exceeded, the command still returns
+the complete `metrics` object and emits one warning diagnostic for each
+procedure/metric pair:
+
+```json
+{
+  "status": "failed",
+  "command": "metrics",
+  "error": {
+    "code": "metrics_threshold_exceeded",
+    "message": "1 procedure complexity threshold exceeded"
+  },
+  "metrics": { "schema_version": 1, "procedures": [] },
+  "diagnostics": [
+    {
+      "code": "MX001",
+      "severity": "warning",
+      "file": "src/modules/Main.bas",
+      "line": 1,
+      "module": "Main",
+      "procedure": "Run",
+      "procedure_kind": "sub",
+      "metric": "cyclomatic_complexity",
+      "value": 8,
+      "threshold": 5,
+      "message": "Run cyclomatic_complexity exceeds threshold 5 (value 8)"
+    }
+  ],
+  "warnings": [],
+  "logs": []
+}
+```
+
+The example abbreviates `procedures`; a real result never drops procedures
+because a threshold is exceeded. `diagnostics` is sorted by procedure order and
+the fixed metric order in the table above. `MX001` is metrics-specific: it is
+not in the static-analysis rule registry, is not inline-suppressible, and is
+not controlled by `[analyze].disabled_rules` or legacy analyzer booleans.
+
+With no enabled threshold, a successful metrics run exits `0` and does not emit
+`MX001`. With at least one threshold diagnostic, the command exits `1` and the
+failure envelope retains all metrics for reporting. Source/configuration and
+environment failures use the normal xlflow exit-code contract and do not emit
+partial metrics.
+
+## Determinism and consumers
+
+The collector sorts normalized source paths, procedures, and diagnostics before
+serialization. Exclusion patterns are normalized, deduplicated, and sorted;
+valid unmatched patterns produce stable warnings. The same source bytes,
+configuration, and tool version therefore produce identical metric structs and
+JSON output regardless of filesystem enumeration order, path separator, or
+line-ending convention.
+
+Consumers should key a procedure by `(file, line, module, name, kind)` rather
+than by name alone. They should preserve `schema_version`, tolerate additive
+fields, and treat a missing or unsupported version as unavailable metrics.
+Threshold diagnostics are suitable for CI gates, while raw values are suitable
+for future reports, baselines, and trend stores. Module/project aggregates,
+recommended thresholds, history, and LSP projections are outside v1.
+
+## Related
+
+- `docs/adr/ADR-0036-procedure-complexity-metrics.md`
+- `docs/specs/cli-contract.md`
+- `vitepress/reference/json-output.md`
+- `docs/specs/vba-analysis-ir.md`
+- `docs/specs/vba-control-flow-graph.md`

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -1,0 +1,261 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/spf13/cobra"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/output"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+	"github.com/harumiWeb/xlflow/internal/vba/proceduremetrics"
+	"github.com/harumiWeb/xlflow/internal/vba/symbols"
+)
+
+// metricsCommand is intentionally source-only. It builds procedure IR and
+// project call resolution directly, without invoking lint/analyze findings.
+func (a *app) metricsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "metrics",
+		Short: "Calculate deterministic VBA procedure complexity metrics",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := a.loadConfig("metrics")
+			if err != nil {
+				return err
+			}
+			result, warnings, err := collectProcedureMetrics(cmd.Context(), a.cwd, cfg)
+			if err != nil {
+				code := output.ExitEnvironment
+				if strings.Contains(strings.ToLower(err.Error()), "parse") {
+					code = output.ExitValidation
+				}
+				return a.writeFailure("metrics", code, "metrics_failed", err)
+			}
+			thresholds := procedureMetricThresholds(cfg.Metrics.Thresholds)
+			violations, err := proceduremetrics.EvaluateThresholds(result, thresholds)
+			if err != nil {
+				return a.writeFailure("metrics", output.ExitConfig, "metrics_thresholds_invalid", err)
+			}
+			env := output.New("metrics")
+			env.Metrics = map[string]any{
+				"schema_version": proceduremetrics.JSONSchemaVersion,
+				"procedures":     result,
+			}
+			if len(violations) > 0 {
+				env.Diagnostics = violations
+				env.Status = output.StatusFailed
+				env.Error = &output.Error{
+					Code:    "metrics_threshold_exceeded",
+					Message: metricsThresholdFailureMessage(len(violations)),
+				}
+			}
+			env.Warnings = warnings
+			env.Logs = []string{fmt.Sprintf("calculated metrics for %d procedure(s)", len(result))}
+			if len(violations) > 0 {
+				return a.write(env, output.ExitValidation)
+			}
+			return a.write(env, output.ExitSuccess)
+		},
+	}
+}
+
+func metricsThresholdFailureMessage(count int) string {
+	if count == 1 {
+		return "1 procedure complexity threshold exceeded"
+	}
+	return fmt.Sprintf("%d procedure complexity thresholds exceeded", count)
+}
+
+// collectProcedureMetrics discovers, parses, resolves, and collects all
+// configured source procedures. The resolver is assembled from the complete
+// project before any call metrics are evaluated, making call fan-out stable
+// regardless of filesystem enumeration order.
+func collectProcedureMetrics(ctx context.Context, root string, cfg config.Config) ([]proceduremetrics.ProcedureMetrics, []map[string]any, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	files, err := discoverMetricsSourceFiles(root, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	type sourceDocument struct {
+		doc        procedureir.DocumentIR
+		relative   string
+		moduleKind string
+	}
+	documents := make([]sourceDocument, 0, len(files))
+	warnings := make([]map[string]any, 0)
+	matchedExcludes := make([]bool, len(cfg.Metrics.Exclude))
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		relative, err := filepath.Rel(root, file.Path)
+		if err != nil {
+			return nil, nil, err
+		}
+		relative = filepath.ToSlash(filepath.Clean(relative))
+		if excluded, matched := metricsExcluded(relative, cfg.Metrics.Exclude); excluded {
+			for i := range matched {
+				if matched[i] {
+					matchedExcludes[i] = true
+				}
+			}
+			continue
+		}
+		source, err := os.ReadFile(file.Path)
+		if err != nil {
+			return nil, nil, err
+		}
+		doc, err := procedureir.BuildSourceContext(ctx, procedureir.BuildOptions{
+			RootDir: root, Path: relative, ModuleKind: file.ModuleKind,
+		}, source)
+		if err != nil {
+			return nil, nil, err
+		}
+		if doc.Parse.HasError || doc.Parse.HasMissing {
+			return nil, nil, fmt.Errorf("parse recovery in %s; metrics require complete source", relative)
+		}
+		if strings.TrimSpace(doc.ModuleName) == "" {
+			doc.ModuleName = strings.TrimSuffix(filepath.Base(relative), filepath.Ext(relative))
+		}
+		doc.Path = relative
+		documents = append(documents, sourceDocument{doc: doc, relative: relative, moduleKind: file.ModuleKind})
+	}
+	for i, pattern := range cfg.Metrics.Exclude {
+		if !matchedExcludes[i] {
+			warnings = append(warnings, map[string]any{
+				"code": "metrics_exclude_unmatched", "severity": "warning",
+				"pattern": pattern, "message": fmt.Sprintf("metrics exclude pattern %q matched no source files", pattern),
+			})
+		}
+	}
+
+	resolverSymbols := make([]procedureir.ResolverSymbol, 0)
+	for _, item := range documents {
+		for _, procedure := range item.doc.Procedures {
+			resolverSymbols = append(resolverSymbols, procedureir.ResolverSymbol{
+				Name: procedure.Symbol.Name, Module: item.doc.ModuleName, ModuleKind: item.moduleKind,
+				Kind: string(procedure.Symbol.Kind), Visibility: procedure.Symbol.Visibility,
+				File: item.relative, Line: procedure.Symbol.DeclarationRange.StartLine,
+			})
+		}
+	}
+	resolver := procedureir.NewResolver(resolverSymbols)
+	result := make([]proceduremetrics.ProcedureMetrics, 0)
+	for _, item := range documents {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		resolved := procedureir.Resolve(item.doc, resolver)
+		graphs, err := vbacfg.BuildDocumentContext(ctx, resolved)
+		if err != nil {
+			return nil, nil, err
+		}
+		result = append(result, proceduremetrics.CollectDocument(resolved, graphs)...)
+	}
+	proceduremetrics.Sort(result)
+	return result, warnings, nil
+}
+
+// discoverMetricsSourceFiles extends the shared configured-root discovery with
+// the repository's literal tests/ tree. The latter is intentionally not part
+// of symbols.DiscoverSourceFiles because symbols inspection only reports
+// configured production roots.
+func discoverMetricsSourceFiles(root string, projectCfg config.Config) ([]symbols.SourceFile, error) {
+	files, err := symbols.DiscoverSourceFiles(symbols.Options{RootDir: root, Config: projectCfg})
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(files))
+	for _, file := range files {
+		abs, absErr := filepath.Abs(file.Path)
+		if absErr == nil {
+			seen[strings.ToLower(filepath.Clean(abs))] = true
+		}
+	}
+	testsRoot := filepath.Join(root, "tests")
+	if _, statErr := os.Stat(testsRoot); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return files, nil
+		}
+		return nil, statErr
+	}
+	err = filepath.WalkDir(testsRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".bas" && ext != ".cls" && ext != ".frm" {
+			return nil
+		}
+		abs, absErr := filepath.Abs(path)
+		if absErr != nil {
+			return absErr
+		}
+		key := strings.ToLower(filepath.Clean(abs))
+		if seen[key] {
+			return nil
+		}
+		seen[key] = true
+		moduleKind := "standard"
+		switch ext {
+		case ".cls":
+			moduleKind = "class"
+		case ".frm":
+			moduleKind = "form"
+		}
+		files = append(files, symbols.SourceFile{Path: abs, ModuleKind: moduleKind})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, nil
+}
+
+func metricsExcluded(path string, patterns []string) (bool, []bool) {
+	matched := make([]bool, len(patterns))
+	for i, pattern := range patterns {
+		ok, err := doublestar.Match(pattern, path)
+		if err == nil && ok {
+			matched[i] = true
+		}
+	}
+	for _, ok := range matched {
+		if ok {
+			return true, matched
+		}
+	}
+	return false, matched
+}
+
+func procedureMetricThresholds(cfg config.Thresholds) proceduremetrics.Thresholds {
+	return proceduremetrics.Thresholds{
+		proceduremetrics.MetricCyclomaticComplexity: cfg.CyclomaticComplexity,
+		proceduremetrics.MetricMaxNestingDepth:      cfg.MaxNestingDepth,
+		proceduremetrics.MetricStatementCount:       cfg.StatementCount,
+		proceduremetrics.MetricSourceLineCount:      cfg.SourceLineCount,
+		proceduremetrics.MetricBranchCount:          cfg.BranchCount,
+		proceduremetrics.MetricLoopCount:            cfg.LoopCount,
+		proceduremetrics.MetricGotoCount:            cfg.GoToCount,
+		proceduremetrics.MetricExitPointCount:       cfg.ExitPointCount,
+		proceduremetrics.MetricParameterCount:       cfg.ParameterCount,
+		proceduremetrics.MetricByRefParameterCount:  cfg.ByRefParameterCount,
+		proceduremetrics.MetricLocalVariableCount:   cfg.LocalVariableCount,
+		proceduremetrics.MetricCallFanOut:           cfg.CallFanOut,
+	}
+}

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -209,14 +209,11 @@ func discoverMetricsSourceFiles(root string, projectCfg config.Config) ([]symbol
 		if seen[key] {
 			return nil
 		}
-		seen[key] = true
-		moduleKind := "standard"
-		switch ext {
-		case ".cls":
-			moduleKind = "class"
-		case ".frm":
-			moduleKind = "form"
+		moduleKind, include := metricsTestSourceKind(projectCfg, abs)
+		if !include {
+			return nil
 		}
+		seen[key] = true
 		files = append(files, symbols.SourceFile{Path: abs, ModuleKind: moduleKind})
 		return nil
 	})
@@ -225,6 +222,41 @@ func discoverMetricsSourceFiles(root string, projectCfg config.Config) ([]symbol
 	}
 	sort.SliceStable(files, func(i, j int) bool { return files[i].Path < files[j].Path })
 	return files, nil
+}
+
+// metricsTestSourceKind applies the same UserForm source-of-truth rule to the
+// literal tests/ tree that symbols.DiscoverSourceFiles applies to configured
+// source roots. A tests form pair is conventionally laid out as
+// tests/<forms-dir>/<Name>.frm and tests/<forms-dir>/code/<Name>.bas. Ordinary
+// .bas/.cls files retain their existing standard/class classification.
+func metricsTestSourceKind(cfg config.Config, path string) (string, bool) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".cls":
+		return "class", true
+	case ".frm":
+		sidecar := filepath.Join(filepath.Dir(path), "code", strings.TrimSuffix(filepath.Base(path), ext)+".bas")
+		if strings.EqualFold(cfg.UserForm.CodeSource, "sidecar") {
+			if _, err := os.Stat(sidecar); err == nil {
+				return "", false
+			}
+		}
+		return "form", true
+	case ".bas":
+		if strings.EqualFold(filepath.Base(filepath.Dir(path)), "code") {
+			formsDir := filepath.Dir(filepath.Dir(path))
+			form := filepath.Join(formsDir, strings.TrimSuffix(filepath.Base(path), ext)+".frm")
+			if _, err := os.Stat(form); err == nil {
+				if strings.EqualFold(cfg.UserForm.CodeSource, "sidecar") {
+					return "form", true
+				}
+				return "", false
+			}
+		}
+		return "standard", true
+	default:
+		return "", false
+	}
 }
 
 func metricsExcluded(path string, patterns []string) (bool, []bool) {

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/output"
+)
+
+func TestRootCommandIncludesMetricsCommand(t *testing.T) {
+	root := (&app{}).rootCommand()
+	cmd, _, err := root.Find([]string{"metrics"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd == nil || cmd.Name() != "metrics" {
+		t.Fatalf("metrics command = %#v", cmd)
+	}
+}
+
+func TestCollectProcedureMetricsResolvesProjectFanOutAndSorts(t *testing.T) {
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleDir, "Main.bas"), []byte(`Attribute VB_Name = "Main"
+Public Sub Run()
+    If True Then
+        Helper
+    Else
+        Helper
+    End If
+End Sub
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleDir, "Helper.bas"), []byte(`Attribute VB_Name = "Helper"
+Public Sub Helper()
+End Sub
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	cfg.Src.Modules = filepath.ToSlash(filepath.Join("src", "modules"))
+	got, warnings, err := collectProcedureMetrics(context.Background(), root, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 || len(got) != 2 {
+		t.Fatalf("metrics = %+v, warnings = %+v", got, warnings)
+	}
+	if got[0].Name != "Helper" || got[1].Name != "Run" {
+		t.Fatalf("procedure order = %q, %q", got[0].Name, got[1].Name)
+	}
+	if got[1].CallFanOut != 1 || got[1].BranchCount != 1 || got[1].CyclomaticComplexity != 2 {
+		t.Fatalf("Run metrics = %+v", got[1].Metrics)
+	}
+}
+
+func TestMetricsCommandJSONThresholdFailureRetainsMetrics(t *testing.T) {
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleDir, "Main.bas"), []byte("Attribute VB_Name = \"Main\"\nPublic Sub Run()\n    If True Then\n    End If\nEnd Sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, config.FileName), []byte(`[src]
+modules = "src/modules"
+classes = "src/classes"
+forms = "src/forms"
+workbook = "src/workbook"
+[metrics.thresholds]
+branch_count = 0
+cyclomatic_complexity = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr strings.Builder
+	a := &app{cwd: root, stdout: &stdout, stderr: &stderr}
+	rootCmd := a.rootCommand()
+	rootCmd.SetArgs([]string{"--json", "metrics"})
+	if err := rootCmd.Execute(); output.ExitCode(err) != output.ExitValidation {
+		t.Fatalf("metrics exit = %v (%v), stdout=%s", output.ExitCode(err), err, stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatalf("JSON = %v\n%s", err, stdout.String())
+	}
+	if payload["metrics"] == nil || payload["diagnostics"] == nil {
+		t.Fatalf("threshold failure omitted metrics/diagnostics: %s", stdout.String())
+	}
+	if payload["status"] != output.StatusFailed || payload["error"].(map[string]any)["code"] != "metrics_threshold_exceeded" {
+		t.Fatalf("payload status/error = %#v", payload)
+	}
+}

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -119,6 +119,9 @@ func TestDiscoverMetricsSourceFilesRespectsUserFormCodeSourceForTests(t *testing
 	if _, ok := got[filepath.Clean(sidecarPath)]; ok {
 		t.Fatalf("frm mode included sidecar form code: %+v", got)
 	}
+	if got[filepath.Clean(standardPath)] != "standard" || got[filepath.Clean(classPath)] != "class" {
+		t.Fatalf("frm mode changed ordinary test sources: %+v", got)
+	}
 }
 
 func metricsSourceKinds(files []symbols.SourceFile) map[string]string {

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/output"
+	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 )
 
 func TestRootCommandIncludesMetricsCommand(t *testing.T) {
@@ -61,6 +62,71 @@ End Sub
 	if got[1].CallFanOut != 1 || got[1].BranchCount != 1 || got[1].CyclomaticComplexity != 2 {
 		t.Fatalf("Run metrics = %+v", got[1].Metrics)
 	}
+}
+
+func TestDiscoverMetricsSourceFilesRespectsUserFormCodeSourceForTests(t *testing.T) {
+	root := t.TempDir()
+	formsDir := filepath.Join(root, "tests", "forms")
+	codeDir := filepath.Join(formsDir, "code")
+	if err := os.MkdirAll(codeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	frmPath := filepath.Join(formsDir, "Fixture.frm")
+	sidecarPath := filepath.Join(codeDir, "Fixture.bas")
+	if err := os.WriteFile(frmPath, []byte("VERSION 5.00\nBegin VB.Form Fixture\nEnd\nAttribute VB_Name = \"Fixture\"\nPrivate Sub Embedded()\nEnd Sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sidecarPath, []byte("Option Explicit\nPrivate Sub Sidecar()\nEnd Sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	standardPath := filepath.Join(root, "tests", "Keep.bas")
+	classPath := filepath.Join(root, "tests", "Keep.cls")
+	for path, source := range map[string]string{
+		standardPath: "Public Sub KeepStandard()\nEnd Sub\n",
+		classPath:    "Public Sub KeepClass()\nEnd Sub\n",
+	} {
+		if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := config.Default()
+	cfg.UserForm.CodeSource = "sidecar"
+	files, err := discoverMetricsSourceFiles(root, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := metricsSourceKinds(files)
+	if _, ok := got[filepath.Clean(frmPath)]; ok {
+		t.Fatalf("sidecar mode included generated form: %+v", got)
+	}
+	if got[filepath.Clean(sidecarPath)] != "form" {
+		t.Fatalf("sidecar mode classified form code as %q: %+v", got[filepath.Clean(sidecarPath)], got)
+	}
+	if got[filepath.Clean(standardPath)] != "standard" || got[filepath.Clean(classPath)] != "class" {
+		t.Fatalf("sidecar mode changed ordinary test sources: %+v", got)
+	}
+
+	cfg.UserForm.CodeSource = "frm"
+	files, err = discoverMetricsSourceFiles(root, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = metricsSourceKinds(files)
+	if got[filepath.Clean(frmPath)] != "form" {
+		t.Fatalf("frm mode did not include embedded form: %+v", got)
+	}
+	if _, ok := got[filepath.Clean(sidecarPath)]; ok {
+		t.Fatalf("frm mode included sidecar form code: %+v", got)
+	}
+}
+
+func metricsSourceKinds(files []symbols.SourceFile) map[string]string {
+	result := make(map[string]string, len(files))
+	for _, file := range files {
+		result[filepath.Clean(file.Path)] = file.ModuleKind
+	}
+	return result
 }
 
 func TestMetricsCommandJSONThresholdFailureRetainsMetrics(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -234,6 +234,7 @@ func (a *app) rootCommand() *cobra.Command {
 		a.lspCommand(),
 		a.fmtCommand(),
 		a.analyzeCommand(),
+		a.metricsCommand(),
 		a.checkCommand(),
 		a.generateCommand(),
 		a.moduleCommand(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/BurntSushi/toml"
+	"github.com/bmatcuk/doublestar/v4"
 	excelbridge "github.com/harumiWeb/xlflow/internal/excel/bridge"
 	staticrules "github.com/harumiWeb/xlflow/internal/staticanalysis/rules"
 )
@@ -28,6 +30,7 @@ type Config struct {
 	VBA      VBAConfig        `toml:"vba"`
 	UserForm UserFormConfig   `toml:"userform"`
 	Build    BuildConfig      `toml:"build"`
+	Metrics  MetricsConfig    `toml:"metrics"`
 	Backup   BackupConfig     `toml:"backup"`
 	Fmt      FmtConfig        `toml:"fmt"`
 	Lint     LintConfig       `toml:"lint"`
@@ -76,6 +79,39 @@ type UserFormConfig struct {
 type BuildConfig struct {
 	Exclude []string `toml:"exclude"`
 }
+
+// MetricsConfig controls procedure-complexity metric collection. It is kept
+// separate from BuildConfig because metric collection and release-build source
+// selection have different scopes and consumers.
+type MetricsConfig struct {
+	Exclude    []string   `toml:"exclude"`
+	Thresholds Thresholds `toml:"thresholds"`
+}
+
+// Thresholds contains optional procedure metric limits. A zero value disables
+// the corresponding threshold; positive values are evaluated as strict upper
+// bounds by the metrics command.
+//
+// The field names intentionally mirror the JSON metric names while TOML tags
+// preserve the snake_case configuration contract.
+type Thresholds struct {
+	CyclomaticComplexity int `toml:"cyclomatic_complexity"`
+	MaxNestingDepth      int `toml:"max_nesting_depth"`
+	StatementCount       int `toml:"statement_count"`
+	SourceLineCount      int `toml:"source_line_count"`
+	BranchCount          int `toml:"branch_count"`
+	LoopCount            int `toml:"loop_count"`
+	GoToCount            int `toml:"goto_count"`
+	ExitPointCount       int `toml:"exit_point_count"`
+	ParameterCount       int `toml:"parameter_count"`
+	ByRefParameterCount  int `toml:"byref_parameter_count"`
+	LocalVariableCount   int `toml:"local_variable_count"`
+	CallFanOut           int `toml:"call_fan_out"`
+}
+
+// MetricsThresholds is retained as a descriptive alias for callers that
+// prefer to qualify the threshold type. The TOML contract uses [metrics.thresholds].
+type MetricsThresholds = Thresholds
 
 type BackupConfig struct {
 	Retention BackupRetentionConfig `toml:"retention"`
@@ -369,6 +405,12 @@ func load(cwd string, allowInvalidExcelBridge bool) (Config, error) {
 	if err != nil {
 		return cfg, err
 	}
+	for _, key := range meta.Undecoded() {
+		name := key.String()
+		if name == "metrics" || strings.HasPrefix(name, "metrics.") {
+			return cfg, fmt.Errorf("unknown metrics configuration key: %s", name)
+		}
+	}
 	applyDefaults(&cfg)
 	if err := applyLintRuleConfig(&cfg, meta); err != nil {
 		return cfg, err
@@ -377,6 +419,9 @@ func load(cwd string, allowInvalidExcelBridge bool) (Config, error) {
 		return cfg, err
 	}
 	if err := normalizeExcelBridge(&cfg, allowInvalidExcelBridge); err != nil {
+		return cfg, err
+	}
+	if err := normalizeMetricsExclude(&cfg.Metrics); err != nil {
 		return cfg, err
 	}
 	return cfg, validate(cfg)
@@ -446,6 +491,9 @@ func validate(cfg Config) error {
 	if cfg.Backup.Retention.MaxCount > 0 && cfg.Backup.Retention.MinKeep > cfg.Backup.Retention.MaxCount {
 		return errors.New("backup.retention.min_keep must be less than or equal to backup.retention.max_count when max_count is enabled")
 	}
+	if err := validateMetricsThresholds(cfg.Metrics.Thresholds); err != nil {
+		return err
+	}
 	if cfg.Lint.ProcedureNameConstant.Enabled {
 		name := strings.TrimSpace(cfg.Lint.ProcedureNameConstant.ConstantName)
 		if name == "" {
@@ -456,6 +504,63 @@ func validate(cfg Config) error {
 		}
 	}
 	return nil
+}
+
+func validateMetricsThresholds(thresholds Thresholds) error {
+	values := []struct {
+		name  string
+		value int
+	}{
+		{"cyclomatic_complexity", thresholds.CyclomaticComplexity},
+		{"max_nesting_depth", thresholds.MaxNestingDepth},
+		{"statement_count", thresholds.StatementCount},
+		{"source_line_count", thresholds.SourceLineCount},
+		{"branch_count", thresholds.BranchCount},
+		{"loop_count", thresholds.LoopCount},
+		{"goto_count", thresholds.GoToCount},
+		{"exit_point_count", thresholds.ExitPointCount},
+		{"parameter_count", thresholds.ParameterCount},
+		{"byref_parameter_count", thresholds.ByRefParameterCount},
+		{"local_variable_count", thresholds.LocalVariableCount},
+		{"call_fan_out", thresholds.CallFanOut},
+	}
+	for _, item := range values {
+		if item.value < 0 {
+			return fmt.Errorf("metrics.thresholds.%s must be zero or greater", item.name)
+		}
+	}
+	return nil
+}
+
+// normalizeMetricsExclude validates and canonicalizes procedure-metrics file
+// globs. Unlike build.exclude, metrics excludes are normalized as part of
+// configuration loading because the metrics collector consumes them directly.
+func normalizeMetricsExclude(cfg *MetricsConfig) error {
+	seen := map[string]bool{}
+	patterns := make([]string, 0, len(cfg.Exclude))
+	for _, value := range cfg.Exclude {
+		pattern := filepath.ToSlash(strings.TrimSpace(strings.ReplaceAll(value, "\\", "/")))
+		if pattern == "" {
+			return errors.New("metrics.exclude must not contain an empty pattern")
+		}
+		if strings.HasPrefix(pattern, "/") || isDriveAbsolute(pattern) || pattern == ".." || strings.HasPrefix(pattern, "../") || strings.Contains(pattern, "/../") {
+			return fmt.Errorf("metrics exclusion pattern %q must be project-root-relative", value)
+		}
+		if !doublestar.ValidatePattern(pattern) {
+			return fmt.Errorf("invalid metrics exclusion pattern %q", value)
+		}
+		if !seen[pattern] {
+			seen[pattern] = true
+			patterns = append(patterns, pattern)
+		}
+	}
+	sort.Strings(patterns)
+	cfg.Exclude = patterns
+	return nil
+}
+
+func isDriveAbsolute(path string) bool {
+	return len(path) >= 2 && path[1] == ':' && ((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z'))
 }
 
 func validVBAIdentifier(name string) bool {
@@ -883,7 +988,51 @@ func legacyOptInAnalyzeRulesForWrite(cfg AnalyzeConfig) []analyzeRuleConfig {
 	return out
 }
 
+func renderMetricsConfig(cfg MetricsConfig) string {
+	var b strings.Builder
+	b.WriteString("# Procedure complexity metrics.\n")
+	b.WriteString("[metrics]\n")
+	b.WriteString("# Project-root-relative doublestar globs excluded from metric collection.\n")
+	b.WriteString("exclude = [")
+	for i, pattern := range cfg.Exclude {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(strconv.Quote(pattern))
+	}
+	b.WriteString("]\n\n")
+	b.WriteString("# A value of zero disables that threshold; positive values are strict upper bounds.\n")
+	b.WriteString("[metrics.thresholds]\n")
+	for _, item := range []struct {
+		name  string
+		value int
+	}{
+		{"cyclomatic_complexity", cfg.Thresholds.CyclomaticComplexity},
+		{"max_nesting_depth", cfg.Thresholds.MaxNestingDepth},
+		{"statement_count", cfg.Thresholds.StatementCount},
+		{"source_line_count", cfg.Thresholds.SourceLineCount},
+		{"branch_count", cfg.Thresholds.BranchCount},
+		{"loop_count", cfg.Thresholds.LoopCount},
+		{"goto_count", cfg.Thresholds.GoToCount},
+		{"exit_point_count", cfg.Thresholds.ExitPointCount},
+		{"parameter_count", cfg.Thresholds.ParameterCount},
+		{"byref_parameter_count", cfg.Thresholds.ByRefParameterCount},
+		{"local_variable_count", cfg.Thresholds.LocalVariableCount},
+		{"call_fan_out", cfg.Thresholds.CallFanOut},
+	} {
+		fmt.Fprintf(&b, "%s = %d\n", item.name, item.value)
+	}
+	return b.String()
+}
+
 func Write(path string, cfg Config) (err error) {
+	metricsConfig := cfg.Metrics
+	if err := normalizeMetricsExclude(&metricsConfig); err != nil {
+		return err
+	}
+	if err := validateMetricsThresholds(metricsConfig.Thresholds); err != nil {
+		return err
+	}
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		return err
@@ -896,6 +1045,7 @@ func Write(path string, cfg Config) (err error) {
 
 	lintConfigText := renderLintConfig(cfg.Lint)
 	analyzeConfigText := renderAnalyzeConfig(cfg.Analyze)
+	metricsConfigText := renderMetricsConfig(metricsConfig)
 
 	const tmpl = `# Project identity and entry point.
 [project]
@@ -952,6 +1102,7 @@ default_component_folders = %t
 #   "sidecar" – code is split into src/forms/code/<FormName>.bas.
 code_source = %q
 
+%s
 # Automatic backup retention is disabled by default. Uncomment to prune old
 # metadata-backed backups for the configured workbook after successful backup-
 # producing push and rollback operations.
@@ -987,6 +1138,7 @@ builtin_casing = %t
 		cfg.Src.Modules, cfg.Src.Classes, cfg.Src.Forms, cfg.Src.Workbook,
 		cfg.VBA.Folders, cfg.VBA.FolderAnnotation, cfg.VBA.DefaultComponentFolders,
 		cfg.UserForm.CodeSource,
+		metricsConfigText,
 		cfg.Fmt.OperatorSpacing, cfg.Fmt.DeclarationSpacing, cfg.Fmt.KeywordCasing, cfg.Fmt.BuiltinCasing,
 		lintConfigText,
 		analyzeConfigText,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -440,6 +440,204 @@ exclude = ["src/modules/Tests/**"]
 	}
 }
 
+func TestMetricsConfigDefaultsAreDisabled(t *testing.T) {
+	cfg := Default()
+	if len(cfg.Metrics.Exclude) != 0 {
+		t.Fatalf("metrics.exclude default = %#v, want empty", cfg.Metrics.Exclude)
+	}
+	thresholds := cfg.Metrics.Thresholds
+	for name, value := range map[string]int{
+		"cyclomatic_complexity": thresholds.CyclomaticComplexity,
+		"max_nesting_depth":     thresholds.MaxNestingDepth,
+		"statement_count":       thresholds.StatementCount,
+		"source_line_count":     thresholds.SourceLineCount,
+		"branch_count":          thresholds.BranchCount,
+		"loop_count":            thresholds.LoopCount,
+		"goto_count":            thresholds.GoToCount,
+		"exit_point_count":      thresholds.ExitPointCount,
+		"parameter_count":       thresholds.ParameterCount,
+		"byref_parameter_count": thresholds.ByRefParameterCount,
+		"local_variable_count":  thresholds.LocalVariableCount,
+		"call_fan_out":          thresholds.CallFanOut,
+	} {
+		if value != 0 {
+			t.Errorf("metrics.thresholds.%s default = %d, want 0 (disabled)", name, value)
+		}
+	}
+}
+
+func TestLoadMetricsConfigNormalizesExcludeAndParsesThresholds(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[metrics]
+exclude = ["src\\modules\\Tests\\**", "src/forms/code/*.bas", "src/modules/Tests/**"]
+
+[metrics.thresholds]
+cyclomatic_complexity = 10
+max_nesting_depth = 4
+statement_count = 25
+source_line_count = 40
+branch_count = 8
+loop_count = 3
+goto_count = 2
+exit_point_count = 5
+parameter_count = 6
+byref_parameter_count = 2
+local_variable_count = 12
+call_fan_out = 9
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cfg.Metrics.Exclude, []string{"src/forms/code/*.bas", "src/modules/Tests/**"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("metrics.exclude = %#v, want %#v", got, want)
+	}
+	got := cfg.Metrics.Thresholds
+	want := Thresholds{
+		CyclomaticComplexity: 10,
+		MaxNestingDepth:      4,
+		StatementCount:       25,
+		SourceLineCount:      40,
+		BranchCount:          8,
+		LoopCount:            3,
+		GoToCount:            2,
+		ExitPointCount:       5,
+		ParameterCount:       6,
+		ByRefParameterCount:  2,
+		LocalVariableCount:   12,
+		CallFanOut:           9,
+	}
+	if got != want {
+		t.Fatalf("metrics.thresholds = %+v, want %+v", got, want)
+	}
+}
+
+func TestLoadMetricsConfigRejectsInvalidExcludePatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{name: "empty", pattern: `"   "`, want: "empty pattern"},
+		{name: "parent", pattern: `"../outside/**"`, want: "project-root-relative"},
+		{name: "absolute", pattern: `"C:\\repo\\src\\**"`, want: "project-root-relative"},
+		{name: "invalid glob", pattern: `"src/["`, want: "invalid metrics exclusion pattern"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := []byte("[project]\nentry = \"Main.Run\"\n\n[excel]\npath = \"build/Book.xlsm\"\n\n[metrics]\nexclude = [" + tt.pattern + "]\n")
+			if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(dir)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadMetricsConfigRejectsNegativeThresholds(t *testing.T) {
+	keys := []string{
+		"cyclomatic_complexity", "max_nesting_depth", "statement_count", "source_line_count",
+		"branch_count", "loop_count", "goto_count", "exit_point_count", "parameter_count",
+		"byref_parameter_count", "local_variable_count", "call_fan_out",
+	}
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			dir := t.TempDir()
+			body := []byte("[project]\nentry = \"Main.Run\"\n\n[excel]\npath = \"build/Book.xlsm\"\n\n[metrics.thresholds]\n" + key + " = -1\n")
+			if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(dir)
+			if err == nil || !strings.Contains(err.Error(), "must be zero or greater") {
+				t.Fatalf("Load error = %v, want non-negative threshold validation", err)
+			}
+		})
+	}
+}
+
+func TestWriteRoundTripsMetricsConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Default()
+	cfg.Metrics.Exclude = []string{"src\\z\\**", "src/a/**", "src\\z\\**"}
+	cfg.Metrics.Thresholds = Thresholds{
+		CyclomaticComplexity: 10,
+		MaxNestingDepth:      4,
+		StatementCount:       25,
+		SourceLineCount:      40,
+		BranchCount:          8,
+		LoopCount:            3,
+		GoToCount:            2,
+		ExitPointCount:       5,
+		ParameterCount:       6,
+		ByRefParameterCount:  2,
+		LocalVariableCount:   12,
+		CallFanOut:           9,
+	}
+	path := filepath.Join(dir, FileName)
+	if err := Write(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := loaded.Metrics.Exclude, []string{"src/a/**", "src/z/**"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("round-trip metrics.exclude = %#v, want %#v", got, want)
+	}
+	if loaded.Metrics.Thresholds != cfg.Metrics.Thresholds {
+		t.Fatalf("round-trip metrics.thresholds = %+v, want %+v", loaded.Metrics.Thresholds, cfg.Metrics.Thresholds)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"[metrics]", "exclude = [\"src/a/**\", \"src/z/**\"]", "[metrics.thresholds]",
+		"cyclomatic_complexity = 10", "byref_parameter_count = 2", "call_fan_out = 9",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generated config missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestMetricsExcludeDoesNotNormalizeBuildExclude(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[build]
+exclude = ["src\\modules\\Tests\\**"]
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cfg.Build.Exclude, []string{`src\modules\Tests\**`}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("build.exclude = %#v, want raw build-only value %#v", got, want)
+	}
+}
+
 func TestLoadParsesVBALineNumbers(t *testing.T) {
 	dir := t.TempDir()
 	body := []byte(`[project]
@@ -1592,6 +1790,17 @@ func TestUpdateUserFormCodeSourceHandlesTableCommentsAndQuotedKeys(t *testing.T)
 	}
 	if !strings.Contains(text, "[userform] # settings\ncode_source = \"sidecar\"") {
 		t.Fatalf("expected quoted key to be replaced in existing table:\n%s", text)
+	}
+}
+
+func TestLoadMetricsConfigRejectsUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	body := "[project]\nentry = \"Main.Run\"\n\n[metrics.thresholds]\nunknown_metric = 3\n"
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(dir); err == nil || !strings.Contains(err.Error(), "unknown metrics configuration key") {
+		t.Fatalf("unknown metrics key error = %v", err)
 	}
 }
 

--- a/internal/coordination/descriptors.go
+++ b/internal/coordination/descriptors.go
@@ -89,6 +89,7 @@ func buildDescriptors() []Descriptor {
 		cli("lint", "lint", sourceRead),
 		cli("lsp", "lsp", sourceRead),
 		cli("analyze", "analyze", sourceRead),
+		cli("metrics", "metrics", sourceRead),
 		cliExcel("check", "check", excelRead),
 		cli("inspect-gui", "inspect-gui", sourceRead),
 		cli("skill.install", "skill install", sourceMutate),

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -65,32 +65,37 @@ type Envelope struct {
 	Runner          any `json:"runner,omitempty"`
 	Analysis        any `json:"analysis,omitempty"`
 	AnalysisMetrics any `json:"analysis_metrics,omitempty"`
-	Check           any `json:"check,omitempty"`
-	Version         any `json:"version,omitempty"`
-	Update          any `json:"update,omitempty"`
-	RunDiagnostic   any `json:"run_diagnostic,omitempty"`
-	PushDiagnostic  any `json:"push_diagnostic,omitempty"`
-	Backups         any `json:"backups,omitempty"`
-	BackupPrune     any `json:"backup_prune,omitempty"`
-	BackupDelete    any `json:"backup_delete,omitempty"`
-	Rollback        any `json:"rollback,omitempty"`
-	Target          any `json:"target,omitempty"`
-	Output          any `json:"output,omitempty"`
-	Build           any `json:"build,omitempty"`
-	Pack            any `json:"pack,omitempty"`
-	Spec            any `json:"spec,omitempty"`
-	Edit            any `json:"edit,omitempty"`
-	Project         any `json:"project,omitempty"`
-	State           any `json:"state,omitempty"`
-	TypeDB          any `json:"type_db,omitempty"`
-	Warnings        any `json:"warnings,omitempty"`
-	Hints           any `json:"hints,omitempty"`
-	DefaultEntry    any `json:"default_entry,omitempty"`
-	Suggestions     any `json:"suggestions,omitempty"`
-	Process         any `json:"process,omitempty"`
-	Recovery        any `json:"recovery,omitempty"`
-	Capabilities    any `json:"capabilities,omitempty"`
-	Rules           any `json:"rules,omitempty"`
+	// Metrics contains the protocol-neutral procedure complexity metrics
+	// projection. It is intentionally separate from AnalysisMetrics, which is
+	// owned by the diagnostics/analyze command and has different compatibility
+	// semantics.
+	Metrics        any `json:"metrics,omitempty"`
+	Check          any `json:"check,omitempty"`
+	Version        any `json:"version,omitempty"`
+	Update         any `json:"update,omitempty"`
+	RunDiagnostic  any `json:"run_diagnostic,omitempty"`
+	PushDiagnostic any `json:"push_diagnostic,omitempty"`
+	Backups        any `json:"backups,omitempty"`
+	BackupPrune    any `json:"backup_prune,omitempty"`
+	BackupDelete   any `json:"backup_delete,omitempty"`
+	Rollback       any `json:"rollback,omitempty"`
+	Target         any `json:"target,omitempty"`
+	Output         any `json:"output,omitempty"`
+	Build          any `json:"build,omitempty"`
+	Pack           any `json:"pack,omitempty"`
+	Spec           any `json:"spec,omitempty"`
+	Edit           any `json:"edit,omitempty"`
+	Project        any `json:"project,omitempty"`
+	State          any `json:"state,omitempty"`
+	TypeDB         any `json:"type_db,omitempty"`
+	Warnings       any `json:"warnings,omitempty"`
+	Hints          any `json:"hints,omitempty"`
+	DefaultEntry   any `json:"default_entry,omitempty"`
+	Suggestions    any `json:"suggestions,omitempty"`
+	Process        any `json:"process,omitempty"`
+	Recovery       any `json:"recovery,omitempty"`
+	Capabilities   any `json:"capabilities,omitempty"`
+	Rules          any `json:"rules,omitempty"`
 }
 
 type Options struct {
@@ -416,6 +421,8 @@ func renderHuman(env Envelope, opts Options) string {
 		b.WriteString(r.renderLint(env))
 	case "analyze":
 		b.WriteString(r.renderAnalysis(env))
+	case "metrics":
+		b.WriteString(r.renderMetrics(env))
 	case "check":
 		b.WriteString(r.renderCheck(env))
 		if env.Issues != nil {
@@ -1751,6 +1758,131 @@ func (r renderer) renderAnalysisMetrics(value any) string {
 		fmt.Fprintf(&b, "%d more field(s); use --json for the complete metrics.\n", len(fields)-limit)
 	}
 	return b.String()
+}
+
+// renderMetrics renders the standalone procedure-complexity projection. The
+// metrics command deliberately has its own renderer so that the existing
+// analyze/module-state presentation remains unchanged.
+func (r renderer) renderMetrics(env Envelope) string {
+	metrics := objectMap(env.Metrics)
+	procedures := listOfObjects(metrics["procedures"])
+	var b strings.Builder
+	b.WriteString(r.section("Procedure metrics"))
+	if version, ok := numberValue(metrics, "schema_version"); ok {
+		b.WriteString(r.kvRows(kvRow{"Schema", fmt.Sprintf("v%d", int(version))}))
+	}
+	if len(procedures) == 0 {
+		b.WriteString("No procedures found.\n")
+	} else {
+		headers := []string{
+			"Procedure", "Complexity", "Nesting", "Statements", "Source lines",
+			"Branches", "Loops", "GoTo", "Exits", "Parameters", "ByRef",
+			"Locals", "Fan-out",
+		}
+		rows := make([][]string, 0, len(procedures))
+		for _, procedure := range procedures {
+			rows = append(rows, []string{
+				metricsProcedureLocation(procedure),
+				metricsNumber(procedure, "cyclomatic_complexity"),
+				metricsNumber(procedure, "max_nesting_depth"),
+				metricsNumber(procedure, "statement_count"),
+				metricsNumber(procedure, "source_line_count"),
+				metricsNumber(procedure, "branch_count"),
+				metricsNumber(procedure, "loop_count"),
+				metricsNumber(procedure, "goto_count"),
+				metricsNumber(procedure, "exit_point_count", "exit_points"),
+				metricsNumber(procedure, "parameter_count", "parameters"),
+				metricsNumber(procedure, "byref_parameter_count", "byref_parameters"),
+				metricsNumber(procedure, "local_variable_count", "local_variables"),
+				metricsNumber(procedure, "call_fan_out"),
+			})
+		}
+		b.WriteString(r.table(headers, rows))
+	}
+	if diagnostics := listOfObjects(env.Diagnostics); len(diagnostics) > 0 {
+		b.WriteString(r.section("Thresholds"))
+		rows := make([][]string, 0, len(diagnostics))
+		for _, diagnostic := range diagnostics {
+			rows = append(rows, []string{
+				r.severityBadge(stringValue(diagnostic, "severity")),
+				stringValue(diagnostic, "metric"),
+				metricsDiagnosticLocation(diagnostic),
+				metricsDiagnosticMessage(diagnostic),
+			})
+		}
+		b.WriteString(r.table([]string{"Severity", "Metric", "Location", "Message"}, rows))
+	}
+	b.WriteString(r.renderWarningsAndHints(env))
+	b.WriteString(r.renderLogs(env))
+	return b.String()
+}
+
+func metricsProcedureLocation(procedure map[string]any) string {
+	name := stringValue(procedure, "name")
+	if name == "" {
+		name = stringValue(procedure, "procedure")
+	}
+	module := stringValue(procedure, "module")
+	if module != "" {
+		name = module + "." + name
+	}
+	file := stringValue(procedure, "file")
+	line := intNumber(procedure, "start_line")
+	if line == 0 {
+		line = intNumber(procedure, "startLine")
+	}
+	if line == 0 {
+		declaration := objectMap(procedure["declaration_range"])
+		line = intNumber(declaration, "startLine")
+		if line == 0 {
+			line = intNumber(declaration, "start_line")
+		}
+	}
+	if file != "" && line > 0 {
+		return fmt.Sprintf("%s:%d %s", file, line, name)
+	}
+	if file != "" && name != "" {
+		return file + " " + name
+	}
+	return name
+}
+
+func metricsNumber(procedure map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := numberValue(procedure, key); ok {
+			return fmt.Sprintf("%d", int(value))
+		}
+	}
+	// A collector may group the scalar values under a metrics object. Accept
+	// that representation as well; this keeps the renderer forward compatible
+	// while the JSON contract remains explicit at the envelope level.
+	if nested := objectMap(procedure["metrics"]); len(nested) > 0 {
+		for _, key := range keys {
+			if value, ok := numberValue(nested, key); ok {
+				return fmt.Sprintf("%d", int(value))
+			}
+		}
+	}
+	return "0"
+}
+
+func metricsDiagnosticLocation(diagnostic map[string]any) string {
+	file := stringValue(diagnostic, "file")
+	line := intNumber(diagnostic, "line")
+	if file != "" && line > 0 {
+		return fmt.Sprintf("%s:%d", file, line)
+	}
+	return file
+}
+
+func metricsDiagnosticMessage(diagnostic map[string]any) string {
+	if message := stringValue(diagnostic, "message"); message != "" {
+		return message
+	}
+	metric := stringValue(diagnostic, "metric")
+	value := metricsNumber(diagnostic, "value")
+	threshold := metricsNumber(diagnostic, "threshold")
+	return fmt.Sprintf("%s = %s exceeds threshold %s", metric, value, threshold)
 }
 
 func (r renderer) renderCheck(env Envelope) string {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -262,6 +262,42 @@ func TestWriteAnalysisMetricsHumanOutputForWorkbookCommands(t *testing.T) {
 	}
 }
 
+func TestWriteProcedureMetricsJSONAndHumanOutput(t *testing.T) {
+	env := New("metrics")
+	env.Metrics = map[string]any{
+		"schema_version": 1,
+		"procedures": []map[string]any{{
+			"file": "src/modules/Main.bas", "module": "Main", "name": "Run", "start_line": 4,
+			"cyclomatic_complexity": 3, "max_nesting_depth": 2, "statement_count": 8,
+			"source_line_count": 12, "branch_count": 1, "loop_count": 1, "goto_count": 0,
+			"exit_point_count": 1, "parameter_count": 2, "byref_parameter_count": 1,
+			"local_variable_count": 3, "call_fan_out": 2,
+		}},
+	}
+	env.Diagnostics = []map[string]any{{"code": "MX001", "severity": "warning", "metric": "loop_count", "file": "src/modules/Main.bas", "line": 4, "message": "loop_count exceeds threshold"}}
+	var jsonBuf bytes.Buffer
+	if err := WriteWithOptions(&jsonBuf, env, Options{JSON: true}); err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(jsonBuf.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	metrics, ok := decoded["metrics"].(map[string]any)
+	if !ok || metrics["schema_version"] != float64(1) {
+		t.Fatalf("metrics JSON = %#v", decoded["metrics"])
+	}
+	var human bytes.Buffer
+	if err := WriteWithOptions(&human, env, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, text := range []string{"Procedure metrics:", "Main.Run", "Complexity", "Fan-out", "loop_count exceeds threshold"} {
+		if !strings.Contains(human.String(), text) {
+			t.Fatalf("human metrics output missing %q: %s", text, human.String())
+		}
+	}
+}
+
 func TestWriteJSONEnvelopeIncludesPushDiagnostic(t *testing.T) {
 	env := New("push")
 	env.PushDiagnostic = map[string]any{

--- a/internal/vba/proceduremetrics/metrics.go
+++ b/internal/vba/proceduremetrics/metrics.go
@@ -1,0 +1,482 @@
+// Package proceduremetrics computes deterministic, protocol-neutral
+// maintainability metrics for one VBA procedure.  The package deliberately
+// does not depend on analyzer findings or rule enablement; callers can use
+// the resulting values for reporting, thresholds, or other future consumers.
+package proceduremetrics
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	vbast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+// JSONSchemaVersion is the version of the public procedure metrics object.
+// Adding fields is backward compatible; removing a field or changing its
+// meaning requires incrementing this value.
+const JSONSchemaVersion = 1
+
+// MetricName is the stable identifier used by configuration and threshold
+// diagnostics.  Metric names are intentionally snake_case so they are also
+// suitable as JSON and TOML keys.
+type MetricName string
+
+const (
+	MetricCyclomaticComplexity MetricName = "cyclomatic_complexity"
+	MetricMaxNestingDepth      MetricName = "max_nesting_depth"
+	MetricStatementCount       MetricName = "statement_count"
+	MetricSourceLineCount      MetricName = "source_line_count"
+	MetricBranchCount          MetricName = "branch_count"
+	MetricLoopCount            MetricName = "loop_count"
+	MetricGotoCount            MetricName = "goto_count"
+	MetricExitPointCount       MetricName = "exit_point_count"
+	MetricParameterCount       MetricName = "parameter_count"
+	MetricByRefParameterCount  MetricName = "byref_parameter_count"
+	MetricLocalVariableCount   MetricName = "local_variable_count"
+	MetricCallFanOut           MetricName = "call_fan_out"
+)
+
+var canonicalMetricNames = [...]MetricName{
+	MetricCyclomaticComplexity,
+	MetricMaxNestingDepth,
+	MetricStatementCount,
+	MetricSourceLineCount,
+	MetricBranchCount,
+	MetricLoopCount,
+	MetricGotoCount,
+	MetricExitPointCount,
+	MetricParameterCount,
+	MetricByRefParameterCount,
+	MetricLocalVariableCount,
+	MetricCallFanOut,
+}
+
+// MetricNames is a copy of the canonical order used for display and
+// configuration help.  Evaluation uses a private immutable array so a caller
+// mutating this compatibility slice cannot make results non-deterministic.
+var MetricNames = append([]MetricName(nil), canonicalMetricNames[:]...)
+
+// Metrics contains all initial procedure metrics.  The fields are kept as
+// integers because every metric is a count in schema version 1.
+type Metrics struct {
+	CyclomaticComplexity int `json:"cyclomatic_complexity"`
+	MaxNestingDepth      int `json:"max_nesting_depth"`
+	StatementCount       int `json:"statement_count"`
+	SourceLineCount      int `json:"source_line_count"`
+	BranchCount          int `json:"branch_count"`
+	LoopCount            int `json:"loop_count"`
+	GotoCount            int `json:"goto_count"`
+	ExitPointCount       int `json:"exit_point_count"`
+	ParameterCount       int `json:"parameter_count"`
+	ByRefParameterCount  int `json:"byref_parameter_count"`
+	LocalVariableCount   int `json:"local_variable_count"`
+	CallFanOut           int `json:"call_fan_out"`
+}
+
+// Value returns a metric by its stable name.  The bool is false for an
+// unknown name, allowing configuration validation to reject typos.
+func (m Metrics) Value(name MetricName) (int, bool) {
+	switch name {
+	case MetricCyclomaticComplexity:
+		return m.CyclomaticComplexity, true
+	case MetricMaxNestingDepth:
+		return m.MaxNestingDepth, true
+	case MetricStatementCount:
+		return m.StatementCount, true
+	case MetricSourceLineCount:
+		return m.SourceLineCount, true
+	case MetricBranchCount:
+		return m.BranchCount, true
+	case MetricLoopCount:
+		return m.LoopCount, true
+	case MetricGotoCount:
+		return m.GotoCount, true
+	case MetricExitPointCount:
+		return m.ExitPointCount, true
+	case MetricParameterCount:
+		return m.ParameterCount, true
+	case MetricByRefParameterCount:
+		return m.ByRefParameterCount, true
+	case MetricLocalVariableCount:
+		return m.LocalVariableCount, true
+	case MetricCallFanOut:
+		return m.CallFanOut, true
+	default:
+		return 0, false
+	}
+}
+
+// ProcedureMetrics combines the procedure identity and its metrics.  The
+// anonymous Metrics field intentionally flattens the twelve values in JSON,
+// while keeping identity available to threshold/reporting consumers.
+type ProcedureMetrics struct {
+	File             string                    `json:"file"`
+	Module           string                    `json:"module"`
+	ModuleKind       string                    `json:"module_kind"`
+	Name             string                    `json:"name"`
+	Kind             procedureir.ProcedureKind `json:"kind"`
+	DeclarationRange vbast.Range               `json:"declaration_range"`
+	Metrics
+}
+
+// Input is the protocol-neutral input to Collect.  IR is authoritative when
+// present.  Graph is accepted so callers that already built a CFG need not
+// discard it; when IR statements are absent, statement blocks from Graph are
+// used as a conservative fallback.  Calls overrides IR.Calls when non-nil.
+type Input struct {
+	IR         procedureir.ProcedureIR
+	Graph      *cfg.Graph
+	Calls      []procedureir.CallSite
+	File       string
+	Module     string
+	ModuleKind string
+}
+
+// Collect computes all metrics for one procedure.  It never mutates input
+// slices and does not inspect analyzer findings.
+func Collect(input Input) ProcedureMetrics {
+	procedure := input.IR
+	symbol := procedure.Symbol
+	if symbol.Name == "" && input.Graph != nil {
+		symbol = input.Graph.Procedure
+	}
+	statements := orderedStatements(procedure.Statements)
+	if len(statements) == 0 && input.Graph != nil {
+		statements = statementsFromGraph(*input.Graph)
+	}
+	calls := input.Calls
+	if calls == nil {
+		calls = procedure.Calls
+	}
+
+	result := ProcedureMetrics{
+		File:             input.File,
+		Module:           input.Module,
+		ModuleKind:       input.ModuleKind,
+		Name:             symbol.Name,
+		Kind:             symbol.Kind,
+		DeclarationRange: symbol.DeclarationRange,
+	}
+	result.SourceLineCount = sourceLineCount(symbol.DeclarationRange)
+	result.StatementCount = statementCount(statements)
+	result.BranchCount = branchCount(statements)
+	result.LoopCount = loopCount(statements)
+	result.CyclomaticComplexity = 1 + result.BranchCount + result.LoopCount
+	result.MaxNestingDepth = maxNestingDepth(statements)
+	result.GotoCount = gotoCount(statements)
+	result.ExitPointCount = exitPointCount(symbol.Kind, statements)
+	result.ParameterCount = len(symbol.Parameters)
+	for _, parameter := range symbol.Parameters {
+		// VBA's default parameter passing mode is ByRef.  Count that effective
+		// mode even when the source omitted the ByRef keyword.
+		if !strings.EqualFold(strings.TrimSpace(parameter.Passing), "ByVal") {
+			result.ByRefParameterCount++
+		}
+	}
+	for _, declaration := range procedure.Declarations {
+		kind := strings.ToLower(strings.TrimSpace(declaration.Kind))
+		if declaration.Scope == procedureir.ScopeLocal &&
+			kind != "return_slot" && kind != "parameter" {
+			result.LocalVariableCount++
+		}
+	}
+	result.CallFanOut = callFanOut(calls)
+	return result
+}
+
+// CollectProcedure is a convenience for callers that have only a procedure
+// and an optional CFG.  It is equivalent to Collect(Input{IR: procedure,
+// Graph: graph}).
+func CollectProcedure(procedure procedureir.ProcedureIR, graph *cfg.Graph) ProcedureMetrics {
+	return Collect(Input{IR: procedure, Graph: graph})
+}
+
+// CollectDocument computes and canonically sorts all procedures in a document.
+// Graphs are matched by source declaration offset, making the result stable
+// even when a caller supplies an independently sorted CFG document.
+func CollectDocument(document procedureir.DocumentIR, graphs cfg.Document) []ProcedureMetrics {
+	graphByStart := make(map[int]*cfg.Graph, len(graphs.Graphs))
+	for i := range graphs.Graphs {
+		graph := &graphs.Graphs[i]
+		graphByStart[graph.Procedure.DeclarationRange.StartByte] = graph
+	}
+	result := make([]ProcedureMetrics, 0, len(document.Procedures))
+	for _, procedure := range document.Procedures {
+		var graph *cfg.Graph
+		if candidate, ok := graphByStart[procedure.Symbol.DeclarationRange.StartByte]; ok {
+			graph = candidate
+		}
+		result = append(result, Collect(Input{
+			IR: procedure, Graph: graph, File: document.Path,
+			Module: document.ModuleName, ModuleKind: document.ModuleKind,
+		}))
+	}
+	Sort(result)
+	return result
+}
+
+// Sort orders procedure metrics by project file, declaration position, and a
+// stable identity tie-breaker.  It sorts in place and returns the same slice
+// for convenient chaining.
+func Sort(metrics []ProcedureMetrics) []ProcedureMetrics {
+	sort.SliceStable(metrics, func(i, j int) bool {
+		a, b := metrics[i], metrics[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.DeclarationRange.StartByte != b.DeclarationRange.StartByte {
+			return a.DeclarationRange.StartByte < b.DeclarationRange.StartByte
+		}
+		if a.DeclarationRange.StartLine != b.DeclarationRange.StartLine {
+			return a.DeclarationRange.StartLine < b.DeclarationRange.StartLine
+		}
+		if a.DeclarationRange.EndByte != b.DeclarationRange.EndByte {
+			return a.DeclarationRange.EndByte < b.DeclarationRange.EndByte
+		}
+		if a.DeclarationRange.EndLine != b.DeclarationRange.EndLine {
+			return a.DeclarationRange.EndLine < b.DeclarationRange.EndLine
+		}
+		if !strings.EqualFold(a.Module, b.Module) {
+			return strings.ToLower(a.Module) < strings.ToLower(b.Module)
+		}
+		if a.Module != b.Module {
+			return a.Module < b.Module
+		}
+		if !strings.EqualFold(a.Name, b.Name) {
+			return strings.ToLower(a.Name) < strings.ToLower(b.Name)
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.Kind < b.Kind
+	})
+	return metrics
+}
+
+func orderedStatements(in []procedureir.Statement) []procedureir.Statement {
+	statements := append([]procedureir.Statement(nil), in...)
+	sort.SliceStable(statements, func(i, j int) bool {
+		if statements[i].Range.StartByte != statements[j].Range.StartByte {
+			return statements[i].Range.StartByte < statements[j].Range.StartByte
+		}
+		if statements[i].Range.EndByte != statements[j].Range.EndByte {
+			return statements[i].Range.EndByte < statements[j].Range.EndByte
+		}
+		return statements[i].ID < statements[j].ID
+	})
+	return statements
+}
+
+func statementsFromGraph(graph cfg.Graph) []procedureir.Statement {
+	statements := make([]procedureir.Statement, 0, len(graph.Blocks))
+	for _, block := range graph.Blocks {
+		if block.Kind == cfg.BlockStatement && block.Statement != nil {
+			statements = append(statements, *block.Statement)
+		}
+	}
+	return orderedStatements(statements)
+}
+
+func isDoCondition(statement procedureir.Statement) bool {
+	return strings.EqualFold(strings.TrimSpace(statement.SyntaxKind), "do_condition")
+}
+
+func statementCount(statements []procedureir.Statement) int {
+	count := 0
+	for _, statement := range statements {
+		if !isDoCondition(statement) {
+			count++
+		}
+	}
+	return count
+}
+
+func branchCount(statements []procedureir.Statement) int {
+	count := 0
+	for _, statement := range statements {
+		if isDoCondition(statement) {
+			continue
+		}
+		switch statement.Kind {
+		case procedureir.StatementIf, procedureir.StatementElseIf:
+			count++
+		case procedureir.StatementCase:
+			if !isCaseElse(statement) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func isCaseElse(statement procedureir.Statement) bool {
+	if statement.Control != nil && statement.Control.CaseElse {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(statement.Text), "case else")
+}
+
+func loopCount(statements []procedureir.Statement) int {
+	count := 0
+	for _, statement := range statements {
+		if isDoCondition(statement) {
+			continue
+		}
+		switch statement.Kind {
+		case procedureir.StatementFor, procedureir.StatementForEach,
+			procedureir.StatementWhile, procedureir.StatementDo:
+			count++
+		}
+	}
+	return count
+}
+
+func contributesNesting(kind procedureir.StatementKind) bool {
+	switch kind {
+	case procedureir.StatementIf, procedureir.StatementSelect,
+		procedureir.StatementFor, procedureir.StatementForEach,
+		procedureir.StatementWhile, procedureir.StatementDo,
+		procedureir.StatementWith:
+		return true
+	default:
+		// ElseIf, Else, and Case are alternatives inside their parent
+		// construct, not additional nesting levels.
+		return false
+	}
+}
+
+func maxNestingDepth(statements []procedureir.Statement) int {
+	byID := make(map[int]procedureir.Statement, len(statements))
+	for _, statement := range statements {
+		if statement.ID > 0 {
+			byID[statement.ID] = statement
+		}
+	}
+	depths := make(map[int]int, len(byID))
+	visiting := make(map[int]bool, len(byID))
+	var depth func(int) int
+	depth = func(id int) int {
+		if id <= 0 {
+			return 0
+		}
+		if value, ok := depths[id]; ok {
+			return value
+		}
+		if visiting[id] {
+			// Malformed/recovered IR can contain a parent cycle.  Treat the
+			// cycle as an unknown root rather than looping indefinitely.
+			return 0
+		}
+		statement, ok := byID[id]
+		if !ok {
+			return 0
+		}
+		if isDoCondition(statement) {
+			// The parser exposes the trailing Do condition as a synthetic
+			// statement.  It contributes no level, but descendants recovered
+			// under that node still belong to the enclosing loop.
+			return depth(statement.ParentID)
+		}
+		visiting[id] = true
+		value := depth(statement.ParentID)
+		if contributesNesting(statement.Kind) ||
+			(statement.Kind == procedureir.StatementElseIf && statement.ParentID == 0) {
+			// A recovered standalone ElseIf has no enclosing If in its
+			// parent chain; count it as its own conditional level.  Normal
+			// ElseIf nodes are children of the outer If and remain at that
+			// same level.
+			value++
+		}
+		visiting[id] = false
+		depths[id] = value
+		return value
+	}
+	maximum := 0
+	for _, statement := range statements {
+		if value := depth(statement.ID); value > maximum {
+			maximum = value
+		}
+	}
+	return maximum
+}
+
+func gotoCount(statements []procedureir.Statement) int {
+	count := 0
+	for _, statement := range statements {
+		if !isDoCondition(statement) && statement.Kind == procedureir.StatementGoTo {
+			count++
+		}
+	}
+	return count
+}
+
+func isProcedureExit(statement procedureir.Statement, kind procedureir.ProcedureKind) bool {
+	if statement.Kind != procedureir.StatementExit || isDoCondition(statement) {
+		return false
+	}
+	if statement.Control != nil {
+		switch statement.Control.Transfer {
+		case procedureir.TransferExitSub, procedureir.TransferExitFunction, procedureir.TransferExitProperty:
+			return true
+		}
+	}
+	// Preserve the same behavior for hand-built IR that omits control metadata.
+	fields := strings.Fields(strings.ToLower(statement.Text))
+	if len(fields) != 2 || fields[0] != "exit" {
+		return false
+	}
+	switch fields[1] {
+	case "sub":
+		return kind == procedureir.ProcedureSub
+	case "function":
+		return kind == procedureir.ProcedureFunction
+	case "property":
+		return kind == procedureir.ProcedureProperty || kind == procedureir.ProcedurePropertyGet ||
+			kind == procedureir.ProcedurePropertyLet || kind == procedureir.ProcedurePropertySet
+	default:
+		return false
+	}
+}
+
+func exitPointCount(kind procedureir.ProcedureKind, statements []procedureir.Statement) int {
+	// Reaching the matching End Sub/Function/Property is one implicit exit.
+	count := 1
+	for _, statement := range statements {
+		if isProcedureExit(statement, kind) {
+			count++
+			continue
+		}
+		if !isDoCondition(statement) && statement.Kind == procedureir.StatementEnd {
+			count++
+		}
+	}
+	return count
+}
+
+func callFanOut(calls []procedureir.CallSite) int {
+	seen := make(map[string]struct{}, len(calls))
+	for _, call := range calls {
+		if call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 {
+			continue
+		}
+		candidate := call.Resolution.Candidates[0]
+		key := strings.TrimSpace(candidate.QualifiedName)
+		if key == "" {
+			// A resolver should normally provide QualifiedName.  Keep a
+			// deterministic fallback for older cached IR artifacts.
+			key = fmt.Sprintf("%s:%s:%d", candidate.File, candidate.Kind, candidate.Line)
+		}
+		seen[strings.ToLower(key)] = struct{}{}
+	}
+	return len(seen)
+}
+
+func sourceLineCount(r vbast.Range) int {
+	if r.StartLine <= 0 || r.EndLine < r.StartLine {
+		return 0
+	}
+	return r.EndLine - r.StartLine + 1
+}

--- a/internal/vba/proceduremetrics/metrics_test.go
+++ b/internal/vba/proceduremetrics/metrics_test.go
@@ -1,0 +1,147 @@
+package proceduremetrics
+
+import (
+	"reflect"
+	"testing"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+func testRange(start, end int) vbaast.Range {
+	return vbaast.Range{StartLine: start, EndLine: end, StartByte: start * 10, EndByte: end * 10}
+}
+
+func TestCollectComputesAllProcedureMetrics(t *testing.T) {
+	procedure := procedureir.ProcedureIR{
+		Symbol: procedureir.ProcedureSymbol{
+			Name: "Run", Kind: procedureir.ProcedureFunction,
+			DeclarationRange: testRange(2, 20),
+			Parameters: []procedureir.Parameter{
+				{Name: "implicitRef"},
+				{Name: "byVal", Passing: "ByVal"},
+				{Name: "byRef", Passing: "ByRef"},
+			},
+		},
+		Declarations: []procedureir.Declaration{
+			{Scope: procedureir.ScopeLocal, Kind: "return_slot"},
+			{Scope: procedureir.ScopeLocal, Kind: "variable"},
+			{Scope: procedureir.ScopeLocal, Kind: "const"},
+			{Scope: procedureir.ScopeParameter, Kind: "parameter"},
+		},
+		Statements: []procedureir.Statement{
+			{ID: 1, Kind: procedureir.StatementIf, Range: testRange(3, 3)},
+			{ID: 2, ParentID: 1, Kind: procedureir.StatementElseIf, Range: testRange(4, 4)},
+			{ID: 3, ParentID: 1, Kind: procedureir.StatementElse, Range: testRange(5, 5)},
+			{ID: 4, ParentID: 1, Kind: procedureir.StatementSelect, Range: testRange(6, 6)},
+			{ID: 5, ParentID: 4, Kind: procedureir.StatementCase, Range: testRange(7, 7)},
+			{ID: 6, ParentID: 5, Kind: procedureir.StatementFor, Range: testRange(8, 8)},
+			{ID: 7, ParentID: 6, Kind: procedureir.StatementForEach, Range: testRange(9, 9)},
+			{ID: 8, ParentID: 7, Kind: procedureir.StatementWhile, Range: testRange(10, 10)},
+			{ID: 9, ParentID: 8, Kind: procedureir.StatementDo, Range: testRange(11, 11)},
+			{ID: 10, ParentID: 9, SyntaxKind: "do_condition", Kind: procedureir.StatementUnknown, Range: testRange(12, 12)},
+			{ID: 11, Kind: procedureir.StatementGoTo, Range: testRange(13, 13)},
+			{ID: 12, Kind: procedureir.StatementOnError, Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferOnErrorGoto}, Range: testRange(14, 14)},
+			{ID: 13, Kind: procedureir.StatementExit, Text: "Exit Function", Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferExitFunction}, Range: testRange(15, 15)},
+			{ID: 14, Kind: procedureir.StatementExit, Text: "Exit For", Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferExitFor}, Range: testRange(16, 16)},
+			{ID: 15, Kind: procedureir.StatementEnd, Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferTerminate}, Range: testRange(17, 17)},
+			{ID: 16, ParentID: 4, Kind: procedureir.StatementCase, Control: &procedureir.ControlFlowMetadata{CaseElse: true}, Range: testRange(18, 18)},
+		},
+		Calls: []procedureir.CallSite{
+			{Resolution: procedureir.CallResolution{Status: procedureir.ResolutionMatched, Candidates: []procedureir.Candidate{{QualifiedName: "Other.First"}}}},
+			{Resolution: procedureir.CallResolution{Status: procedureir.ResolutionMatched, Candidates: []procedureir.Candidate{{QualifiedName: "other.first"}}}},
+			{Resolution: procedureir.CallResolution{Status: procedureir.ResolutionMatched, Candidates: []procedureir.Candidate{{QualifiedName: "Other.Second"}}}},
+			{Resolution: procedureir.CallResolution{Status: procedureir.ResolutionAmbiguous, Candidates: []procedureir.Candidate{{QualifiedName: "Other.A"}, {QualifiedName: "Other.B"}}}},
+		},
+	}
+	got := Collect(Input{IR: procedure, File: "src/Main.bas", Module: "Main", ModuleKind: "standard"})
+	want := ProcedureMetrics{
+		File: "src/Main.bas", Module: "Main", ModuleKind: "standard", Name: "Run", Kind: procedureir.ProcedureFunction,
+		DeclarationRange: testRange(2, 20),
+		Metrics: Metrics{
+			CyclomaticComplexity: 8, MaxNestingDepth: 6, StatementCount: 15,
+			SourceLineCount: 19, BranchCount: 3, LoopCount: 4, GotoCount: 1,
+			ExitPointCount: 3, ParameterCount: 3, ByRefParameterCount: 2,
+			LocalVariableCount: 2, CallFanOut: 2,
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("metrics = %+v, want %+v", got, want)
+	}
+}
+
+func TestEvaluateThresholdsUsesStrictPositiveThresholdsAndStableOrder(t *testing.T) {
+	procedures := []ProcedureMetrics{
+		{Name: "Second", File: "b.bas", DeclarationRange: testRange(4, 4), Metrics: Metrics{LoopCount: 3, GotoCount: 2}},
+		{Name: "First", File: "a.bas", DeclarationRange: testRange(9, 9), Metrics: Metrics{LoopCount: 3, GotoCount: 1}},
+	}
+	violations, err := EvaluateThresholds(procedures, Thresholds{
+		MetricLoopCount:      3, // equal is allowed
+		MetricGotoCount:      1, // only Second exceeds
+		MetricStatementCount: 0, // disabled
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 1 || violations[0].Procedure != "Second" || violations[0].Metric != MetricGotoCount ||
+		violations[0].Code != "MX001" || violations[0].Severity != "warning" {
+		t.Fatalf("violations = %+v", violations)
+	}
+	if _, err := EvaluateThresholds(nil, Thresholds{MetricLoopCount: -1}); err == nil {
+		t.Fatal("negative threshold was accepted")
+	}
+	if _, err := EvaluateThresholds(nil, Thresholds{MetricName("typo"): 1}); err == nil {
+		t.Fatal("unknown threshold was accepted")
+	}
+}
+
+func TestPropertyExitAndLoopExitAreCountedSeparately(t *testing.T) {
+	procedure := procedureir.ProcedureIR{
+		Symbol: procedureir.ProcedureSymbol{
+			Name: "Value", Kind: procedureir.ProcedurePropertySet,
+			DeclarationRange: testRange(1, 5),
+		},
+		Statements: []procedureir.Statement{
+			{ID: 1, Kind: procedureir.StatementExit, Text: "Exit Property", Range: testRange(3, 3)},
+			{ID: 2, Kind: procedureir.StatementExit, Text: "Exit Do", Control: &procedureir.ControlFlowMetadata{Transfer: procedureir.TransferExitDo}, Range: testRange(4, 4)},
+			{ID: 3, Kind: procedureir.StatementEnd, Range: testRange(5, 5)},
+		},
+	}
+	got := Collect(Input{IR: procedure})
+	if got.ExitPointCount != 3 {
+		t.Fatalf("property exits = %d, want implicit + Exit Property + End = 3", got.ExitPointCount)
+	}
+}
+
+func TestDoConditionDoesNotBreakNestingForRecoveredChildren(t *testing.T) {
+	procedure := procedureir.ProcedureIR{
+		Symbol: procedureir.ProcedureSymbol{Kind: procedureir.ProcedureSub, DeclarationRange: testRange(1, 4)},
+		Statements: []procedureir.Statement{
+			{ID: 1, Kind: procedureir.StatementDo, Range: testRange(2, 2)},
+			{ID: 2, ParentID: 1, Kind: procedureir.StatementDo, SyntaxKind: "do_condition", Range: testRange(3, 3)},
+			{ID: 3, ParentID: 2, Kind: procedureir.StatementIf, Range: testRange(4, 4)},
+		},
+	}
+	got := Collect(Input{IR: procedure})
+	if got.MaxNestingDepth != 2 {
+		t.Fatalf("nesting through do_condition = %d, want 2", got.MaxNestingDepth)
+	}
+}
+
+func TestCollectDocumentSortsByFileAndDeclarationOffset(t *testing.T) {
+	document := procedureir.DocumentIR{
+		Path: "z.bas", ModuleName: "Z", ModuleKind: "standard",
+		Procedures: []procedureir.ProcedureIR{
+			{Symbol: procedureir.ProcedureSymbol{Name: "Later", DeclarationRange: testRange(5, 5)}},
+			{Symbol: procedureir.ProcedureSymbol{Name: "Earlier", DeclarationRange: testRange(2, 2)}},
+		},
+	}
+	got := CollectDocument(document, cfg.Document{})
+	if len(got) != 2 || got[0].Name != "Earlier" || got[1].Name != "Later" {
+		t.Fatalf("document metrics order = %+v", got)
+	}
+	if got[0].File != "z.bas" || got[0].Module != "Z" || got[0].ModuleKind != "standard" {
+		t.Fatalf("document identity = %+v", got[0])
+	}
+}

--- a/internal/vba/proceduremetrics/thresholds.go
+++ b/internal/vba/proceduremetrics/thresholds.go
@@ -1,0 +1,114 @@
+package proceduremetrics
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Thresholds maps metric names to their configured maximum values.  Missing
+// keys and zero values disable that metric.  Positive values report a
+// violation only when the measured value is strictly greater than the
+// threshold; negative values are invalid configuration.
+type Thresholds map[MetricName]int
+
+// ThresholdViolation is the protocol-neutral form of an MX001 threshold
+// finding.  The CLI can project it into its diagnostic envelope without
+// making the collector depend on analyzer finding types.
+type ThresholdViolation struct {
+	File            string     `json:"file"`
+	Line            int        `json:"line"`
+	Module          string     `json:"module"`
+	Procedure       string     `json:"procedure"`
+	ProcedureKind   string     `json:"procedure_kind"`
+	Metric          MetricName `json:"metric"`
+	Value           int        `json:"value"`
+	Threshold       int        `json:"threshold"`
+	Severity        string     `json:"severity"`
+	Code            string     `json:"code"`
+	Message         string     `json:"message"`
+	declarationByte int        // ordering-only; intentionally not serialized
+}
+
+// ValidateThresholds validates names and values before evaluation.  A nil
+// map is valid and means all threshold diagnostics are disabled.
+func ValidateThresholds(thresholds Thresholds) error {
+	names := make([]string, 0, len(thresholds))
+	for name := range thresholds {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+	for _, rawName := range names {
+		name := MetricName(rawName)
+		threshold := thresholds[name]
+		if _, ok := (Metrics{}).Value(name); !ok {
+			return fmt.Errorf("unknown procedure metric threshold %q", name)
+		}
+		if threshold < 0 {
+			return fmt.Errorf("procedure metric threshold %q must be non-negative", name)
+		}
+	}
+	return nil
+}
+
+// EvaluateThresholds returns deterministic MX001 candidates for all
+// procedures.  Metrics themselves are never modified.  The function rejects
+// invalid threshold maps before inspecting procedure values.
+func EvaluateThresholds(procedures []ProcedureMetrics, thresholds Thresholds) ([]ThresholdViolation, error) {
+	if err := ValidateThresholds(thresholds); err != nil {
+		return nil, err
+	}
+	ordered := append([]ProcedureMetrics(nil), procedures...)
+	Sort(ordered)
+	violations := make([]ThresholdViolation, 0)
+	for _, procedure := range ordered {
+		for _, metric := range canonicalMetricNames {
+			threshold, enabled := thresholds[metric]
+			if !enabled || threshold == 0 {
+				continue
+			}
+			value, ok := procedure.Value(metric)
+			if !ok || value <= threshold {
+				continue
+			}
+			violations = append(violations, ThresholdViolation{
+				File: procedure.File, Line: procedure.DeclarationRange.StartLine,
+				Module: procedure.Module, Procedure: procedure.Name,
+				ProcedureKind: string(procedure.Kind), Metric: metric,
+				Value: value, Threshold: threshold, Severity: "warning", Code: "MX001",
+				Message:         fmt.Sprintf("%s %s exceeds threshold %d (value %d)", procedure.Name, metric, threshold, value),
+				declarationByte: procedure.DeclarationRange.StartByte,
+			})
+		}
+	}
+	// Keep a defensive sort in case callers provide procedures with duplicate
+	// identities or declaration offsets.
+	sort.SliceStable(violations, func(i, j int) bool {
+		a, b := violations[i], violations[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		if a.declarationByte != b.declarationByte {
+			return a.declarationByte < b.declarationByte
+		}
+		if a.Module != b.Module {
+			return a.Module < b.Module
+		}
+		if a.Procedure != b.Procedure {
+			return a.Procedure < b.Procedure
+		}
+		return metricIndex(a.Metric) < metricIndex(b.Metric)
+	})
+	return violations, nil
+}
+
+func metricIndex(name MetricName) int {
+	for index, candidate := range canonicalMetricNames {
+		if candidate == name {
+			return index
+		}
+	}
+	return len(canonicalMetricNames)
+}

--- a/scripts/docs/generate-cli-inventory.mjs
+++ b/scripts/docs/generate-cli-inventory.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 
 const repo = path.resolve(".");
 const check = process.argv.includes("--check");
-const source = `${fs.readFileSync(path.join(repo, "internal/cli/root.go"), "utf8")}\n${fs.readFileSync(path.join(repo, "internal/cli/recovery.go"), "utf8")}`;
+const source = `${fs.readFileSync(path.join(repo, "internal/cli/root.go"), "utf8")}\n${fs.readFileSync(path.join(repo, "internal/cli/recovery.go"), "utf8")}\n${fs.readFileSync(path.join(repo, "internal/cli/metrics.go"), "utf8")}`;
 const commands = [
   ["capabilities", "capabilities"],
   ["rules", "rules"],
@@ -39,6 +39,7 @@ const commands = [
   ["lsp", "lsp"],
   ["fmt", "fmt"],
   ["analyze", "analyze"],
+  ["metrics", "metrics"],
   ["check", "check"],
   ["generate", "generate"],
   ["module", "module"],

--- a/vitepress/.vitepress/config.mts
+++ b/vitepress/.vitepress/config.mts
@@ -94,6 +94,7 @@ function commandSidebar() {
         { text: "inspect-gui", link: "/commands/inspect-gui" },
         { text: "lint", link: "/commands/lint" },
         { text: "analyze", link: "/commands/analyze" },
+        { text: "metrics", link: "/commands/metrics" },
         { text: "check", link: "/commands/check" },
         { text: "generate", link: "/commands/generate" },
         { text: "module", link: "/commands/module" },

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -27,6 +27,14 @@ xlflow analyze --json
 Use `analyze` for fast source-level feedback before opening Excel.
 :::
 
+Procedure complexity measurements are deliberately a separate source-only
+surface. Use [`xlflow metrics`](./metrics) for the twelve deterministic
+procedure metrics and optional `[metrics.thresholds]` policy. `analyze` does
+not populate that payload, does not apply metrics thresholds, and keeps the
+existing `analysis_metrics.module_state` contract unchanged. `MX001` threshold
+diagnostics are owned by `metrics`, not by the analyzer rule registry or
+`[analyze].disabled_rules`.
+
 `VBA203` tracks each recognized `Application` state write through normal,
 early-exit, error-handler, termination, and unknown CFG exits. A direct saved
 value (including an exact saved-variable copy) restores the state only when it
@@ -277,6 +285,7 @@ Failed `--json` output uses the xlflow envelope plus command-specific fields.
 
 - [lint](./lint)
 - [check](./check)
+- [metrics](./metrics)
 - [inspect-gui](./inspect-gui)
 
 <!-- xlflow-command-guidance -->

--- a/vitepress/commands/index.md
+++ b/vitepress/commands/index.md
@@ -55,6 +55,7 @@ Use command pages for workflow guidance and the canonical CLI contract in [JSON 
 | [lsp](./lsp)                               | Start the reusable VBA language server for editor integrations.                            |
 | [fmt](./fmt)                               | Format VBA source files with a conservative, non-destructive formatter.                    |
 | [analyze](./analyze)                       | Analyze VBA source for runtime-risk patterns without Excel COM.                            |
+| [metrics](./metrics)                       | Calculate deterministic procedure complexity metrics without Excel COM.                    |
 | [check](./check)                           | Run lint, analyze, and doctor as a combined preflight.                                     |
 | [module](./module)                         | Create module source files and install bundled xlflow helper modules.                      |
 | [completion](./completion)                 | Generate shell completion scripts through Cobra.                                           |

--- a/vitepress/commands/metrics.md
+++ b/vitepress/commands/metrics.md
@@ -1,0 +1,169 @@
+# xlflow metrics
+
+Calculate deterministic maintainability metrics for VBA procedures without
+opening Excel.
+
+## Usage
+
+```bash
+xlflow metrics
+xlflow metrics --json
+```
+
+`metrics` is source-only. It scans the configured `[src]` roots and `tests`,
+uses the procedure IR/CFG and uniquely resolved project-local calls, and does
+not run `lint`, `analyze`, `check`, LSP diagnostics, preflight, or VBA. The only
+command-local output option is the global `--json` flag.
+
+In UserForm `sidecar` mode the sidecar code file is measured and generated
+`.frm` code is skipped. In `frm` mode embedded UserForm code is measured once.
+Build artifacts, `.frx` files, `.xlflow` state, and other generated files are
+not inputs. Apply `[metrics].exclude` after normal source discovery when a
+project path should be omitted; this policy is independent from
+`[build].exclude` and `[analyze].disabled_rules`.
+
+## Metrics
+
+Every procedure reports these twelve integer fields:
+
+| Metric                  | Meaning                                                                                                                    |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `cyclomatic_complexity` | `1 + branch_count + loop_count`.                                                                                           |
+| `max_nesting_depth`     | Maximum simultaneous `If`, `Select`, loop, and `With` nesting.                                                             |
+| `statement_count`       | Normalized source-backed statements; colon-separated statements are separate and continuations are one.                    |
+| `source_line_count`     | Physical lines from the procedure header through matching `End`, including blank/comment/continued lines.                  |
+| `branch_count`          | `If`, `ElseIf`, and each `Case` other than `Case Else`.                                                                    |
+| `loop_count`            | `For`, `For Each`, `While`/`Wend`, and each `Do`/`Loop`.                                                                   |
+| `goto_count`            | Explicit `GoTo` only; `On Error GoTo` is excluded.                                                                         |
+| `exit_point_count`      | Implicit tail exit, `Exit Sub`/`Function`/`Property`, and standalone `End`.                                                |
+| `parameter_count`       | All parameters, including Property Let/Set `value` and `ParamArray`.                                                       |
+| `byref_parameter_count` | Effective `ByRef`, including omitted `ByRef`; `ByVal` is excluded and `ParamArray` follows its effective passing mode.     |
+| `local_variable_count`  | Each `Dim`/`Static`/`Const` declarator, excluding parameters, fields, and synthetic return slots.                          |
+| `call_fan_out`          | Unique resolved project-local callees; repeated, ambiguous, unresolved, external, member, and built-in calls are excluded. |
+
+Single-line and multiline syntax use the same structural rules. Properties are
+separate `property_get`, `property_let`, and `property_set` procedures. See the
+permanent counting and schema contract in
+`docs/specs/vba-procedure-complexity-metrics.md`.
+
+## Thresholds
+
+Thresholds are disabled by default and configured separately from analyzer
+diagnostics:
+
+```toml
+[metrics]
+exclude = ["src/modules/Generated/**"]
+
+[metrics.thresholds]
+cyclomatic_complexity = 10
+max_nesting_depth = 4
+statement_count = 0 # zero disables this threshold
+```
+
+Omitted and zero values disable a threshold. A positive threshold is exceeded
+only when `value > threshold`; equal values pass. Negative values, unknown
+keys, non-integers, malformed tables, absolute paths, and escaping exclusion
+patterns fail as configuration errors (exit `2`). An unmatched valid exclusion
+glob is a warning.
+
+When a threshold is exceeded, `metrics` emits one metrics-specific `MX001`
+warning per procedure/metric pair, keeps the complete metrics array, sets
+`error.code` to `metrics_threshold_exceeded`, and exits `1`. `MX001` is not an
+analyzer rule, is not controlled by `[analyze].disabled_rules`, and cannot be
+inline-suppressed. With no enabled threshold, the command returns only metrics
+and exits `0`.
+
+## JSON output
+
+```json
+{
+  "status": "ok",
+  "command": "metrics",
+  "metrics": {
+    "schema_version": 1,
+    "procedures": [
+      {
+        "file": "src/modules/Main.bas",
+        "module": "Main",
+        "module_kind": "standard",
+        "name": "Run",
+        "kind": "sub",
+        "declaration_range": {
+          "startLine": 1,
+          "startColumn": 1,
+          "endLine": 18,
+          "endColumn": 7,
+          "startByte": 0,
+          "endByte": 256
+        },
+        "cyclomatic_complexity": 3,
+        "max_nesting_depth": 2,
+        "statement_count": 12,
+        "source_line_count": 18,
+        "branch_count": 1,
+        "loop_count": 1,
+        "goto_count": 0,
+        "exit_point_count": 2,
+        "parameter_count": 1,
+        "byref_parameter_count": 1,
+        "local_variable_count": 2,
+        "call_fan_out": 2
+      }
+    ]
+  },
+  "diagnostics": [],
+  "warnings": [],
+  "logs": []
+}
+```
+
+`metrics.schema_version` is `1`. Additive fields may appear without a version
+change; removing or redefining a field requires a new version. Procedures are
+sorted by normalized file, declaration start position, module, name, and kind. Threshold
+diagnostics are sorted by that procedure order and the fixed metric order. This
+ordering, slash-separated paths, normalized exclusion list, and stable JSON
+serialization make repeated runs deterministic.
+
+## Related
+
+- [JSON Output](../reference/json-output)
+- [Configuration file](../reference/config-file)
+- [analyze](./analyze)
+- [check](./check)
+
+<!-- xlflow-command-guidance -->
+
+## When to use this command
+
+Use `xlflow metrics` when a report, baseline, CI threshold, or editor
+integration needs procedure measurements independent of diagnostic findings.
+
+## Prerequisites
+
+Only source files and a valid project configuration are required. Excel, the
+bridge, VBIDE access, and a workbook are not required.
+
+## What this command reads and changes
+
+The command reads configured source roots, `tests`, and `[metrics]` settings.
+It is read-only and does not modify source, workbooks, or project state.
+
+## Effect on source-of-truth state
+
+None. Metrics are derived from the current source tree and are not persisted by
+xlflow.
+
+## Common workflows
+
+Run `xlflow metrics --json` in CI or an agent loop, store the versioned
+`metrics` object, and opt into thresholds only when the project wants a failing
+gate. Use `xlflow analyze` separately for runtime-risk diagnostics.
+
+## Common failures
+
+Read `error.code` and the process exit code. Invalid configuration exits `2`;
+`metrics_threshold_exceeded` exits `1` while retaining all raw metrics; an
+unrecoverable parse or source read returns an operation error without partial
+metrics. The [JSON Output](../reference/json-output) reference defines the
+failure envelope.

--- a/vitepress/reference/cli-command-inventory.md
+++ b/vitepress/reference/cli-command-inventory.md
@@ -38,6 +38,7 @@ Generated from the Cobra command registrations in `internal/cli/root.go`. Run `p
 | `xlflow lsp`                | [command guide](../commands/lsp)                |
 | `xlflow fmt`                | [command guide](../commands/fmt)                |
 | `xlflow analyze`            | [command guide](../commands/analyze)            |
+| `xlflow metrics`            | [command guide](../commands/metrics)            |
 | `xlflow check`              | [command guide](../commands/check)              |
 | `xlflow generate`           | [command guide](../commands/generate)           |
 | `xlflow module`             | [command guide](../commands/module)             |

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -109,6 +109,24 @@ disabled_rules = []
 [analyze]
 # Disable specific analyzer rules by diagnostic ID.
 disabled_rules = []
+
+# Procedure complexity metrics are independent from lint/analyze diagnostics.
+[metrics]
+exclude = []
+
+[metrics.thresholds]
+cyclomatic_complexity = 0
+max_nesting_depth = 0
+statement_count = 0
+source_line_count = 0
+branch_count = 0
+loop_count = 0
+goto_count = 0
+exit_point_count = 0
+parameter_count = 0
+byref_parameter_count = 0
+local_variable_count = 0
+call_fan_out = 0
 ```
 
 ## Section reference
@@ -253,6 +271,48 @@ Range("A1").Value = 1
 Rules marked `inline_suppressible: false` in the catalog cannot be suppressed
 inline. This includes every preflight-blocking analyzer error. Unknown inline
 IDs, unsupported IDs, and unused suppressions are reported as command warnings.
+
+### `[metrics]`
+
+| Key       | Type     | Required | Default | Description                                                                                     |
+| --------- | -------- | -------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `exclude` | string[] | no       | `[]`    | Project-root-relative `doublestar` globs excluded from `xlflow metrics` after source discovery. |
+
+`exclude` is normalized to `/`, deduplicated, and evaluated in stable order.
+Absolute patterns and patterns that traverse outside the project root are
+invalid. A valid pattern that matches no source produces a
+`metrics_exclude_unmatched` warning. The setting affects only `metrics`; it is
+not shared with `[build].exclude`, `[lint].disabled_rules`, or
+`[analyze].disabled_rules`.
+
+### `[metrics.thresholds]`
+
+| Key                     | Type | Required | Default | Description                                                             |
+| ----------------------- | ---- | -------- | ------- | ----------------------------------------------------------------------- |
+| `cyclomatic_complexity` | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `max_nesting_depth`     | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `statement_count`       | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `source_line_count`     | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `branch_count`          | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `loop_count`            | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `goto_count`            | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `exit_point_count`      | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `parameter_count`       | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `byref_parameter_count` | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `local_variable_count`  | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+| `call_fan_out`          | int  | no       | `0`     | Report `MX001` when the procedure value is greater than this threshold. |
+
+The twelve names are the v1 metric schema. Omitted and zero values disable a
+threshold; positive values use a strict `value > threshold` comparison, so an
+equal value passes. Negative values, non-integers, unknown keys, and malformed
+tables are configuration errors. Thresholds are evaluated after the complete
+metrics collection and do not change raw values. Each exceeded
+procedure/metric pair produces one metrics-specific warning diagnostic with
+code `MX001`; it is not a static-analysis rule, cannot be inline-suppressed,
+and is not controlled by `[analyze].disabled_rules`. Without enabled
+thresholds, `xlflow metrics` exits `0`; one or more `MX001` diagnostics retain
+the full metrics result and exit `1` with `error.code =
+"metrics_threshold_exceeded"`.
 
 ## Defaults differ between `new` and `init`
 

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -52,6 +52,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `before_dialog_action`
 - `binary_expression`
 - `block_kind`
+- `branch_count`
 - `branch_false`
 - `branch_true`
 - `bridge_file_not_openable`
@@ -77,9 +78,12 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `by_kind`
 - `byref_diagnostics`
 - `byref_modifier`
+- `byref_parameter_count`
+- `byref_parameters`
 - `byval_modifier`
 - `cached_excel_reference`
 - `call_expression`
+- `call_fan_out`
 - `call_statement`
 - `capability_version`
 - `capture_state`
@@ -163,10 +167,12 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `cross_module`
 - `current_version`
 - `customer_name`
+- `cyclomatic_complexity`
 - `data_flow`
 - `database_result`
 - `debug_log`
 - `debug_stream_init_failed`
+- `declaration_range`
 - `declaration_spacing`
 - `declare_function`
 - `declare_function_statement`
@@ -322,6 +328,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `exit_do`
 - `exit_for`
 - `exit_function`
+- `exit_point_count`
+- `exit_points`
 - `exit_property`
 - `exit_statement`
 - `exit_sub`
@@ -409,6 +417,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `generator_version`
 - `generator_version_changed`
 - `global_values`
+- `goto_count`
 - `goto_statement`
 - `graph_dependencies_failed`
 - `gui_boundaries`
@@ -505,6 +514,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `live_workbook`
 - `local_type_diagnostics`
 - `local_variable`
+- `local_variable_count`
+- `local_variables`
 - `locale_sensitive_value`
 - `location_capture`
 - `logical_line`
@@ -512,6 +523,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `logs_and_continues`
 - `loop_back`
 - `loop_body`
+- `loop_count`
 - `loop_exit`
 - `lsp_args_invalid`
 - `lsp_check_failed`
@@ -531,6 +543,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `max_cols`
 - `max_concurrent`
 - `max_count`
+- `max_nesting_depth`
 - `max_rows`
 - `max_total_size_mb`
 - `may_raise`
@@ -542,6 +555,10 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `merged_ranges`
 - `message_pump`
 - `metadata_read_failed`
+- `metrics_exclude_unmatched`
+- `metrics_failed`
+- `metrics_threshold_exceeded`
+- `metrics_thresholds_invalid`
 - `min_keep`
 - `missing_backup_file`
 - `missing_module_attribute`
@@ -642,6 +659,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `paramarray_not_last`
 - `paramarray_optional`
 - `paramarray_shape`
+- `parameter_count`
 - `parameter_limit`
 - `parameter_list`
 - `parenthesized_condition_expression`
@@ -671,6 +689,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `procedure_ir_builds`
 - `procedure_ir_reuses`
 - `procedure_ir_singleflight`
+- `procedure_kind`
 - `procedure_modifier`
 - `procedure_name`
 - `procedure_name_constant`
@@ -839,6 +858,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `source_counts`
 - `source_file`
 - `source_files`
+- `source_line_count`
 - `source_lines`
 - `source_newer_than_workbook`
 - `source_of_truth`
@@ -861,6 +881,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `start_column`
 - `start_line`
 - `started_at`
+- `statement_count`
 - `static_modifier`
 - `status_hint`
 - `stop_statement`

--- a/vitepress/reference/exit-codes.md
+++ b/vitepress/reference/exit-codes.md
@@ -1,10 +1,10 @@
 # Exit Codes
 
-| Code | Meaning                                                                                   |
-| ---: | ----------------------------------------------------------------------------------------- |
-|  `0` | Success                                                                                   |
-|  `1` | Validation or user-code failure (`fmt --check` found unformatted files, etc.)             |
-|  `2` | CLI argument or configuration error (including invalid wait combinations)                 |
-|  `3` | Operational or environment failure (including workbook busy, wait, and recovery outcomes) |
+| Code | Meaning                                                                                                           |
+| ---: | ----------------------------------------------------------------------------------------------------------------- |
+|  `0` | Success                                                                                                           |
+|  `1` | Validation or user-code failure (`fmt --check` found unformatted files, `metrics` thresholds were exceeded, etc.) |
+|  `2` | CLI argument or configuration error (including invalid wait combinations and metrics thresholds/exclusions)       |
+|  `3` | Operational or environment failure (including workbook busy, wait, and recovery outcomes)                         |
 
 `diff` returns `0` when differences are found. Inspect `diff.summary.total_diffs` in JSON.

--- a/vitepress/reference/json-output.md
+++ b/vitepress/reference/json-output.md
@@ -116,6 +116,104 @@ Command-specific fields are top-level fields such as `issues`, `analysis`,
 `output` carries `fmt` result summaries, `export-image` output paths, and `form`
 command artifacts.
 
+## Procedure complexity metrics
+
+`xlflow metrics --json` is a source-only command. It does not open Excel or run
+`lint`, `analyze`, `check`, LSP diagnostics, or preflight. The result adds a
+versioned `metrics` object. Procedure entries are project-relative, use `/`
+path separators, and are sorted by file, declaration start position, module, name, and
+kind. The twelve metric fields are defined in
+`docs/specs/vba-procedure-complexity-metrics.md`.
+
+```json
+{
+  "status": "ok",
+  "command": "metrics",
+  "metrics": {
+    "schema_version": 1,
+    "procedures": [
+      {
+        "file": "src/modules/Main.bas",
+        "module": "Main",
+        "module_kind": "standard",
+        "name": "Run",
+        "kind": "sub",
+        "declaration_range": {
+          "startLine": 1,
+          "startColumn": 1,
+          "endLine": 18,
+          "endColumn": 7,
+          "startByte": 0,
+          "endByte": 256
+        },
+        "cyclomatic_complexity": 3,
+        "max_nesting_depth": 2,
+        "statement_count": 12,
+        "source_line_count": 18,
+        "branch_count": 1,
+        "loop_count": 1,
+        "goto_count": 0,
+        "exit_point_count": 2,
+        "parameter_count": 1,
+        "byref_parameter_count": 1,
+        "local_variable_count": 2,
+        "call_fan_out": 2
+      }
+    ]
+  },
+  "diagnostics": [],
+  "warnings": [],
+  "logs": []
+}
+```
+
+`metrics.schema_version` is `1`. Additive fields are allowed without changing
+the version; removing a field or changing its meaning requires a new version.
+Consumers must ignore unknown fields and should reject unsupported versions
+instead of guessing their semantics. An unrecoverable source parse fails
+without publishing partial procedures.
+
+Thresholds are independent from analyzer diagnostics and are disabled unless a
+positive value is configured under `[metrics.thresholds]`. `0` and omitted keys
+disable a threshold; a positive threshold is exceeded only when `value >
+threshold`. Each exceeded procedure/metric pair emits one warning diagnostic:
+
+```json
+{
+  "status": "failed",
+  "command": "metrics",
+  "error": {
+    "code": "metrics_threshold_exceeded",
+    "message": "1 procedure complexity threshold exceeded"
+  },
+  "metrics": { "schema_version": 1, "procedures": [] },
+  "diagnostics": [
+    {
+      "code": "MX001",
+      "severity": "warning",
+      "file": "src/modules/Main.bas",
+      "line": 1,
+      "module": "Main",
+      "procedure": "Run",
+      "procedure_kind": "sub",
+      "metric": "cyclomatic_complexity",
+      "value": 8,
+      "threshold": 5,
+      "message": "Run cyclomatic_complexity exceeds threshold 5 (value 8)"
+    }
+  ],
+  "warnings": [],
+  "logs": []
+}
+```
+
+The `procedures` array in a real threshold result is complete; the abbreviated
+example above only shortens it for readability. `diagnostics` are sorted by
+procedure order and the fixed metric order. `MX001` is not a static-analysis
+rule, cannot be inline-suppressed, and is unaffected by
+`[analyze].disabled_rules`. No enabled thresholds means exit `0`; one or more
+`MX001` entries retain the full metrics payload and use exit `1`.
+
 ## Build manifest
 
 `build --json` returns a versioned `build` manifest. Non-dry successful builds


### PR DESCRIPTION
## Summary

- Add the source-only `xlflow metrics` command for deterministic VBA procedure complexity metrics.
- Add versioned `metrics.schema_version = 1` JSON output and human-readable tables.
- Add configurable `[metrics]` exclusions and per-metric thresholds with opt-in MX001 diagnostics.
- Keep existing `analysis_metrics.module_state` and analyze/check behavior unchanged.
- Document the contract in ADR-0036, specs, CLI/config/JSON references, and the changelog.

## Metric behavior

The collector reuses Procedure IR, CFG, and resolved project-local calls to calculate all 12 requested metrics. It handles configured source roots, the `tests` tree, UserForm sidecars, deterministic ordering, parser recovery fail-closed behavior, and project-relative doublestar exclusions.

Configured thresholds use strict `value > threshold` semantics. Threshold violations retain the complete metrics payload and return `MX001` diagnostics with exit code 1.

Closes #460

## Validation

- `rtk task test`
- `rtk task lint`
- `rtk pnpm docs:check`
- `rtk pnpm format:check`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the source-only `xlflow metrics` command for deterministic VBA procedure complexity reporting.
  * Reports twelve metrics, including complexity, nesting, statements, branches, loops, parameters, locals, and call fan-out.
  * Supports JSON output, configurable exclusions, and optional `MX001` threshold warnings.
  * Preserves complete metrics output when thresholds are exceeded and returns a failure status.

* **Documentation**
  * Added command usage, configuration, JSON schema, threshold, exclusion, and exit-code documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->