### PR TITLE
Add architectural hotspot metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added deterministic procedure and module hotspot ranking to `xlflow metrics`
+  (`metrics.hotspots`, schema version 1, score model
+  `percentile_equal_weight_v1`). The report exposes raw and normalized
+  architectural signals, supports independent top-N and percentage selectors
+  through `[metrics.hotspots]`, and emits metrics-owned `MX002` entries (top-N
+  informational, threshold-selected warning) while retaining the complete
+  metrics payload. Hotspot scores are maintainability review signals rather
+  than definite analyzer findings.
+
 - Added default-enabled `VBA246` HTTP transport-security analysis and `VBA247`
   timeout reliability analysis for common XMLHTTP, ServerXMLHTTP, WinHTTP, and
   identifiable ADODB.Stream download-and-launch patterns. Findings are

--- a/docs/adr/ADR-0036-procedure-complexity-metrics.md
+++ b/docs/adr/ADR-0036-procedure-complexity-metrics.md
@@ -119,9 +119,10 @@ warning. No generated file is silently counted twice.
 - IR/CFG and call-resolution limitations remain visible: unresolved or
   ambiguous calls do not inflate fan-out, and unrecoverable syntax fails closed
   rather than producing misleading values.
-- This first version reports procedures only. Module/project aggregates,
-  historical trends, recommended thresholds, and LSP projections remain future
-  work.
+- The procedure-complexity schema remains procedure-focused; architectural
+  procedure/module hotspot ranking is an additive projection governed by
+  ADR-0039. Historical trends, recommended thresholds, and LSP projections
+  remain future work.
 
 ## Alternatives Considered
 
@@ -168,4 +169,5 @@ None.
 
 - Issue #460
 - ADR-0021, ADR-0022, ADR-0035
+- ADR-0039
 - `docs/specs/vba-procedure-complexity-metrics.md`

--- a/docs/adr/ADR-0039-procedure-and-module-hotspots.md
+++ b/docs/adr/ADR-0039-procedure-and-module-hotspots.md
@@ -1,0 +1,118 @@
+# ADR-0039: Procedure and Module Hotspot Ranking
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #461 asks xlflow to identify procedures and modules with unusually high
+responsibility or dependency centrality. A single complexity threshold cannot
+represent call centrality, Excel effects, mutable state, cycles, public API
+surface, error handling, or resource ownership. Conversely, presenting a
+subjective composite as a definite analyzer finding would make maintainability
+triage look like a correctness diagnosis.
+
+ADR-0036 established `xlflow metrics` as a source-only, deterministic surface
+for procedure measurements. It deliberately left module/project aggregates,
+recommended thresholds, and history outside v1. The hotspot projection needs
+those aggregate and dependency signals while retaining the independent metrics
+compatibility boundary.
+
+## Decision
+
+Extend `xlflow metrics` with a versioned `metrics.hotspots` projection. The
+projection ranks procedure and module cohorts independently and includes both
+raw scalar signals and the normalized values that contribute to each score.
+The source scan remains read-only and source-only: no Excel/COM operations,
+diagnostic enablement, LSP projection, or analyzer rule execution is required.
+
+The v1 score model is named `percentile_equal_weight_v1`. For each signal in a
+cohort, values are converted to average-rank percentiles. Constant and
+single-entity signals are inactive; the score is the equal-weight mean of the
+remaining signals, rounded to two decimals. Scores and arrays are sorted
+deterministically, with stable identity tie-breakers. A new score interpretation
+requires a new model identifier rather than silently changing historical scores.
+
+The raw signal vocabulary is additive and conservative: structural complexity,
+module complexity maximum, resolved call fan-in/out, affected modules, confirmed Excel effects, mutable
+state reads/writes/mutations, cycle participation, external dependencies,
+error-handling structures, resource ownership, and module public-procedure
+count. Missing, unresolved, ambiguous, external, or dynamic facts contribute no
+invented project-local dependency. Ambiguous, unresolved, and dynamic call
+counts remain available in an `uncertainty` evidence map but are excluded from
+the score.
+
+Selection is opt-in under `[metrics.hotspots]`, independently for procedures and
+modules. `procedure_top_n` and `module_top_n` select ranked entities; positive
+`*_score_threshold` values select scores greater than or equal to the configured
+percentage. The two modes are unioned and the JSON `selected_by` field records
+the reason. Selected entities emit metrics-owned `MX002`: top-N-only output is
+informational, while threshold-selected output is warning-level and exits `1`.
+Threshold findings retain the complete metrics/hotspot payload. `MX002` is not a
+lint/analyze rule and cannot be inline-suppressed.
+
+## Consequences
+
+- Reports, CI jobs, and editor integrations can rank architectural review leads
+  without parsing diagnostic prose or enabling runtime-risk rules.
+- Raw and normalized evidence makes every score auditable and allows projects to
+  calibrate selectors against real distributions before adopting a gate.
+- Percentile normalization avoids coupling v1 to arbitrary cross-project units,
+  but scores are relative to the current procedure/module cohort and are not
+  comparable across snapshots without preserving the source population.
+- Equal weighting is intentionally simple and transparent; domain-specific
+  weighting, historical baselines, trend detection, and LSP projections remain
+  future work and require a new decision or model version.
+- Conservative dependency/effect resolution avoids false certainty but can
+  under-rank code whose dynamic behavior cannot be resolved statically.
+- Warning-level threshold selection can fail CI only when a project opts in;
+  raw rankings and informational top-N output remain non-blocking.
+
+## Alternatives Considered
+
+1. **Add a complexity-only `MX002` threshold.** Rejected because one metric
+   cannot represent centrality, effects, state, cycles, or ownership and would
+   recreate the arbitrary-threshold problem from Issue #461.
+2. **Register hotspots as an `analyze` rule.** Rejected because hotspot scores
+   are measurements and prioritization aids, not definite runtime-risk
+   diagnostics; coupling them to analyzer enablement would make output and exit
+   behavior unstable.
+3. **Use hand-tuned weights or a single global threshold.** Rejected for v1:
+   weights require reviewed project evidence and a policy owner. Percentile
+   equal weighting is inspectable and can evolve through an explicit model ID.
+4. **Count every unresolved or external call as a dependency.** Rejected
+   because uncertainty is not evidence of a project-local relationship and
+   would inflate scores in dynamic or incomplete projects.
+5. **Create a separate `hotspots` command.** Rejected because the projection
+   consumes the same source snapshot and procedure/call facts as `metrics`;
+   embedding it keeps one deterministic scan and one versioned envelope while
+   leaving room for a future dedicated report command.
+
+## Evidence
+
+- Issue #461 acceptance criteria for composite scores, raw signals, top-N and
+  threshold selection, deterministic ranking, and informational/warning output.
+- `docs/specs/vba-procedure-complexity-metrics.md` and ADR-0036 for the
+  source-only metrics boundary and schema/versioning rules.
+- `docs/specs/vba-call-graph-reachability.md` and ADR-0035 for conservative
+  project-local call resolution and deterministic ordering.
+- `docs/specs/vba-module-state-analysis.md` for mutable-state evidence and
+  uncertainty boundaries.
+- `internal/vba/hotspots` for percentile ranking, equal-weight scoring, and
+  stable tie-break implementation, with deterministic ranking tests in
+  `internal/vba/hotspots/hotspots_test.go`.
+
+## Supersedes
+
+None.
+
+## Superseded by
+
+None.
+
+## Related
+
+- Issue #461
+- ADR-0035, ADR-0036
+- `docs/specs/vba-procedure-and-module-hotspots.md`

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -300,6 +300,15 @@ top-N, non-finite or out-of-range percentages, unknown keys, and malformed
 tables) exit `2`. Hotspot scores are maintainability review signals, not
 definite analyzer findings, and `MX002` is not inline-suppressible.
 
+When both an `MX001` complexity threshold and a threshold-selected `MX002`
+occur, the envelope retains both diagnostic sets in deterministic order:
+`MX001` entries first (procedure order, then canonical metric order), followed
+by `MX002` procedure entries and then module entries in rank order. The
+compatibility error code `metrics_threshold_exceeded` wins whenever at least
+one `MX001` is present. `metrics_hotspot_threshold_exceeded` is used only when
+hotspot threshold findings are present without an `MX001`; Top-N-only findings
+never fail the command.
+
 `VBA229` is a default-enabled, realtime and batch compile-equivalent error for an unresolved type identifier in a procedure-local `Dim` or `Static ... As <Type>` declaration. It uses the production built-in/host/TypeLib and project symbol resolver, including embedded enum groups and class, UserForm, and document-module types, points at the type identifier, cannot be suppressed, and blocks source preflight. A missing, malformed, empty, or partially materialized generated TypeLib manifest leaves absence resolution incomplete: embedded types may still resolve positively, but a lookup miss does not emit `VBA229`. Parameters, return types, and module-level declarations remain outside this rule's v1 scope.
 
 `macros` opens the configured workbook and discovers VBA entrypoints without executing user code. JSON output includes top-level `macros`, where each entry contains `module`, `name`, `qualified_name`, `kind` when available, and `args` when available. `macros --session` reads from the workbook opened by `session start`. Agents should use this command before guessing a `run` target.
@@ -473,9 +482,10 @@ integers; `0` disables the corresponding top-N selector. Positive
 percentages in `1..100`; `0` disables the corresponding selector. Top-N and
 threshold selection are independent and unioned. A threshold-selected entity
 emits warning `MX002` and sets `error.code = "metrics_hotspot_threshold_exceeded"`;
-top-N-only entities emit informational `MX002` entries. Invalid values,
-non-finite scores, unknown keys, and malformed tables are configuration errors
-and exit `2`. The score model, signal vocabulary, normalized percentile rules,
+top-N-only entities emit informational `MX002` entries. Invalid selector
+values, non-finite selector percentages, unknown keys, and malformed tables are
+configuration errors and exit `2`; a non-finite computed score is an internal
+failure without partial metrics output. The score model, signal vocabulary, normalized percentile rules,
 and deterministic ranking contract are defined by
 [VBA Procedure and Module Hotspots](vba-procedure-and-module-hotspots.md).
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -284,6 +284,22 @@ publishing partial metrics. Procedure and diagnostic ordering, path
 normalization, sidecar/generated-file exclusions, and all counting rules are
 specified by [VBA Procedure Complexity Metrics](vba-procedure-complexity-metrics.md).
 
+The same result includes `metrics.hotspots`, a versioned procedure/module
+ranking projection defined by
+`docs/specs/vba-procedure-and-module-hotspots.md`. Hotspots use the
+`percentile_equal_weight_v1` model, expose raw and normalized signal maps, and
+rank procedure and module cohorts independently with deterministic tie-breaks.
+The report is present even when no selector is configured. `[metrics.hotspots]`
+supports independent procedure/module top-N and percentage score thresholds;
+top-N and threshold selections are unioned and recorded in `selected_by`.
+Selected entities emit metrics-owned `MX002`: top-N-only entries are
+informational, while threshold-selected entries are warning-level, set
+`error.code = "metrics_hotspot_threshold_exceeded"`, and exit `1` while retaining the
+complete metrics and hotspot arrays. Hotspot configuration errors (negative
+top-N, non-finite or out-of-range percentages, unknown keys, and malformed
+tables) exit `2`. Hotspot scores are maintainability review signals, not
+definite analyzer findings, and `MX002` is not inline-suppressible.
+
 `VBA229` is a default-enabled, realtime and batch compile-equivalent error for an unresolved type identifier in a procedure-local `Dim` or `Static ... As <Type>` declaration. It uses the production built-in/host/TypeLib and project symbol resolver, including embedded enum groups and class, UserForm, and document-module types, points at the type identifier, cannot be suppressed, and blocks source preflight. A missing, malformed, empty, or partially materialized generated TypeLib manifest leaves absence resolution incomplete: embedded types may still resolve positively, but a lookup miss does not emit `VBA229`. Parameters, return types, and module-level declarations remain outside this rule's v1 scope.
 
 `macros` opens the configured workbook and discovers VBA entrypoints without executing user code. JSON output includes top-level `macros`, where each entry contains `module`, `name`, `qualified_name`, `kind` when available, and `args` when available. `macros --session` reads from the workbook opened by `session start`. Agents should use this command before guessing a `run` target.
@@ -401,6 +417,12 @@ parameter_count = 0
 byref_parameter_count = 0
 local_variable_count = 0
 call_fan_out = 0
+
+[metrics.hotspots]
+procedure_top_n = 0
+module_top_n = 0
+procedure_score_threshold = 0
+module_score_threshold = 0
 ```
 
 `[analyze].development_http_origins` is an optional list of exact normalized
@@ -443,6 +465,19 @@ change the raw values. They emit `MX001` warning diagnostics only when
 explicitly enabled, so `metrics` does not produce subjective diagnostics by
 default. `MX001` is not an analyzer rule and cannot be configured through
 `[analyze].disabled_rules` or inline suppression.
+
+`[metrics.hotspots]` controls only the ranking projection embedded in
+`xlflow metrics`. `procedure_top_n` and `module_top_n` are non-negative
+integers; `0` disables the corresponding top-N selector. Positive
+`procedure_score_threshold` and `module_score_threshold` values are inclusive
+percentages in `1..100`; `0` disables the corresponding selector. Top-N and
+threshold selection are independent and unioned. A threshold-selected entity
+emits warning `MX002` and sets `error.code = "metrics_hotspot_threshold_exceeded"`;
+top-N-only entities emit informational `MX002` entries. Invalid values,
+non-finite scores, unknown keys, and malformed tables are configuration errors
+and exit `2`. The score model, signal vocabulary, normalized percentile rules,
+and deterministic ranking contract are defined by
+[VBA Procedure and Module Hotspots](vba-procedure-and-module-hotspots.md).
 
 ## JSON Envelope
 
@@ -848,7 +883,7 @@ the corresponding marker. Cleanup results add `recovery.cleared[]` and
 ## Exit Codes
 
 - `0`: success
-- `1`: user-code or validation failure, including lint findings, analysis findings, metrics threshold findings (`metrics_threshold_exceeded`), GUI boundary preflight failures, macro failure, macro timeout, VBE compile failure, missing macro target, removed-helper findings, missing UI sheets or buttons, VBA test failure, no tests found, missing or ambiguous filter targets, active workbook mismatches, duplicate test names within one module, invalid exported ranges, existing output files, unsupported export-image formats, unsupported form export-image formats, missing UserForms, `form_already_exists`, `unsupported_form_control`, `designer_write_failed`, capture window lookup failures, image capture failures, `edit` session requirements, invalid workbook edit selectors, invalid edit colors, `invalid_sheet_name`, `sheet_exists`, `fmt_check_failed` (unformatted files in `--check` mode), and workbook event-handler failures returned by the bridge
+- `1`: user-code or validation failure, including lint findings, analysis findings, metrics threshold findings (`metrics_threshold_exceeded`), hotspot score-threshold findings (`metrics_hotspot_threshold_exceeded`), GUI boundary preflight failures, macro failure, macro timeout, VBE compile failure, missing macro target, removed-helper findings, missing UI sheets or buttons, VBA test failure, no tests found, missing or ambiguous filter targets, active workbook mismatches, duplicate test names within one module, invalid exported ranges, existing output files, unsupported export-image formats, unsupported form export-image formats, missing UserForms, `form_already_exists`, `unsupported_form_control`, `designer_write_failed`, capture window lookup failures, image capture failures, `edit` session requirements, invalid workbook edit selectors, invalid edit colors, `invalid_sheet_name`, `sheet_exists`, `fmt_check_failed` (unformatted files in `--check` mode), and workbook event-handler failures returned by the bridge
 - `2`: CLI argument or configuration error, including invalid `push`, `run`, `session`, `save`, `runner`, `export-image`, `form new`, `form build`, `form export-image`, `module new`, `edit`, and `process` option combinations, invalid `fmt` mode combinations, invalid metrics thresholds or exclusion patterns, plus `process_args_invalid` and `process_not_found` errors from the bridge
 - `3`: environment or operational failure, including workbook lock contention
   (`workbook_busy`, `workbook_busy_timeout`, `workbook_busy_cancelled`),

--- a/docs/specs/vba-procedure-and-module-hotspots.md
+++ b/docs/specs/vba-procedure-and-module-hotspots.md
@@ -99,36 +99,44 @@ Signals are intentionally exposed so a score is auditable. A missing or
 uncertain fact contributes `0`; unresolved, ambiguous, external, and dynamic
 relationships do not become invented project-local dependencies.
 
-| Signal                      | Evidence represented                                                    |
-| --------------------------- | ----------------------------------------------------------------------- |
-| `complexity`                | Structural procedure complexity from the metrics IR/CFG.                |
-| `complexity_max`            | Maximum procedure complexity in a module (module cohort only).          |
-| `call_fan_in`               | Unique resolved project-local callers.                                  |
-| `call_fan_out`              | Unique resolved project-local callees.                                  |
-| `affected_module_count`     | Distinct project modules reached by resolved dependencies/effects.      |
-| `excel_effect_count`        | Confirmed Excel object-model effects.                                   |
-| `mutable_state_reads`       | Reads of indexed mutable module state.                                  |
-| `mutable_state_writes`      | Writes to indexed mutable module state.                                 |
-| `mutable_state_mutations`   | Confirmed mutable-state mutations.                                      |
-| `cycle_count`               | Distinct detected project-local call cycles containing the entity.      |
-| `external_dependency_count` | External or declared dependency references retained as scalar evidence. |
-| `error_handling_count`      | Error-handler and failure-handling structures.                          |
-| `resource_ownership_count`  | Resource-acquisition/ownership boundaries.                              |
-| `public_procedure_count`    | Public procedures in a module (module cohort).                          |
+| Signal                      | Evidence represented                                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `complexity`                | Structural procedure complexity from the metrics IR/CFG.                                                                 |
+| `complexity_max`            | Maximum procedure complexity in a module (module cohort only).                                                           |
+| `call_fan_in`               | Unique resolved project-local callers.                                                                                   |
+| `call_fan_out`              | Unique resolved project-local callees.                                                                                   |
+| `affected_module_count`     | Distinct project modules reached through resolved project-local call dependencies, including the entity's origin module. |
+| `excel_effect_count`        | Confirmed Excel object-model effects.                                                                                    |
+| `mutable_state_reads`       | Reads of indexed mutable module state.                                                                                   |
+| `mutable_state_writes`      | Writes to indexed mutable module state.                                                                                  |
+| `mutable_state_mutations`   | Confirmed mutable-state mutations.                                                                                       |
+| `cycle_count`               | Distinct detected project-local call cycles containing the entity.                                                       |
+| `external_dependency_count` | External or declared dependency references retained as scalar evidence.                                                  |
+| `error_handling_count`      | Error-handler and failure-handling structures.                                                                           |
+| `resource_ownership_count`  | Resource-acquisition/ownership boundaries.                                                                               |
+| `public_procedure_count`    | Public procedures in a module (module cohort).                                                                           |
 
 Signal values are counts, not diagnostic severities. A high score is a
 maintainability-review lead, not proof of a bug, security issue, or required
-refactor. The collector remains conservative when evidence is incomplete.
+refactor. The collector remains conservative when evidence is incomplete. To
+keep source-only metrics bounded on dense graphs, elementary-cycle enumeration
+uses a deterministic fixed work budget; if it is exhausted, `cycle_count` is a
+conservative lower bound for that report.
 
 ## Score and ordering
 
-Procedure and module cohorts are normalized independently. For each signal,
-the collector computes an average-rank percentile from `0` (lowest) to `100`
-(highest), using the other entities in the same cohort. Ties receive the
-average rank. A signal whose values are constant (or whose cohort has one
-entity) is inactive and omitted from that entity's denominator. The score is
-the equal-weight arithmetic mean of active normalized signals, rounded to two
-decimal places; entities with no active signals score `0`.
+Procedure and module cohorts are normalized independently. For a cohort of
+`N >= 2` entities, each signal is sorted ascending and a value tied from the
+1-based ordinal `r_first` through `r_last` receives
+`average_rank = (r_first + r_last) / 2`, then
+`percentile = 100 * (average_rank - 1) / (N - 1)`. Thus the lowest and highest
+values are exactly `0` and `100`, and ties share their average-rank percentile.
+A signal whose values are constant (or whose cohort has one entity) is
+inactive, contributes percentile `0`, and is omitted from the score
+denominator. The score is the equal-weight arithmetic mean of active
+normalized signals, rounded to two decimal places; entities with no active
+signals score `0`. Score-threshold selection compares the emitted two-decimal
+score (`score >= threshold`), not an unrounded intermediate value.
 
 Entities sort by descending score. Equal scores use normalized file,
 declaration byte, module, name, procedure kind, and stable `id` as tie-breakers.
@@ -165,10 +173,12 @@ Diagnostics follow ranked procedure order, then ranked module order. Their
 structured fields mirror the selected entity (`kind`, `file`, `line`, `module`,
 `procedure`, `rank`, `score`, `score_model`, signal maps, and `selected_by`).
 
-Invalid hotspot values, unknown keys, malformed tables, negative top-N values,
-NaN scores, or thresholds outside `0..100` are configuration errors (exit
-`2`). Source read/parse failures fail closed without publishing partial
-metrics or hotspot rankings.
+Invalid selector values, unknown keys, malformed tables, negative top-N values,
+non-finite selector percentages, or thresholds outside `0..100` are
+configuration errors (exit `2`). A non-finite computed score is an internal
+failure and must not publish partial metrics or hotspot rankings. Source
+read/parse failures fail closed without publishing partial metrics or hotspot
+rankings.
 
 ## Determinism and consumers
 

--- a/docs/specs/vba-procedure-and-module-hotspots.md
+++ b/docs/specs/vba-procedure-and-module-hotspots.md
@@ -1,0 +1,188 @@
+# VBA Procedure and Module Hotspots
+
+This specification defines the architectural-hotspot projection embedded in
+`xlflow metrics`. It extends the procedure-complexity contract without turning
+hotspots into an analyzer rule or a claim that a procedure is defective.
+
+## Scope and command
+
+```text
+xlflow [--json] metrics
+```
+
+Hotspots are collected during the same source-only scan as procedure metrics.
+The command does not open Excel, use the bridge, execute VBA, run `lint`,
+`analyze`, `check`, LSP diagnostics, or preflight. Source discovery,
+UserForm-sidecar handling, and `[metrics].exclude` follow
+[VBA Procedure Complexity Metrics](vba-procedure-complexity-metrics.md).
+
+The report ranks procedures and modules in separate cohorts. It is emitted in
+the `metrics.hotspots` object even when no selector is configured, so reports
+and editors can consume the raw evidence without enabling a subjective gate.
+
+## Report schema
+
+The additive `hotspots` projection has its own schema version and score-model
+identifier:
+
+```json
+{
+  "metrics": {
+    "schema_version": 1,
+    "procedures": [],
+    "hotspots": {
+      "schema_version": 1,
+      "score_model": "percentile_equal_weight_v1",
+      "procedures": [
+        {
+          "id": "src/modules/Main.bas|Main|Run|sub",
+          "kind": "procedure",
+          "file": "src/modules/Main.bas",
+          "module": "Main",
+          "module_kind": "standard",
+          "name": "Run",
+          "procedure_kind": "sub",
+          "line": 1,
+          "rank": 1,
+          "score": 87.5,
+          "score_model": "percentile_equal_weight_v1",
+          "active_signal_count": 4,
+          "raw_signals": {
+            "complexity": 8,
+            "call_fan_in": 3,
+            "call_fan_out": 4,
+            "affected_module_count": 2
+          },
+          "normalized_signals": {
+            "complexity": 100,
+            "call_fan_in": 75,
+            "call_fan_out": 75,
+            "affected_module_count": 100
+          },
+          "uncertainty": {
+            "ambiguous_call_count": 0,
+            "unresolved_call_count": 1,
+            "dynamic_call_count": 0
+          },
+          "selected_by": { "top_n": true }
+        }
+      ],
+      "modules": []
+    }
+  }
+}
+```
+
+`id`, paths, module and procedure identity fields are project-relative and use
+`/` separators. `rank` is one-based, with the highest score first. Procedure
+entities include `procedure_kind` and may include a one-based declaration
+`line`; module entities omit `procedure_kind`. `raw_signals`
+contains non-negative integer evidence and `normalized_signals` contains the
+percentile values that contributed to the score. `active_signal_count` is the
+number of non-constant signals in that cohort. `selected_by` is present only
+for entities selected by `[metrics.hotspots]` and records the union reason:
+`top_n` and/or `threshold`.
+
+`uncertainty` exposes ambiguous, unresolved, and dynamic call counts. These
+values are retained as audit evidence and are deliberately excluded from the
+composite score; uncertain relationships are never treated as confirmed
+project-local dependencies.
+
+`hotspots.schema_version` is `1`. Additive fields and signals are compatible;
+removing a field or changing a signal's meaning or score calculation requires a
+new schema version or score-model identifier. Consumers must not infer a
+meaning for an unknown version or model.
+
+## Raw signals
+
+Signals are intentionally exposed so a score is auditable. A missing or
+uncertain fact contributes `0`; unresolved, ambiguous, external, and dynamic
+relationships do not become invented project-local dependencies.
+
+| Signal                      | Evidence represented                                                    |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `complexity`                | Structural procedure complexity from the metrics IR/CFG.                |
+| `complexity_max`            | Maximum procedure complexity in a module (module cohort only).          |
+| `call_fan_in`               | Unique resolved project-local callers.                                  |
+| `call_fan_out`              | Unique resolved project-local callees.                                  |
+| `affected_module_count`     | Distinct project modules reached by resolved dependencies/effects.      |
+| `excel_effect_count`        | Confirmed Excel object-model effects.                                   |
+| `mutable_state_reads`       | Reads of indexed mutable module state.                                  |
+| `mutable_state_writes`      | Writes to indexed mutable module state.                                 |
+| `mutable_state_mutations`   | Confirmed mutable-state mutations.                                      |
+| `cycle_count`               | Distinct detected project-local call cycles containing the entity.      |
+| `external_dependency_count` | External or declared dependency references retained as scalar evidence. |
+| `error_handling_count`      | Error-handler and failure-handling structures.                          |
+| `resource_ownership_count`  | Resource-acquisition/ownership boundaries.                              |
+| `public_procedure_count`    | Public procedures in a module (module cohort).                          |
+
+Signal values are counts, not diagnostic severities. A high score is a
+maintainability-review lead, not proof of a bug, security issue, or required
+refactor. The collector remains conservative when evidence is incomplete.
+
+## Score and ordering
+
+Procedure and module cohorts are normalized independently. For each signal,
+the collector computes an average-rank percentile from `0` (lowest) to `100`
+(highest), using the other entities in the same cohort. Ties receive the
+average rank. A signal whose values are constant (or whose cohort has one
+entity) is inactive and omitted from that entity's denominator. The score is
+the equal-weight arithmetic mean of active normalized signals, rounded to two
+decimal places; entities with no active signals score `0`.
+
+Entities sort by descending score. Equal scores use normalized file,
+declaration byte, module, name, procedure kind, and stable `id` as tie-breakers.
+The resulting arrays and rank values are independent of source enumeration,
+map iteration, path separator, or line-ending order.
+
+## Selection and `MX002`
+
+Selectors are opt-in and configured independently for procedures and modules:
+
+```toml
+[metrics.hotspots]
+procedure_top_n = 0
+module_top_n = 0
+procedure_score_threshold = 0
+module_score_threshold = 0
+```
+
+`*_top_n` must be a non-negative integer; `0` disables it. A positive value
+selects that many highest-ranked entities (or all entities when fewer exist).
+`*_score_threshold` is a percentage in the inclusive range `1..100`; `0`
+disables it. An entity is selected when `score >= threshold`. Top-N and
+threshold selections are unioned, and `selected_by` records every reason.
+
+Each selected entity produces one `MX002` diagnostic with the entity identity,
+score, score model, raw signals, and selection reason. Top-N-only selections
+are informational and do not fail the command. A selection caused by a score
+threshold is warning-level (including an entity selected by both modes) and
+causes exit code `1`; the complete metrics and hotspot arrays remain in the
+failure envelope. `MX002` is owned by `metrics`, is not in the analyzer rule
+registry, and is not inline-suppressible.
+
+Diagnostics follow ranked procedure order, then ranked module order. Their
+structured fields mirror the selected entity (`kind`, `file`, `line`, `module`,
+`procedure`, `rank`, `score`, `score_model`, signal maps, and `selected_by`).
+
+Invalid hotspot values, unknown keys, malformed tables, negative top-N values,
+NaN scores, or thresholds outside `0..100` are configuration errors (exit
+`2`). Source read/parse failures fail closed without publishing partial
+metrics or hotspot rankings.
+
+## Determinism and consumers
+
+The hotspot report is derived from the same source snapshot as procedure
+metrics. Consumers should persist both `schema_version` and `score_model`, keep
+the raw and normalized signal maps, and treat unsupported versions/models as
+unavailable rather than guessing. Hotspots are a prioritization aid; use
+`xlflow analyze` for definite runtime-risk diagnostics and use `MX001` only for
+explicit procedure metric limits.
+
+## Related
+
+- `docs/adr/ADR-0039-procedure-and-module-hotspots.md`
+- `docs/specs/vba-procedure-complexity-metrics.md`
+- `docs/specs/vba-call-graph-reachability.md`
+- `docs/specs/vba-module-state-analysis.md`
+- `vitepress/reference/json-output.md`

--- a/docs/specs/vba-procedure-complexity-metrics.md
+++ b/docs/specs/vba-procedure-complexity-metrics.md
@@ -2,7 +2,9 @@
 
 This specification defines the source-only `xlflow metrics` command and its
 procedure metric schema. ADR-0036 records why metrics have an independent
-surface and why thresholds are not analyzer rules.
+surface and why thresholds are not analyzer rules. The additive architectural
+hotspot projection is defined by
+`docs/specs/vba-procedure-and-module-hotspots.md` and ADR-0039.
 
 ## Scope and command
 
@@ -174,7 +176,16 @@ procedure/metric pair:
     "code": "metrics_threshold_exceeded",
     "message": "1 procedure complexity threshold exceeded"
   },
-  "metrics": { "schema_version": 1, "procedures": [] },
+  "metrics": {
+    "schema_version": 1,
+    "procedures": [],
+    "hotspots": {
+      "schema_version": 1,
+      "score_model": "percentile_equal_weight_v1",
+      "procedures": [],
+      "modules": []
+    }
+  },
   "diagnostics": [
     {
       "code": "MX001",
@@ -220,12 +231,15 @@ Consumers should key a procedure by `(file, line, module, name, kind)` rather
 than by name alone. They should preserve `schema_version`, tolerate additive
 fields, and treat a missing or unsupported version as unavailable metrics.
 Threshold diagnostics are suitable for CI gates, while raw values are suitable
-for future reports, baselines, and trend stores. Module/project aggregates,
-recommended thresholds, history, and LSP projections are outside v1.
+for reports, baselines, and trend stores. Procedure/module hotspot ranking is
+an additive v1 projection with its own schema and score model; see
+`docs/specs/vba-procedure-and-module-hotspots.md`. Recommended thresholds,
+history, and LSP projections remain outside v1.
 
 ## Related
 
 - `docs/adr/ADR-0036-procedure-complexity-metrics.md`
+- `docs/adr/ADR-0039-procedure-and-module-hotspots.md`
 - `docs/specs/cli-contract.md`
 - `vitepress/reference/json-output.md`
 - `docs/specs/vba-analysis-ir.md`

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -74,16 +74,17 @@ func (a *app) metricsCommand() *cobra.Command {
 				} else {
 					env.Diagnostics = hotspotFindings
 				}
-				if cfg.Metrics.Hotspots.ProcedureScoreThreshold > 0 || cfg.Metrics.Hotspots.ModuleScoreThreshold > 0 {
+				thresholdFindings := hotspotThresholdFindingCount(hotspotFindings)
+				if thresholdFindings > 0 {
 					env.Status = output.StatusFailed
 					if len(violations) == 0 {
-						env.Error = &output.Error{Code: "metrics_hotspot_threshold_exceeded", Message: fmt.Sprintf("%d architectural hotspot threshold finding(s)", len(hotspotFindings))}
+						env.Error = &output.Error{Code: "metrics_hotspot_threshold_exceeded", Message: fmt.Sprintf("%d architectural hotspot threshold finding(s)", thresholdFindings)}
 					}
 				}
 			}
 			env.Warnings = warnings
 			env.Logs = []string{fmt.Sprintf("calculated metrics for %d procedure(s)", len(result))}
-			if len(violations) > 0 || (len(hotspotFindings) > 0 && (cfg.Metrics.Hotspots.ProcedureScoreThreshold > 0 || cfg.Metrics.Hotspots.ModuleScoreThreshold > 0)) {
+			if len(violations) > 0 || hotspotThresholdFindingCount(hotspotFindings) > 0 {
 				return a.write(env, output.ExitValidation)
 			}
 			return a.write(env, output.ExitSuccess)
@@ -207,6 +208,9 @@ func buildHotspotReport(procedures []proceduremetrics.ProcedureMetrics) hotspots
 	return hotspots.BuildReport(procedureInputs, modules)
 }
 
+// The traversal starts at each procedure intentionally. Reusing a module-level
+// closure would overstate affected modules when a module contains procedures
+// with different reachable callees.
 func reachableProcedureModules(start string, adjacency map[string]map[string]bool, moduleByProcedure map[string]string) map[string]bool {
 	modules := map[string]bool{}
 	if module := moduleByProcedure[start]; module != "" {
@@ -246,10 +250,14 @@ func reachableModules(start string, adjacency map[string]map[string]bool) map[st
 	return seen
 }
 
+const cycleEnumerationWorkBudget = 100_000
+
 // cycleParticipationCounts enumerates elementary cycles in the confirmed
 // procedure graph. Restricting traversal to nodes >= the cycle's start node
 // makes the lexicographically smallest node the canonical start, so each
-// directed cycle is counted once while keeping the result deterministic.
+// directed cycle is counted once while keeping the result deterministic. A
+// fixed work budget prevents dense graphs from making metrics unbounded; when
+// the budget is exhausted, counts are a conservative lower bound.
 func cycleParticipationCounts(adjacency map[string]map[string]bool) map[string]int {
 	result := map[string]int{}
 	nodesSet := map[string]bool{}
@@ -264,17 +272,35 @@ func cycleParticipationCounts(adjacency map[string]map[string]bool) map[string]i
 		nodes = append(nodes, node)
 	}
 	sort.Strings(nodes)
+	work := 0
+	exhausted := false
 	for _, start := range nodes {
+		if exhausted {
+			break
+		}
 		path := []string{start}
 		visited := map[string]bool{start: true}
 		var visit func(string)
 		visit = func(current string) {
+			if exhausted {
+				return
+			}
+			work++
+			if work > cycleEnumerationWorkBudget {
+				exhausted = true
+				return
+			}
 			nexts := make([]string, 0, len(adjacency[current]))
 			for next := range adjacency[current] {
 				nexts = append(nexts, next)
 			}
 			sort.Strings(nexts)
 			for _, next := range nexts {
+				work++
+				if work > cycleEnumerationWorkBudget {
+					exhausted = true
+					return
+				}
 				if next == start {
 					for _, member := range path {
 						result[member]++
@@ -301,7 +327,7 @@ func hotspotFindingsForConfig(report hotspots.Report, cfg config.HotspotsConfig)
 	appendFindings := func(entities []hotspots.Entity, topN int, threshold float64) {
 		for _, entity := range hotspots.Select(entities, topN, threshold) {
 			severity := "information"
-			if entity.SelectedBy.Threshold {
+			if entity.SelectedBy != nil && entity.SelectedBy.Threshold {
 				severity = "warning"
 			}
 			findings = append(findings, map[string]any{"code": "MX002", "severity": severity, "kind": entity.Kind, "file": entity.File, "line": entity.Line, "module": entity.Module, "procedure": entity.Name, "rank": entity.Rank, "score": entity.Score, "score_model": entity.ScoreModel, "raw_signals": entity.RawSignals, "normalized_signals": entity.NormalizedSignals, "uncertainty": entity.Uncertainty, "active_signal_count": entity.ActiveSignalCount, "selected_by": entity.SelectedBy, "message": fmt.Sprintf("%s is an architectural hotspot candidate (score %.2f)", entity.Name, entity.Score)})
@@ -310,6 +336,23 @@ func hotspotFindingsForConfig(report hotspots.Report, cfg config.HotspotsConfig)
 	appendFindings(report.Procedures, cfg.ProcedureTopN, cfg.ProcedureScoreThreshold)
 	appendFindings(report.Modules, cfg.ModuleTopN, cfg.ModuleScoreThreshold)
 	return findings
+}
+
+func hotspotThresholdFindingCount(findings []map[string]any) int {
+	count := 0
+	for _, finding := range findings {
+		switch selected := finding["selected_by"].(type) {
+		case *hotspots.Selection:
+			if selected != nil && selected.Threshold {
+				count++
+			}
+		case hotspots.Selection:
+			if selected.Threshold {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 func metricsThresholdFailureMessage(count int) string {

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/output"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/hotspots"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/proceduremetrics"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
@@ -44,10 +45,13 @@ func (a *app) metricsCommand() *cobra.Command {
 			if err != nil {
 				return a.writeFailure("metrics", output.ExitConfig, "metrics_thresholds_invalid", err)
 			}
+			hotspotReport := buildHotspotReport(result)
+			hotspotFindings := hotspotFindingsForConfig(hotspotReport, cfg.Metrics.Hotspots)
 			env := output.New("metrics")
 			env.Metrics = map[string]any{
 				"schema_version": proceduremetrics.JSONSchemaVersion,
 				"procedures":     result,
+				"hotspots":       hotspotReport,
 			}
 			if len(violations) > 0 {
 				env.Diagnostics = violations
@@ -57,14 +61,255 @@ func (a *app) metricsCommand() *cobra.Command {
 					Message: metricsThresholdFailureMessage(len(violations)),
 				}
 			}
+			if len(hotspotFindings) > 0 {
+				if existing, ok := env.Diagnostics.([]proceduremetrics.ThresholdViolation); ok {
+					merged := make([]any, 0, len(existing)+len(hotspotFindings))
+					for _, item := range existing {
+						merged = append(merged, item)
+					}
+					for _, item := range hotspotFindings {
+						merged = append(merged, item)
+					}
+					env.Diagnostics = merged
+				} else {
+					env.Diagnostics = hotspotFindings
+				}
+				if cfg.Metrics.Hotspots.ProcedureScoreThreshold > 0 || cfg.Metrics.Hotspots.ModuleScoreThreshold > 0 {
+					env.Status = output.StatusFailed
+					if len(violations) == 0 {
+						env.Error = &output.Error{Code: "metrics_hotspot_threshold_exceeded", Message: fmt.Sprintf("%d architectural hotspot threshold finding(s)", len(hotspotFindings))}
+					}
+				}
+			}
 			env.Warnings = warnings
 			env.Logs = []string{fmt.Sprintf("calculated metrics for %d procedure(s)", len(result))}
-			if len(violations) > 0 {
+			if len(violations) > 0 || (len(hotspotFindings) > 0 && (cfg.Metrics.Hotspots.ProcedureScoreThreshold > 0 || cfg.Metrics.Hotspots.ModuleScoreThreshold > 0)) {
 				return a.write(env, output.ExitValidation)
 			}
 			return a.write(env, output.ExitSuccess)
 		},
 	}
+}
+
+func buildHotspotReport(procedures []proceduremetrics.ProcedureMetrics) hotspots.Report {
+	procedureInputs := make([]hotspots.Input, 0, len(procedures))
+	moduleMap := map[string]hotspots.Input{}
+	callersByCallee := map[string]map[string]bool{}
+	procedureIDs := map[string]string{}
+	moduleIDsByProcedure := map[string]string{}
+	procedureAdjacency := map[string]map[string]bool{}
+	moduleOut := map[string]map[string]bool{}
+	moduleIn := map[string]map[string]bool{}
+	for _, procedure := range procedures {
+		qualified := strings.ToLower(procedure.Module + "." + procedure.Name)
+		moduleID := procedure.File + "|" + procedure.Module
+		id := procedure.File + "|" + procedure.Module + "|" + procedure.Name + "|" + string(procedure.Kind)
+		procedureIDs[qualified] = id
+		moduleIDsByProcedure[id] = moduleID
+	}
+	for _, procedure := range procedures {
+		callerID := procedure.File + "|" + procedure.Module + "|" + procedure.Name + "|" + string(procedure.Kind)
+		callerModuleID := procedure.File + "|" + procedure.Module
+		for _, callee := range procedure.ResolvedCallees {
+			if callersByCallee[callee] == nil {
+				callersByCallee[callee] = map[string]bool{}
+			}
+			callersByCallee[callee][callerID] = true
+			calleeID, ok := procedureIDs[callee]
+			if !ok {
+				continue
+			}
+			if procedureAdjacency[callerID] == nil {
+				procedureAdjacency[callerID] = map[string]bool{}
+			}
+			procedureAdjacency[callerID][calleeID] = true
+			calleeModuleID := moduleIDsByProcedure[calleeID]
+			if callerModuleID == calleeModuleID {
+				continue
+			}
+			if moduleOut[callerModuleID] == nil {
+				moduleOut[callerModuleID] = map[string]bool{}
+			}
+			if moduleIn[calleeModuleID] == nil {
+				moduleIn[calleeModuleID] = map[string]bool{}
+			}
+			moduleOut[callerModuleID][calleeModuleID] = true
+			moduleIn[calleeModuleID][callerModuleID] = true
+		}
+	}
+	cycleParticipation := cycleParticipationCounts(procedureAdjacency)
+	for _, procedure := range procedures {
+		id := procedure.File + "|" + procedure.Module + "|" + procedure.Name + "|" + string(procedure.Kind)
+		moduleID := procedure.File + "|" + procedure.Module
+		raw := map[string]int{
+			string(hotspots.SignalComplexity):       procedure.CyclomaticComplexity,
+			string(hotspots.SignalCallFanOut):       procedure.CallFanOut,
+			string(hotspots.SignalCallFanIn):        len(callersByCallee[strings.ToLower(procedure.Module+"."+procedure.Name)]),
+			string(hotspots.SignalAffectedModules):  0,
+			string(hotspots.SignalExcelEffects):     procedure.ExcelEffectCount,
+			string(hotspots.SignalMutableReads):     procedure.MutableStateReads,
+			string(hotspots.SignalMutableWrites):    procedure.MutableStateWrites,
+			string(hotspots.SignalMutableMutations): procedure.MutableStateMutations,
+			string(hotspots.SignalCycleCount):       cycleParticipation[id],
+			string(hotspots.SignalExternalDeps):     procedure.ExternalDependencyCount,
+			string(hotspots.SignalErrorHandling):    procedure.ErrorHandlingCount,
+			string(hotspots.SignalResourceOwned):    procedure.ResourceOwnershipCount,
+		}
+		uncertainty := map[string]int{
+			string(hotspots.UncertaintyAmbiguous):  procedure.AmbiguousCallCount,
+			string(hotspots.UncertaintyUnresolved): procedure.UnresolvedCallCount,
+			string(hotspots.UncertaintyDynamic):    procedure.DynamicCallCount,
+		}
+		affected := reachableProcedureModules(id, procedureAdjacency, moduleIDsByProcedure)
+		raw[string(hotspots.SignalAffectedModules)] = len(affected)
+		procedureInputs = append(procedureInputs, hotspots.Input{ID: id, Kind: "procedure", File: procedure.File, Module: procedure.Module, ModuleKind: procedure.ModuleKind, Name: procedure.Name, ProcedureKind: string(procedure.Kind), DeclarationByte: procedure.DeclarationRange.StartByte, Line: procedure.DeclarationRange.StartLine, RawSignals: raw, Uncertainty: uncertainty})
+		module := moduleMap[moduleID]
+		if module.ID == "" {
+			module = hotspots.Input{ID: moduleID, Kind: "module", File: procedure.File, Module: procedure.Module, ModuleKind: procedure.ModuleKind, Name: procedure.Module, Line: procedure.DeclarationRange.StartLine, RawSignals: map[string]int{}}
+			for _, signal := range []hotspots.SignalName{hotspots.SignalComplexity, hotspots.SignalComplexityMax, hotspots.SignalCallFanIn, hotspots.SignalCallFanOut, hotspots.SignalAffectedModules, hotspots.SignalExcelEffects, hotspots.SignalMutableReads, hotspots.SignalMutableWrites, hotspots.SignalMutableMutations, hotspots.SignalCycleCount, hotspots.SignalExternalDeps, hotspots.SignalErrorHandling, hotspots.SignalResourceOwned, hotspots.SignalPublicProcedures} {
+				module.RawSignals[string(signal)] = 0
+			}
+		}
+		module.RawSignals[string(hotspots.SignalComplexity)] += procedure.CyclomaticComplexity
+		if procedure.CyclomaticComplexity > module.RawSignals[string(hotspots.SignalComplexityMax)] {
+			module.RawSignals[string(hotspots.SignalComplexityMax)] = procedure.CyclomaticComplexity
+		}
+		module.RawSignals[string(hotspots.SignalCallFanOut)] += procedure.CallFanOut
+		module.RawSignals[string(hotspots.SignalExcelEffects)] += procedure.ExcelEffectCount
+		module.RawSignals[string(hotspots.SignalMutableReads)] += procedure.MutableStateReads
+		module.RawSignals[string(hotspots.SignalMutableWrites)] += procedure.MutableStateWrites
+		module.RawSignals[string(hotspots.SignalMutableMutations)] += procedure.MutableStateMutations
+		module.RawSignals[string(hotspots.SignalCycleCount)] += cycleParticipation[id]
+		module.RawSignals[string(hotspots.SignalExternalDeps)] += procedure.ExternalDependencyCount
+		module.RawSignals[string(hotspots.SignalErrorHandling)] += procedure.ErrorHandlingCount
+		module.RawSignals[string(hotspots.SignalResourceOwned)] += procedure.ResourceOwnershipCount
+		if module.Uncertainty == nil {
+			module.Uncertainty = map[string]int{}
+		}
+		for key, value := range uncertainty {
+			module.Uncertainty[key] += value
+		}
+		if !strings.EqualFold(strings.TrimSpace(procedure.Visibility), "private") {
+			module.RawSignals[string(hotspots.SignalPublicProcedures)]++
+		}
+		moduleMap[moduleID] = module
+	}
+	for moduleID, module := range moduleMap {
+		module.RawSignals[string(hotspots.SignalCallFanIn)] = len(moduleIn[moduleID])
+		module.RawSignals[string(hotspots.SignalCallFanOut)] = len(moduleOut[moduleID])
+		module.RawSignals[string(hotspots.SignalAffectedModules)] = len(reachableModules(moduleID, moduleOut))
+		moduleMap[moduleID] = module
+	}
+	modules := make([]hotspots.Input, 0, len(moduleMap))
+	for _, module := range moduleMap {
+		modules = append(modules, module)
+	}
+	return hotspots.BuildReport(procedureInputs, modules)
+}
+
+func reachableProcedureModules(start string, adjacency map[string]map[string]bool, moduleByProcedure map[string]string) map[string]bool {
+	modules := map[string]bool{}
+	if module := moduleByProcedure[start]; module != "" {
+		modules[module] = true
+	}
+	seen := map[string]bool{start: true}
+	queue := []string{start}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for next := range adjacency[current] {
+			if !seen[next] {
+				seen[next] = true
+				queue = append(queue, next)
+			}
+			if module := moduleByProcedure[next]; module != "" {
+				modules[module] = true
+			}
+		}
+	}
+	return modules
+}
+
+func reachableModules(start string, adjacency map[string]map[string]bool) map[string]bool {
+	seen := map[string]bool{start: true}
+	queue := []string{start}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for next := range adjacency[current] {
+			if !seen[next] {
+				seen[next] = true
+				queue = append(queue, next)
+			}
+		}
+	}
+	return seen
+}
+
+// cycleParticipationCounts enumerates elementary cycles in the confirmed
+// procedure graph. Restricting traversal to nodes >= the cycle's start node
+// makes the lexicographically smallest node the canonical start, so each
+// directed cycle is counted once while keeping the result deterministic.
+func cycleParticipationCounts(adjacency map[string]map[string]bool) map[string]int {
+	result := map[string]int{}
+	nodesSet := map[string]bool{}
+	for from, targets := range adjacency {
+		nodesSet[from] = true
+		for to := range targets {
+			nodesSet[to] = true
+		}
+	}
+	nodes := make([]string, 0, len(nodesSet))
+	for node := range nodesSet {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+	for _, start := range nodes {
+		path := []string{start}
+		visited := map[string]bool{start: true}
+		var visit func(string)
+		visit = func(current string) {
+			nexts := make([]string, 0, len(adjacency[current]))
+			for next := range adjacency[current] {
+				nexts = append(nexts, next)
+			}
+			sort.Strings(nexts)
+			for _, next := range nexts {
+				if next == start {
+					for _, member := range path {
+						result[member]++
+					}
+					continue
+				}
+				if next < start || visited[next] {
+					continue
+				}
+				visited[next] = true
+				path = append(path, next)
+				visit(next)
+				path = path[:len(path)-1]
+				delete(visited, next)
+			}
+		}
+		visit(start)
+	}
+	return result
+}
+
+func hotspotFindingsForConfig(report hotspots.Report, cfg config.HotspotsConfig) []map[string]any {
+	findings := make([]map[string]any, 0)
+	appendFindings := func(entities []hotspots.Entity, topN int, threshold float64) {
+		for _, entity := range hotspots.Select(entities, topN, threshold) {
+			severity := "information"
+			if entity.SelectedBy.Threshold {
+				severity = "warning"
+			}
+			findings = append(findings, map[string]any{"code": "MX002", "severity": severity, "kind": entity.Kind, "file": entity.File, "line": entity.Line, "module": entity.Module, "procedure": entity.Name, "rank": entity.Rank, "score": entity.Score, "score_model": entity.ScoreModel, "raw_signals": entity.RawSignals, "normalized_signals": entity.NormalizedSignals, "uncertainty": entity.Uncertainty, "active_signal_count": entity.ActiveSignalCount, "selected_by": entity.SelectedBy, "message": fmt.Sprintf("%s is an architectural hotspot candidate (score %.2f)", entity.Name, entity.Score)})
+		}
+	}
+	appendFindings(report.Procedures, cfg.ProcedureTopN, cfg.ProcedureScoreThreshold)
+	appendFindings(report.Modules, cfg.ModuleTopN, cfg.ModuleScoreThreshold)
+	return findings
 }
 
 func metricsThresholdFailureMessage(count int) string {

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/output"
+	"github.com/harumiWeb/xlflow/internal/vba/hotspots"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+	"github.com/harumiWeb/xlflow/internal/vba/proceduremetrics"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 )
 
@@ -168,5 +171,82 @@ cyclomatic_complexity = 1
 	}
 	if payload["status"] != output.StatusFailed || payload["error"].(map[string]any)["code"] != "metrics_threshold_exceeded" {
 		t.Fatalf("payload status/error = %#v", payload)
+	}
+}
+
+func TestMetricsCommandHotspotsReportAndSelectors(t *testing.T) {
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sources := map[string]string{
+		"Main.bas":   "Attribute VB_Name = \"Main\"\nPublic Sub Run()\n If True Then\n End If\nEnd Sub\n",
+		"Helper.bas": "Attribute VB_Name = \"Helper\"\nPublic Sub Help()\nEnd Sub\n",
+	}
+	for name, source := range sources {
+		if err := os.WriteFile(filepath.Join(moduleDir, name), []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, config.FileName), []byte(`[project]
+entry = "Main.Run"
+[excel]
+path = "build/Book.xlsm"
+[src]
+modules = "src/modules"
+[metrics.hotspots]
+procedure_top_n = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr strings.Builder
+	a := &app{cwd: root, stdout: &stdout, stderr: &stderr}
+	cmd := a.rootCommand()
+	cmd.SetArgs([]string{"--json", "metrics"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("top-n metrics failed: %v\n%s", err, stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatal(err)
+	}
+	metrics := payload["metrics"].(map[string]any)
+	hotspots := metrics["hotspots"].(map[string]any)
+	if len(hotspots["procedures"].([]any)) != 2 || len(payload["diagnostics"].([]any)) != 1 {
+		t.Fatalf("hotspot payload = %#v", payload)
+	}
+	diagnostic := payload["diagnostics"].([]any)[0].(map[string]any)
+	if diagnostic["code"] != "MX002" || diagnostic["severity"] != "information" {
+		t.Fatalf("hotspot diagnostic = %#v", diagnostic)
+	}
+}
+
+func TestBuildHotspotReportAggregatesGraphSignals(t *testing.T) {
+	metrics := []proceduremetrics.ProcedureMetrics{
+		{File: "main.bas", Module: "Main", Name: "A", Kind: procedureir.ProcedureSub, ResolvedCallees: []string{"helper.b"}, Metrics: proceduremetrics.Metrics{CyclomaticComplexity: 2, CallFanOut: 1}},
+		{File: "helper.bas", Module: "Helper", Name: "B", Kind: procedureir.ProcedureSub, ResolvedCallees: []string{"main.a"}, Metrics: proceduremetrics.Metrics{CyclomaticComplexity: 3, CallFanOut: 1}},
+		{File: "other.bas", Module: "Other", Name: "C", Kind: procedureir.ProcedureSub, ResolvedCallees: []string{"helper.b"}, Metrics: proceduremetrics.Metrics{CyclomaticComplexity: 1, CallFanOut: 1}},
+	}
+	report := buildHotspotReport(metrics)
+	byProcedure := map[string]hotspots.Entity{}
+	for _, entity := range report.Procedures {
+		byProcedure[entity.Name] = entity
+	}
+	if byProcedure["A"].RawSignals["call_fan_in"] != 1 || byProcedure["A"].RawSignals["cycle_count"] != 1 {
+		t.Fatalf("procedure A graph signals = %#v", byProcedure["A"].RawSignals)
+	}
+	if byProcedure["A"].RawSignals["affected_module_count"] != 2 {
+		t.Fatalf("procedure A affected modules = %#v", byProcedure["A"].RawSignals)
+	}
+	byModule := map[string]hotspots.Entity{}
+	for _, entity := range report.Modules {
+		byModule[entity.Name] = entity
+	}
+	if byModule["Helper"].RawSignals["call_fan_in"] != 2 || byModule["Helper"].RawSignals["call_fan_out"] != 1 {
+		t.Fatalf("Helper module graph signals = %#v", byModule["Helper"].RawSignals)
+	}
+	if byModule["Main"].RawSignals["affected_module_count"] != 2 {
+		t.Fatalf("Main module affected modules = %#v", byModule["Main"].RawSignals)
 	}
 }

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -222,6 +224,120 @@ procedure_top_n = 1
 	}
 }
 
+func TestMetricsCommandHotspotThresholdFailure(t *testing.T) {
+	root := writeHotspotMetricsProject(t, map[string]string{
+		"Main.bas":   "Attribute VB_Name = \"Main\"\nPublic Sub Run()\n If True Then\n End If\nEnd Sub\n",
+		"Helper.bas": "Attribute VB_Name = \"Helper\"\nPublic Sub Help()\nEnd Sub\n",
+	}, "procedure_score_threshold = 1")
+	var stdout, stderr strings.Builder
+	a := &app{cwd: root, stdout: &stdout, stderr: &stderr}
+	cmd := a.rootCommand()
+	cmd.SetArgs([]string{"--json", "metrics"})
+	if err := cmd.Execute(); output.ExitCode(err) != output.ExitValidation {
+		t.Fatalf("threshold metrics exit = %v (%v)\n%s", output.ExitCode(err), err, stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["status"] != output.StatusFailed || payload["error"].(map[string]any)["code"] != "metrics_hotspot_threshold_exceeded" {
+		t.Fatalf("threshold payload = %#v", payload)
+	}
+	diagnostics := payload["diagnostics"].([]any)
+	if len(diagnostics) == 0 || diagnostics[0].(map[string]any)["severity"] != "warning" {
+		t.Fatalf("threshold diagnostics = %#v", diagnostics)
+	}
+	selectedBy := diagnostics[0].(map[string]any)["selected_by"].(map[string]any)
+	if selectedBy["threshold"] != true {
+		t.Fatalf("threshold selection = %#v", selectedBy)
+	}
+}
+
+func TestMetricsCommandUnmetHotspotThresholdWithTopNIsSuccessful(t *testing.T) {
+	root := writeHotspotMetricsProject(t, map[string]string{
+		"Main.bas": "Attribute VB_Name = \"Main\"\nPublic Sub Run()\nEnd Sub\n",
+	}, "procedure_top_n = 1\nprocedure_score_threshold = 1")
+	var stdout, stderr strings.Builder
+	a := &app{cwd: root, stdout: &stdout, stderr: &stderr}
+	cmd := a.rootCommand()
+	cmd.SetArgs([]string{"--json", "metrics"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("top-n with unmet threshold failed: %v\n%s", err, stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["status"] != output.StatusOK || payload["error"] != nil {
+		t.Fatalf("unmet threshold payload = %#v", payload)
+	}
+	diagnostics := payload["diagnostics"].([]any)
+	if len(diagnostics) != 1 || diagnostics[0].(map[string]any)["severity"] != "information" {
+		t.Fatalf("top-n diagnostics = %#v", diagnostics)
+	}
+}
+
+func TestMetricsCommandPrefersComplexityThresholdErrorWhenCombined(t *testing.T) {
+	root := writeHotspotMetricsProject(t, map[string]string{
+		"Main.bas":   "Attribute VB_Name = \"Main\"\nPublic Sub Run()\n If True Then\n End If\nEnd Sub\n",
+		"Helper.bas": "Attribute VB_Name = \"Helper\"\nPublic Sub Help()\nEnd Sub\n",
+	}, "procedure_score_threshold = 1")
+	path := filepath.Join(root, config.FileName)
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents = []byte(strings.Replace(string(contents), "[metrics.hotspots]", "[metrics.thresholds]\ncyclomatic_complexity = 1\n[metrics.hotspots]", 1))
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr strings.Builder
+	a := &app{cwd: root, stdout: &stdout, stderr: &stderr}
+	cmd := a.rootCommand()
+	cmd.SetArgs([]string{"--json", "metrics"})
+	if err := cmd.Execute(); output.ExitCode(err) != output.ExitValidation {
+		t.Fatalf("combined thresholds exit = %v (%v)\n%s", output.ExitCode(err), err, stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["error"].(map[string]any)["code"] != "metrics_threshold_exceeded" {
+		t.Fatalf("combined threshold error = %#v", payload["error"])
+	}
+	diagnostics := payload["diagnostics"].([]any)
+	if len(diagnostics) < 2 || diagnostics[0].(map[string]any)["code"] != "MX001" {
+		t.Fatalf("combined diagnostics ordering = %#v", diagnostics)
+	}
+}
+
+func writeHotspotMetricsProject(t *testing.T, sources map[string]string, hotspotConfig string) string {
+	t.Helper()
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, source := range sources {
+		if err := os.WriteFile(filepath.Join(moduleDir, name), []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	configText := fmt.Sprintf(`[project]
+entry = "Main.Run"
+[excel]
+path = "build/Book.xlsm"
+[src]
+modules = "src/modules"
+[metrics.hotspots]
+%s
+`, hotspotConfig)
+	if err := os.WriteFile(filepath.Join(root, config.FileName), []byte(configText), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
 func TestBuildHotspotReportAggregatesGraphSignals(t *testing.T) {
 	metrics := []proceduremetrics.ProcedureMetrics{
 		{File: "main.bas", Module: "Main", Name: "A", Kind: procedureir.ProcedureSub, ResolvedCallees: []string{"helper.b"}, Metrics: proceduremetrics.Metrics{CyclomaticComplexity: 2, CallFanOut: 1}},
@@ -248,5 +364,41 @@ func TestBuildHotspotReportAggregatesGraphSignals(t *testing.T) {
 	}
 	if byModule["Main"].RawSignals["affected_module_count"] != 2 {
 		t.Fatalf("Main module affected modules = %#v", byModule["Main"].RawSignals)
+	}
+}
+
+func TestCycleParticipationCountsIsDeterministicAndBounded(t *testing.T) {
+	build := func(reverse bool) map[string]map[string]bool {
+		graph := make(map[string]map[string]bool)
+		for offset := 0; offset < 10; offset++ {
+			i := offset
+			if reverse {
+				i = 9 - offset
+			}
+			from := fmt.Sprintf("n%02d", i)
+			graph[from] = map[string]bool{}
+			for targetOffset := 0; targetOffset < 10; targetOffset++ {
+				j := targetOffset
+				if reverse {
+					j = 9 - targetOffset
+				}
+				if i == j {
+					continue
+				}
+				to := fmt.Sprintf("n%02d", j)
+				graph[from][to] = true
+			}
+		}
+		return graph
+	}
+	first := cycleParticipationCounts(build(false))
+	second := cycleParticipationCounts(build(true))
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("cycle counts changed with input order: %#v vs %#v", first, second)
+	}
+	for i := 0; i < 10; i++ {
+		if first[fmt.Sprintf("n%02d", i)] == 0 {
+			t.Fatalf("node n%02d did not participate in a cycle: %#v", i, first)
+		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -87,8 +88,19 @@ type BuildConfig struct {
 // separate from BuildConfig because metric collection and release-build source
 // selection have different scopes and consumers.
 type MetricsConfig struct {
-	Exclude    []string   `toml:"exclude"`
-	Thresholds Thresholds `toml:"thresholds"`
+	Exclude    []string       `toml:"exclude"`
+	Thresholds Thresholds     `toml:"thresholds"`
+	Hotspots   HotspotsConfig `toml:"hotspots"`
+}
+
+// HotspotsConfig controls optional hotspot ranking in the metrics command.
+// A zero top-N or score threshold disables the corresponding limit. Score
+// thresholds are expressed as percentages in the inclusive range 1..100.
+type HotspotsConfig struct {
+	ProcedureTopN           int     `toml:"procedure_top_n"`
+	ModuleTopN              int     `toml:"module_top_n"`
+	ProcedureScoreThreshold float64 `toml:"procedure_score_threshold"`
+	ModuleScoreThreshold    float64 `toml:"module_score_threshold"`
 }
 
 // Thresholds contains optional procedure metric limits. A zero value disables
@@ -542,6 +554,9 @@ func validate(cfg Config) error {
 	if err := validateMetricsThresholds(cfg.Metrics.Thresholds); err != nil {
 		return err
 	}
+	if err := validateMetricsHotspots(cfg.Metrics.Hotspots); err != nil {
+		return err
+	}
 	if cfg.Lint.ProcedureNameConstant.Enabled {
 		name := strings.TrimSpace(cfg.Lint.ProcedureNameConstant.ConstantName)
 		if name == "" {
@@ -549,6 +564,31 @@ func validate(cfg Config) error {
 		}
 		if !validVBAIdentifier(name) {
 			return fmt.Errorf("lint.procedure_name_constant.constant_name must be a VBA identifier: %q", name)
+		}
+	}
+	return nil
+}
+
+func validateMetricsHotspots(hotspots HotspotsConfig) error {
+	if hotspots.ProcedureTopN < 0 {
+		return errors.New("metrics.hotspots.procedure_top_n must be zero or greater")
+	}
+	if hotspots.ModuleTopN < 0 {
+		return errors.New("metrics.hotspots.module_top_n must be zero or greater")
+	}
+	for _, item := range []struct {
+		name  string
+		value float64
+	}{
+		{"procedure_score_threshold", hotspots.ProcedureScoreThreshold},
+		{"module_score_threshold", hotspots.ModuleScoreThreshold},
+	} {
+		// A zero threshold disables filtering; otherwise scores are percentages.
+		if math.IsNaN(item.value) || item.value < 0 || item.value > 100 {
+			return fmt.Errorf("metrics.hotspots.%s must be zero or between 1 and 100", item.name)
+		}
+		if item.value != 0 && item.value < 1 {
+			return fmt.Errorf("metrics.hotspots.%s must be zero or between 1 and 100", item.name)
 		}
 	}
 	return nil
@@ -1171,6 +1211,12 @@ func renderMetricsConfig(cfg MetricsConfig) string {
 	} {
 		fmt.Fprintf(&b, "%s = %d\n", item.name, item.value)
 	}
+	b.WriteString("\n# Optional hotspot ranking. A zero top-N or score threshold disables it.\n")
+	b.WriteString("[metrics.hotspots]\n")
+	fmt.Fprintf(&b, "procedure_top_n = %d\n", cfg.Hotspots.ProcedureTopN)
+	fmt.Fprintf(&b, "module_top_n = %d\n", cfg.Hotspots.ModuleTopN)
+	fmt.Fprintf(&b, "procedure_score_threshold = %g\n", cfg.Hotspots.ProcedureScoreThreshold)
+	fmt.Fprintf(&b, "module_score_threshold = %g\n", cfg.Hotspots.ModuleScoreThreshold)
 	return b.String()
 }
 
@@ -1184,6 +1230,9 @@ func Write(path string, cfg Config) (err error) {
 		return err
 	}
 	if err := validateMetricsThresholds(metricsConfig.Thresholds); err != nil {
+		return err
+	}
+	if err := validateMetricsHotspots(metricsConfig.Hotspots); err != nil {
 		return err
 	}
 	analyzeConfig := cfg.Analyze

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -600,6 +600,57 @@ func TestMetricsConfigDefaultsAreDisabled(t *testing.T) {
 			t.Errorf("metrics.thresholds.%s default = %d, want 0 (disabled)", name, value)
 		}
 	}
+	if got := cfg.Metrics.Hotspots; got != (HotspotsConfig{}) {
+		t.Fatalf("metrics.hotspots default = %+v, want zero values", got)
+	}
+}
+
+func TestLoadMetricsHotspotsConfigAndValidation(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`[project]
+entry = "Main.Run"
+
+[excel]
+path = "build/Book.xlsm"
+
+[metrics.hotspots]
+procedure_top_n = 5
+module_top_n = 3
+procedure_score_threshold = 80.5
+module_score_threshold = 60
+`)
+	if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := HotspotsConfig{ProcedureTopN: 5, ModuleTopN: 3, ProcedureScoreThreshold: 80.5, ModuleScoreThreshold: 60}
+	if cfg.Metrics.Hotspots != want {
+		t.Fatalf("metrics.hotspots = %+v, want %+v", cfg.Metrics.Hotspots, want)
+	}
+
+	for _, tt := range []struct {
+		name, key, value, want string
+	}{
+		{"negative procedure top n", "procedure_top_n", "-1", "procedure_top_n must be zero or greater"},
+		{"negative module top n", "module_top_n", "-1", "module_top_n must be zero or greater"},
+		{"score above 100", "procedure_score_threshold", "101", "procedure_score_threshold must be zero or between 1 and 100"},
+		{"score fractional", "module_score_threshold", "0.5", "module_score_threshold must be zero or between 1 and 100"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			d := t.TempDir()
+			b := []byte("[project]\nentry = \"Main.Run\"\n\n[excel]\npath = \"build/Book.xlsm\"\n\n[metrics.hotspots]\n" + tt.key + " = " + tt.value + "\n")
+			if err := os.WriteFile(filepath.Join(d, FileName), b, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(d)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
 }
 
 func TestLoadMetricsConfigNormalizesExcludeAndParsesThresholds(t *testing.T) {
@@ -722,6 +773,7 @@ func TestWriteRoundTripsMetricsConfig(t *testing.T) {
 		LocalVariableCount:   12,
 		CallFanOut:           9,
 	}
+	cfg.Metrics.Hotspots = HotspotsConfig{ProcedureTopN: 5, ModuleTopN: 3, ProcedureScoreThreshold: 80.5, ModuleScoreThreshold: 60}
 	path := filepath.Join(dir, FileName)
 	if err := Write(path, cfg); err != nil {
 		t.Fatal(err)
@@ -736,6 +788,9 @@ func TestWriteRoundTripsMetricsConfig(t *testing.T) {
 	if loaded.Metrics.Thresholds != cfg.Metrics.Thresholds {
 		t.Fatalf("round-trip metrics.thresholds = %+v, want %+v", loaded.Metrics.Thresholds, cfg.Metrics.Thresholds)
 	}
+	if loaded.Metrics.Hotspots != cfg.Metrics.Hotspots {
+		t.Fatalf("round-trip metrics.hotspots = %+v, want %+v", loaded.Metrics.Hotspots, cfg.Metrics.Hotspots)
+	}
 	body, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
@@ -744,6 +799,7 @@ func TestWriteRoundTripsMetricsConfig(t *testing.T) {
 	for _, want := range []string{
 		"[metrics]", "exclude = [\"src/a/**\", \"src/z/**\"]", "[metrics.thresholds]",
 		"cyclomatic_complexity = 10", "byref_parameter_count = 2", "call_fan_out = 9",
+		"[metrics.hotspots]", "procedure_top_n = 5", "module_score_threshold = 60",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("generated config missing %q:\n%s", want, text)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1800,21 +1800,58 @@ func (r renderer) renderMetrics(env Envelope) string {
 		b.WriteString(r.table(headers, rows))
 	}
 	if diagnostics := listOfObjects(env.Diagnostics); len(diagnostics) > 0 {
-		b.WriteString(r.section("Thresholds"))
-		rows := make([][]string, 0, len(diagnostics))
-		for _, diagnostic := range diagnostics {
-			rows = append(rows, []string{
-				r.severityBadge(stringValue(diagnostic, "severity")),
-				stringValue(diagnostic, "metric"),
-				metricsDiagnosticLocation(diagnostic),
-				metricsDiagnosticMessage(diagnostic),
-			})
+		renderDiagnostics := func(title string, selected []map[string]any, hotspot bool) {
+			if len(selected) == 0 {
+				return
+			}
+			b.WriteString(r.section(title))
+			rows := make([][]string, 0, len(selected))
+			for _, diagnostic := range selected {
+				label := stringValue(diagnostic, "metric")
+				if hotspot {
+					score, _ := numberValue(diagnostic, "score")
+					label = fmt.Sprintf("rank %d / score %.2f", intNumber(diagnostic, "rank"), score)
+				}
+				rows = append(rows, []string{r.severityBadge(stringValue(diagnostic, "severity")), label, metricsDiagnosticLocation(diagnostic), metricsDiagnosticMessage(diagnostic)})
+			}
+			b.WriteString(r.table([]string{"Severity", "Metric", "Location", "Message"}, rows))
 		}
-		b.WriteString(r.table([]string{"Severity", "Metric", "Location", "Message"}, rows))
+		thresholds := make([]map[string]any, 0)
+		hotspotDiagnostics := make([]map[string]any, 0)
+		for _, diagnostic := range diagnostics {
+			if stringValue(diagnostic, "code") == "MX002" {
+				hotspotDiagnostics = append(hotspotDiagnostics, diagnostic)
+			} else {
+				thresholds = append(thresholds, diagnostic)
+			}
+		}
+		renderDiagnostics("Thresholds", thresholds, false)
+		renderDiagnostics("Hotspot selections", hotspotDiagnostics, true)
+	}
+	if hotspots := objectMap(metrics["hotspots"]); len(hotspots) > 0 {
+		b.WriteString(r.section("Architectural hotspots"))
+		for _, kind := range []string{"procedures", "modules"} {
+			entities := listOfObjects(hotspots[kind])
+			if len(entities) == 0 {
+				continue
+			}
+			rows := make([][]string, 0, len(entities))
+			for _, entity := range entities {
+				rows = append(rows, []string{fmt.Sprintf("%d", intNumber(entity, "rank")), metricsProcedureLocation(entity), fmt.Sprintf("%.2f", func() float64 { n, _ := numberValue(entity, "score"); return n }()), fmt.Sprintf("%d", intNumber(entity, "active_signal_count"))})
+			}
+			b.WriteString(r.table([]string{titleCaseASCII(kind), "Entity", "Score", "Signals"}, rows))
+		}
 	}
 	b.WriteString(r.renderWarningsAndHints(env))
 	b.WriteString(r.renderLogs(env))
 	return b.String()
+}
+
+func titleCaseASCII(value string) string {
+	if value == "" {
+		return value
+	}
+	return strings.ToUpper(value[:1]) + value[1:]
 }
 
 func metricsProcedureLocation(procedure map[string]any) string {
@@ -1830,6 +1867,9 @@ func metricsProcedureLocation(procedure map[string]any) string {
 	line := intNumber(procedure, "start_line")
 	if line == 0 {
 		line = intNumber(procedure, "startLine")
+	}
+	if line == 0 {
+		line = intNumber(procedure, "line")
 	}
 	if line == 0 {
 		declaration := objectMap(procedure["declaration_range"])

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1835,11 +1835,29 @@ func (r renderer) renderMetrics(env Envelope) string {
 			if len(entities) == 0 {
 				continue
 			}
-			rows := make([][]string, 0, len(entities))
-			for _, entity := range entities {
-				rows = append(rows, []string{fmt.Sprintf("%d", intNumber(entity, "rank")), metricsProcedureLocation(entity), fmt.Sprintf("%.2f", func() float64 { n, _ := numberValue(entity, "score"); return n }()), fmt.Sprintf("%d", intNumber(entity, "active_signal_count"))})
+			limit := len(entities)
+			if limit > 10 {
+				limit = 10
 			}
-			b.WriteString(r.table([]string{titleCaseASCII(kind), "Entity", "Score", "Signals"}, rows))
+			rows := make([][]string, 0, limit)
+			for _, entity := range entities[:limit] {
+				score, _ := numberValue(entity, "score")
+				label := metricsProcedureLocation(entity)
+				if kind == "modules" {
+					label = metricsHotspotModuleLocation(entity)
+				}
+				rows = append(rows, []string{
+					fmt.Sprintf("%d", intNumber(entity, "rank")),
+					label,
+					fmt.Sprintf("%.2f", score),
+					fmt.Sprintf("%d", intNumber(entity, "active_signal_count")),
+				})
+			}
+			fmt.Fprintf(&b, "%s:\n", titleCaseASCII(kind))
+			b.WriteString(r.table([]string{"Rank", "Entity", "Score", "Signals"}, rows))
+			if len(entities) > limit {
+				fmt.Fprintf(&b, "%d more %s hotspot(s); use --json for the complete metrics.\n", len(entities)-limit, kind)
+			}
 		}
 	}
 	b.WriteString(r.renderWarningsAndHints(env))
@@ -1883,6 +1901,22 @@ func metricsProcedureLocation(procedure map[string]any) string {
 	}
 	if file != "" && name != "" {
 		return file + " " + name
+	}
+	return name
+}
+
+func metricsHotspotModuleLocation(module map[string]any) string {
+	file := stringValue(module, "file")
+	name := stringValue(module, "module")
+	line := intNumber(module, "line")
+	if file != "" && line > 0 {
+		return fmt.Sprintf("%s:%d %s", file, line, name)
+	}
+	if file != "" && name != "" {
+		return file + " " + name
+	}
+	if file != "" {
+		return file
 	}
 	return name
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -298,6 +298,44 @@ func TestWriteProcedureMetricsJSONAndHumanOutput(t *testing.T) {
 	}
 }
 
+func TestWriteHotspotHumanOutputUsesLabelsAndLimitsRows(t *testing.T) {
+	procedures := make([]map[string]any, 0, 11)
+	modules := make([]map[string]any, 0, 11)
+	for i := 0; i < 11; i++ {
+		procedures = append(procedures, map[string]any{
+			"file": "src/modules/Main.bas", "module": "Main", "name": fmt.Sprintf("Run%d", i),
+			"line": i + 1, "rank": i + 1, "score": float64(100 - i), "active_signal_count": 2,
+		})
+		modules = append(modules, map[string]any{
+			"file": "src/modules/Main.bas", "module": fmt.Sprintf("Module%d", i), "name": fmt.Sprintf("Module%d", i),
+			"line": i + 1, "rank": i + 1, "score": float64(100 - i), "active_signal_count": 2,
+		})
+	}
+	env := New("metrics")
+	env.Metrics = map[string]any{
+		"schema_version": 1,
+		"procedures":     []map[string]any{},
+		"hotspots": map[string]any{
+			"schema_version": 1,
+			"procedures":     procedures,
+			"modules":        modules,
+		},
+	}
+	var human bytes.Buffer
+	if err := WriteWithOptions(&human, env, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	text := human.String()
+	for _, want := range []string{"Procedures:", "Modules:", "Rank", "1 more procedures hotspot(s); use --json", "1 more modules hotspot(s); use --json"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("hotspot human output missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "Module0.Module0") {
+		t.Fatalf("module location duplicated module name:\n%s", text)
+	}
+}
+
 func TestWriteJSONEnvelopeIncludesPushDiagnostic(t *testing.T) {
 	env := New("push")
 	env.PushDiagnostic = map[string]any{

--- a/internal/vba/hotspots/hotspots.go
+++ b/internal/vba/hotspots/hotspots.go
@@ -110,7 +110,7 @@ type Entity struct {
 	ActiveSignalCount int                `json:"active_signal_count"`
 	RawSignals        map[string]int     `json:"raw_signals"`
 	NormalizedSignals map[string]float64 `json:"normalized_signals"`
-	SelectedBy        Selection          `json:"selected_by,omitempty"`
+	SelectedBy        *Selection         `json:"selected_by,omitempty"`
 	DeclarationByte   int                `json:"-"`
 	Line              int                `json:"line,omitempty"`
 	Uncertainty       map[string]int     `json:"uncertainty,omitempty"`
@@ -188,7 +188,8 @@ func Select(entities []Entity, topN int, threshold float64) []Entity {
 		if !reason.TopN && !reason.Threshold {
 			continue
 		}
-		entity.SelectedBy = reason
+		selection := reason
+		entity.SelectedBy = &selection
 		selected = append(selected, entity)
 	}
 	return selected

--- a/internal/vba/hotspots/hotspots.go
+++ b/internal/vba/hotspots/hotspots.go
@@ -1,0 +1,285 @@
+// Package hotspots computes deterministic, project-relative architectural
+// hotspot scores. It intentionally depends only on scalar facts supplied by
+// callers; parsing, diagnostics, and configuration remain outside this layer.
+package hotspots
+
+import (
+	"math"
+	"sort"
+	"strings"
+)
+
+const (
+	SchemaVersion = 1
+	ScoreModel    = "percentile_equal_weight_v1"
+)
+
+// SignalName is a stable raw-signal identifier. Additive signals are
+// backwards compatible; changing a signal's meaning requires a new model.
+type SignalName string
+
+const (
+	SignalComplexity       SignalName = "complexity"
+	SignalComplexityMax    SignalName = "complexity_max"
+	SignalCallFanIn        SignalName = "call_fan_in"
+	SignalCallFanOut       SignalName = "call_fan_out"
+	SignalAffectedModules  SignalName = "affected_module_count"
+	SignalExcelEffects     SignalName = "excel_effect_count"
+	SignalMutableReads     SignalName = "mutable_state_reads"
+	SignalMutableWrites    SignalName = "mutable_state_writes"
+	SignalMutableMutations SignalName = "mutable_state_mutations"
+	SignalCycleCount       SignalName = "cycle_count"
+	SignalExternalDeps     SignalName = "external_dependency_count"
+	SignalErrorHandling    SignalName = "error_handling_count"
+	SignalResourceOwned    SignalName = "resource_ownership_count"
+	SignalPublicProcedures SignalName = "public_procedure_count"
+)
+
+// UncertaintyName identifies relationships retained for auditability but
+// intentionally excluded from the composite score.
+type UncertaintyName string
+
+const (
+	UncertaintyAmbiguous  UncertaintyName = "ambiguous_call_count"
+	UncertaintyUnresolved UncertaintyName = "unresolved_call_count"
+	UncertaintyDynamic    UncertaintyName = "dynamic_call_count"
+)
+
+// ProcedureSignals and ModuleSignals provide typed construction helpers while
+// the wire representation remains an extensible signal map.
+type ProcedureSignals struct {
+	Complexity, CallFanIn, CallFanOut, AffectedModules                 int
+	ExcelEffects, MutableReads, MutableWrites, MutableMutations        int
+	CycleCount, ExternalDependencies, ErrorHandling, ResourceOwnership int
+}
+
+func (s ProcedureSignals) Map() map[string]int {
+	return map[string]int{
+		string(SignalComplexity): s.Complexity, string(SignalCallFanIn): s.CallFanIn, string(SignalCallFanOut): s.CallFanOut,
+		string(SignalAffectedModules): s.AffectedModules, string(SignalExcelEffects): s.ExcelEffects,
+		string(SignalMutableReads): s.MutableReads, string(SignalMutableWrites): s.MutableWrites, string(SignalMutableMutations): s.MutableMutations,
+		string(SignalCycleCount): s.CycleCount, string(SignalExternalDeps): s.ExternalDependencies, string(SignalErrorHandling): s.ErrorHandling,
+		string(SignalResourceOwned): s.ResourceOwnership,
+	}
+}
+
+type ModuleSignals struct {
+	ComplexityTotal, ComplexityMax, CallFanIn, CallFanOut, AffectedModules               int
+	ExcelEffects, MutableReads, MutableWrites, MutableMutations                          int
+	CycleCount, ExternalDependencies, ErrorHandling, ResourceOwnership, PublicProcedures int
+}
+
+func (s ModuleSignals) Map() map[string]int {
+	return map[string]int{
+		string(SignalComplexity): s.ComplexityTotal, string(SignalComplexityMax): s.ComplexityMax,
+		string(SignalCallFanIn): s.CallFanIn, string(SignalCallFanOut): s.CallFanOut, string(SignalAffectedModules): s.AffectedModules,
+		string(SignalExcelEffects): s.ExcelEffects, string(SignalMutableReads): s.MutableReads, string(SignalMutableWrites): s.MutableWrites,
+		string(SignalMutableMutations): s.MutableMutations, string(SignalCycleCount): s.CycleCount, string(SignalExternalDeps): s.ExternalDependencies,
+		string(SignalErrorHandling): s.ErrorHandling, string(SignalResourceOwned): s.ResourceOwnership, string(SignalPublicProcedures): s.PublicProcedures,
+	}
+}
+
+// Input is a project-relative entity and its raw scalar facts. Kind must be
+// "procedure" or "module". Missing signals are treated as zero.
+type Input struct {
+	ID              string         `json:"id"`
+	Kind            string         `json:"kind"`
+	File            string         `json:"file"`
+	Module          string         `json:"module"`
+	ModuleKind      string         `json:"module_kind,omitempty"`
+	Name            string         `json:"name"`
+	ProcedureKind   string         `json:"procedure_kind,omitempty"`
+	DeclarationByte int            `json:"-"`
+	Line            int            `json:"line,omitempty"`
+	RawSignals      map[string]int `json:"raw_signals"`
+	Uncertainty     map[string]int `json:"uncertainty,omitempty"`
+}
+
+// Entity is a ranked hotspot with both raw and normalized contributing facts.
+type Entity struct {
+	ID                string             `json:"id"`
+	Kind              string             `json:"kind"`
+	File              string             `json:"file"`
+	Module            string             `json:"module,omitempty"`
+	ModuleKind        string             `json:"module_kind,omitempty"`
+	Name              string             `json:"name"`
+	ProcedureKind     string             `json:"procedure_kind,omitempty"`
+	Rank              int                `json:"rank"`
+	Score             float64            `json:"score"`
+	ScoreModel        string             `json:"score_model"`
+	ActiveSignalCount int                `json:"active_signal_count"`
+	RawSignals        map[string]int     `json:"raw_signals"`
+	NormalizedSignals map[string]float64 `json:"normalized_signals"`
+	SelectedBy        Selection          `json:"selected_by,omitempty"`
+	DeclarationByte   int                `json:"-"`
+	Line              int                `json:"line,omitempty"`
+	Uncertainty       map[string]int     `json:"uncertainty,omitempty"`
+}
+
+// Selection records why an opt-in finding was selected.
+type Selection struct {
+	TopN      bool `json:"top_n,omitempty"`
+	Threshold bool `json:"threshold,omitempty"`
+}
+
+// Report is the versioned hotspot projection embedded in the metrics output.
+type Report struct {
+	SchemaVersion int      `json:"schema_version"`
+	ScoreModel    string   `json:"score_model"`
+	Procedures    []Entity `json:"procedures"`
+	Modules       []Entity `json:"modules"`
+}
+
+// Rank computes percentile-normalized, equal-weight scores and stable ranks.
+// The input is copied and may be in arbitrary order.
+func Rank(inputs []Input) []Entity {
+	entities := make([]Entity, 0, len(inputs))
+	for _, in := range inputs {
+		raw := cloneInts(in.RawSignals)
+		entities = append(entities, Entity{ID: in.ID, Kind: in.Kind, File: in.File, Module: in.Module, ModuleKind: in.ModuleKind, Name: in.Name, ProcedureKind: in.ProcedureKind, DeclarationByte: in.DeclarationByte, Line: in.Line, ScoreModel: ScoreModel, RawSignals: raw, Uncertainty: cloneInts(in.Uncertainty), NormalizedSignals: map[string]float64{}})
+	}
+	keys := signalKeys(entities)
+	for _, key := range keys {
+		values := make([]int, len(entities))
+		for i := range entities {
+			values[i] = entities[i].RawSignals[key]
+		}
+		ranks := Percentiles(values)
+		active := signalVaries(values)
+		for i := range entities {
+			if active {
+				entities[i].NormalizedSignals[key] = ranks[i]
+				entities[i].ActiveSignalCount++
+			}
+		}
+	}
+	for i := range entities {
+		if entities[i].ActiveSignalCount == 0 {
+			entities[i].Score = 0
+			continue
+		}
+		total := 0.0
+		for _, value := range entities[i].NormalizedSignals {
+			total += value
+		}
+		entities[i].Score = round2(total / float64(entities[i].ActiveSignalCount))
+	}
+	sort.SliceStable(entities, func(i, j int) bool { return less(entities[i], entities[j]) })
+	for i := range entities {
+		entities[i].Rank = i + 1
+	}
+	return entities
+}
+
+// BuildReport ranks procedure and module inputs in independent cohorts.
+func BuildReport(procedures, modules []Input) Report {
+	return Report{SchemaVersion: SchemaVersion, ScoreModel: ScoreModel, Procedures: Rank(procedures), Modules: Rank(modules)}
+}
+
+// Select returns the union of top-N and threshold selections. It preserves
+// rank order and marks the selection reasons on each entity.
+func Select(entities []Entity, topN int, threshold float64) []Entity {
+	if topN < 0 {
+		topN = 0
+	}
+	selected := make([]Entity, 0)
+	for i, entity := range entities {
+		reason := Selection{TopN: topN > 0 && i < topN, Threshold: threshold > 0 && entity.Score >= threshold}
+		if !reason.TopN && !reason.Threshold {
+			continue
+		}
+		entity.SelectedBy = reason
+		selected = append(selected, entity)
+	}
+	return selected
+}
+
+// Percentiles returns average-rank percentiles in input order. Constant and
+// singleton cohorts intentionally return zero for every value.
+func Percentiles(values []int) []float64 {
+	out := make([]float64, len(values))
+	if len(values) < 2 || !signalVaries(values) {
+		return out
+	}
+	order := make([]int, len(values))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		if values[order[i]] != values[order[j]] {
+			return values[order[i]] < values[order[j]]
+		}
+		return order[i] < order[j]
+	})
+	for start := 0; start < len(order); {
+		end := start + 1
+		for end < len(order) && values[order[end]] == values[order[start]] {
+			end++
+		}
+		averageRank := (float64(start+1) + float64(end)) / 2
+		percentile := 100 * (averageRank - 1) / float64(len(values)-1)
+		for i := start; i < end; i++ {
+			out[order[i]] = percentile
+		}
+		start = end
+	}
+	return out
+}
+
+func signalKeys(entities []Entity) []string {
+	set := map[string]bool{}
+	for _, entity := range entities {
+		for key := range entity.RawSignals {
+			if strings.TrimSpace(key) != "" {
+				set[key] = true
+			}
+		}
+	}
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+func signalVaries(values []int) bool {
+	if len(values) < 2 {
+		return false
+	}
+	first := values[0]
+	for _, value := range values[1:] {
+		if value != first {
+			return true
+		}
+	}
+	return false
+}
+func cloneInts(in map[string]int) map[string]int {
+	out := make(map[string]int, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+func less(a, b Entity) bool {
+	if math.Abs(a.Score-b.Score) > 1e-9 {
+		return a.Score > b.Score
+	}
+	if a.File != b.File {
+		return a.File < b.File
+	}
+	if a.DeclarationByte != b.DeclarationByte {
+		return a.DeclarationByte < b.DeclarationByte
+	}
+	if a.Module != b.Module {
+		return a.Module < b.Module
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	if a.ProcedureKind != b.ProcedureKind {
+		return a.ProcedureKind < b.ProcedureKind
+	}
+	return a.ID < b.ID
+}
+func round2(value float64) float64 { return math.Round(value*100) / 100 }

--- a/internal/vba/hotspots/hotspots_json_test.go
+++ b/internal/vba/hotspots/hotspots_json_test.go
@@ -2,6 +2,7 @@ package hotspots
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -34,5 +35,26 @@ func TestReportJSONIncludesRawAndNormalizedSignals(t *testing.T) {
 	}
 	if entity.NormalizedSignals == nil {
 		t.Fatal("normalized signals were omitted")
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	procedures := raw["procedures"].([]any)
+	if _, ok := procedures[0].(map[string]any)["selected_by"]; ok {
+		t.Fatalf("unselected entity included selected_by: %#v", procedures[0])
+	}
+	selected := Select(report.Procedures, 1, 0)
+	selectedReport := BuildReport([]Input{{
+		ID: "M.Run", Kind: "procedure", File: "m.bas", Module: "M", Name: "Run",
+		RawSignals: map[string]int{"complexity": 2},
+	}}, nil)
+	selectedReport.Procedures = selected
+	selectedData, err := json.Marshal(selectedReport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(selectedData), `"selected_by":{"top_n":true}`) {
+		t.Fatalf("selected entity omitted selected_by: %s", selectedData)
 	}
 }

--- a/internal/vba/hotspots/hotspots_json_test.go
+++ b/internal/vba/hotspots/hotspots_json_test.go
@@ -1,0 +1,38 @@
+package hotspots
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestReportJSONIncludesRawAndNormalizedSignals(t *testing.T) {
+	report := BuildReport([]Input{{
+		ID: "M.Run", Kind: "procedure", File: "m.bas", Module: "M", Name: "Run",
+		RawSignals: map[string]int{"complexity": 2},
+	}}, nil)
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded struct {
+		SchemaVersion int      `json:"schema_version"`
+		ScoreModel    string   `json:"score_model"`
+		Procedures    []Entity `json:"procedures"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.SchemaVersion != SchemaVersion || decoded.ScoreModel != ScoreModel {
+		t.Fatalf("metadata = schema %d/model %q", decoded.SchemaVersion, decoded.ScoreModel)
+	}
+	if len(decoded.Procedures) != 1 {
+		t.Fatalf("procedures = %#v", decoded.Procedures)
+	}
+	entity := decoded.Procedures[0]
+	if entity.RawSignals["complexity"] != 2 {
+		t.Fatalf("raw signals = %#v", entity.RawSignals)
+	}
+	if entity.NormalizedSignals == nil {
+		t.Fatal("normalized signals were omitted")
+	}
+}

--- a/internal/vba/hotspots/hotspots_test.go
+++ b/internal/vba/hotspots/hotspots_test.go
@@ -1,0 +1,40 @@
+package hotspots
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPercentilesAverageTiesAndConstantSignals(t *testing.T) {
+	got := Percentiles([]int{1, 2, 2, 4})
+	want := []float64{0, 50, 50, 100}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("percentiles = %#v, want %#v", got, want)
+	}
+	if got := Percentiles([]int{4, 4, 4}); !reflect.DeepEqual(got, []float64{0, 0, 0}) {
+		t.Fatalf("constant percentiles = %#v", got)
+	}
+}
+
+func TestRankIsDeterministicAndUsesEqualWeightSignals(t *testing.T) {
+	inputs := []Input{
+		{ID: "b", Kind: "procedure", File: "b.bas", Name: "B", RawSignals: map[string]int{"complexity": 2, "call_fan_out": 0}},
+		{ID: "a", Kind: "procedure", File: "a.bas", Name: "A", RawSignals: map[string]int{"complexity": 1, "call_fan_out": 2}},
+	}
+	first := Rank(inputs)
+	second := Rank([]Input{inputs[1], inputs[0]})
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("rank changed with input order:\n%#v\n%#v", first, second)
+	}
+	if first[0].ID != "a" || first[1].ID != "b" || first[0].Score != 50 || first[1].Score != 50 {
+		t.Fatalf("rank = %#v, want tied score with stable identity order", first)
+	}
+}
+
+func TestSelectUsesUnionAndMarksThresholdPromotion(t *testing.T) {
+	entities := []Entity{{ID: "a", Rank: 1, Score: 90}, {ID: "b", Rank: 2, Score: 40}, {ID: "c", Rank: 3, Score: 10}}
+	got := Select(entities, 1, 40)
+	if len(got) != 2 || !got[0].SelectedBy.TopN || !got[0].SelectedBy.Threshold || !got[1].SelectedBy.Threshold {
+		t.Fatalf("selection = %#v", got)
+	}
+}

--- a/internal/vba/hotspots/hotspots_test.go
+++ b/internal/vba/hotspots/hotspots_test.go
@@ -34,7 +34,7 @@ func TestRankIsDeterministicAndUsesEqualWeightSignals(t *testing.T) {
 func TestSelectUsesUnionAndMarksThresholdPromotion(t *testing.T) {
 	entities := []Entity{{ID: "a", Rank: 1, Score: 90}, {ID: "b", Rank: 2, Score: 40}, {ID: "c", Rank: 3, Score: 10}}
 	got := Select(entities, 1, 40)
-	if len(got) != 2 || !got[0].SelectedBy.TopN || !got[0].SelectedBy.Threshold || !got[1].SelectedBy.Threshold {
+	if len(got) != 2 || got[0].SelectedBy == nil || !got[0].SelectedBy.TopN || !got[0].SelectedBy.Threshold || got[1].SelectedBy == nil || !got[1].SelectedBy.Threshold {
 		t.Fatalf("selection = %#v", got)
 	}
 }

--- a/internal/vba/proceduremetrics/metrics.go
+++ b/internal/vba/proceduremetrics/metrics.go
@@ -113,12 +113,24 @@ func (m Metrics) Value(name MetricName) (int, bool) {
 // anonymous Metrics field intentionally flattens the twelve values in JSON,
 // while keeping identity available to threshold/reporting consumers.
 type ProcedureMetrics struct {
-	File             string                    `json:"file"`
-	Module           string                    `json:"module"`
-	ModuleKind       string                    `json:"module_kind"`
-	Name             string                    `json:"name"`
-	Kind             procedureir.ProcedureKind `json:"kind"`
-	DeclarationRange vbast.Range               `json:"declaration_range"`
+	File                    string                    `json:"file"`
+	Module                  string                    `json:"module"`
+	ModuleKind              string                    `json:"module_kind"`
+	Name                    string                    `json:"name"`
+	Kind                    procedureir.ProcedureKind `json:"kind"`
+	Visibility              string                    `json:"visibility,omitempty"`
+	ResolvedCallees         []string                  `json:"-"`
+	ExternalDependencyCount int                       `json:"-"`
+	ExcelEffectCount        int                       `json:"-"`
+	MutableStateReads       int                       `json:"-"`
+	MutableStateWrites      int                       `json:"-"`
+	MutableStateMutations   int                       `json:"-"`
+	ErrorHandlingCount      int                       `json:"-"`
+	ResourceOwnershipCount  int                       `json:"-"`
+	AmbiguousCallCount      int                       `json:"-"`
+	UnresolvedCallCount     int                       `json:"-"`
+	DynamicCallCount        int                       `json:"-"`
+	DeclarationRange        vbast.Range               `json:"declaration_range"`
 	Metrics
 }
 
@@ -158,6 +170,7 @@ func Collect(input Input) ProcedureMetrics {
 		ModuleKind:       input.ModuleKind,
 		Name:             symbol.Name,
 		Kind:             symbol.Kind,
+		Visibility:       symbol.Visibility,
 		DeclarationRange: symbol.DeclarationRange,
 	}
 	result.SourceLineCount = sourceLineCount(symbol.DeclarationRange)
@@ -184,6 +197,37 @@ func Collect(input Input) ProcedureMetrics {
 		}
 	}
 	result.CallFanOut = callFanOut(calls)
+	result.ResolvedCallees = resolvedCalleeNames(calls)
+	result.ExternalDependencyCount = externalDependencyCount(calls)
+	result.AmbiguousCallCount, result.UnresolvedCallCount, result.DynamicCallCount = callUncertaintyCounts(calls)
+	for _, access := range procedure.Accesses {
+		if access.Scope != procedureir.ScopeModule && access.Scope != procedureir.ScopeProject {
+			continue
+		}
+		switch access.Mode {
+		case procedureir.AccessRead:
+			result.MutableStateReads++
+		case procedureir.AccessWrite:
+			result.MutableStateWrites++
+			result.MutableStateMutations++
+		case procedureir.AccessReadWrite:
+			result.MutableStateReads++
+			result.MutableStateWrites++
+			result.MutableStateMutations++
+		}
+	}
+	for _, statement := range statements {
+		text := strings.ToLower(statement.Text)
+		if strings.Contains(text, "application.") || strings.Contains(text, "range(") || strings.Contains(text, "cells(") || strings.Contains(text, "worksheets(") || strings.Contains(text, "workbooks(") {
+			result.ExcelEffectCount++
+		}
+		if statement.Kind == procedureir.StatementOnError || statement.Kind == procedureir.StatementResume || strings.Contains(text, "err.raise") {
+			result.ErrorHandlingCount++
+		}
+		if strings.Contains(text, "workbooks.open") || strings.HasPrefix(strings.TrimSpace(text), "open ") {
+			result.ResourceOwnershipCount++
+		}
+	}
 	return result
 }
 
@@ -457,6 +501,10 @@ func exitPointCount(kind procedureir.ProcedureKind, statements []procedureir.Sta
 }
 
 func callFanOut(calls []procedureir.CallSite) int {
+	return len(resolvedCalleeNames(calls))
+}
+
+func resolvedCalleeNames(calls []procedureir.CallSite) []string {
 	seen := make(map[string]struct{}, len(calls))
 	for _, call := range calls {
 		if call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 {
@@ -471,7 +519,40 @@ func callFanOut(calls []procedureir.CallSite) int {
 		}
 		seen[strings.ToLower(key)] = struct{}{}
 	}
+	result := make([]string, 0, len(seen))
+	for key := range seen {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func externalDependencyCount(calls []procedureir.CallSite) int {
+	seen := map[string]bool{}
+	for _, call := range calls {
+		status := strings.ToLower(string(call.Resolution.Status))
+		if status == string(procedureir.ResolutionExternal) || status == string(procedureir.ResolutionMemberCall) || status == string(procedureir.ResolutionBuiltinLike) {
+			key := strings.ToLower(strings.TrimSpace(call.Callee.Text))
+			if key != "" {
+				seen[key] = true
+			}
+		}
+	}
 	return len(seen)
+}
+
+func callUncertaintyCounts(calls []procedureir.CallSite) (ambiguous, unresolved, dynamic int) {
+	for _, call := range calls {
+		switch call.Resolution.Status {
+		case procedureir.ResolutionAmbiguous:
+			ambiguous++
+		case procedureir.ResolutionUnresolved, procedureir.ResolutionIncomplete:
+			unresolved++
+		case procedureir.ResolutionDynamic:
+			dynamic++
+		}
+	}
+	return ambiguous, unresolved, dynamic
 }
 
 func sourceLineCount(r vbast.Range) int {

--- a/internal/vba/proceduremetrics/metrics.go
+++ b/internal/vba/proceduremetrics/metrics.go
@@ -216,11 +216,29 @@ func Collect(input Input) ProcedureMetrics {
 			result.MutableStateMutations++
 		}
 	}
+	children := make(map[int]bool, len(statements))
 	for _, statement := range statements {
-		text := strings.ToLower(statement.Text)
-		if strings.Contains(text, "application.") || strings.Contains(text, "range(") || strings.Contains(text, "cells(") || strings.Contains(text, "worksheets(") || strings.Contains(text, "workbooks(") {
+		if statement.ParentID != 0 {
+			children[statement.ParentID] = true
+		}
+	}
+	for _, statement := range statements {
+		texts := make([]string, 0, 4)
+		// Statement.Text for a control node contains its complete nested body.
+		// Only leaf text is used for executable effects; control expressions are
+		// added separately so `If Range(...) Then` remains observable.
+		if !children[statement.ID] {
+			texts = append(texts, statement.Text)
+		}
+		for _, expression := range []*procedureir.Expression{statement.Target, statement.Value, statement.Condition} {
+			if expression != nil {
+				texts = append(texts, expression.Text)
+			}
+		}
+		if containsExcelEffect(texts) {
 			result.ExcelEffectCount++
 		}
+		text := strings.ToLower(statement.Text)
 		if statement.Kind == procedureir.StatementOnError || statement.Kind == procedureir.StatementResume || strings.Contains(text, "err.raise") {
 			result.ErrorHandlingCount++
 		}
@@ -229,6 +247,44 @@ func Collect(input Input) ProcedureMetrics {
 		}
 	}
 	return result
+}
+
+func containsExcelEffect(texts []string) bool {
+	for _, text := range texts {
+		lower := strings.ToLower(text)
+		for _, name := range []string{"application", "range", "cells", "worksheets", "workbooks"} {
+			if containsVBAReference(lower, name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsVBAReference(text, name string) bool {
+	for offset := 0; offset < len(text); {
+		relative := strings.Index(text[offset:], name)
+		if relative < 0 {
+			return false
+		}
+		index := offset + relative
+		beforeOK := index == 0 || !isVBAIdentifierByte(text[index-1])
+		end := index + len(name)
+		after := end
+		for after < len(text) && (text[after] == ' ' || text[after] == '\t') {
+			after++
+		}
+		afterOK := after < len(text) && (text[after] == '(' || text[after] == '.')
+		if beforeOK && afterOK {
+			return true
+		}
+		offset = index + len(name)
+	}
+	return false
+}
+
+func isVBAIdentifierByte(value byte) bool {
+	return value == '_' || value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9'
 }
 
 // CollectProcedure is a convenience for callers that have only a procedure

--- a/internal/vba/proceduremetrics/metrics_test.go
+++ b/internal/vba/proceduremetrics/metrics_test.go
@@ -75,6 +75,22 @@ func TestCollectComputesAllProcedureMetrics(t *testing.T) {
 	}
 }
 
+func TestExcelEffectCountUsesLeafStatementsAndIdentifierBoundaries(t *testing.T) {
+	procedure := procedureir.ProcedureIR{
+		Symbol: procedureir.ProcedureSymbol{Kind: procedureir.ProcedureSub, DeclarationRange: testRange(1, 8)},
+		Statements: []procedureir.Statement{
+			{ID: 1, Kind: procedureir.StatementIf, Condition: &procedureir.Expression{Text: `Range("A1")`}, Range: testRange(2, 5)},
+			{ID: 2, ParentID: 1, Kind: procedureir.StatementUnknown, Text: `SetRange("A1")`, Range: testRange(3, 3)},
+			{ID: 3, Kind: procedureir.StatementUnknown, Text: `Set target = Range("B1")`, Range: testRange(6, 6)},
+			{ID: 4, Kind: procedureir.StatementUnknown, Text: `Application.Cells(1, 1) = 1`, Range: testRange(7, 7)},
+		},
+	}
+	got := Collect(Input{IR: procedure})
+	if got.ExcelEffectCount != 3 {
+		t.Fatalf("excel effects = %d, want 3", got.ExcelEffectCount)
+	}
+}
+
 func TestEvaluateThresholdsUsesStrictPositiveThresholdsAndStableOrder(t *testing.T) {
 	procedures := []ProcedureMetrics{
 		{Name: "Second", File: "b.bas", DeclarationRange: testRange(4, 4), Metrics: Metrics{LoopCount: 3, GotoCount: 2}},

--- a/internal/vba/proceduremetrics/metrics_test.go
+++ b/internal/vba/proceduremetrics/metrics_test.go
@@ -58,7 +58,11 @@ func TestCollectComputesAllProcedureMetrics(t *testing.T) {
 	got := Collect(Input{IR: procedure, File: "src/Main.bas", Module: "Main", ModuleKind: "standard"})
 	want := ProcedureMetrics{
 		File: "src/Main.bas", Module: "Main", ModuleKind: "standard", Name: "Run", Kind: procedureir.ProcedureFunction,
-		DeclarationRange: testRange(2, 20),
+		Visibility:         "",
+		ResolvedCallees:    []string{"other.first", "other.second"},
+		ErrorHandlingCount: 1,
+		AmbiguousCallCount: 1,
+		DeclarationRange:   testRange(2, 20),
 		Metrics: Metrics{
 			CyclomaticComplexity: 8, MaxNestingDepth: 6, StatementCount: 15,
 			SourceLineCount: 19, BranchCount: 3, LoopCount: 4, GotoCount: 1,

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -29,11 +29,12 @@ Use `analyze` for fast source-level feedback before opening Excel.
 
 Procedure complexity measurements are deliberately a separate source-only
 surface. Use [`xlflow metrics`](./metrics) for the twelve deterministic
-procedure metrics and optional `[metrics.thresholds]` policy. `analyze` does
-not populate that payload, does not apply metrics thresholds, and keeps the
-existing `analysis_metrics.module_state` contract unchanged. `MX001` threshold
-diagnostics are owned by `metrics`, not by the analyzer rule registry or
-`[analyze].disabled_rules`.
+procedure metrics, architectural procedure/module hotspot rankings, and
+optional `[metrics.thresholds]` / `[metrics.hotspots]` policies. `analyze` does
+not populate that payload, does not apply metrics thresholds or hotspot
+selectors, and keeps the existing `analysis_metrics.module_state` contract
+unchanged. `MX001` and `MX002` diagnostics are owned by `metrics`, not by the
+analyzer rule registry or `[analyze].disabled_rules`.
 
 `VBA203` tracks each recognized `Application` state write through normal,
 early-exit, error-handler, termination, and unknown CFG exits. A direct saved

--- a/vitepress/commands/index.md
+++ b/vitepress/commands/index.md
@@ -55,7 +55,7 @@ Use command pages for workflow guidance and the canonical CLI contract in [JSON 
 | [lsp](./lsp)                               | Start the reusable VBA language server for editor integrations.                            |
 | [fmt](./fmt)                               | Format VBA source files with a conservative, non-destructive formatter.                    |
 | [analyze](./analyze)                       | Analyze VBA source for runtime-risk patterns without Excel COM.                            |
-| [metrics](./metrics)                       | Calculate deterministic procedure complexity metrics without Excel COM.                    |
+| [metrics](./metrics)                       | Calculate procedure metrics and architectural hotspot rankings without Excel COM.          |
 | [check](./check)                           | Run lint, analyze, and doctor as a combined preflight.                                     |
 | [module](./module)                         | Create module source files and install bundled xlflow helper modules.                      |
 | [completion](./completion)                 | Generate shell completion scripts through Cobra.                                           |

--- a/vitepress/commands/metrics.md
+++ b/vitepress/commands/metrics.md
@@ -99,8 +99,9 @@ warning `MX002` entries and set
 `error.code = "metrics_hotspot_threshold_exceeded"` (exit `1`). The complete
 metrics and hotspot arrays remain available in the failure envelope. Hotspot
 selectors are opt-in, are not analyzer rules, and cannot be inline-suppressed.
-Negative top-N values, non-finite scores, malformed tables, unknown keys, and
-percentages outside `0..100` are configuration errors (exit `2`). The complete
+Negative top-N values, non-finite or otherwise invalid selector input values,
+malformed tables, unknown keys, and percentages outside `0..100` are
+configuration errors (exit `2`). The complete
 signal and ordering contract is in
 `docs/specs/vba-procedure-and-module-hotspots.md`.
 

--- a/vitepress/commands/metrics.md
+++ b/vitepress/commands/metrics.md
@@ -74,6 +74,36 @@ analyzer rule, is not controlled by `[analyze].disabled_rules`, and cannot be
 inline-suppressed. With no enabled threshold, the command returns only metrics
 and exits `0`.
 
+## Hotspot ranking
+
+The same source scan adds `metrics.hotspots`, a versioned ranking of
+procedures and modules. It uses the `percentile_equal_weight_v1` model: each
+raw signal is converted to an average-rank percentile within its cohort, active
+signals are averaged equally, and ties use stable project-relative identity
+ordering. The report retains both `raw_signals` and `normalized_signals`, so a
+score is an auditable maintainability lead rather than a definite bug finding.
+
+Enable selectors independently when a project wants findings:
+
+```toml
+[metrics.hotspots]
+procedure_top_n = 10
+module_top_n = 5
+procedure_score_threshold = 0 # 0 disables; scores are percentages 1..100
+module_score_threshold = 0
+```
+
+Top-N and score-threshold selections are unioned. Top-N-only entities produce
+informational `MX002` entries; entities selected by a score threshold produce
+warning `MX002` entries and set
+`error.code = "metrics_hotspot_threshold_exceeded"` (exit `1`). The complete
+metrics and hotspot arrays remain available in the failure envelope. Hotspot
+selectors are opt-in, are not analyzer rules, and cannot be inline-suppressed.
+Negative top-N values, non-finite scores, malformed tables, unknown keys, and
+percentages outside `0..100` are configuration errors (exit `2`). The complete
+signal and ordering contract is in
+`docs/specs/vba-procedure-and-module-hotspots.md`.
+
 ## JSON output
 
 ```json
@@ -110,7 +140,13 @@ and exits `0`.
         "local_variable_count": 2,
         "call_fan_out": 2
       }
-    ]
+    ],
+    "hotspots": {
+      "schema_version": 1,
+      "score_model": "percentile_equal_weight_v1",
+      "procedures": [],
+      "modules": []
+    }
   },
   "diagnostics": [],
   "warnings": [],
@@ -123,7 +159,9 @@ change; removing or redefining a field requires a new version. Procedures are
 sorted by normalized file, declaration start position, module, name, and kind. Threshold
 diagnostics are sorted by that procedure order and the fixed metric order. This
 ordering, slash-separated paths, normalized exclusion list, and stable JSON
-serialization make repeated runs deterministic.
+serialization make repeated runs deterministic. The nested `hotspots` report
+uses its own schema version and `percentile_equal_weight_v1` score model; its
+procedure/module arrays are ranked independently with stable identity tie-breaks.
 
 ## Related
 

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -375,8 +375,9 @@ Top-N and score-threshold selections are unioned. Top-N-only `MX002` entries
 are informational; threshold-selected entries are warning-level and return
 `error.code = "metrics_hotspot_threshold_exceeded"` with exit `1`, while
 retaining the complete metrics payload. Negative top-N values, non-finite
-numbers, unknown keys, malformed tables, and percentages outside `0..100` are
-configuration errors (exit `2`). The signal vocabulary and deterministic
+selector percentages, unknown keys, malformed tables, and percentages outside
+`0..100` are configuration errors (exit `2`); valid percentages are exactly
+`0` or values from `1` through `100`. The signal vocabulary and deterministic
 ranking contract are defined in
 `docs/specs/vba-procedure-and-module-hotspots.md`.
 

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -133,6 +133,12 @@ parameter_count = 0
 byref_parameter_count = 0
 local_variable_count = 0
 call_fan_out = 0
+
+[metrics.hotspots]
+procedure_top_n = 0
+module_top_n = 0
+procedure_score_threshold = 0
+module_score_threshold = 0
 ```
 
 ## Section reference
@@ -351,6 +357,28 @@ and is not controlled by `[analyze].disabled_rules`. Without enabled
 thresholds, `xlflow metrics` exits `0`; one or more `MX001` diagnostics retain
 the full metrics result and exit `1` with `error.code =
 "metrics_threshold_exceeded"`.
+
+### `[metrics.hotspots]`
+
+| Key                         | Type  | Required | Default | Description                                                                                |
+| --------------------------- | ----- | -------- | ------- | ------------------------------------------------------------------------------------------ |
+| `procedure_top_n`           | int   | no       | `0`     | Select the top N ranked procedure hotspots; `0` disables top-N selection.                  |
+| `module_top_n`              | int   | no       | `0`     | Select the top N ranked module hotspots; `0` disables top-N selection.                     |
+| `procedure_score_threshold` | float | no       | `0`     | Select procedure scores greater than or equal to this percentage (`1..100`); `0` disables. |
+| `module_score_threshold`    | float | no       | `0`     | Select module scores greater than or equal to this percentage (`1..100`); `0` disables.    |
+
+Hotspots are emitted under `metrics.hotspots` by `xlflow metrics` even when no
+selector is enabled. Scores use the versioned
+`percentile_equal_weight_v1` model and retain `raw_signals` plus
+`normalized_signals`; procedure and module cohorts are ranked independently.
+Top-N and score-threshold selections are unioned. Top-N-only `MX002` entries
+are informational; threshold-selected entries are warning-level and return
+`error.code = "metrics_hotspot_threshold_exceeded"` with exit `1`, while
+retaining the complete metrics payload. Negative top-N values, non-finite
+numbers, unknown keys, malformed tables, and percentages outside `0..100` are
+configuration errors (exit `2`). The signal vocabulary and deterministic
+ranking contract are defined in
+`docs/specs/vba-procedure-and-module-hotspots.md`.
 
 ## Defaults differ between `new` and `init`
 

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -4,10 +4,13 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 
 - `access_denied`
 - `active_sheet`
+- `active_signal_count`
 - `active_workbook_mismatch`
+- `affected_module_count`
 - `affected_modules`
 - `allowed_diagnostics`
 - `alternative_body`
+- `ambiguous_call_count`
 - `ambiguous_test_name`
 - `analysis_metrics`
 - `analyze_disabled_rules_precedence`
@@ -85,6 +88,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `byval_modifier`
 - `cached_excel_reference`
 - `call_expression`
+- `call_fan_in`
 - `call_fan_out`
 - `call_statement`
 - `capability_version`
@@ -136,6 +140,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `compile_equivalent`
 - `compile_invoked`
 - `compile_vba`
+- `complexity_max`
 - `component_type`
 - `components_applied`
 - `compressible_short_roundtrips`
@@ -172,6 +177,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `current_directory_dependency`
 - `current_version`
 - `customer_name`
+- `cycle_count`
 - `cyclomatic_complexity`
 - `data_flow`
 - `database_result`
@@ -288,6 +294,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `duplicate_test_name`
 - `duplicate_todo`
 - `duration_ms`
+- `dynamic_call_count`
 - `dynamic_identifier`
 - `edit_args_invalid`
 - `edit_coordinates_unreconciled`
@@ -311,6 +318,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `enum_group`
 - `enum_member`
 - `environment_variable`
+- `error_handling_count`
 - `event_declaration`
 - `event_reader_count`
 - `event_statement`
@@ -328,6 +336,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `excel_com`
 - `excel_com_failure`
 - `excel_com_state_uncertain`
+- `excel_effect_count`
 - `excel_installed`
 - `excel_instance`
 - `excel_pid`
@@ -351,6 +360,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `expected_closer`
 - `expected_error`
 - `export_image_args_invalid`
+- `external_dependency_count`
 - `external_function_declaration`
 - `external_process`
 - `external_reference`
@@ -573,6 +583,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `metadata_read_failed`
 - `metrics_exclude_unmatched`
 - `metrics_failed`
+- `metrics_hotspot_threshold_exceeded`
 - `metrics_threshold_exceeded`
 - `metrics_thresholds_invalid`
 - `min_keep`
@@ -595,9 +606,14 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `module_not_found`
 - `module_only_declaration_in_procedure`
 - `module_path`
+- `module_score_threshold`
 - `module_state`
+- `module_top_n`
 - `module_variable`
 - `modules_dir`
+- `mutable_state_mutations`
+- `mutable_state_reads`
+- `mutable_state_writes`
 - `mutator_count`
 - `named_argument`
 - `nearby_code`
@@ -615,6 +631,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `non_numeric`
 - `non_test`
 - `normal_exit`
+- `normalized_signals`
 - `not_applicable`
 - `not_attempted`
 - `not_performed`
@@ -691,6 +708,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `parser_token`
 - `passing_mode`
 - `path_translation`
+- `percentile_equal_weight_v1`
 - `plain_http_credentials`
 - `plan_invalid`
 - `poison_reason`
@@ -714,6 +732,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `procedure_modifier`
 - `procedure_name`
 - `procedure_name_constant`
+- `procedure_score_threshold`
+- `procedure_top_n`
 - `process_architecture`
 - `process_args_invalid`
 - `process_cancelled`
@@ -745,6 +765,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `property_value_type`
 - `protected_module`
 - `protocol_version`
+- `public_procedure_count`
 - `published_runs`
 - `pull_args_invalid`
 - `pull_formulas_failed`
@@ -760,6 +781,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `raise_event`
 - `raise_event_statement`
 - `raises_error`
+- `raw_signals`
 - `read_only`
 - `read_only_configuration`
 - `read_write`
@@ -789,6 +811,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `residual_path`
 - `resolved_result`
 - `resolved_value`
+- `resource_ownership_count`
 - `resource_scope`
 - `response_source`
 - `restored_from`
@@ -836,12 +859,14 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `saved_workbook`
 - `schema_version`
 - `schema_version_changed`
+- `score_model`
 - `script_failed`
 - `script_host`
 - `script_not_found`
 - `search_order`
 - `select_statement`
 - `selected_bridge`
+- `selected_by`
 - `selected_index`
 - `sensitive_module_constant`
 - `session_args_invalid`
@@ -988,6 +1013,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `unknown_transformation`
 - `unnamed_control_placeholder`
 - `unquoted_executable_path`
+- `unresolved_call_count`
 - `unsafe_backup_file_path`
 - `unsafe_original_workbook_path`
 - `unsupported_form_control`

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -971,6 +971,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `timeout_ms`
 - `timeout_state`
 - `too_long`
+- `top_n`
 - `total_diffs`
 - `tree_sitter_vba`
 - `trust_vba_access`

--- a/vitepress/reference/exit-codes.md
+++ b/vitepress/reference/exit-codes.md
@@ -1,10 +1,10 @@
 # Exit Codes
 
-| Code | Meaning                                                                                                           |
-| ---: | ----------------------------------------------------------------------------------------------------------------- |
-|  `0` | Success                                                                                                           |
-|  `1` | Validation or user-code failure (`fmt --check` found unformatted files, `metrics` thresholds were exceeded, etc.) |
-|  `2` | CLI argument or configuration error (including invalid wait combinations and metrics thresholds/exclusions)       |
-|  `3` | Operational or environment failure (including workbook busy, wait, and recovery outcomes)                         |
+| Code | Meaning                                                                                                                                       |
+| ---: | --------------------------------------------------------------------------------------------------------------------------------------------- |
+|  `0` | Success                                                                                                                                       |
+|  `1` | Validation or user-code failure (`fmt --check` found unformatted files, `metrics` thresholds or hotspot score thresholds were exceeded, etc.) |
+|  `2` | CLI argument or configuration error (including invalid wait combinations, metrics thresholds/exclusions, and hotspot selectors)               |
+|  `3` | Operational or environment failure (including workbook busy, wait, and recovery outcomes)                                                     |
 
 `diff` returns `0` when differences are found. Inspect `diff.summary.total_diffs` in JSON.

--- a/vitepress/reference/json-output.md
+++ b/vitepress/reference/json-output.md
@@ -123,7 +123,8 @@ command artifacts.
 versioned `metrics` object. Procedure entries are project-relative, use `/`
 path separators, and are sorted by file, declaration start position, module, name, and
 kind. The twelve metric fields are defined in
-`docs/specs/vba-procedure-complexity-metrics.md`.
+`docs/specs/vba-procedure-complexity-metrics.md`; the additive hotspot projection
+is defined in `docs/specs/vba-procedure-and-module-hotspots.md`.
 
 ```json
 {
@@ -159,7 +160,13 @@ kind. The twelve metric fields are defined in
         "local_variable_count": 2,
         "call_fan_out": 2
       }
-    ]
+    ],
+    "hotspots": {
+      "schema_version": 1,
+      "score_model": "percentile_equal_weight_v1",
+      "procedures": [],
+      "modules": []
+    }
   },
   "diagnostics": [],
   "warnings": [],
@@ -186,7 +193,16 @@ threshold`. Each exceeded procedure/metric pair emits one warning diagnostic:
     "code": "metrics_threshold_exceeded",
     "message": "1 procedure complexity threshold exceeded"
   },
-  "metrics": { "schema_version": 1, "procedures": [] },
+  "metrics": {
+    "schema_version": 1,
+    "procedures": [],
+    "hotspots": {
+      "schema_version": 1,
+      "score_model": "percentile_equal_weight_v1",
+      "procedures": [],
+      "modules": []
+    }
+  },
   "diagnostics": [
     {
       "code": "MX001",
@@ -213,6 +229,67 @@ procedure order and the fixed metric order. `MX001` is not a static-analysis
 rule, cannot be inline-suppressed, and is unaffected by
 `[analyze].disabled_rules`. No enabled thresholds means exit `0`; one or more
 `MX001` entries retain the full metrics payload and use exit `1`.
+
+### Hotspot ranking
+
+`metrics.hotspots` is always present in a successful or threshold-failure
+metrics result. It ranks procedure and module cohorts independently with the
+versioned `percentile_equal_weight_v1` model. Each entity includes `rank`, a
+`score` from `0` to `100`, `active_signal_count`, stable identity fields, and
+both `raw_signals` and `normalized_signals`; selected entities additionally
+include `selected_by` (`top_n` and/or `threshold`).
+
+Each entity also exposes `uncertainty` counts for ambiguous, unresolved, and
+dynamic calls. These counts are audit evidence only and do not contribute to
+the composite score.
+
+```json
+{
+  "schema_version": 1,
+  "score_model": "percentile_equal_weight_v1",
+  "procedures": [
+    {
+      "id": "src/modules/Main.bas|Main|Run|sub",
+      "kind": "procedure",
+      "file": "src/modules/Main.bas",
+      "module": "Main",
+      "module_kind": "standard",
+      "name": "Run",
+      "procedure_kind": "sub",
+      "line": 1,
+      "rank": 1,
+      "score": 87.5,
+      "score_model": "percentile_equal_weight_v1",
+      "active_signal_count": 4,
+      "raw_signals": {
+        "complexity": 8,
+        "call_fan_in": 3,
+        "call_fan_out": 4,
+        "affected_module_count": 2
+      },
+      "normalized_signals": {
+        "complexity": 100,
+        "call_fan_in": 75,
+        "call_fan_out": 75,
+        "affected_module_count": 100
+      },
+      "selected_by": { "top_n": true }
+    }
+  ],
+  "modules": []
+}
+```
+
+Raw signal names (including module-only `complexity_max` and
+`public_procedure_count`) and counting boundaries are defined in
+`docs/specs/vba-procedure-and-module-hotspots.md`. Average-rank percentiles
+ignore constant/singleton signals, scores are equal-weight means rounded to
+two decimals, and stable identity tie-breakers make ranking independent of
+source enumeration. Top-N-only `MX002` diagnostics are informational;
+threshold-selected entities are warning-level and use
+`error.code = "metrics_hotspot_threshold_exceeded"` with exit `1`. The full
+metrics and hotspot arrays remain in that failure envelope. `MX002` is not an
+analyzer rule and cannot be inline-suppressed.
 
 ## Build manifest
 


### PR DESCRIPTION
Closes #461

## Summary

- Extend `xlflow metrics` with deterministic procedure and module architectural-hotspot rankings.
- Expose raw signals, normalized percentiles, uncertainty evidence, score metadata, and selection reasons.
- Add opt-in `[metrics.hotspots]` Top-N and score-threshold selectors with metrics-owned `MX002` findings.
- Keep hotspot reporting outside `analyze`, LSP, the static-analysis registry, and inline suppression.
- Add the hotspot package, configuration/output/CLI tests, ADR-0039, specification, CLI contracts, and user documentation.

## Behavior

- Procedure and module cohorts are ranked independently using `percentile_equal_weight_v1`.
- Constant and singleton signals are excluded from the score denominator.
- Top-N-only selections are informational and non-failing; threshold selections are warnings and exit with code 1.
- Existing `MX001` behavior and `metrics_threshold_exceeded` compatibility are preserved.
- Ambiguous, unresolved, and dynamic call counts are retained as uncertainty evidence but are not used as confirmed dependencies or score inputs.

## Validation

- `scripts/dev/go.ps1 test ./...`
- `pnpm format:check`
- `pnpm docs:check`
- `git diff --check`

All checks pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic procedure and module hotspot rankings to `xlflow metrics`.
  - Metrics JSON now includes versioned hotspot scores, rankings, signals, uncertainty details, and selection reasons.
  - Added configurable top-N and score-threshold selectors for procedures and modules.
  - Added `MX002` hotspot diagnostics and corresponding exit-code behavior.
  - Hotspot reports now display ranked tables with scores and active-signal counts.

- **Documentation**
  - Added configuration, JSON output, command behavior, scoring, validation, and exit-code guidance for hotspot metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->