### PR TITLE
Add shared VBA constant-expression evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added a shared, Excel-free VBA constant-expression evaluator for issue #595.
+  Typed `Known` / `Unknown` / `Invalid` results now power Optional defaults,
+  Const and Enum references, fixed-array bounds, and `ReDim` bounds across
+  batch and LSP analysis. Runtime calls, ambiguous or unresolved values, and
+  safely unmodelled overflow remain fail-open instead of becoming diagnostics.
+
 - Fixed `VBA204` false positives for project-specific labels used as shared
   cleanup or loop-finalization paths, while retaining findings for normal
   fallthrough into logging, error reporting, or arbitrary handler code. Cleanup

--- a/docs/adr/ADR-0041-shared-vba-constant-expression-evaluation.md
+++ b/docs/adr/ADR-0041-shared-vba-constant-expression-evaluation.md
@@ -1,0 +1,99 @@
+# ADR-0041: Shared VBA Constant-Expression Evaluation
+
+## Status
+
+Accepted
+
+## Context
+
+Declaration validation needs to answer whether a VBA expression is a value that
+can be known without running a procedure. Optional parameter defaults, Enum
+members, array bounds, `ReDim` bounds, and literal arithmetic previously used
+separate integer or text heuristics. Those heuristics disagreed about suffixes,
+operator precedence, forward Const references, and whether an unresolved value
+was an error or merely not provable. Batch analysis and LSP also built
+name-only project constant tables, so the same source could receive different
+results depending on the entry point.
+
+The evaluator is static-analysis infrastructure. It must not load Excel, call
+COM, or execute arbitrary VBA while deciding a diagnostic.
+
+## Decision
+
+Add `internal/vba/constexpr` as the shared, presentation-independent evaluator.
+It exposes a typed scalar `Value`, a case-insensitive immutable `Environment`,
+and `Result` with the three independent outcomes `Known`, `Unknown`, and
+`Invalid`. `Known` carries the original typed value and retains the historical
+integer projection used by existing bound analyses.
+
+The parser implements a deliberately conservative VBA subset: numeric and
+string/date/Boolean literals, intrinsic literal values, resolved Const and Enum
+symbols, parentheses, unary operators, arithmetic and Boolean operators,
+comparisons, and string concatenation. Calls, runtime-dependent names,
+unsupported comparison semantics, unresolved symbols, conditional uncertainty,
+and safely unmodelled overflow return `Unknown`. Malformed syntax and domains
+such as division by zero return `Invalid`. The evaluator never invokes a call
+expression.
+
+Project environments are immutable snapshots assembled from the same parsed
+source used by batch and LSP analysis. Public/Friend module constants, Enum
+values (including implicit and forward references), and static TypeLib values
+are projected into qualified and, only when unique, unqualified names.
+Ambiguous or incomplete names remain available to name-only resolver logic but
+are filtered from value evaluation. Local source values are overlaid for the
+current document without mutating the project snapshot.
+
+Existing `Optional`-default, fixed-array, and `ReDim` bound consumers call the
+shared API through adapters. Their diagnostic ownership and codes do not
+change; unknown values continue to fail open.
+
+## Consequences
+
+- Const, Enum, optional-default, declaration-bound, and ReDim checks share one
+  deterministic grammar and result model.
+- Batch and LSP can evaluate the same revision from the same value-bearing
+  snapshot, while incomplete snapshots remain conservative.
+- Typed strings, Booleans, floating-point values, currency, suffixes, and
+  checked integer boundaries are represented explicitly instead of being
+  coerced into `int`.
+- The supported subset intentionally misses runtime functions, `Like`/`Is`
+  semantics, conditional-compilation execution, and other context-dependent
+  VBA behavior. Those cases are `Unknown`, not false compile errors.
+- Source projection remains a temporary compatibility adapter until
+  declaration initializers and Enum value expressions are first-class IR facts;
+  the evaluator API itself does not retain parser nodes or source buffers.
+
+## Alternatives Considered
+
+1. **Execute VBA or ask Excel for a value.** Rejected because analysis must be
+   deterministic, snapshot-safe, Excel-free, and safe in CI/LSP processes.
+2. **Keep independent integer parsers in each rule.** Rejected because it
+   duplicates precedence, overflow, suffix, and ambiguity policy and caused
+   batch/LSP drift.
+3. **Treat every unresolved expression as invalid.** Rejected because an
+   unresolved, runtime-dependent, or conditional value is not evidence of
+   malformed source; collapsing it would create false positives.
+4. **Model every VBA coercion and intrinsic call immediately.** Rejected for
+   the first increment; unsafe or context-dependent semantics are explicitly
+   `Unknown` until they can be specified and tested.
+
+## Evidence
+
+- Issue #595 acceptance criteria and boundary-value corpus in
+  `internal/vba/constexpr/constexpr_test.go` and
+  `internal/lint/constant_values_test.go`.
+- Existing declaration and array contracts in
+  `internal/lint/signature_diagnostics_test.go`,
+  `internal/lint/array_shape_diagnostics_test.go`, and
+  `internal/analyze/analyzer_test.go`.
+- `internal/vba/intel` and `internal/lspserver` project-snapshot tests verify
+  that shared lint and compile-equivalent paths retain their existing
+  batch/LSP convergence.
+
+## Related
+
+- Issue #595
+- ADR-0021 (procedure analysis IR)
+- ADR-0040 (shared array-operation shape validation)
+- `docs/specs/vba-constant-expression-evaluation.md`
+- `docs/specs/vba-analysis-ir.md`

--- a/docs/specs/vba-constant-expression-evaluation.md
+++ b/docs/specs/vba-constant-expression-evaluation.md
@@ -1,0 +1,82 @@
+# VBA Constant-Expression Evaluation
+
+This specification defines the internal, Excel-free contract for deciding
+whether a VBA expression has a safe static value. It is used by declaration
+and compile-equivalent analysis; it is not a VBA interpreter and does not
+change CLI or LSP wire formats.
+
+## API
+
+`internal/vba/constexpr` provides:
+
+```go
+type Result struct {
+    Kind   ResultKind // Known, Unknown, or Invalid
+    Value  int        // compatibility projection for integral Known values
+    Typed  Value      // typed Known value
+    Type   string
+    Reason string
+}
+
+func Evaluate(expression string, env Environment) Result
+func EvaluateValues(expression string, values map[string]Value) Result
+func EvaluateInteger(expression string, constants map[string]int) Result
+```
+
+`EvaluateInteger` is a compatibility adapter. It returns `Known` only when the
+typed result is integral and representable by the host `int`; otherwise it
+returns `Unknown`.
+
+## Supported subset
+
+- decimal, hexadecimal (`&H`), octal (`&O`), floating-point, currency, and
+  VBA numeric suffixes;
+- quoted strings with doubled-quote escaping, date literals, `True`/`False`,
+  `Empty`, `Null`, and `Nothing`;
+- values supplied by an immutable environment, including Const, Enum, and
+  static TypeLib/intrinsic constants;
+- parentheses, unary `+`, `-`, `Not`, arithmetic (`+`, `-`, `*`, `/`, `\`,
+  `Mod`, `^`), Boolean (`And`, `Or`, `Xor`, `Eqv`, `Imp`), comparisons, and
+  string concatenation (`&`).
+
+Operator precedence follows the evaluator grammar and is covered by fixtures.
+`Like` and `Is` are recognized but remain `Unknown` because their semantics are
+context-dependent or object/runtime-based.
+
+## Outcome policy
+
+`Known` means all operands and operations were modelled safely. `Unknown` is
+used for unresolved or ambiguous symbols, runtime calls, conditional or
+recovered source, unsupported semantics, non-integral compatibility results,
+and overflow whose VBA behavior is not modelled. `Invalid` is reserved for
+malformed syntax, incompatible statically known operand types, and invalid
+domains such as division by zero. Consumers must not turn `Unknown` into an
+error.
+
+The evaluator uses checked integer operations and finite floating-point
+results. Currency values retain four-decimal fixed-point storage. Environment
+lookups are case-insensitive and deterministic even if a caller's map contains
+case-only duplicate keys.
+
+## Environment construction
+
+Batch and LSP project snapshots build value maps from the parsed source and
+static TypeLib database. Only public/friend declarations are exported across
+modules. Qualified module/Enum/library names are retained; unqualified names
+are retained only for a unique winner. A document's local Const/Enum values are
+overlaid on the immutable project map for that document. Conditional,
+recovered, unresolved, or cyclic declarations remain absent from the value map
+and therefore evaluate as `Unknown`.
+
+## Consumers and verification
+
+- Optional parameter defaults use the typed result for existing `VB048`
+  constant/type checks and keep runtime calls as nonconstant.
+- Fixed declaration bounds, `ReDim` bounds, and compile-equivalent array
+  adapters use the integer compatibility projection; dynamic or non-integral
+  bounds remain unclassified.
+- Dedicated evaluator fixtures cover suffixes, numeric boundaries,
+  floating-point and currency literals, strings, Booleans, Const/Enum
+  references, precedence, invalid expressions, unresolved names, and calls.
+- Lint, analyze, Intel, and LSP tests verify existing diagnostic ownership and
+  deterministic behavior without Excel or COM.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/gui"
+	"github.com/harumiWeb/xlflow/internal/lint"
 	staticpreflight "github.com/harumiWeb/xlflow/internal/staticanalysis/preflight"
 	staticrules "github.com/harumiWeb/xlflow/internal/staticanalysis/rules"
 	"github.com/harumiWeb/xlflow/internal/suppression"
 	"github.com/harumiWeb/xlflow/internal/typedb"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
 	"github.com/harumiWeb/xlflow/internal/vba/effects"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
@@ -94,6 +96,7 @@ type Analyzer struct {
 	typeDB                     *vbadb.DB
 	typeDBResolutionIncomplete bool
 	visibleConstants           map[string]bool
+	visibleConstantValues      map[string]constexpr.Value
 	byRefSymbols               []intel.Symbol
 	errorGuardAliases          map[string]bool
 	errorValueWrappers         map[string]bool
@@ -242,6 +245,7 @@ type parsedFile struct {
 	Parsed                    *vbaast.ParsedDocument
 	IntelDocument             intel.Document
 	RangeValueModuleConstants map[string]int
+	ConstantValues            map[string]constexpr.Value
 	DataFlowModuleBindings    map[string]bool
 }
 
@@ -391,6 +395,10 @@ func (a Analyzer) RunResultContext(ctx context.Context) (Result, error) {
 		if a.Config.Analyze.DetectRangeValueArrayShape {
 			rangeValueConstants = rangeValueModuleIntegerConstants(lines, ir)
 		}
+		var constantValues map[string]constexpr.Value
+		if a.Config.Analyze.DetectArrayLifecycleSafety || a.Config.Analyze.DetectRedimPreserveDimension || a.Config.Analyze.DetectObjectArrayComparison {
+			constantValues = lint.ConstantValuesFromSource(string(source), &ir, nil)
+		}
 		var dataFlowModuleBindings map[string]bool
 		if a.Config.Analyze.DetectUntrustedDataFlow || a.Config.Analyze.DetectUnsafeCommandConstruction || a.Config.Analyze.DetectUnsafeSQLConstruction {
 			dataFlowModuleBindings = dataFlowBindings(ir.Declarations)
@@ -406,6 +414,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (Result, error) {
 			Parsed:                    parsed,
 			IntelDocument:             intelDocument,
 			RangeValueModuleConstants: rangeValueConstants,
+			ConstantValues:            constantValues,
 			DataFlowModuleBindings:    dataFlowModuleBindings,
 		})
 	}
@@ -439,6 +448,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (Result, error) {
 		}
 	}
 	analysis.visibleConstants = projectVisibleConstants(parsedFiles, analysis.typeDB)
+	analysis.visibleConstantValues = projectConstantValues(parsedFiles, analysis.typeDB)
 	if dictionaryCollectionAnalysisEnabled(analysis.Config.Analyze) {
 		analysis.dictionaryCollection = buildDictionaryCollectionIndex(parsedFiles)
 	}
@@ -595,6 +605,7 @@ func (a Analyzer) compileEquivalentFindings(file parsedFile) ([]Finding, []Findi
 		TypeDBResolutionIncomplete: a.typeDBResolutionIncomplete,
 		WorkspaceSymbolQueryFunc:   a.byRefWorkspaceSymbolQuery,
 		VisibleConstants:           a.visibleConstants,
+		ConstantValues:             a.visibleConstantValues,
 	}).CompileEquivalentDiagnosticsContext(context.Background(), file.intelDocument())
 	if len(diagnostics) == 0 {
 		return nil, nil
@@ -1020,6 +1031,13 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBContext(ctx context.Context, roo
 // diagnostics use it for cross-file rules while legacy callers retain the
 // single-document entry point above.
 func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectContext(ctx context.Context, rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document, typeDB *vbadb.DB, projectEffects effects.ProjectSummary) ([]Finding, error) {
+	return SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx, rootDir, cfg, doc, ir, controlFlow, typeDB, projectEffects, nil)
+}
+
+// SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext is
+// the snapshot-aware form used by LSP and other project callers that already
+// own a value-bearing constant environment.
+func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx context.Context, rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document, typeDB *vbadb.DB, projectEffects effects.ProjectSummary, projectConstants map[string]constexpr.Value) ([]Finding, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -1043,6 +1061,10 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectContext(ctx context.Co
 		if cfg.Analyze.DetectRangeValueArrayShape {
 			rangeValueConstants = rangeValueModuleIntegerConstants(lines, ir)
 		}
+		var constantValues map[string]constexpr.Value
+		if cfg.Analyze.DetectArrayLifecycleSafety || cfg.Analyze.DetectRedimPreserveDimension || cfg.Analyze.DetectObjectArrayComparison {
+			constantValues = lint.ConstantValuesFromSource(string(view.Source), &ir, projectConstants)
+		}
 		var dataFlowModuleBindings map[string]bool
 		if cfg.Analyze.DetectUntrustedDataFlow || cfg.Analyze.DetectUnsafeCommandConstruction || cfg.Analyze.DetectUnsafeSQLConstruction {
 			dataFlowModuleBindings = dataFlowBindings(ir.Declarations)
@@ -1056,9 +1078,10 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectContext(ctx context.Co
 			IR:                        ir,
 			CFG:                       controlFlow,
 			RangeValueModuleConstants: rangeValueConstants,
+			ConstantValues:            constantValues,
 			DataFlowModuleBindings:    dataFlowModuleBindings,
 		}
-		analyzer := Analyzer{RootDir: rootDir, Config: cfg, typeDB: typeDB}
+		analyzer := Analyzer{RootDir: rootDir, Config: cfg, typeDB: typeDB, visibleConstantValues: projectConstants}
 		if dictionaryCollectionAnalysisEnabled(cfg.Analyze) {
 			analyzer.dictionaryCollection = buildDictionaryCollectionIndex([]parsedFile{file})
 		}

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -931,10 +931,11 @@ func arrayIntegerConstants(file parsedFile, proc sourceProcedure, projectValues 
 		if value.Kind != constexpr.ValueInteger && value.Kind != constexpr.ValueLong && value.Kind != constexpr.ValueLongLong {
 			continue
 		}
-		if int64(int(value.Integer)) != value.Integer {
+		integer, ok := constexpr.IntegerAsInt(value)
+		if !ok {
 			continue
 		}
-		constants[strings.ToLower(name)] = int(value.Integer)
+		constants[strings.ToLower(name)] = integer
 	}
 	inEnum := false
 	var next *int

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/harumiWeb/xlflow/internal/lint"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
@@ -127,7 +129,7 @@ func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, 
 	// Constant bounds are scoped to the current procedure. Resolve them once
 	// for this CFG walk so every ReDim transfer shares the same table without
 	// repeatedly reparsing the module and procedure declarations.
-	constants := arrayIntegerConstants(file, proc)
+	constants := arrayIntegerConstants(file, proc, a.visibleConstantValues, a.visibleConstants)
 	if proc.Graph == nil {
 		findings := append([]Finding(nil), comparisonFindings...)
 		findings = append(findings, a.arrayLifecycleLinearFindings(file, proc, ctx, variables, initial, constants)...)
@@ -901,13 +903,58 @@ func parseArrayDimensionsWithConstants(text string, base int, constants map[stri
 // the Enum members that are valid integer bound names in VBA.  The parser is
 // intentionally small and fail-open: unresolved expressions simply do not
 // enter the table, so dynamic bounds remain unclassified.
-func arrayIntegerConstants(file parsedFile, proc sourceProcedure) map[string]int {
+func arrayIntegerConstants(file parsedFile, proc sourceProcedure, projectValues map[string]constexpr.Value, visibleNames map[string]bool) map[string]int {
 	constants := rangeValueIntegerConstants(rangeValueModuleIntegerConstants(file.Lines, file.IR), proc)
+	// Seed the ReDim evaluator from the shared typed projection so arithmetic,
+	// Enum references, and qualified project constants follow the same rules as
+	// declaration and Optional-default validation. Non-integral and unresolved
+	// values intentionally stay out of this integer-only adapter.
+	sharedValues := file.ConstantValues
+	if sharedValues == nil {
+		sharedValues = lint.ConstantValuesFromSource(string(file.Source), &file.IR, nil)
+	}
+	if len(projectValues) > 0 {
+		merged := make(map[string]constexpr.Value, len(sharedValues)+len(projectValues))
+		for name, value := range projectValues {
+			key := strings.ToLower(cleanIdentifier(name))
+			if visibleNames != nil && !visibleNames[key] {
+				continue
+			}
+			merged[name] = value
+		}
+		for name, value := range sharedValues {
+			merged[name] = value
+		}
+		sharedValues = merged
+	}
+	for name, value := range sharedValues {
+		if value.Kind != constexpr.ValueInteger && value.Kind != constexpr.ValueLong && value.Kind != constexpr.ValueLongLong {
+			continue
+		}
+		if int64(int(value.Integer)) != value.Integer {
+			continue
+		}
+		constants[strings.ToLower(name)] = int(value.Integer)
+	}
 	inEnum := false
 	var next *int
+	conditionalDepth := 0
 	for _, line := range file.Lines {
 		code := strings.TrimSpace(normalizedCodeLine(line))
 		lower := strings.ToLower(code)
+		if strings.HasPrefix(lower, "#if ") {
+			conditionalDepth++
+			continue
+		}
+		if strings.HasPrefix(lower, "#end if") {
+			if conditionalDepth > 0 {
+				conditionalDepth--
+			}
+			continue
+		}
+		if conditionalDepth > 0 || strings.HasPrefix(lower, "#elseif ") || strings.HasPrefix(lower, "#else") {
+			continue
+		}
 		if strings.HasPrefix(lower, "enum ") || strings.HasPrefix(lower, "public enum ") || strings.HasPrefix(lower, "private enum ") || strings.HasPrefix(lower, "friend enum ") {
 			inEnum = true
 			next = nil
@@ -1311,7 +1358,7 @@ func inferArrayReturnSummaries(files []parsedFile) map[string]arrayValue {
 				// unconditional return assignments, so leave the summary unknown.
 				continue
 			}
-			constants := arrayIntegerConstants(file, proc)
+			constants := arrayIntegerConstants(file, proc, nil, nil)
 			walkArrayCFG(proc.Graph, file.Lines, arrayInitialState(variables), func(text string, line int, in arrayFlowState) arrayFlowState {
 				if lhs, rhs, indexed, ok := arrayAssignment(text); ok && !indexed && strings.EqualFold(lhs, proc.Name) {
 					value, known := arrayExpressionState(rhs, in, ctx)

--- a/internal/analyze/constant_values.go
+++ b/internal/analyze/constant_values.go
@@ -1,90 +1,15 @@
 package analyze
 
 import (
-	"strings"
-
 	"github.com/harumiWeb/xlflow/internal/lint"
 	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
-	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vbadb"
 )
 
 func projectConstantValues(files []parsedFile, typeDB *vbadb.DB) map[string]constexpr.Value {
-	values := make(map[string]constexpr.Value)
+	documents := make([]lint.ConstantValueDocument, 0, len(files))
 	for _, file := range files {
-		fileValues := file.ConstantValues
-		if fileValues == nil {
-			fileValues = lint.ConstantValuesFromSource(string(file.Source), &file.IR, nil)
-		}
-		standard := strings.EqualFold(file.ModuleKind, "standard")
-		for _, declaration := range file.IR.Declarations {
-			if !declaration.IsConst && !procedureir.IsConstKind(declaration.Kind) {
-				continue
-			}
-			if !strings.EqualFold(declaration.Visibility, "public") && !strings.EqualFold(declaration.Visibility, "friend") {
-				continue
-			}
-			value, ok := fileValues[strings.ToLower(cleanIdentifier(declaration.Name))]
-			if !ok {
-				continue
-			}
-			name := strings.ToLower(cleanIdentifier(declaration.Name))
-			if standard {
-				values[name] = value
-			}
-			if file.IR.ModuleName != "" {
-				values[strings.ToLower(cleanIdentifier(file.IR.ModuleName))+"."+name] = value
-			}
-			if declaration.Parent != "" {
-				values[strings.ToLower(cleanIdentifier(declaration.Parent))+"."+name] = value
-			}
-		}
+		documents = append(documents, lint.ConstantValueDocument{Source: string(file.Source), IR: &file.IR})
 	}
-	if typeDB == nil {
-		return values
-	}
-	all := typeDB.AllConstantsList()
-	counts := make(map[string]int)
-	for _, constant := range all {
-		name := strings.ToLower(cleanIdentifier(constant.Name))
-		if name != "" {
-			counts[name]++
-		}
-	}
-	for _, constant := range all {
-		value, ok := typeLibConstantValue(constant)
-		if !ok {
-			continue
-		}
-		name := strings.ToLower(cleanIdentifier(constant.Name))
-		if name != "" && counts[name] == 1 {
-			values[name] = value
-		}
-		if group := strings.ToLower(cleanIdentifier(constant.EnumGroup)); group != "" && name != "" {
-			values[group+"."+name] = value
-		}
-		if library := strings.ToLower(cleanIdentifier(constant.Library)); library != "" && name != "" {
-			values[library+"."+name] = value
-		}
-	}
-	return values
-}
-
-func typeLibConstantValue(constant vbadb.ConstantInfo) (constexpr.Value, bool) {
-	switch strings.ToLower(strings.TrimSpace(constant.Type)) {
-	case "string":
-		return constexpr.Value{Kind: constexpr.ValueString, String: constant.Value}, true
-	case "boolean":
-		if strings.EqualFold(strings.TrimSpace(constant.Value), "true") {
-			return constexpr.Value{Kind: constexpr.ValueBoolean, Boolean: true}, true
-		}
-		if strings.EqualFold(strings.TrimSpace(constant.Value), "false") {
-			return constexpr.Value{Kind: constexpr.ValueBoolean}, true
-		}
-	}
-	result := constexpr.Evaluate(constant.Value, nil)
-	if result.Kind != constexpr.Known {
-		return constexpr.Value{}, false
-	}
-	return result.Typed, true
+	return lint.ProjectConstantValues(documents, typeDB)
 }

--- a/internal/analyze/constant_values.go
+++ b/internal/analyze/constant_values.go
@@ -1,0 +1,90 @@
+package analyze
+
+import (
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/lint"
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+	"github.com/harumiWeb/xlflow/internal/vbadb"
+)
+
+func projectConstantValues(files []parsedFile, typeDB *vbadb.DB) map[string]constexpr.Value {
+	values := make(map[string]constexpr.Value)
+	for _, file := range files {
+		fileValues := file.ConstantValues
+		if fileValues == nil {
+			fileValues = lint.ConstantValuesFromSource(string(file.Source), &file.IR, nil)
+		}
+		standard := strings.EqualFold(file.ModuleKind, "standard")
+		for _, declaration := range file.IR.Declarations {
+			if !declaration.IsConst && !procedureir.IsConstKind(declaration.Kind) {
+				continue
+			}
+			if !strings.EqualFold(declaration.Visibility, "public") && !strings.EqualFold(declaration.Visibility, "friend") {
+				continue
+			}
+			value, ok := fileValues[strings.ToLower(cleanIdentifier(declaration.Name))]
+			if !ok {
+				continue
+			}
+			name := strings.ToLower(cleanIdentifier(declaration.Name))
+			if standard {
+				values[name] = value
+			}
+			if file.IR.ModuleName != "" {
+				values[strings.ToLower(cleanIdentifier(file.IR.ModuleName))+"."+name] = value
+			}
+			if declaration.Parent != "" {
+				values[strings.ToLower(cleanIdentifier(declaration.Parent))+"."+name] = value
+			}
+		}
+	}
+	if typeDB == nil {
+		return values
+	}
+	all := typeDB.AllConstantsList()
+	counts := make(map[string]int)
+	for _, constant := range all {
+		name := strings.ToLower(cleanIdentifier(constant.Name))
+		if name != "" {
+			counts[name]++
+		}
+	}
+	for _, constant := range all {
+		value, ok := typeLibConstantValue(constant)
+		if !ok {
+			continue
+		}
+		name := strings.ToLower(cleanIdentifier(constant.Name))
+		if name != "" && counts[name] == 1 {
+			values[name] = value
+		}
+		if group := strings.ToLower(cleanIdentifier(constant.EnumGroup)); group != "" && name != "" {
+			values[group+"."+name] = value
+		}
+		if library := strings.ToLower(cleanIdentifier(constant.Library)); library != "" && name != "" {
+			values[library+"."+name] = value
+		}
+	}
+	return values
+}
+
+func typeLibConstantValue(constant vbadb.ConstantInfo) (constexpr.Value, bool) {
+	switch strings.ToLower(strings.TrimSpace(constant.Type)) {
+	case "string":
+		return constexpr.Value{Kind: constexpr.ValueString, String: constant.Value}, true
+	case "boolean":
+		if strings.EqualFold(strings.TrimSpace(constant.Value), "true") {
+			return constexpr.Value{Kind: constexpr.ValueBoolean, Boolean: true}, true
+		}
+		if strings.EqualFold(strings.TrimSpace(constant.Value), "false") {
+			return constexpr.Value{Kind: constexpr.ValueBoolean}, true
+		}
+	}
+	result := constexpr.Evaluate(constant.Value, nil)
+	if result.Kind != constexpr.Known {
+		return constexpr.Value{}, false
+	}
+	return result.Typed, true
+}

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -300,11 +300,26 @@ func rangeValueModuleIntegerConstants(lines []string, ir procedureir.DocumentIR)
 			insideProcedure[line] = true
 		}
 	}
+	conditionalDepth := 0
 	for lineIndex, line := range lines {
 		if insideProcedure[lineIndex+1] {
 			continue
 		}
-		match := constIntegerRe.FindStringSubmatch(strings.TrimSpace(normalizedCodeLine(line)))
+		code := strings.TrimSpace(normalizedCodeLine(line))
+		if strings.HasPrefix(strings.ToLower(code), "#if ") {
+			conditionalDepth++
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(code), "#end if") {
+			if conditionalDepth > 0 {
+				conditionalDepth--
+			}
+			continue
+		}
+		if conditionalDepth > 0 || strings.HasPrefix(strings.ToLower(code), "#elseif ") || strings.HasPrefix(strings.ToLower(code), "#else") {
+			continue
+		}
+		match := constIntegerRe.FindStringSubmatch(code)
 		if len(match) != 3 {
 			continue
 		}
@@ -321,6 +336,9 @@ func rangeValueIntegerConstants(moduleConstants map[string]int, proc sourceProce
 		constants[name] = value
 	}
 	for _, statement := range proc.Statements {
+		if len(statement.ConditionalBranches) > 0 {
+			continue
+		}
 		match := constIntegerRe.FindStringSubmatch(strings.TrimSpace(normalizedCodeLine(statement.Text)))
 		if len(match) != 3 {
 			continue

--- a/internal/lint/array_shape_diagnostics.go
+++ b/internal/lint/array_shape_diagnostics.go
@@ -21,6 +21,26 @@ func (l Linter) arrayShapeIssues(path, source string, ir *procedureir.DocumentIR
 	qualifiedConsts := map[string]bool{}
 	constValues := map[string]int{}
 	constExprs := map[string]string{}
+	for name, value := range l.ConstantValues {
+		if value.Kind != constexpr.ValueInteger && value.Kind != constexpr.ValueLong && value.Kind != constexpr.ValueLongLong {
+			continue
+		}
+		if int64(int(value.Integer)) != value.Integer {
+			continue
+		}
+		key := normalizeQualifiedIdentifier(name)
+		if key == "" {
+			continue
+		}
+		if !strings.Contains(key, ".") && l.VisibleConstants != nil && !l.VisibleConstants[key] {
+			continue
+		}
+		constValues[key] = int(value.Integer)
+		consts[key] = true
+		if strings.Contains(key, ".") {
+			qualifiedConsts[key] = true
+		}
+	}
 	addQualifiedConst := func(qualifier, name string) {
 		qualifier = normalizeQualifiedIdentifier(qualifier)
 		name = normalizeQualifiedIdentifier(name)
@@ -392,6 +412,12 @@ func CompileEquivalentArrayShapeIssues(path, source string, ir *procedureir.Docu
 // resolver or expression-inference implementation in this rule.
 func CompileEquivalentArrayShapeIssuesWithConstants(path, source string, ir *procedureir.DocumentIR, visibleConstants map[string]bool) []Issue {
 	return (Linter{VisibleConstants: visibleConstants}).arrayShapeIssues(path, source, ir)
+}
+
+// CompileEquivalentArrayShapeIssuesWithValues is the value-bearing project
+// adapter used by batch/LSP callers that already own a coherent snapshot.
+func CompileEquivalentArrayShapeIssuesWithValues(path, source string, ir *procedureir.DocumentIR, visibleConstants map[string]bool, values map[string]constexpr.Value) []Issue {
+	return (Linter{VisibleConstants: visibleConstants, ConstantValues: values}).arrayShapeIssues(path, source, ir)
 }
 
 func declarationPrefix(lower string) bool {

--- a/internal/lint/array_shape_diagnostics.go
+++ b/internal/lint/array_shape_diagnostics.go
@@ -25,7 +25,8 @@ func (l Linter) arrayShapeIssues(path, source string, ir *procedureir.DocumentIR
 		if value.Kind != constexpr.ValueInteger && value.Kind != constexpr.ValueLong && value.Kind != constexpr.ValueLongLong {
 			continue
 		}
-		if int64(int(value.Integer)) != value.Integer {
+		integer, ok := constexpr.IntegerAsInt(value)
+		if !ok {
 			continue
 		}
 		key := normalizeQualifiedIdentifier(name)
@@ -35,7 +36,7 @@ func (l Linter) arrayShapeIssues(path, source string, ir *procedureir.DocumentIR
 		if !strings.Contains(key, ".") && l.VisibleConstants != nil && !l.VisibleConstants[key] {
 			continue
 		}
-		constValues[key] = int(value.Integer)
+		constValues[key] = integer
 		consts[key] = true
 		if strings.Contains(key, ".") {
 			qualifiedConsts[key] = true

--- a/internal/lint/constant_values.go
+++ b/internal/lint/constant_values.go
@@ -1,0 +1,280 @@
+package lint
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/typedb"
+	"github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+	"github.com/harumiWeb/xlflow/internal/vbadb"
+)
+
+// constantValuesFromSource projects the module-level Const and Enum values
+// into the shared evaluator's immutable value map. It deliberately records
+// only Known values; an unresolved or conditional declaration remains visible
+// through the name-only map and therefore cannot accidentally become a value.
+func constantValuesFromSource(source string, ir *procedureir.DocumentIR, base map[string]constexpr.Value) map[string]constexpr.Value {
+	values := make(map[string]constexpr.Value, len(base)+8)
+	for name, value := range base {
+		values[name] = value
+	}
+	lines := strings.Split(strings.ReplaceAll(source, "\r\n", "\n"), "\n")
+	insideProcedure := make([]bool, len(lines)+1)
+	if ir != nil {
+		delta := make([]int, len(lines)+2)
+		for _, procedure := range ir.Procedures {
+			start := procedure.Symbol.DeclarationRange.StartLine
+			end := procedure.Symbol.DeclarationRange.EndLine
+			if start < 1 {
+				start = 1
+			}
+			if end > len(lines) {
+				end = len(lines)
+			}
+			if start <= end {
+				delta[start]++
+				delta[end+1]--
+			}
+		}
+		active := 0
+		for line := 1; line <= len(lines); line++ {
+			active += delta[line]
+			insideProcedure[line] = active > 0
+		}
+	}
+	type pending struct {
+		name, expression string
+		qualified        []string
+		enumGroup        string
+		implicit         bool
+	}
+	var pendingConsts []pending
+	inEnum := false
+	enumName := ""
+	conditionalDepth := 0
+	for lineNo, line := range lines {
+		trim := strings.TrimSpace(strings.SplitN(line, "'", 2)[0])
+		lower := strings.ToLower(trim)
+		if strings.HasPrefix(lower, "#if ") {
+			conditionalDepth++
+			continue
+		}
+		if strings.HasPrefix(lower, "#elseif ") || strings.HasPrefix(lower, "#else") {
+			continue
+		}
+		if strings.HasPrefix(lower, "#end if") {
+			if conditionalDepth > 0 {
+				conditionalDepth--
+			}
+			continue
+		}
+		if conditionalDepth > 0 || insideProcedure[lineNo+1] {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(lower, "enum ") || strings.HasPrefix(lower, "public enum ") || strings.HasPrefix(lower, "private enum ") || strings.HasPrefix(lower, "friend enum "):
+			inEnum = true
+			enumName = ""
+			fields := strings.Fields(trim)
+			for i, field := range fields {
+				if strings.EqualFold(field, "enum") && i+1 < len(fields) {
+					enumName = cleanIdentifier(fields[i+1])
+					break
+				}
+			}
+			continue
+		case inEnum && strings.HasPrefix(lower, "end enum"):
+			inEnum = false
+			enumName = ""
+			continue
+		}
+		if inEnum && trim != "" {
+			name, expression := enumMemberConstant(trim, nil)
+			if name == "" {
+				continue
+			}
+			item := pending{
+				name: name, expression: expression, enumGroup: enumName,
+				implicit: !strings.Contains(trim, "="),
+			}
+			if enumName != "" {
+				item.qualified = []string{enumName + "." + name}
+			}
+			pendingConsts = append(pendingConsts, item)
+			continue
+		}
+		if name, expression, ok := arrayShapeConstLine(trim); ok {
+			pendingConsts = append(pendingConsts, pending{name: cleanIdentifier(name), expression: expression})
+		}
+	}
+	// Resolve forward references without making map iteration order observable.
+	for pass := 0; pass < len(pendingConsts); pass++ {
+		changed := false
+		enumNext := make(map[string]int64)
+		enumSeen := make(map[string]bool)
+		for _, item := range pendingConsts {
+			if item.name == "" {
+				continue
+			}
+			expression := item.expression
+			if item.enumGroup != "" {
+				group := strings.ToLower(item.enumGroup)
+				if item.implicit {
+					if !enumSeen[group] {
+						expression = "0"
+					} else if next, ok := enumNext[group]; ok {
+						expression = strconv.FormatInt(next, 10)
+					} else {
+						expression = "MissingEnumValue"
+					}
+				}
+				enumSeen[group] = true
+			}
+			result := constexpr.Evaluate(expression, constexpr.Values(values))
+			if result.Kind != constexpr.Known {
+				if item.enumGroup != "" {
+					delete(enumNext, strings.ToLower(item.enumGroup))
+				}
+				continue
+			}
+			if item.enumGroup != "" && !isIntegralConstant(result.Typed) {
+				delete(enumNext, strings.ToLower(item.enumGroup))
+				continue
+			}
+			key := strings.ToLower(item.name)
+			if prior, exists := values[key]; !exists || prior != result.Typed {
+				values[key] = result.Typed
+				for _, qualified := range item.qualified {
+					values[strings.ToLower(qualified)] = result.Typed
+				}
+				if ir != nil && ir.ModuleName != "" {
+					values[strings.ToLower(cleanIdentifier(ir.ModuleName))+"."+key] = result.Typed
+				}
+				changed = true
+			}
+			if item.enumGroup != "" {
+				if result.Typed.Integer == int64(^uint64(0)>>1) {
+					delete(enumNext, strings.ToLower(item.enumGroup))
+				} else {
+					enumNext[strings.ToLower(item.enumGroup)] = result.Typed.Integer + 1
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return values
+}
+
+func isIntegralConstant(value constexpr.Value) bool {
+	switch value.Kind {
+	case constexpr.ValueInteger, constexpr.ValueLong, constexpr.ValueLongLong:
+		return true
+	default:
+		return false
+	}
+}
+
+// ConstantValuesFromSource exposes the deterministic module projection for
+// batch analyzers that already own the parsed DocumentIR.
+func ConstantValuesFromSource(source string, ir *procedureir.DocumentIR, base map[string]constexpr.Value) map[string]constexpr.Value {
+	return constantValuesFromSource(source, ir, base)
+}
+
+func (l Linter) projectConstantValuesContext(ctx context.Context, files []string) map[string]constexpr.Value {
+	values := make(map[string]constexpr.Value)
+	for _, path := range files {
+		if err := ctx.Err(); err != nil {
+			return values
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		parsed, err := ast.ParseDocument(path, source)
+		if err != nil {
+			continue
+		}
+		ir, err := procedureir.BuildParsedContext(ctx, procedureir.BuildOptions{
+			RootDir: l.RootDir, Path: path, ModuleKind: l.moduleKindForPath(path),
+		}, parsed)
+		parsed.Close()
+		if err != nil {
+			continue
+		}
+		fileValues := constantValuesFromSource(string(source), &ir, nil)
+		standard := strings.EqualFold(ir.ModuleKind, "standard")
+		for _, declaration := range ir.Declarations {
+			if !declaration.IsConst && !procedureir.IsConstKind(declaration.Kind) {
+				continue
+			}
+			if !strings.EqualFold(declaration.Visibility, "public") && !strings.EqualFold(declaration.Visibility, "friend") {
+				continue
+			}
+			value, ok := fileValues[strings.ToLower(cleanIdentifier(declaration.Name))]
+			if !ok {
+				continue
+			}
+			if standard {
+				values[strings.ToLower(cleanIdentifier(declaration.Name))] = value
+			}
+			if ir.ModuleName != "" {
+				values[strings.ToLower(cleanIdentifier(ir.ModuleName))+"."+strings.ToLower(cleanIdentifier(declaration.Name))] = value
+			}
+			if declaration.Parent != "" {
+				values[strings.ToLower(cleanIdentifier(declaration.Parent))+"."+strings.ToLower(cleanIdentifier(declaration.Name))] = value
+			}
+		}
+	}
+	if result, err := typedb.LoadForRuntime(""); err == nil && result.DB != nil {
+		constants := result.DB.AllConstantsList()
+		counts := make(map[string]int)
+		for _, constant := range constants {
+			name := strings.ToLower(cleanIdentifier(constant.Name))
+			if name != "" {
+				counts[name]++
+			}
+		}
+		for _, constant := range constants {
+			value, ok := staticTypeLibConstantValue(constant)
+			if !ok {
+				continue
+			}
+			name := strings.ToLower(cleanIdentifier(constant.Name))
+			if name != "" && counts[name] == 1 {
+				values[name] = value
+			}
+			if group := strings.ToLower(cleanIdentifier(constant.EnumGroup)); group != "" && name != "" {
+				values[group+"."+name] = value
+			}
+			if library := strings.ToLower(cleanIdentifier(constant.Library)); library != "" && name != "" {
+				values[library+"."+name] = value
+			}
+		}
+	}
+	return values
+}
+
+func staticTypeLibConstantValue(constant vbadb.ConstantInfo) (constexpr.Value, bool) {
+	switch strings.ToLower(strings.TrimSpace(constant.Type)) {
+	case "string":
+		return constexpr.Value{Kind: constexpr.ValueString, String: constant.Value}, true
+	case "boolean":
+		if strings.EqualFold(strings.TrimSpace(constant.Value), "true") {
+			return constexpr.Value{Kind: constexpr.ValueBoolean, Boolean: true}, true
+		}
+		if strings.EqualFold(strings.TrimSpace(constant.Value), "false") {
+			return constexpr.Value{Kind: constexpr.ValueBoolean}, true
+		}
+	}
+	result := constexpr.Evaluate(constant.Value, nil)
+	if result.Kind != constexpr.Known {
+		return constexpr.Value{}, false
+	}
+	return result.Typed, true
+}

--- a/internal/lint/constant_values.go
+++ b/internal/lint/constant_values.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"context"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -45,6 +46,8 @@ func constantValuesFromSource(source string, ir *procedureir.DocumentIR, base ma
 			active += delta[line]
 			insideProcedure[line] = active > 0
 		}
+	} else {
+		markProcedureLines(lines, insideProcedure)
 	}
 	type pending struct {
 		name, expression string
@@ -114,6 +117,7 @@ func constantValuesFromSource(source string, ir *procedureir.DocumentIR, base ma
 	// Resolve forward references without making map iteration order observable.
 	for pass := 0; pass < len(pendingConsts); pass++ {
 		changed := false
+		environment := constexpr.NewValues(values)
 		enumNext := make(map[string]int64)
 		enumSeen := make(map[string]bool)
 		for _, item := range pendingConsts {
@@ -134,7 +138,7 @@ func constantValuesFromSource(source string, ir *procedureir.DocumentIR, base ma
 				}
 				enumSeen[group] = true
 			}
-			result := constexpr.Evaluate(expression, constexpr.Values(values))
+			result := constexpr.Evaluate(expression, environment)
 			if result.Kind != constexpr.Known {
 				if item.enumGroup != "" {
 					delete(enumNext, strings.ToLower(item.enumGroup))
@@ -148,16 +152,21 @@ func constantValuesFromSource(source string, ir *procedureir.DocumentIR, base ma
 			key := strings.ToLower(item.name)
 			if prior, exists := values[key]; !exists || prior != result.Typed {
 				values[key] = result.Typed
+				environment[key] = result.Typed
 				for _, qualified := range item.qualified {
-					values[strings.ToLower(qualified)] = result.Typed
+					qualifiedKey := strings.ToLower(qualified)
+					values[qualifiedKey] = result.Typed
+					environment[qualifiedKey] = result.Typed
 				}
 				if ir != nil && ir.ModuleName != "" {
-					values[strings.ToLower(cleanIdentifier(ir.ModuleName))+"."+key] = result.Typed
+					moduleKey := strings.ToLower(cleanIdentifier(ir.ModuleName)) + "." + key
+					values[moduleKey] = result.Typed
+					environment[moduleKey] = result.Typed
 				}
 				changed = true
 			}
 			if item.enumGroup != "" {
-				if result.Typed.Integer == int64(^uint64(0)>>1) {
+				if result.Typed.Integer == math.MaxInt64 {
 					delete(enumNext, strings.ToLower(item.enumGroup))
 				} else {
 					enumNext[strings.ToLower(item.enumGroup)] = result.Typed.Integer + 1
@@ -169,6 +178,36 @@ func constantValuesFromSource(source string, ir *procedureir.DocumentIR, base ma
 		}
 	}
 	return values
+}
+
+// markProcedureLines conservatively identifies procedure bodies when callers
+// do not have a parsed DocumentIR. It keeps the source-only projection useful
+// while ensuring procedure-local Const declarations cannot leak into the
+// module-level environment.
+func markProcedureLines(lines []string, inside []bool) {
+	depth := 0
+	for lineNo, line := range lines {
+		trim := strings.TrimSpace(strings.SplitN(line, "'", 2)[0])
+		lower := strings.ToLower(trim)
+		fields := strings.Fields(lower)
+		if depth > 0 {
+			inside[lineNo+1] = true
+			if len(fields) >= 2 && fields[0] == "end" && (fields[1] == "sub" || fields[1] == "function" || fields[1] == "property") {
+				depth = 0
+			}
+			continue
+		}
+		if len(fields) == 0 || fields[0] == "declare" || fields[0] == "end" {
+			continue
+		}
+		for _, field := range fields {
+			if field == "sub" || field == "function" || field == "property" {
+				depth = 1
+				inside[lineNo+1] = true
+				break
+			}
+		}
+	}
 }
 
 func isIntegralConstant(value constexpr.Value) bool {
@@ -186,81 +225,16 @@ func ConstantValuesFromSource(source string, ir *procedureir.DocumentIR, base ma
 	return constantValuesFromSource(source, ir, base)
 }
 
-func (l Linter) projectConstantValuesContext(ctx context.Context, files []string) map[string]constexpr.Value {
-	values := make(map[string]constexpr.Value)
-	for _, path := range files {
-		if err := ctx.Err(); err != nil {
-			return values
-		}
-		source, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		parsed, err := ast.ParseDocument(path, source)
-		if err != nil {
-			continue
-		}
-		ir, err := procedureir.BuildParsedContext(ctx, procedureir.BuildOptions{
-			RootDir: l.RootDir, Path: path, ModuleKind: l.moduleKindForPath(path),
-		}, parsed)
-		parsed.Close()
-		if err != nil {
-			continue
-		}
-		fileValues := constantValuesFromSource(string(source), &ir, nil)
-		standard := strings.EqualFold(ir.ModuleKind, "standard")
-		for _, declaration := range ir.Declarations {
-			if !declaration.IsConst && !procedureir.IsConstKind(declaration.Kind) {
-				continue
-			}
-			if !strings.EqualFold(declaration.Visibility, "public") && !strings.EqualFold(declaration.Visibility, "friend") {
-				continue
-			}
-			value, ok := fileValues[strings.ToLower(cleanIdentifier(declaration.Name))]
-			if !ok {
-				continue
-			}
-			if standard {
-				values[strings.ToLower(cleanIdentifier(declaration.Name))] = value
-			}
-			if ir.ModuleName != "" {
-				values[strings.ToLower(cleanIdentifier(ir.ModuleName))+"."+strings.ToLower(cleanIdentifier(declaration.Name))] = value
-			}
-			if declaration.Parent != "" {
-				values[strings.ToLower(cleanIdentifier(declaration.Parent))+"."+strings.ToLower(cleanIdentifier(declaration.Name))] = value
-			}
-		}
-	}
-	if result, err := typedb.LoadForRuntime(""); err == nil && result.DB != nil {
-		constants := result.DB.AllConstantsList()
-		counts := make(map[string]int)
-		for _, constant := range constants {
-			name := strings.ToLower(cleanIdentifier(constant.Name))
-			if name != "" {
-				counts[name]++
-			}
-		}
-		for _, constant := range constants {
-			value, ok := staticTypeLibConstantValue(constant)
-			if !ok {
-				continue
-			}
-			name := strings.ToLower(cleanIdentifier(constant.Name))
-			if name != "" && counts[name] == 1 {
-				values[name] = value
-			}
-			if group := strings.ToLower(cleanIdentifier(constant.EnumGroup)); group != "" && name != "" {
-				values[group+"."+name] = value
-			}
-			if library := strings.ToLower(cleanIdentifier(constant.Library)); library != "" && name != "" {
-				values[library+"."+name] = value
-			}
-		}
-	}
-	return values
+// ConstantValueDocument is the immutable source/IR pair used to build a
+// project-wide constant environment.
+type ConstantValueDocument struct {
+	Source string
+	IR     *procedureir.DocumentIR
 }
 
-func staticTypeLibConstantValue(constant vbadb.ConstantInfo) (constexpr.Value, bool) {
+// TypeLibConstantValue converts a static TypeLib record without invoking VBA
+// or Excel. Unsupported and malformed records remain unknown to callers.
+func TypeLibConstantValue(constant vbadb.ConstantInfo) (constexpr.Value, bool) {
 	switch strings.ToLower(strings.TrimSpace(constant.Type)) {
 	case "string":
 		return constexpr.Value{Kind: constexpr.ValueString, String: constant.Value}, true
@@ -277,4 +251,140 @@ func staticTypeLibConstantValue(constant vbadb.ConstantInfo) (constexpr.Value, b
 		return constexpr.Value{}, false
 	}
 	return result.Typed, true
+}
+
+// ProjectConstantValues builds a deterministic, ambiguity-free project
+// environment. Qualified source and TypeLib names are retained only when
+// their qualifier is unique; unqualified names are retained only when there
+// is one visible declaration. Repeated passes resolve cross-module forward
+// references without making map iteration order observable.
+func ProjectConstantValues(documents []ConstantValueDocument, typeDB *vbadb.DB) map[string]constexpr.Value {
+	type candidate struct {
+		identity string
+		value    constexpr.Value
+		known    bool
+	}
+	add := func(byKey map[string][]candidate, key, identity string, value constexpr.Value, known bool) {
+		key = normalizeConstantValueKey(key)
+		if key == "" {
+			return
+		}
+		for _, prior := range byKey[key] {
+			if prior.identity == identity {
+				return
+			}
+		}
+		byKey[key] = append(byKey[key], candidate{identity: identity, value: value, known: known})
+	}
+	unique := func(byKey map[string][]candidate) map[string]constexpr.Value {
+		values := make(map[string]constexpr.Value, len(byKey))
+		for key, candidates := range byKey {
+			if len(candidates) == 1 && candidates[0].known {
+				values[key] = candidates[0].value
+			}
+		}
+		return values
+	}
+	equal := func(left, right map[string]constexpr.Value) bool {
+		if len(left) != len(right) {
+			return false
+		}
+		for key, value := range left {
+			if other, ok := right[key]; !ok || other != value {
+				return false
+			}
+		}
+		return true
+	}
+	environment := map[string]constexpr.Value{}
+	passes := len(documents) + 2
+	if passes < 2 {
+		passes = 2
+	}
+	for pass := 0; pass < passes; pass++ {
+		byKey := make(map[string][]candidate)
+		if typeDB != nil {
+			for index, constant := range typeDB.AllConstantsList() {
+				value, ok := TypeLibConstantValue(constant)
+				identity := "typelib:" + strconv.Itoa(index)
+				name := cleanIdentifier(constant.Name)
+				add(byKey, name, identity, value, ok)
+				add(byKey, cleanIdentifier(constant.EnumGroup)+"."+name, identity, value, ok)
+				add(byKey, cleanIdentifier(constant.Library)+"."+name, identity, value, ok)
+			}
+		}
+		for documentIndex, document := range documents {
+			if document.IR == nil {
+				continue
+			}
+			fileValues := constantValuesFromSource(document.Source, document.IR, environment)
+			standard := strings.EqualFold(document.IR.ModuleKind, "standard")
+			for declarationIndex, declaration := range document.IR.Declarations {
+				if !declaration.IsConst && !procedureir.IsConstKind(declaration.Kind) {
+					continue
+				}
+				if !strings.EqualFold(declaration.Visibility, "public") && !strings.EqualFold(declaration.Visibility, "friend") {
+					continue
+				}
+				name := cleanIdentifier(declaration.Name)
+				value, ok := fileValues[normalizeConstantValueKey(name)]
+				if name == "" {
+					continue
+				}
+				identity := "source:" + strconv.Itoa(documentIndex) + ":" + strconv.Itoa(declarationIndex)
+				if standard {
+					add(byKey, name, identity, value, ok)
+				}
+				add(byKey, cleanIdentifier(document.IR.ModuleName)+"."+name, identity, value, ok)
+				add(byKey, cleanIdentifier(declaration.Parent)+"."+name, identity, value, ok)
+			}
+		}
+		next := unique(byKey)
+		if equal(environment, next) {
+			return next
+		}
+		environment = next
+	}
+	return environment
+}
+
+func normalizeConstantValueKey(text string) string {
+	parts := strings.Split(text, ".")
+	for index, part := range parts {
+		parts[index] = strings.ToLower(cleanIdentifier(part))
+		if parts[index] == "" {
+			return ""
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+func (l Linter) projectConstantValuesContext(ctx context.Context, files []string) map[string]constexpr.Value {
+	var documents []ConstantValueDocument
+	for _, path := range files {
+		if err := ctx.Err(); err != nil {
+			return ProjectConstantValues(documents, nil)
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		parsed, err := ast.ParseDocument(path, source)
+		if err != nil {
+			continue
+		}
+		ir, err := procedureir.BuildParsedContext(ctx, procedureir.BuildOptions{
+			RootDir: l.RootDir, Path: path, ModuleKind: l.moduleKindForPath(path),
+		}, parsed)
+		parsed.Close()
+		if err != nil {
+			continue
+		}
+		documents = append(documents, ConstantValueDocument{Source: string(source), IR: &ir})
+	}
+	var typeDB *vbadb.DB
+	if result, err := typedb.LoadForRuntime(""); err == nil {
+		typeDB = result.DB
+	}
+	return ProjectConstantValues(documents, typeDB)
 }

--- a/internal/lint/constant_values_test.go
+++ b/internal/lint/constant_values_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 func TestConstantValuesFromSourceResolvesConstAndEnumReferences(t *testing.T) {
@@ -37,5 +38,57 @@ Public Const ConditionalValue As Long = 99
 	}
 	if _, ok := values["conditionalvalue"]; ok {
 		t.Fatal("conditional Const must remain unknown")
+	}
+}
+
+func TestConstantValuesFromSourceNilIRExcludesProcedureLocals(t *testing.T) {
+	source := `Public Const ModuleValue As Long = 1
+Sub Example()
+    Const LocalValue As Long = 2
+End Sub
+`
+	values := ConstantValuesFromSource(source, nil, nil)
+	if _, ok := values["modulevalue"]; !ok {
+		t.Fatal("module-level Const should remain available without IR")
+	}
+	if _, ok := values["localvalue"]; ok {
+		t.Fatal("procedure-local Const must not be projected without IR")
+	}
+}
+
+func TestProjectConstantValuesResolvesForwardReferencesAndAmbiguity(t *testing.T) {
+	first := procedureir.DocumentIR{
+		ModuleName: "First", ModuleKind: "standard",
+		Declarations: []procedureir.Declaration{{Name: "FirstValue", Kind: "const", IsConst: true, Visibility: "Public"}},
+	}
+	second := procedureir.DocumentIR{
+		ModuleName: "Second", ModuleKind: "standard",
+		Declarations: []procedureir.Declaration{{Name: "SecondValue", Kind: "const", IsConst: true, Visibility: "Public"}},
+	}
+	values := ProjectConstantValues([]ConstantValueDocument{
+		{Source: "Public Const FirstValue As Long = SecondValue\n", IR: &first},
+		{Source: "Public Const SecondValue As Long = 3\n", IR: &second},
+	}, nil)
+	if got, ok := values["first.firstvalue"]; !ok || got.Integer != 3 {
+		t.Fatalf("qualified First.FirstValue = %#v, %v; want 3", got, ok)
+	}
+
+	duplicate := procedureir.DocumentIR{
+		ModuleName: "Duplicate", ModuleKind: "standard",
+		Declarations: []procedureir.Declaration{{Name: "SecondValue", Kind: "const", IsConst: true, Visibility: "Public"}},
+	}
+	values = ProjectConstantValues([]ConstantValueDocument{
+		{Source: "Public Const FirstValue As Long = SecondValue\n", IR: &first},
+		{Source: "Public Const SecondValue As Long = 3\n", IR: &second},
+		{Source: "Public Const SecondValue As Long = 4\n", IR: &duplicate},
+	}, nil)
+	if _, ok := values["secondvalue"]; ok {
+		t.Fatal("duplicate public names must not be projected unqualified")
+	}
+	if got, ok := values["second.secondvalue"]; !ok || got.Integer != 3 {
+		t.Fatalf("qualified Second.SecondValue = %#v, %v; want 3", got, ok)
+	}
+	if _, ok := values["first.firstvalue"]; ok {
+		t.Fatal("FirstValue should remain unresolved while its reference is ambiguous")
 	}
 }

--- a/internal/lint/constant_values_test.go
+++ b/internal/lint/constant_values_test.go
@@ -1,0 +1,41 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
+)
+
+func TestConstantValuesFromSourceResolvesConstAndEnumReferences(t *testing.T) {
+	source := `Public Const Limit As Long = 2
+Public Const Expanded As Long = Limit + 3
+Enum State
+    Ready = Expanded
+    Done
+End Enum
+Public Const RuntimeValue As Long = Missing()
+#If WINDOWS Then
+Public Const ConditionalValue As Long = 99
+#End If
+`
+	values := ConstantValuesFromSource(source, nil, nil)
+	for name, want := range map[string]int64{
+		"limit":       2,
+		"expanded":    5,
+		"ready":       5,
+		"state.ready": 5,
+		"done":        6,
+		"state.done":  6,
+	} {
+		value, ok := values[name]
+		if !ok || value.Kind != constexpr.ValueLong || value.Integer != want {
+			t.Fatalf("value[%q] = %#v, %v; want Long(%d)", name, value, ok, want)
+		}
+	}
+	if _, ok := values["runtimevalue"]; ok {
+		t.Fatal("runtime-dependent Const must not be projected as a known value")
+	}
+	if _, ok := values["conditionalvalue"]; ok {
+		t.Fatal("conditional Const must remain unknown")
+	}
+}

--- a/internal/lint/linter.go
+++ b/internal/lint/linter.go
@@ -19,6 +19,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/callgraph"
 	"github.com/harumiWeb/xlflow/internal/vba/calls"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/reachability"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
@@ -64,10 +65,15 @@ type Linter struct {
 	// document (for example, an editor buffer whose project metadata already
 	// identified it as a document module). Batch lint leaves this empty and
 	// uses the canonical source-root classification from symbols instead.
-	ModuleKind             string
-	PathFilter             func(string) bool
-	VisibleDeclarations    map[string]bool
-	VisibleConstants       map[string]bool
+	ModuleKind          string
+	PathFilter          func(string) bool
+	VisibleDeclarations map[string]bool
+	VisibleConstants    map[string]bool
+	// ConstantValues carries the immutable, value-bearing subset of the
+	// project constant environment. VisibleConstants remains for legacy
+	// name-only callers and constant-assignment diagnostics.
+	ConstantValues         map[string]constexpr.Value
+	localConstantValues    map[string]constexpr.Value
 	TypeDeclarations       map[string]int
 	ObjectTypeDeclarations map[string]int
 }
@@ -138,6 +144,9 @@ func (l Linter) RunResultContext(ctx context.Context) (Result, error) {
 	files, err := l.filesContext(ctx)
 	if err != nil {
 		return Result{}, err
+	}
+	if l.ConstantValues == nil {
+		l.ConstantValues = l.projectConstantValuesContext(ctx, files)
 	}
 	visibleDeclarations := l.VisibleDeclarations
 	visibleConstants := l.VisibleConstants
@@ -386,6 +395,12 @@ func (l Linter) lintParsedContext(ctx context.Context, doc *vbaast.ParsedDocumen
 		return nil, irErr
 	}
 	procedureIR := &ir
+	l.localConstantValues = constantValuesFromSource(string(source), procedureIR, nil)
+	if l.ConstantValues == nil {
+		l.ConstantValues = l.localConstantValues
+	} else {
+		l.ConstantValues = constantValuesFromSource(string(source), procedureIR, l.ConstantValues)
+	}
 	if err := doc.ReadContext(ctx, func(view vbaast.ParsedView) error {
 		numericLiteralRecovery := vbaast.IsNumericLiteralRecovery(view.Root, view.Source)
 		lintCtx := astLintContext{

--- a/internal/lint/signature_diagnostics.go
+++ b/internal/lint/signature_diagnostics.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -138,10 +139,10 @@ func (l Linter) validateProcedureSignature(path string, sig procedureSignature, 
 			}
 		}
 		if param.optional && strings.TrimSpace(param.defaultValue) != "" {
-			constant, definitelyNonconstant := classifyOptionalDefault(param.defaultValue)
+			constant, definitelyNonconstant, evaluated := l.classifyOptionalDefault(param.defaultValue)
 			if definitelyNonconstant {
 				issues = append(issues, signatureIssue(l, path, param.nameRange, sig.name, "optional_default_nonconstant", "Optional parameter defaults must be constant expressions."))
-			} else if constant && optionalDefaultTypeMismatch(param.defaultValue, param.typ, kind) {
+			} else if constant && optionalDefaultResultTypeMismatch(evaluated, param.typ, kind) {
 				issues = append(issues, signatureIssue(l, path, param.nameRange, sig.name, "optional_default_type", fmt.Sprintf("Optional default %q is incompatible with parameter type %s.", strings.TrimSpace(param.defaultValue), displaySignatureType(param.typ))))
 			}
 		}
@@ -524,36 +525,62 @@ func displaySignatureType(typ string) string {
 }
 
 // classifyOptionalDefault returns whether the expression is a known constant
-// and whether it is definitely non-constant.  Expressions such as Const or
-// Enum references and arithmetic are intentionally unknown here; #595's
-// shared evaluator will own those cases, so this rule must remain fail-open.
-func classifyOptionalDefault(value string) (constant, definitelyNonconstant bool) {
+// and whether it is definitely non-constant. Runtime calls remain a definite
+// error, while unresolved/unsupported expressions stay Unknown so the rule
+// remains fail-open.
+func (l Linter) classifyOptionalDefault(value string) (constant, definitelyNonconstant bool, result constexpr.Result) {
 	value = strings.TrimSpace(value)
 	for strings.HasPrefix(value, "(") && strings.HasSuffix(value, ")") && balancedParens(value) {
 		value = strings.TrimSpace(value[1 : len(value)-1])
 	}
 	if value == "" {
-		return false, false
+		return false, false, constexpr.Result{Kind: constexpr.Unknown, Reason: "empty expression"}
 	}
 	if identifierCallDefault.MatchString(value) || strings.HasPrefix(strings.ToLower(value), "new ") {
-		return false, true
+		return false, true, constexpr.Result{Kind: constexpr.Unknown, Reason: "runtime expression"}
 	}
-	if strings.EqualFold(value, "true") || strings.EqualFold(value, "false") || strings.EqualFold(value, "empty") || strings.EqualFold(value, "null") || strings.EqualFold(value, "nothing") {
-		return true, false
+	result = constexpr.EvaluateValues(value, l.constantEvaluationValues())
+	if result.Kind == constexpr.Known {
+		return true, false, result
 	}
-	if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
-		return true, false
+	return false, false, result
+}
+
+// constantEvaluationValues keeps project-level ambiguity conservative. The
+// legacy VisibleConstants map records only names that have a unique unqualified
+// winner; qualified names are safe to retain because their scope is explicit.
+func (l Linter) constantEvaluationValues() map[string]constexpr.Value {
+	if l.ConstantValues == nil || l.VisibleConstants == nil {
+		return l.ConstantValues
 	}
-	if strings.HasPrefix(value, "#") && strings.HasSuffix(value, "#") {
-		return true, false
+	filtered := make(map[string]constexpr.Value, len(l.ConstantValues))
+	for name, value := range l.ConstantValues {
+		key := strings.ToLower(cleanIdentifier(name))
+		_, local := l.localConstantValues[key]
+		if local || l.VisibleConstants[key] {
+			filtered[name] = value
+		}
 	}
-	if isNumericLiteral(value) {
-		return true, false
+	return filtered
+}
+
+func optionalDefaultResultTypeMismatch(result constexpr.Result, typ string, kind signatureType) bool {
+	if result.Kind != constexpr.Known || kind == signatureTypeVariant || kind == signatureTypeUnknown || kind == signatureTypeUDT {
+		return false
 	}
-	if strings.HasPrefix(value, "+") || strings.HasPrefix(value, "-") {
-		return classifyOptionalDefault(strings.TrimSpace(value[1:]))
+	target := strings.ToLower(cleanIdentifier(typ))
+	switch result.Typed.Kind {
+	case constexpr.ValueString:
+		return target != "string"
+	case constexpr.ValueBoolean:
+		return target != "boolean"
+	case constexpr.ValueDate:
+		return target != "date"
+	case constexpr.ValueInteger, constexpr.ValueLong, constexpr.ValueLongLong, constexpr.ValueSingle, constexpr.ValueDouble, constexpr.ValueCurrency:
+		return target == "string" || target == "boolean"
+	default:
+		return false
 	}
-	return false, false
 }
 
 func optionalDefaultTypeMismatch(value, typ string, kind signatureType) bool {

--- a/internal/lint/signature_diagnostics.go
+++ b/internal/lint/signature_diagnostics.go
@@ -573,11 +573,20 @@ func optionalDefaultResultTypeMismatch(result constexpr.Result, typ string, kind
 	case constexpr.ValueString:
 		return target != "string"
 	case constexpr.ValueBoolean:
-		return target != "boolean"
+		return target != "boolean" && !isNumericSignatureTarget(target)
 	case constexpr.ValueDate:
-		return target != "date"
+		return target != "date" && target != "double"
 	case constexpr.ValueInteger, constexpr.ValueLong, constexpr.ValueLongLong, constexpr.ValueSingle, constexpr.ValueDouble, constexpr.ValueCurrency:
 		return target == "string" || target == "boolean"
+	default:
+		return false
+	}
+}
+
+func isNumericSignatureTarget(target string) bool {
+	switch target {
+	case "byte", "currency", "decimal", "double", "integer", "long", "longlong", "longptr", "single":
+		return true
 	default:
 		return false
 	}

--- a/internal/lint/signature_diagnostics_test.go
+++ b/internal/lint/signature_diagnostics_test.go
@@ -262,6 +262,24 @@ func TestOptionalDefaultExpressionIsUnknown(t *testing.T) {
 	}
 }
 
+func TestOptionalDefaultUsesSharedConstantEvaluation(t *testing.T) {
+	source := `Public Const Limit As Long = 2
+Enum State
+    Ready = Limit + 1
+End Enum
+Sub Defaults(Optional value As Long = Ready, Optional text As String = Limit + 1)
+End Sub
+`
+	issues, err := (Linter{}).LintSourceContext(context.Background(), "Main.bas", []byte(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := issuesByCode(issues, "VB048")
+	if len(got) != 1 || got[0].Kind != "optional_default_type" {
+		t.Fatalf("shared Const/Enum evaluation findings = %+v, want one type mismatch", got)
+	}
+}
+
 func TestOptionalDefaultLiteralTypeMismatch(t *testing.T) {
 	source := "Sub Defaults(Optional text As Long = \"bad\", Optional flag As Boolean = 1)\nEnd Sub\n"
 	issues, err := (Linter{}).LintSourceContext(context.Background(), "Main.bas", []byte(source))

--- a/internal/lint/signature_diagnostics_test.go
+++ b/internal/lint/signature_diagnostics_test.go
@@ -336,6 +336,17 @@ func TestOptionalDefaultDateLiteralHandling(t *testing.T) {
 	}
 }
 
+func TestOptionalDefaultKnownBooleanAndDateNumericCompatibility(t *testing.T) {
+	source := "Sub Defaults(Optional flag As Long = True, Optional stamp As Double = #1/1/2024#)\nEnd Sub\n"
+	issues, err := (Linter{}).LintSourceContext(context.Background(), "Main.bas", []byte(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := issuesByCode(issues, "VB048"); len(got) != 0 {
+		t.Fatalf("Boolean-to-numeric and Date-to-Double defaults should be compatible: %+v", got)
+	}
+}
+
 func manyParameters(n int) string {
 	params := ""
 	for i := 1; i <= n; i++ {

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -379,70 +379,11 @@ func projectVisibleConstants(project intel.ProjectAnalysisSnapshot, typeDB *vbad
 }
 
 func projectConstantValues(project intel.ProjectAnalysisSnapshot, typeDB *vbadb.DB) map[string]constexpr.Value {
-	values := make(map[string]constexpr.Value)
+	documents := make([]lint.ConstantValueDocument, 0, len(project.Documents))
 	for _, document := range project.Documents {
-		fileValues := lint.ConstantValuesFromSource(document.Source, &document.IR, nil)
-		standard := strings.EqualFold(document.IR.ModuleKind, "standard")
-		for _, declaration := range document.IR.Declarations {
-			if !declaration.IsConst && !procedureir.IsConstKind(declaration.Kind) {
-				continue
-			}
-			if !strings.EqualFold(declaration.Visibility, "public") && !strings.EqualFold(declaration.Visibility, "friend") {
-				continue
-			}
-			name := projectConstantIdentifier(declaration.Name)
-			value, ok := fileValues[name]
-			if !ok {
-				continue
-			}
-			if standard {
-				values[name] = value
-			}
-			if document.IR.ModuleName != "" {
-				values[projectConstantIdentifier(document.IR.ModuleName)+"."+name] = value
-			}
-			if declaration.Parent != "" {
-				values[projectConstantIdentifier(declaration.Parent)+"."+name] = value
-			}
-		}
+		documents = append(documents, lint.ConstantValueDocument{Source: document.Source, IR: &document.IR})
 	}
-	if typeDB == nil {
-		return values
-	}
-	all := typeDB.AllConstantsList()
-	counts := make(map[string]int)
-	for _, constant := range all {
-		name := projectConstantIdentifier(constant.Name)
-		if name != "" {
-			counts[name]++
-		}
-	}
-	for _, constant := range all {
-		name := projectConstantIdentifier(constant.Name)
-		if name == "" {
-			continue
-		}
-		var value constexpr.Value
-		if strings.EqualFold(constant.Type, "String") {
-			value = constexpr.Value{Kind: constexpr.ValueString, String: constant.Value}
-		} else {
-			result := constexpr.Evaluate(constant.Value, nil)
-			if result.Kind != constexpr.Known {
-				continue
-			}
-			value = result.Typed
-		}
-		if counts[name] == 1 {
-			values[name] = value
-		}
-		if group := projectConstantIdentifier(constant.EnumGroup); group != "" {
-			values[group+"."+name] = value
-		}
-		if library := projectConstantIdentifier(constant.Library); library != "" {
-			values[library+"."+name] = value
-		}
-	}
-	return values
+	return lint.ProjectConstantValues(documents, typeDB)
 }
 
 func projectConstantIdentifier(text string) string {

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -29,12 +29,14 @@ import (
 	"github.com/harumiWeb/xlflow/internal/analyze"
 	"github.com/harumiWeb/xlflow/internal/config"
 	formsintel "github.com/harumiWeb/xlflow/internal/excel/forms/intel"
+	"github.com/harumiWeb/xlflow/internal/lint"
 	staticrules "github.com/harumiWeb/xlflow/internal/staticanalysis/rules"
 	"github.com/harumiWeb/xlflow/internal/typedb"
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/calls"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
 	"github.com/harumiWeb/xlflow/internal/vba/effects"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
@@ -222,6 +224,7 @@ func New(opts Options) (*Server, func(), error) {
 	var visibleConstantsMu sync.Mutex
 	var visibleConstantsRevision uint64
 	var visibleConstants map[string]bool
+	var constantValues map[string]constexpr.Value
 	s.projectDiagnosticsRequest = func(ctx context.Context, request intel.DiagnosticRequest, project intel.ProjectAnalysisSnapshot) intel.DiagnosticResult {
 		projectEffects := s.projectEffectSummary(project)
 		projectByPath := make(map[string]intel.ProjectAnalysisDocument, len(project.Documents))
@@ -233,9 +236,11 @@ func New(opts Options) (*Server, func(), error) {
 		visibleConstantsMu.Lock()
 		if visibleConstants == nil || visibleConstantsRevision != project.Revision {
 			visibleConstants = projectVisibleConstants(project, typeDB.DB)
+			constantValues = projectConstantValues(project, typeDB.DB)
 			visibleConstantsRevision = project.Revision
 		}
 		analyzer.VisibleConstants = visibleConstants
+		analyzer.ConstantValues = constantValues
 		visibleConstantsMu.Unlock()
 		analyzer.RealtimeFindingsFunc = func(ctx context.Context, rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document) ([]intel.RealtimeFinding, error) {
 			projectKey := symbolFileKey(ir.Path)
@@ -247,7 +252,7 @@ func New(opts Options) (*Server, func(), error) {
 				}
 				controlFlow = projectDocument.CFG
 			}
-			findings, err := analyze.SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectContext(ctx, rootDir, cfg, doc, ir, controlFlow, typeDB.DB, projectEffects)
+			findings, err := analyze.SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx, rootDir, cfg, doc, ir, controlFlow, typeDB.DB, projectEffects, analyzer.ConstantValues)
 			if err != nil {
 				return nil, err
 			}
@@ -311,14 +316,14 @@ func New(opts Options) (*Server, func(), error) {
 func projectVisibleConstants(project intel.ProjectAnalysisSnapshot, typeDB *vbadb.DB) map[string]bool {
 	counts := make(map[string]int)
 	add := func(name string) {
-		name = strings.ToLower(strings.TrimSpace(name))
+		name = projectConstantIdentifier(name)
 		if name != "" {
 			counts[name]++
 		}
 	}
 	addQualified := func(qualifier, name string) {
-		qualifier = strings.ToLower(strings.TrimSpace(qualifier))
-		name = strings.ToLower(strings.TrimSpace(name))
+		qualifier = projectConstantIdentifier(qualifier)
+		name = projectConstantIdentifier(name)
 		if qualifier != "" && name != "" {
 			counts[qualifier+"."+name]++
 		}
@@ -343,23 +348,23 @@ func projectVisibleConstants(project intel.ProjectAnalysisSnapshot, typeDB *vbad
 		constants := typeDB.AllConstantsList()
 		countsByName := make(map[string]int)
 		for _, constant := range constants {
-			name := strings.ToLower(strings.TrimSpace(constant.Name))
+			name := projectConstantIdentifier(constant.Name)
 			if name != "" {
 				countsByName[name]++
 			}
 		}
 		for _, constant := range constants {
-			name := strings.ToLower(strings.TrimSpace(constant.Name))
+			name := projectConstantIdentifier(constant.Name)
 			if name == "" {
 				continue
 			}
 			if countsByName[name] == 1 {
 				counts[name]++
 			}
-			if group := strings.ToLower(strings.TrimSpace(constant.EnumGroup)); group != "" {
+			if group := projectConstantIdentifier(constant.EnumGroup); group != "" {
 				counts[group+"."+name]++
 			}
-			if library := strings.ToLower(strings.TrimSpace(constant.Library)); library != "" {
+			if library := projectConstantIdentifier(constant.Library); library != "" {
 				counts[library+"."+name]++
 			}
 		}
@@ -371,6 +376,80 @@ func projectVisibleConstants(project intel.ProjectAnalysisSnapshot, typeDB *vbad
 		}
 	}
 	return constants
+}
+
+func projectConstantValues(project intel.ProjectAnalysisSnapshot, typeDB *vbadb.DB) map[string]constexpr.Value {
+	values := make(map[string]constexpr.Value)
+	for _, document := range project.Documents {
+		fileValues := lint.ConstantValuesFromSource(document.Source, &document.IR, nil)
+		standard := strings.EqualFold(document.IR.ModuleKind, "standard")
+		for _, declaration := range document.IR.Declarations {
+			if !declaration.IsConst && !procedureir.IsConstKind(declaration.Kind) {
+				continue
+			}
+			if !strings.EqualFold(declaration.Visibility, "public") && !strings.EqualFold(declaration.Visibility, "friend") {
+				continue
+			}
+			name := projectConstantIdentifier(declaration.Name)
+			value, ok := fileValues[name]
+			if !ok {
+				continue
+			}
+			if standard {
+				values[name] = value
+			}
+			if document.IR.ModuleName != "" {
+				values[projectConstantIdentifier(document.IR.ModuleName)+"."+name] = value
+			}
+			if declaration.Parent != "" {
+				values[projectConstantIdentifier(declaration.Parent)+"."+name] = value
+			}
+		}
+	}
+	if typeDB == nil {
+		return values
+	}
+	all := typeDB.AllConstantsList()
+	counts := make(map[string]int)
+	for _, constant := range all {
+		name := projectConstantIdentifier(constant.Name)
+		if name != "" {
+			counts[name]++
+		}
+	}
+	for _, constant := range all {
+		name := projectConstantIdentifier(constant.Name)
+		if name == "" {
+			continue
+		}
+		var value constexpr.Value
+		if strings.EqualFold(constant.Type, "String") {
+			value = constexpr.Value{Kind: constexpr.ValueString, String: constant.Value}
+		} else {
+			result := constexpr.Evaluate(constant.Value, nil)
+			if result.Kind != constexpr.Known {
+				continue
+			}
+			value = result.Typed
+		}
+		if counts[name] == 1 {
+			values[name] = value
+		}
+		if group := projectConstantIdentifier(constant.EnumGroup); group != "" {
+			values[group+"."+name] = value
+		}
+		if library := projectConstantIdentifier(constant.Library); library != "" {
+			values[library+"."+name] = value
+		}
+	}
+	return values
+}
+
+func projectConstantIdentifier(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.Trim(text, "[]")
+	text = strings.TrimRight(text, "$%&#@^!")
+	return strings.ToLower(text)
 }
 
 func (s *Server) projectEffectSummary(project intel.ProjectAnalysisSnapshot) effects.ProjectSummary {

--- a/internal/lspserver/workspace_analysis_index.go
+++ b/internal/lspserver/workspace_analysis_index.go
@@ -653,7 +653,7 @@ func (x *workspaceAnalysisIndex) projectSnapshot() intel.ProjectAnalysisSnapshot
 	var typeReferences []calls.TypeReference
 	for _, entry := range entries {
 		resolvedIR := procedureir.Resolve(entry.procedureIR, resolver)
-		result.Documents = append(result.Documents, intel.ProjectAnalysisDocument{IR: resolvedIR, CFG: entry.controlFlow})
+		result.Documents = append(result.Documents, intel.ProjectAnalysisDocument{IR: resolvedIR, CFG: entry.controlFlow, Source: entry.source})
 		sites = append(sites, entry.callSites...)
 		typeReferences = append(typeReferences, entry.typeReferences...)
 	}

--- a/internal/lspserver/workspace_analysis_index.go
+++ b/internal/lspserver/workspace_analysis_index.go
@@ -624,7 +624,7 @@ func (x *workspaceAnalysisIndex) projectSnapshot() intel.ProjectAnalysisSnapshot
 	graphSymbols := make([]callgraph.Symbol, 0, symbolCapacity)
 	for _, raw := range rawEntries {
 		entry := indexedFileAnalysis{
-			path: raw.path, procedureIR: procedureir.Clone(raw.procedureIR),
+			path: raw.path, source: raw.source, procedureIR: procedureir.Clone(raw.procedureIR),
 			controlFlow: vbacfg.CloneDocument(raw.controlFlow),
 			callSites:   cloneCallSites(raw.callSites), typeReferences: cloneTypeReferences(raw.typeReferences),
 			symbols: append([]intel.Symbol(nil), raw.symbols...),

--- a/internal/lspserver/workspace_project_analysis_test.go
+++ b/internal/lspserver/workspace_project_analysis_test.go
@@ -59,7 +59,7 @@ func TestWorkspaceProjectSnapshotHoldsResolvedIRAndDefensiveCFG(t *testing.T) {
 	}
 	doc := intel.Document{URI: "file:///Main.bas", Path: path, Source: "source", ModuleKind: "standard"}
 	index.setOverlay(doc, indexedFileAnalysis{
-		procedureIR: ir, controlFlow: graph,
+		procedureIR: ir, controlFlow: graph, source: doc.Source,
 		symbols: []intel.Symbol{
 			{Name: "Run", Kind: "sub", Module: "Main", ModuleKind: "standard", File: path, Range: intel.Range{Start: intel.Position{Line: 0}}},
 			{Name: "Work", Kind: "sub", Module: "Main", ModuleKind: "standard", File: path, Range: intel.Range{Start: intel.Position{Line: 3}}},
@@ -69,6 +69,9 @@ func TestWorkspaceProjectSnapshotHoldsResolvedIRAndDefensiveCFG(t *testing.T) {
 	snapshot := index.projectSnapshot()
 	if !snapshot.Complete || len(snapshot.Documents) != 1 || len(snapshot.Documents[0].CFG.Graphs) != 2 {
 		t.Fatalf("snapshot = %#v", snapshot)
+	}
+	if snapshot.Documents[0].Source != doc.Source {
+		t.Fatalf("snapshot source = %q, want %q", snapshot.Documents[0].Source, doc.Source)
 	}
 	if snapshot.Revision == 0 {
 		t.Fatal("published project snapshot revision was not advanced")

--- a/internal/vba/constexpr/constexpr.go
+++ b/internal/vba/constexpr/constexpr.go
@@ -57,24 +57,29 @@ type Environment interface {
 // Values adapts a map to Environment. Keys are matched case-insensitively.
 type Values map[string]Value
 
-func (v Values) Resolve(name string) (Value, bool) {
-	name = strings.ToLower(strings.TrimSpace(name))
-	// A map may contain keys that differ only by case when declarations come
-	// from separate snapshots. Pick the lexicographically smallest spelling so
-	// evaluation does not depend on Go's randomized map iteration order.
-	selected := ""
-	var value Value
-	for key, candidate := range v {
-		if !strings.EqualFold(key, name) || (selected != "" && key >= selected) {
+// NewValues normalizes a value map once for deterministic, constant-time
+// case-insensitive lookups. When declarations differ only by case or
+// surrounding whitespace, the lexicographically smallest spelling wins.
+func NewValues(values map[string]Value) Values {
+	normalized := make(Values, len(values))
+	spellings := make(map[string]string, len(values))
+	for key, value := range values {
+		folded := strings.ToLower(strings.TrimSpace(key))
+		if folded == "" {
 			continue
 		}
-		selected = key
-		value = candidate
+		if prior, ok := spellings[folded]; ok && prior <= key {
+			continue
+		}
+		spellings[folded] = key
+		normalized[folded] = value
 	}
-	if selected == "" {
-		return Value{}, false
-	}
-	return value, true
+	return normalized
+}
+
+func (v Values) Resolve(name string) (Value, bool) {
+	value, ok := v[strings.ToLower(strings.TrimSpace(name))]
+	return value, ok
 }
 
 // Result keeps the historical integer Value field for existing consumers and
@@ -113,7 +118,7 @@ func Evaluate(expression string, env Environment) Result {
 
 // EvaluateValues is a convenience adapter for callers that own a value map.
 func EvaluateValues(expression string, values map[string]Value) Result {
-	return Evaluate(expression, Values(values))
+	return Evaluate(expression, NewValues(values))
 }
 
 // EvaluateInteger preserves the original API used by array and loop analysis.
@@ -127,14 +132,18 @@ func EvaluateInteger(expression string, constants map[string]int) Result {
 		// literals while the final int projection still enforces its own width.
 		values[name] = Value{Kind: ValueLongLong, Integer: int64(value)}
 	}
-	result := Evaluate(expression, values)
+	result := Evaluate(expression, NewValues(values))
 	if result.Kind != Known {
 		return result
 	}
-	if !isIntegral(result.Typed) || int64(int(result.Typed.Integer)) != result.Typed.Integer {
+	if !isIntegral(result.Typed) {
 		return Result{Kind: Unknown, Reason: "non-integral or unrepresentable integer"}
 	}
-	result.Value = int(result.Typed.Integer)
+	value, ok := hostInt(result.Typed.Integer)
+	if !ok {
+		return Result{Kind: Unknown, Reason: "non-integral or unrepresentable integer"}
+	}
+	result.Value = value
 	result.Type = string(result.Typed.Kind)
 	return result
 }
@@ -145,11 +154,29 @@ func known(value Value) Result {
 	}
 	result := Result{Kind: Known, Typed: value, Type: string(value.Kind)}
 	if isIntegral(value) {
-		if int64(int(value.Integer)) == value.Integer {
-			result.Value = int(value.Integer)
+		if projected, ok := hostInt(value.Integer); ok {
+			result.Value = projected
 		}
 	}
 	return result
+}
+
+func hostInt(value int64) (int, bool) {
+	if strconv.IntSize == 32 {
+		if value < math.MinInt32 || value > math.MaxInt32 {
+			return 0, false
+		}
+	}
+	return int(value), true
+}
+
+// IntegerAsInt projects an integral VBA value to the host int used by legacy
+// range and array adapters, rejecting values outside the host width.
+func IntegerAsInt(value Value) (int, bool) {
+	if !isIntegral(value) {
+		return 0, false
+	}
+	return hostInt(value.Integer)
 }
 
 func unknown(reason string) Result { return Result{Kind: Unknown, Reason: reason} }
@@ -247,6 +274,9 @@ func newLexer(text string) lexer {
 				start := i
 				i += 2
 				for i < len(text) && (unicode.IsDigit(rune(text[i])) || unicode.IsLetter(rune(text[i]))) {
+					i++
+				}
+				if i < len(text) && strings.ContainsRune("%&^", rune(text[i])) {
 					i++
 				}
 				out.tokens = append(out.tokens, token{kind: tokenNumber, text: text[start:i]})
@@ -481,7 +511,7 @@ func parseNumber(text string) Result {
 		}
 	case '@':
 		scaled := math.Round(value * 10000)
-		if scaled < math.MinInt64 || scaled > math.MaxInt64 {
+		if scaled < math.MinInt64 || scaled >= math.MaxInt64 {
 			return unknown("currency overflow")
 		}
 		return known(Value{Kind: ValueCurrency, Currency: int64(scaled)})
@@ -525,6 +555,9 @@ func unary(value Result, op string) Result {
 		}
 		return invalid("unary minus requires numeric operand")
 	case "not":
+		if isNumeric(value.Typed) {
+			return unknown("bitwise Not is not modelled")
+		}
 		if value.Typed.Kind != ValueBoolean {
 			return invalid("Not requires Boolean operand")
 		}
@@ -590,10 +623,15 @@ func combine(left, right Result, op string) Result {
 		if left.Typed.Kind == ValueString && right.Typed.Kind == ValueString {
 			return known(Value{Kind: ValueString, String: left.Typed.String + right.Typed.String})
 		}
-		return invalid("string concatenation requires String operands")
+		return unknown("concatenation coercion is not modelled")
 	}
 	if op == "and" || op == "or" || op == "xor" || op == "eqv" || op == "imp" {
 		if left.Typed.Kind != ValueBoolean || right.Typed.Kind != ValueBoolean {
+			if (isNumeric(left.Typed) && isNumeric(right.Typed)) ||
+				(left.Typed.Kind == ValueBoolean && isNumeric(right.Typed)) ||
+				(right.Typed.Kind == ValueBoolean && isNumeric(left.Typed)) {
+				return unknown("bitwise operator semantics are not modelled")
+			}
 			return invalid("Boolean operator requires Boolean operands")
 		}
 		lv, rv := left.Typed.Boolean, right.Typed.Boolean
@@ -736,6 +774,13 @@ func compare(left, right Result, op string) Result {
 	}
 	if left.Typed.Kind == ValueBoolean && right.Typed.Kind == ValueBoolean {
 		return compareFloat(boolFloat(left.Typed.Boolean), boolFloat(right.Typed.Boolean), op)
+	}
+	if (left.Typed.Kind == ValueBoolean && isNumeric(right.Typed)) ||
+		(right.Typed.Kind == ValueBoolean && isNumeric(left.Typed)) {
+		return unknown("comparison coercion is not modelled")
+	}
+	if left.Typed.Kind == ValueDate && right.Typed.Kind == ValueDate {
+		return unknown("date comparison is not modelled")
 	}
 	if !isNumeric(left.Typed) || !isNumeric(right.Typed) {
 		return invalid("comparison requires compatible operands")

--- a/internal/vba/constexpr/constexpr.go
+++ b/internal/vba/constexpr/constexpr.go
@@ -512,7 +512,7 @@ func parseNumber(text string) Result {
 			return unknown("single-precision overflow")
 		}
 	case '@':
-		scaled := math.Round(value * 10000)
+		scaled := math.RoundToEven(value * 10000)
 		if scaled < math.MinInt64 || scaled >= math.MaxInt64 {
 			return unknown("currency overflow")
 		}

--- a/internal/vba/constexpr/constexpr.go
+++ b/internal/vba/constexpr/constexpr.go
@@ -1,10 +1,11 @@
-// Package constexpr evaluates the deliberately small integer constant subset
-// shared by declaration and array-operation validation. It does not attempt
-// to model VBA's full expression language: unresolved names and runtime
-// expressions are explicitly represented as Unknown so callers can fail open.
+// Package constexpr evaluates the deliberately conservative subset of VBA
+// expressions that may be used where a compile-time value is required.  It
+// never invokes VBA, Excel, or COM.  Runtime-dependent and unsupported
+// expressions are represented as Unknown so callers can fail open.
 package constexpr
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"unicode"
@@ -18,144 +19,561 @@ const (
 	Invalid ResultKind = "invalid"
 )
 
+// ValueKind is the stable type tag carried by a known result.
+type ValueKind string
+
+const (
+	ValueInteger  ValueKind = "integer"
+	ValueLong     ValueKind = "long"
+	ValueLongLong ValueKind = "longlong"
+	ValueSingle   ValueKind = "single"
+	ValueDouble   ValueKind = "double"
+	ValueCurrency ValueKind = "currency"
+	ValueString   ValueKind = "string"
+	ValueBoolean  ValueKind = "boolean"
+	ValueDate     ValueKind = "date"
+	ValueEmpty    ValueKind = "empty"
+	ValueNull     ValueKind = "null"
+	ValueNothing  ValueKind = "nothing"
+)
+
+// Value is an immutable, tagged VBA value.  Only the field corresponding to
+// Kind is meaningful. Currency is stored as an integer scaled by 10,000.
+type Value struct {
+	Kind     ValueKind
+	Integer  int64
+	Float    float64
+	String   string
+	Boolean  bool
+	Currency int64
+}
+
+// Environment resolves case-insensitive constant names. Implementations must
+// be immutable for the duration of one evaluation pass.
+type Environment interface {
+	Resolve(name string) (Value, bool)
+}
+
+// Values adapts a map to Environment. Keys are matched case-insensitively.
+type Values map[string]Value
+
+func (v Values) Resolve(name string) (Value, bool) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	// A map may contain keys that differ only by case when declarations come
+	// from separate snapshots. Pick the lexicographically smallest spelling so
+	// evaluation does not depend on Go's randomized map iteration order.
+	selected := ""
+	var value Value
+	for key, candidate := range v {
+		if !strings.EqualFold(key, name) || (selected != "" && key >= selected) {
+			continue
+		}
+		selected = key
+		value = candidate
+	}
+	if selected == "" {
+		return Value{}, false
+	}
+	return value, true
+}
+
+// Result keeps the historical integer Value field for existing consumers and
+// adds Typed for all supported scalar kinds.
 type Result struct {
 	Kind   ResultKind
 	Value  int
+	Typed  Value
 	Type   string
 	Reason string
 }
 
-func EvaluateInteger(expression string, constants map[string]int) Result {
-	text := strings.TrimSpace(expression)
-	if text == "" {
+// Evaluate evaluates expression against env. A nil environment still knows
+// VBA's intrinsic literal values but leaves named constants unresolved.
+func Evaluate(expression string, env Environment) Result {
+	lexer := newLexer(expression)
+	if lexer.invalid != "" {
+		return Result{Kind: Invalid, Reason: lexer.invalid}
+	}
+	if len(lexer.tokens) == 0 {
 		return Result{Kind: Unknown, Reason: "empty expression"}
 	}
-	// Calls and other runtime expressions are intentionally not interpreted as
-	// malformed integer syntax; they are simply unresolved at analysis time.
-	if looksLikeCall(text) {
-		return Result{Kind: Unknown, Reason: "runtime expression"}
-	}
-	p := parser{text: text, constants: constants}
-	result := p.expression()
-	p.space()
+	p := parser{tokens: lexer.tokens, env: env}
+	result := p.parseImp()
 	if result.Kind == Invalid {
 		return result
 	}
-	if p.pos != len(p.text) {
-		if unsupportedIntegerOperator(p.text[p.pos:]) {
-			return Result{Kind: Unknown, Reason: "unsupported integer operator"}
+	if p.pos != len(p.tokens) {
+		if p.tokens[p.pos].kind == tokenOperator {
+			return Result{Kind: Unknown, Reason: "unsupported operator " + p.tokens[p.pos].text}
 		}
 		return Result{Kind: Invalid, Reason: "unexpected token"}
 	}
 	return result
 }
 
-func unsupportedIntegerOperator(remainder string) bool {
-	remainder = strings.TrimSpace(remainder)
-	if remainder == "" {
+// EvaluateValues is a convenience adapter for callers that own a value map.
+func EvaluateValues(expression string, values map[string]Value) Result {
+	return Evaluate(expression, Values(values))
+}
+
+// EvaluateInteger preserves the original API used by array and loop analysis.
+// It returns Known only for an integral value representable by int and keeps
+// non-integral, typed, and overflowing results fail-open.
+func EvaluateInteger(expression string, constants map[string]int) Result {
+	values := make(Values, len(constants))
+	for name, value := range constants {
+		// The compatibility map has no VBA declaration type. LongLong keeps
+		// host-sized integer bounds from being mistaken for 16-bit Integer
+		// literals while the final int projection still enforces its own width.
+		values[name] = Value{Kind: ValueLongLong, Integer: int64(value)}
+	}
+	result := Evaluate(expression, values)
+	if result.Kind != Known {
+		return result
+	}
+	if !isIntegral(result.Typed) || int64(int(result.Typed.Integer)) != result.Typed.Integer {
+		return Result{Kind: Unknown, Reason: "non-integral or unrepresentable integer"}
+	}
+	result.Value = int(result.Typed.Integer)
+	result.Type = string(result.Typed.Kind)
+	return result
+}
+
+func known(value Value) Result {
+	if isIntegral(value) && !fitsInteger(value.Kind, value.Integer) {
+		return unknown("integer overflow")
+	}
+	result := Result{Kind: Known, Typed: value, Type: string(value.Kind)}
+	if isIntegral(value) {
+		if int64(int(value.Integer)) == value.Integer {
+			result.Value = int(value.Integer)
+		}
+	}
+	return result
+}
+
+func unknown(reason string) Result { return Result{Kind: Unknown, Reason: reason} }
+func invalid(reason string) Result { return Result{Kind: Invalid, Reason: reason} }
+
+func isIntegral(value Value) bool {
+	return value.Kind == ValueInteger || value.Kind == ValueLong || value.Kind == ValueLongLong
+}
+
+func fitsInteger(kind ValueKind, value int64) bool {
+	switch kind {
+	case ValueInteger:
+		return value >= math.MinInt16 && value <= math.MaxInt16
+	case ValueLong:
+		return value >= math.MinInt32 && value <= math.MaxInt32
+	case ValueLongLong:
+		return true
+	default:
 		return false
 	}
-	if strings.HasPrefix(remainder, "\\") || strings.HasPrefix(remainder, "^") {
-		return true
-	}
-	lower := strings.ToLower(remainder)
-	return strings.HasPrefix(lower, "mod") && (len(lower) == 3 || !unicode.IsLetter(rune(lower[3])))
 }
 
-type parser struct {
-	text      string
-	pos       int
-	constants map[string]int
+type tokenKind uint8
+
+const (
+	tokenNumber tokenKind = iota
+	tokenString
+	tokenDate
+	tokenIdentifier
+	tokenOperator
+	tokenLParen
+	tokenRParen
+)
+
+type token struct {
+	kind tokenKind
+	text string
 }
 
-func (p *parser) expression() Result {
-	left := p.term()
-	for {
-		p.space()
-		if p.pos >= len(p.text) || (p.text[p.pos] != '+' && p.text[p.pos] != '-') {
-			return left
-		}
-		op := p.text[p.pos]
-		p.pos++
-		right := p.term()
-		left = combine(left, right, op)
-	}
+type lexer struct {
+	tokens  []token
+	invalid string
 }
 
-func (p *parser) term() Result {
-	left := p.factor()
-	for {
-		p.space()
-		if p.pos >= len(p.text) || (p.text[p.pos] != '*' && p.text[p.pos] != '/') {
-			return left
-		}
-		op := p.text[p.pos]
-		p.pos++
-		right := p.factor()
-		if op == '/' && right.Kind == Known && right.Value == 0 {
-			left = Result{Kind: Invalid, Reason: "division by zero"}
+func newLexer(text string) lexer {
+	var out lexer
+	for i := 0; i < len(text); {
+		if text[i] == ' ' || text[i] == '\t' || text[i] == '\r' || text[i] == '\n' {
+			i++
 			continue
 		}
+		switch text[i] {
+		case '(':
+			out.tokens = append(out.tokens, token{kind: tokenLParen, text: "("})
+			i++
+		case ')':
+			out.tokens = append(out.tokens, token{kind: tokenRParen, text: ")"})
+			i++
+		case '"':
+			i++
+			var b strings.Builder
+			for i < len(text) {
+				if text[i] != '"' {
+					b.WriteByte(text[i])
+					i++
+					continue
+				}
+				if i+1 < len(text) && text[i+1] == '"' {
+					b.WriteByte('"')
+					i += 2
+					continue
+				}
+				i++
+				out.tokens = append(out.tokens, token{kind: tokenString, text: b.String()})
+				break
+			}
+			if i > len(text) || (i == len(text) && (len(text) == 0 || text[i-1] != '"')) {
+				out.invalid = "unterminated string literal"
+				return out
+			}
+		case '#':
+			start := i
+			i++
+			for i < len(text) && text[i] != '#' {
+				i++
+			}
+			if i >= len(text) {
+				out.invalid = "unterminated date literal"
+				return out
+			}
+			i++
+			out.tokens = append(out.tokens, token{kind: tokenDate, text: text[start+1 : i-1]})
+		case '&':
+			if i+1 < len(text) && (text[i+1] == 'H' || text[i+1] == 'h' || text[i+1] == 'O' || text[i+1] == 'o') {
+				start := i
+				i += 2
+				for i < len(text) && (unicode.IsDigit(rune(text[i])) || unicode.IsLetter(rune(text[i]))) {
+					i++
+				}
+				out.tokens = append(out.tokens, token{kind: tokenNumber, text: text[start:i]})
+			} else {
+				out.tokens = append(out.tokens, token{kind: tokenOperator, text: "&"})
+				i++
+			}
+		case '<', '>':
+			start := i
+			i++
+			if i < len(text) && (text[i] == '=' || text[i] == '>') {
+				i++
+			}
+			out.tokens = append(out.tokens, token{kind: tokenOperator, text: text[start:i]})
+		case '=', '+', '-', '*', '/', '\\', '^':
+			out.tokens = append(out.tokens, token{kind: tokenOperator, text: text[i : i+1]})
+			i++
+		default:
+			if unicode.IsDigit(rune(text[i])) || text[i] == '.' {
+				start := i
+				i++
+				for i < len(text) && (unicode.IsDigit(rune(text[i])) || text[i] == '.' || text[i] == 'e' || text[i] == 'E' || text[i] == '+' || text[i] == '-' || strings.ContainsRune("%&!#@^", rune(text[i]))) {
+					if (text[i] == '+' || text[i] == '-') && text[i-1] != 'e' && text[i-1] != 'E' {
+						break
+					}
+					i++
+				}
+				out.tokens = append(out.tokens, token{kind: tokenNumber, text: text[start:i]})
+				continue
+			}
+			if isIdentifierStart(text[i]) {
+				start := i
+				i++
+				for i < len(text) && (isIdentifierPart(text[i]) || text[i] == '.' || text[i] == '$') {
+					i++
+				}
+				word := text[start:i]
+				lower := strings.ToLower(word)
+				switch lower {
+				case "mod", "and", "or", "xor", "eqv", "imp", "like", "is", "not":
+					out.tokens = append(out.tokens, token{kind: tokenOperator, text: lower})
+				default:
+					out.tokens = append(out.tokens, token{kind: tokenIdentifier, text: word})
+				}
+				continue
+			}
+			out.invalid = "unexpected character"
+			return out
+		}
+	}
+	return out
+}
+
+func isIdentifierStart(ch byte) bool { return ch == '_' || unicode.IsLetter(rune(ch)) }
+func isIdentifierPart(ch byte) bool  { return isIdentifierStart(ch) || unicode.IsDigit(rune(ch)) }
+
+type parser struct {
+	tokens []token
+	pos    int
+	env    Environment
+}
+
+func (p *parser) parseImp() Result { return p.binary(p.parseEqv, "imp") }
+func (p *parser) parseEqv() Result { return p.binary(p.parseOr, "eqv") }
+func (p *parser) parseOr() Result  { return p.binary(p.parseXor, "or") }
+func (p *parser) parseXor() Result { return p.binary(p.parseAnd, "xor") }
+func (p *parser) parseAnd() Result { return p.binary(p.parseCompare, "and") }
+
+type parseFn func() Result
+
+func (p *parser) binary(next parseFn, operators ...string) Result {
+	left := next()
+	for p.pos < len(p.tokens) && p.tokens[p.pos].kind == tokenOperator && contains(operators, strings.ToLower(p.tokens[p.pos].text)) {
+		op := strings.ToLower(p.tokens[p.pos].text)
+		p.pos++
+		right := next()
 		left = combine(left, right, op)
 	}
+	return left
 }
 
-func (p *parser) factor() Result {
-	p.space()
-	if p.pos >= len(p.text) {
-		return Result{Kind: Invalid, Reason: "missing operand"}
-	}
-	if p.text[p.pos] == '+' || p.text[p.pos] == '-' {
-		op := p.text[p.pos]
+func (p *parser) parseCompare() Result {
+	left := p.parseConcat()
+	for p.pos < len(p.tokens) && p.tokens[p.pos].kind == tokenOperator && contains([]string{"=", "<>", "<", ">", "<=", ">=", "like", "is"}, strings.ToLower(p.tokens[p.pos].text)) {
+		op := strings.ToLower(p.tokens[p.pos].text)
 		p.pos++
-		result := p.factor()
-		if result.Kind == Known && op == '-' {
-			result.Value = -result.Value
+		right := p.parseConcat()
+		left = compare(left, right, op)
+	}
+	return left
+}
+
+func (p *parser) parseConcat() Result { return p.binary(p.parseAdd, "&") }
+func (p *parser) parseAdd() Result    { return p.binary(p.parseMul, "+", "-") }
+func (p *parser) parseMul() Result    { return p.binary(p.parseUnary, "*", "/", "\\", "mod") }
+
+func (p *parser) parseUnary() Result {
+	if p.pos < len(p.tokens) && p.tokens[p.pos].kind == tokenOperator && contains([]string{"+", "-", "not"}, strings.ToLower(p.tokens[p.pos].text)) {
+		op := strings.ToLower(p.tokens[p.pos].text)
+		p.pos++
+		return unary(p.parseUnary(), op)
+	}
+	return p.parsePower()
+}
+
+func (p *parser) parsePower() Result {
+	left := p.parsePrimary()
+	if p.pos < len(p.tokens) && p.tokens[p.pos].kind == tokenOperator && p.tokens[p.pos].text == "^" {
+		p.pos++
+		return power(left, p.parseUnary())
+	}
+	return left
+}
+
+func (p *parser) parsePrimary() Result {
+	if p.pos >= len(p.tokens) {
+		return invalid("missing operand")
+	}
+	tok := p.tokens[p.pos]
+	p.pos++
+	if tok.kind == tokenLParen {
+		result := p.parseImp()
+		if p.pos >= len(p.tokens) || p.tokens[p.pos].kind != tokenRParen {
+			return invalid("unclosed parentheses")
 		}
+		p.pos++
 		return result
 	}
-	if p.text[p.pos] == '(' {
-		p.pos++
-		result := p.expression()
-		p.space()
-		if p.pos >= len(p.text) || p.text[p.pos] != ')' {
-			return Result{Kind: Invalid, Reason: "unclosed parentheses"}
-		}
-		p.pos++
-		return result
+	if tok.kind == tokenString {
+		return known(Value{Kind: ValueString, String: tok.text})
 	}
-	start := p.pos
-	if unicode.IsDigit(rune(p.text[p.pos])) {
-		for p.pos < len(p.text) && unicode.IsDigit(rune(p.text[p.pos])) {
-			p.pos++
+	if tok.kind == tokenDate {
+		return known(Value{Kind: ValueDate, String: tok.text})
+	}
+	if tok.kind == tokenNumber {
+		return parseNumber(tok.text)
+	}
+	if tok.kind != tokenIdentifier {
+		return invalid("unexpected token")
+	}
+	if p.pos < len(p.tokens) && p.tokens[p.pos].kind == tokenLParen {
+		p.skipCall()
+		return unknown("runtime expression")
+	}
+	switch strings.ToLower(tok.text) {
+	case "true":
+		return known(Value{Kind: ValueBoolean, Boolean: true})
+	case "false":
+		return known(Value{Kind: ValueBoolean, Boolean: false})
+	case "empty":
+		return known(Value{Kind: ValueEmpty})
+	case "null":
+		return known(Value{Kind: ValueNull})
+	case "nothing":
+		return known(Value{Kind: ValueNothing})
+	}
+	if p.env != nil {
+		if value, ok := p.env.Resolve(tok.text); ok {
+			return known(value)
 		}
-		value, err := strconv.Atoi(p.text[start:p.pos])
+	}
+	return unknown("unresolved constant " + strings.ToLower(tok.text))
+}
+
+func (p *parser) skipCall() {
+	depth := 0
+	for p.pos < len(p.tokens) {
+		switch p.tokens[p.pos].kind {
+		case tokenLParen:
+			depth++
+		case tokenRParen:
+			depth--
+		}
+		p.pos++
+		if depth == 0 {
+			return
+		}
+	}
+}
+
+func parseNumber(text string) Result {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return invalid("empty number")
+	}
+	suffix := byte(0)
+	if strings.ContainsRune("%&!#@^", rune(trimmed[len(trimmed)-1])) {
+		suffix = trimmed[len(trimmed)-1]
+		trimmed = trimmed[:len(trimmed)-1]
+	}
+	base := 10
+	digits := trimmed
+	if len(trimmed) > 2 && trimmed[0] == '&' && (trimmed[1] == 'H' || trimmed[1] == 'h' || trimmed[1] == 'O' || trimmed[1] == 'o') {
+		if trimmed[1] == 'H' || trimmed[1] == 'h' {
+			base = 16
+		}
+		if trimmed[1] == 'O' || trimmed[1] == 'o' {
+			base = 8
+		}
+		digits = trimmed[2:]
+	}
+	if base != 10 || (!strings.ContainsAny(trimmed, ".eE")) {
+		value, err := strconv.ParseInt(digits, base, 64)
 		if err != nil {
-			return Result{Kind: Invalid, Reason: "integer overflow"}
+			return unknown("integer overflow")
 		}
-		return Result{Kind: Known, Value: value, Type: "integer"}
+		kind := ValueLong
+		switch suffix {
+		case '%':
+			if value < math.MinInt16 || value > math.MaxInt16 {
+				return unknown("integer overflow")
+			}
+			kind = ValueInteger
+		case '^':
+			kind = ValueLongLong
+		case '&':
+			kind = ValueLong
+		}
+		return known(Value{Kind: kind, Integer: value})
 	}
-	if unicode.IsLetter(rune(p.text[p.pos])) || p.text[p.pos] == '_' {
-		p.pos++
-		for p.pos < len(p.text) && (unicode.IsLetter(rune(p.text[p.pos])) || unicode.IsDigit(rune(p.text[p.pos])) || p.text[p.pos] == '_') {
-			p.pos++
-		}
-		name := strings.ToLower(p.text[start:p.pos])
-		if value, ok := p.constants[name]; ok {
-			return Result{Kind: Known, Value: value, Type: "integer"}
-		}
-		return Result{Kind: Unknown, Reason: "unresolved constant " + name}
+	value, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil || math.IsInf(value, 0) || math.IsNaN(value) {
+		return unknown("floating-point overflow")
 	}
-	return Result{Kind: Invalid, Reason: "unexpected token"}
+	kind := ValueDouble
+	switch suffix {
+	case '!':
+		kind = ValueSingle
+		value = float64(float32(value))
+		if math.IsInf(value, 0) {
+			return unknown("single-precision overflow")
+		}
+	case '@':
+		scaled := math.Round(value * 10000)
+		if scaled < math.MinInt64 || scaled > math.MaxInt64 {
+			return unknown("currency overflow")
+		}
+		return known(Value{Kind: ValueCurrency, Currency: int64(scaled)})
+	case '#':
+		kind = ValueDouble
+	}
+	return known(Value{Kind: kind, Float: value})
 }
 
-func (p *parser) space() {
-	for p.pos < len(p.text) && (p.text[p.pos] == ' ' || p.text[p.pos] == '\t') {
-		p.pos++
+func unary(value Result, op string) Result {
+	if value.Kind != Known {
+		return value
+	}
+	if isRuntimeValue(value.Typed) {
+		return unknown("operand coercion is not modelled")
+	}
+	switch op {
+	case "+":
+		if !isNumeric(value.Typed) {
+			return invalid("unary plus requires numeric operand")
+		}
+		return value
+	case "-":
+		if isIntegral(value.Typed) {
+			if value.Typed.Integer == math.MinInt64 {
+				return unknown("integer overflow")
+			}
+			value.Typed.Integer = -value.Typed.Integer
+			return known(value.Typed)
+		}
+		if isFloating(value.Typed) || value.Typed.Kind == ValueCurrency {
+			if value.Typed.Kind == ValueCurrency {
+				if value.Typed.Currency == math.MinInt64 {
+					return unknown("currency overflow")
+				}
+				value.Typed.Currency = -value.Typed.Currency
+				return known(value.Typed)
+			}
+			value.Typed.Float = -value.Typed.Float
+			return known(value.Typed)
+		}
+		return invalid("unary minus requires numeric operand")
+	case "not":
+		if value.Typed.Kind != ValueBoolean {
+			return invalid("Not requires Boolean operand")
+		}
+		value.Typed.Boolean = !value.Typed.Boolean
+		return known(value.Typed)
+	default:
+		return unknown("unsupported unary operator")
 	}
 }
 
-func combine(left, right Result, op byte) Result {
+func power(left, right Result) Result {
+	if left.Kind != Known || right.Kind != Known {
+		return combineUnknown(left, right)
+	}
+	if !isNumeric(left.Typed) || !isNumeric(right.Typed) {
+		return invalid("exponent requires numeric operands")
+	}
+	base := numericFloat(left.Typed)
+	exponent := numericFloat(right.Typed)
+	value := math.Pow(base, exponent)
+	if math.IsInf(value, 0) || math.IsNaN(value) {
+		return unknown("floating-point overflow")
+	}
+	if isIntegral(left.Typed) && isIntegral(right.Typed) && right.Typed.Integer >= 0 {
+		if exact, ok := checkedPow(left.Typed.Integer, right.Typed.Integer); ok {
+			return known(Value{Kind: widerInteger(left.Typed.Kind, right.Typed.Kind), Integer: exact})
+		}
+		return unknown("integer overflow")
+	}
+	return known(Value{Kind: ValueDouble, Float: value})
+}
+
+func checkedPow(base, exponent int64) (int64, bool) {
+	result := int64(1)
+	for exponent > 0 {
+		if exponent&1 == 1 {
+			if !checkedMul(result, base, &result) {
+				return 0, false
+			}
+		}
+		exponent >>= 1
+		if exponent > 0 && !checkedMul(base, base, &base) {
+			return 0, false
+		}
+	}
+	return result, true
+}
+
+func combine(left, right Result, op string) Result {
 	if left.Kind == Invalid {
 		return left
 	}
@@ -163,44 +581,261 @@ func combine(left, right Result, op byte) Result {
 		return right
 	}
 	if left.Kind == Unknown || right.Kind == Unknown {
-		return Result{Kind: Unknown, Reason: "unresolved operand"}
+		return combineUnknown(left, right)
 	}
-	value := left.Value
+	if isRuntimeValue(left.Typed) || isRuntimeValue(right.Typed) {
+		return unknown("operand coercion is not modelled")
+	}
+	if op == "&" {
+		if left.Typed.Kind == ValueString && right.Typed.Kind == ValueString {
+			return known(Value{Kind: ValueString, String: left.Typed.String + right.Typed.String})
+		}
+		return invalid("string concatenation requires String operands")
+	}
+	if op == "and" || op == "or" || op == "xor" || op == "eqv" || op == "imp" {
+		if left.Typed.Kind != ValueBoolean || right.Typed.Kind != ValueBoolean {
+			return invalid("Boolean operator requires Boolean operands")
+		}
+		lv, rv := left.Typed.Boolean, right.Typed.Boolean
+		var value bool
+		switch op {
+		case "and":
+			value = lv && rv
+		case "or":
+			value = lv || rv
+		case "xor":
+			value = lv != rv
+		case "eqv":
+			value = lv == rv
+		case "imp":
+			value = !lv || rv
+		}
+		return known(Value{Kind: ValueBoolean, Boolean: value})
+	}
+	if !isNumeric(left.Typed) || !isNumeric(right.Typed) {
+		return invalid("arithmetic requires numeric operands")
+	}
+	if op == "/" {
+		divisor := numericFloat(right.Typed)
+		if divisor == 0 {
+			return invalid("division by zero")
+		}
+		return known(Value{Kind: ValueDouble, Float: numericFloat(left.Typed) / divisor})
+	}
+	if op == "\\" || op == "mod" {
+		if !isIntegral(left.Typed) || !isIntegral(right.Typed) {
+			return unknown("integer operator requires integral operands")
+		}
+		if right.Typed.Integer == 0 {
+			return invalid("division by zero")
+		}
+		if op == "\\" {
+			if left.Typed.Integer == math.MinInt64 && right.Typed.Integer == -1 {
+				return unknown("integer overflow")
+			}
+			return known(Value{Kind: widerInteger(left.Typed.Kind, right.Typed.Kind), Integer: left.Typed.Integer / right.Typed.Integer})
+		}
+		return known(Value{Kind: widerInteger(left.Typed.Kind, right.Typed.Kind), Integer: left.Typed.Integer % right.Typed.Integer})
+	}
+	if isFloating(left.Typed) || isFloating(right.Typed) {
+		lv, rv := numericFloat(left.Typed), numericFloat(right.Typed)
+		var value float64
+		switch op {
+		case "+":
+			value = lv + rv
+		case "-":
+			value = lv - rv
+		case "*":
+			value = lv * rv
+		default:
+			return unknown("unsupported arithmetic operator")
+		}
+		if math.IsInf(value, 0) || math.IsNaN(value) {
+			return unknown("floating-point overflow")
+		}
+		return known(Value{Kind: widerFloat(left.Typed.Kind, right.Typed.Kind), Float: value})
+	}
+	if left.Typed.Kind == ValueCurrency || right.Typed.Kind == ValueCurrency {
+		if left.Typed.Kind == ValueCurrency && right.Typed.Kind == ValueCurrency && (op == "+" || op == "-") {
+			var scaled int64
+			var ok bool
+			if op == "+" {
+				ok = checkedAdd(left.Typed.Currency, right.Typed.Currency, &scaled)
+			} else {
+				ok = checkedSub(left.Typed.Currency, right.Typed.Currency, &scaled)
+			}
+			if !ok {
+				return unknown("currency overflow")
+			}
+			return known(Value{Kind: ValueCurrency, Currency: scaled})
+		}
+		value := numericFloat(left.Typed)
+		rightValue := numericFloat(right.Typed)
+		switch op {
+		case "+":
+			value += rightValue
+		case "-":
+			value -= rightValue
+		case "*":
+			value *= rightValue
+		default:
+			return unknown("unsupported currency operator")
+		}
+		if math.IsInf(value, 0) || math.IsNaN(value) {
+			return unknown("currency overflow")
+		}
+		return known(Value{Kind: ValueDouble, Float: value})
+	}
+	var value int64
+	var ok bool
 	switch op {
-	case '+':
-		value += right.Value
-	case '-':
-		value -= right.Value
-	case '*':
-		value *= right.Value
-	case '/':
-		if right.Value == 0 {
-			return Result{Kind: Invalid, Reason: "division by zero"}
-		}
-		if left.Value%right.Value != 0 {
-			return Result{Kind: Unknown, Reason: "non-integral division"}
-		}
-		value /= right.Value
+	case "+":
+		ok = checkedAdd(left.Typed.Integer, right.Typed.Integer, &value)
+	case "-":
+		ok = checkedSub(left.Typed.Integer, right.Typed.Integer, &value)
+	case "*":
+		ok = checkedMul(left.Typed.Integer, right.Typed.Integer, &value)
+	default:
+		return unknown("unsupported arithmetic operator")
 	}
-	return Result{Kind: Known, Value: value, Type: "integer"}
+	if !ok {
+		return unknown("integer overflow")
+	}
+	return known(Value{Kind: widerInteger(left.Typed.Kind, right.Typed.Kind), Integer: value})
 }
 
-func looksLikeCall(text string) bool {
-	for i := 0; i < len(text); i++ {
-		if !unicode.IsLetter(rune(text[i])) && text[i] != '_' {
-			continue
+func combineUnknown(left, right Result) Result {
+	if left.Kind == Invalid {
+		return left
+	}
+	if right.Kind == Invalid {
+		return right
+	}
+	return unknown("unresolved operand")
+}
+
+func compare(left, right Result, op string) Result {
+	if left.Kind != Known || right.Kind != Known {
+		return combineUnknown(left, right)
+	}
+	if isRuntimeValue(left.Typed) || isRuntimeValue(right.Typed) {
+		return unknown("comparison coercion is not modelled")
+	}
+	if op == "like" || op == "is" {
+		return unknown("unsupported comparison operator")
+	}
+	if left.Typed.Kind == ValueString && right.Typed.Kind == ValueString {
+		if op != "=" && op != "<>" {
+			return unknown("string ordering depends on Option Compare")
 		}
-		j := i + 1
-		for j < len(text) && (unicode.IsLetter(rune(text[j])) || unicode.IsDigit(rune(text[j])) || text[j] == '_') {
-			j++
+		value := left.Typed.String == right.Typed.String
+		if op == "<>" {
+			value = !value
 		}
-		for j < len(text) && (text[j] == ' ' || text[j] == '\t') {
-			j++
-		}
-		if j < len(text) && text[j] == '(' {
+		return known(Value{Kind: ValueBoolean, Boolean: value})
+	}
+	if left.Typed.Kind == ValueBoolean && right.Typed.Kind == ValueBoolean {
+		return compareFloat(boolFloat(left.Typed.Boolean), boolFloat(right.Typed.Boolean), op)
+	}
+	if !isNumeric(left.Typed) || !isNumeric(right.Typed) {
+		return invalid("comparison requires compatible operands")
+	}
+	return compareFloat(numericFloat(left.Typed), numericFloat(right.Typed), op)
+}
+
+func compareFloat(left, right float64, op string) Result {
+	var value bool
+	switch op {
+	case "=":
+		value = left == right
+	case "<>":
+		value = left != right
+	case "<":
+		value = left < right
+	case ">":
+		value = left > right
+	case "<=":
+		value = left <= right
+	case ">=":
+		value = left >= right
+	default:
+		return unknown("unsupported comparison operator")
+	}
+	return known(Value{Kind: ValueBoolean, Boolean: value})
+}
+
+func boolFloat(value bool) float64 {
+	if value {
+		return -1
+	}
+	return 0
+}
+func numericFloat(value Value) float64 {
+	if isIntegral(value) {
+		return float64(value.Integer)
+	}
+	if value.Kind == ValueCurrency {
+		return float64(value.Currency) / 10000
+	}
+	return value.Float
+}
+func isFloating(value Value) bool { return value.Kind == ValueSingle || value.Kind == ValueDouble }
+func isNumeric(value Value) bool {
+	return isIntegral(value) || isFloating(value) || value.Kind == ValueCurrency
+}
+func isRuntimeValue(value Value) bool {
+	return value.Kind == ValueEmpty || value.Kind == ValueNull || value.Kind == ValueNothing
+}
+func widerInteger(left, right ValueKind) ValueKind {
+	if left == ValueLongLong || right == ValueLongLong {
+		return ValueLongLong
+	}
+	if left == ValueLong || right == ValueLong {
+		return ValueLong
+	}
+	return ValueInteger
+}
+func widerFloat(left, right ValueKind) ValueKind {
+	if left == ValueDouble || right == ValueDouble {
+		return ValueDouble
+	}
+	return ValueSingle
+}
+func contains(values []string, value string) bool {
+	for _, item := range values {
+		if item == value {
 			return true
 		}
-		i = j - 1
 	}
 	return false
+}
+
+func checkedAdd(a, b int64, out *int64) bool {
+	if b > 0 && a > math.MaxInt64-b || b < 0 && a < math.MinInt64-b {
+		return false
+	}
+	*out = a + b
+	return true
+}
+func checkedSub(a, b int64, out *int64) bool {
+	if b < 0 && a > math.MaxInt64+b || b > 0 && a < math.MinInt64+b {
+		return false
+	}
+	*out = a - b
+	return true
+}
+func checkedMul(a, b int64, out *int64) bool {
+	if a == 0 || b == 0 {
+		*out = 0
+		return true
+	}
+	if a == math.MinInt64 && b == -1 || b == math.MinInt64 && a == -1 {
+		return false
+	}
+	value := a * b
+	if value/b != a {
+		return false
+	}
+	*out = value
+	return true
 }

--- a/internal/vba/constexpr/constexpr.go
+++ b/internal/vba/constexpr/constexpr.go
@@ -162,12 +162,14 @@ func known(value Value) Result {
 }
 
 func hostInt(value int64) (int, bool) {
-	if strconv.IntSize == 32 {
-		if value < math.MinInt32 || value > math.MaxInt32 {
-			return 0, false
-		}
+	// Atoi performs the final host-width check itself. This avoids a direct
+	// narrowing conversion from the 64-bit ParseInt result while preserving
+	// the historical int projection on both 32-bit and 64-bit hosts.
+	projected, err := strconv.Atoi(strconv.FormatInt(value, 10))
+	if err != nil {
+		return 0, false
 	}
-	return int(value), true
+	return projected, true
 }
 
 // IntegerAsInt projects an integral VBA value to the host int used by legacy

--- a/internal/vba/constexpr/constexpr_test.go
+++ b/internal/vba/constexpr/constexpr_test.go
@@ -2,6 +2,19 @@ package constexpr
 
 import "testing"
 
+func TestValuesResolveIsCaseInsensitiveAndDeterministic(t *testing.T) {
+	values := Values{
+		"LIMIT": {Kind: ValueLong, Integer: 1},
+		"limit": {Kind: ValueLong, Integer: 2},
+	}
+	for i := 0; i < 20; i++ {
+		value, ok := values.Resolve("Limit")
+		if !ok || value.Integer != 1 {
+			t.Fatalf("Resolve(Limit) = %#v, %v; want the lexicographically first spelling", value, ok)
+		}
+	}
+}
+
 func TestEvaluateIntegerClassifiesKnownUnknownAndInvalid(t *testing.T) {
 	constants := map[string]int{"limit": 3, "offset": -1}
 	for _, test := range []struct {
@@ -15,9 +28,9 @@ func TestEvaluateIntegerClassifiesKnownUnknownAndInvalid(t *testing.T) {
 		{name: "unresolved", expr: "runtimeValue", kind: Unknown},
 		{name: "call", expr: "GetBound()", kind: Unknown},
 		{name: "trailing call", expr: "Limit + GetBound()", kind: Unknown},
-		{name: "integer division operator", expr: "10 \\ 2", kind: Unknown},
-		{name: "mod operator", expr: "10 Mod 3", kind: Unknown},
-		{name: "exponent operator", expr: "10 ^ 2", kind: Unknown},
+		{name: "integer division operator", expr: "10 \\ 2", kind: Known, value: 5},
+		{name: "mod operator", expr: "10 Mod 3", kind: Known, value: 1},
+		{name: "exponent operator", expr: "10 ^ 2", kind: Known, value: 100},
 		{name: "non-integral division", expr: "10 / 3", kind: Unknown},
 		{name: "divide zero", expr: "4 / 0", kind: Invalid},
 		{name: "syntax", expr: "1 To 2", kind: Invalid},
@@ -26,6 +39,80 @@ func TestEvaluateIntegerClassifiesKnownUnknownAndInvalid(t *testing.T) {
 			result := EvaluateInteger(test.expr, constants)
 			if result.Kind != test.kind || result.Kind == Known && result.Value != test.value {
 				t.Fatalf("EvaluateInteger(%q) = %#v, want kind=%q value=%d", test.expr, result, test.kind, test.value)
+			}
+		})
+	}
+}
+
+func TestEvaluateTypedValuesAndOperators(t *testing.T) {
+	values := Values{
+		"limit": {Kind: ValueLong, Integer: 3},
+		"label": {Kind: ValueString, String: "ok"},
+	}
+	tests := []struct {
+		name string
+		expr string
+		kind ResultKind
+		want Value
+	}{
+		{name: "string literal", expr: `"a"`, kind: Known, want: Value{Kind: ValueString, String: "a"}},
+		{name: "escaped string", expr: `"a""b"`, kind: Known, want: Value{Kind: ValueString, String: `a"b`}},
+		{name: "string concat", expr: `"a" & label`, kind: Known, want: Value{Kind: ValueString, String: "aok"}},
+		{name: "boolean comparison", expr: "True And Not False", kind: Known, want: Value{Kind: ValueBoolean, Boolean: true}},
+		{name: "numeric comparison", expr: "limit >= 3", kind: Known, want: Value{Kind: ValueBoolean, Boolean: true}},
+		{name: "float", expr: "1.5! + 2.5#", kind: Known, want: Value{Kind: ValueDouble, Float: 4}},
+		{name: "currency", expr: "1.25@ + 0.75@", kind: Known, want: Value{Kind: ValueCurrency, Currency: 20000}},
+		{name: "hex", expr: "&H10", kind: Known, want: Value{Kind: ValueLong, Integer: 16}},
+		{name: "octal", expr: "&O10", kind: Known, want: Value{Kind: ValueLong, Integer: 8}},
+		{name: "runtime call", expr: "Chr$(65)", kind: Unknown},
+		{name: "unresolved", expr: "missing + 1", kind: Unknown},
+		{name: "null coercion", expr: "Null + 1", kind: Unknown},
+		{name: "divide zero", expr: "1 / 0", kind: Invalid},
+		{name: "integer overflow", expr: "9223372036854775807 + 1", kind: Unknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := Evaluate(test.expr, values)
+			if result.Kind != test.kind {
+				t.Fatalf("Evaluate(%q) kind = %q, want %q (%#v)", test.expr, result.Kind, test.kind, result)
+			}
+			if result.Kind == Known && result.Typed != test.want {
+				t.Fatalf("Evaluate(%q) value = %#v, want %#v", test.expr, result.Typed, test.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateDoesNotExecuteCalls(t *testing.T) {
+	values := Values{}
+	if result := Evaluate("DangerousFunction()", values); result.Kind != Unknown {
+		t.Fatalf("call result = %#v, want Unknown", result)
+	}
+}
+
+func TestEvaluateNumericBoundaryFixtures(t *testing.T) {
+	for _, test := range []struct {
+		expr  string
+		kind  ResultKind
+		value int64
+	}{
+		{expr: "32767%", kind: Known, value: 32767},
+		{expr: "32768%", kind: Unknown},
+		{expr: "2147483647&", kind: Known, value: 2147483647},
+		{expr: "2147483648&", kind: Unknown},
+		{expr: "2147483648", kind: Unknown},
+		{expr: "9223372036854775807^", kind: Known, value: 9223372036854775807},
+		{expr: "9223372036854775808^", kind: Unknown},
+		{expr: "1e309", kind: Unknown},
+		{expr: "1e39!", kind: Unknown},
+	} {
+		t.Run(test.expr, func(t *testing.T) {
+			result := Evaluate(test.expr, nil)
+			if result.Kind != test.kind {
+				t.Fatalf("Evaluate(%q) kind = %q, want %q (%#v)", test.expr, result.Kind, test.kind, result)
+			}
+			if test.kind == Known && result.Typed.Integer != test.value {
+				t.Fatalf("Evaluate(%q) value = %#v, want %d", test.expr, result.Typed, test.value)
 			}
 		})
 	}

--- a/internal/vba/constexpr/constexpr_test.go
+++ b/internal/vba/constexpr/constexpr_test.go
@@ -62,6 +62,7 @@ func TestEvaluateTypedValuesAndOperators(t *testing.T) {
 		{name: "numeric comparison", expr: "limit >= 3", kind: Known, want: Value{Kind: ValueBoolean, Boolean: true}},
 		{name: "float", expr: "1.5! + 2.5#", kind: Known, want: Value{Kind: ValueDouble, Float: 4}},
 		{name: "currency", expr: "1.25@ + 0.75@", kind: Known, want: Value{Kind: ValueCurrency, Currency: 20000}},
+		{name: "currency midpoint", expr: "0.00025@", kind: Known, want: Value{Kind: ValueCurrency, Currency: 2}},
 		{name: "currency banker rounding", expr: "1.23445@", kind: Known, want: Value{Kind: ValueCurrency, Currency: 12344}},
 		{name: "hex", expr: "&H10", kind: Known, want: Value{Kind: ValueLong, Integer: 16}},
 		{name: "octal", expr: "&O10", kind: Known, want: Value{Kind: ValueLong, Integer: 8}},

--- a/internal/vba/constexpr/constexpr_test.go
+++ b/internal/vba/constexpr/constexpr_test.go
@@ -62,6 +62,7 @@ func TestEvaluateTypedValuesAndOperators(t *testing.T) {
 		{name: "numeric comparison", expr: "limit >= 3", kind: Known, want: Value{Kind: ValueBoolean, Boolean: true}},
 		{name: "float", expr: "1.5! + 2.5#", kind: Known, want: Value{Kind: ValueDouble, Float: 4}},
 		{name: "currency", expr: "1.25@ + 0.75@", kind: Known, want: Value{Kind: ValueCurrency, Currency: 20000}},
+		{name: "currency banker rounding", expr: "1.23445@", kind: Known, want: Value{Kind: ValueCurrency, Currency: 12344}},
 		{name: "hex", expr: "&H10", kind: Known, want: Value{Kind: ValueLong, Integer: 16}},
 		{name: "octal", expr: "&O10", kind: Known, want: Value{Kind: ValueLong, Integer: 8}},
 		{name: "runtime call", expr: "Chr$(65)", kind: Unknown},

--- a/internal/vba/constexpr/constexpr_test.go
+++ b/internal/vba/constexpr/constexpr_test.go
@@ -3,10 +3,10 @@ package constexpr
 import "testing"
 
 func TestValuesResolveIsCaseInsensitiveAndDeterministic(t *testing.T) {
-	values := Values{
+	values := NewValues(map[string]Value{
 		"LIMIT": {Kind: ValueLong, Integer: 1},
 		"limit": {Kind: ValueLong, Integer: 2},
-	}
+	})
 	for i := 0; i < 20; i++ {
 		value, ok := values.Resolve("Limit")
 		if !ok || value.Integer != 1 {
@@ -45,10 +45,10 @@ func TestEvaluateIntegerClassifiesKnownUnknownAndInvalid(t *testing.T) {
 }
 
 func TestEvaluateTypedValuesAndOperators(t *testing.T) {
-	values := Values{
+	values := NewValues(map[string]Value{
 		"limit": {Kind: ValueLong, Integer: 3},
 		"label": {Kind: ValueString, String: "ok"},
-	}
+	})
 	tests := []struct {
 		name string
 		expr string
@@ -84,7 +84,7 @@ func TestEvaluateTypedValuesAndOperators(t *testing.T) {
 }
 
 func TestEvaluateDoesNotExecuteCalls(t *testing.T) {
-	values := Values{}
+	values := NewValues(nil)
 	if result := Evaluate("DangerousFunction()", values); result.Kind != Unknown {
 		t.Fatalf("call result = %#v, want Unknown", result)
 	}
@@ -105,6 +105,12 @@ func TestEvaluateNumericBoundaryFixtures(t *testing.T) {
 		{expr: "9223372036854775808^", kind: Unknown},
 		{expr: "1e309", kind: Unknown},
 		{expr: "1e39!", kind: Unknown},
+		{expr: "&HFF&", kind: Known, value: 255},
+		{expr: "&H10%", kind: Known, value: 16},
+		{expr: "1 And 3", kind: Unknown},
+		{expr: "1 & 2", kind: Unknown},
+		{expr: "True = -1", kind: Unknown},
+		{expr: "922337203685477.5808@", kind: Unknown},
 	} {
 		t.Run(test.expr, func(t *testing.T) {
 			result := Evaluate(test.expr, nil)

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -19,6 +19,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 	"github.com/harumiWeb/xlflow/internal/vba/ast"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
 	"github.com/harumiWeb/xlflow/internal/vba/doccomments"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
@@ -63,6 +64,9 @@ type Analyzer struct {
 	// already own a coherent workspace snapshot. File-local callers may leave
 	// it nil; the shared checker then remains conservative.
 	VisibleConstants map[string]bool
+	// ConstantValues carries the immutable value-bearing project constants for
+	// compile-equivalent declaration and array checks.
+	ConstantValues map[string]constexpr.Value
 	// TypeDBResolutionIncomplete is true when the production type database
 	// loaded with warnings. Type-dependent unresolved-name diagnostics must
 	// fail closed until the generated TypeLib view is complete.
@@ -279,7 +283,7 @@ func (a Analyzer) CompileEquivalentDiagnosticsContext(ctx context.Context, doc D
 			return out
 		}
 		if ir, err := procedureIRForDocumentContext(ctx, doc, a.RootDir, parsed); err == nil {
-			for _, issue := range lint.CompileEquivalentArrayShapeIssuesWithConstants(doc.Path, doc.Source, &ir, a.VisibleConstants) {
+			for _, issue := range lint.CompileEquivalentArrayShapeIssuesWithValues(doc.Path, doc.Source, &ir, a.VisibleConstants, a.ConstantValues) {
 				if !isCompileEquivalentDiagnostic(issue.Code) {
 					continue
 				}
@@ -344,6 +348,7 @@ func (a Analyzer) diagnosticsFullContext(ctx context.Context, doc Document) []Di
 		ModuleKind:             doc.ModuleKind,
 		VisibleDeclarations:    a.visibleDeclarations,
 		VisibleConstants:       a.VisibleConstants,
+		ConstantValues:         a.ConstantValues,
 		TypeDeclarations:       a.typeDeclarations,
 		ObjectTypeDeclarations: a.objectTypeDeclarations,
 	}.LintParsedContext(ctx, parsed)

--- a/internal/vba/intel/procedure_diagnostics.go
+++ b/internal/vba/intel/procedure_diagnostics.go
@@ -40,11 +40,13 @@ type DiagnosticResult struct {
 }
 
 // ProjectAnalysisDocument is an immutable, protocol-neutral document input for
-// project-aware Full diagnostics. IR calls are resolved against the exact
-// workspace snapshot represented by Revision; CFG is built from the same IR.
+// project-aware Full diagnostics. IR calls and source-derived constant values
+// are resolved against the exact workspace snapshot represented by Revision;
+// CFG is built from the same IR.
 type ProjectAnalysisDocument struct {
-	IR  procedureir.DocumentIR
-	CFG vbacfg.Document
+	IR     procedureir.DocumentIR
+	CFG    vbacfg.Document
+	Source string
 }
 
 // ProjectAnalysisSnapshot is a coherent view of saved files and published


### PR DESCRIPTION
Closes #595

## Summary

- Add a shared, Excel/COM-free VBA constant-expression evaluator with typed `Known`, `Unknown`, and `Invalid` results.
- Resolve Const and Enum values (including forward references and implicit Enum increments) for Optional defaults, array declarations, and ReDim bounds.
- Use the same value-bearing project snapshot in batch, lint, analyze, Intel, and LSP paths.
- Add boundary fixtures and document the architecture in ADR-0041 and the evaluator specification.

## Design notes

The evaluator supports a conservative static subset: numeric/string/date/Boolean literals, VBA numeric suffixes, resolved Const/Enum/TypeLib values, parentheses, unary and arithmetic operators, Boolean/comparison operators, and string concatenation. Runtime calls, unresolved or ambiguous symbols, conditional uncertainty, unsupported semantics, and safely unmodelled overflow remain `Unknown`; malformed expressions and invalid domains remain `Invalid`.

No VBA, Excel, or COM execution is used.

## Validation

- `go test ./internal/vba/constexpr ./internal/lint ./internal/analyze ./internal/vba/intel ./internal/lspserver`
- `go vet ./internal/vba/constexpr ./internal/lint ./internal/analyze ./internal/vba/intel ./internal/lspserver`
- `gofmt` and `git diff --check`

The branch was rebased onto the latest `origin/main` before publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved VBA analysis of `Const`, `Enum`, optional defaults, array bounds, and `ReDim` expressions.
  - Added evaluation for numeric, string, Boolean, date, currency, and other scalar expressions.
  - Batch and real-time diagnostics now use shared project-wide constant information.
  - Safely handles unresolved, runtime-dependent, ambiguous, and unsupported expressions.

- **Bug Fixes**
  - Improved handling of qualified constants, forward references, implicit enum values, and conditional-compilation declarations.

- **Documentation**
  - Added architecture and specification documentation for shared VBA constant evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->