### PR TITLE
fix(docs): fix VitePress build

### DIFF
--- a/vitepress/commands/lsp.md
+++ b/vitepress/commands/lsp.md
@@ -111,8 +111,7 @@ unsuppressible, preflight-blocking error.
 
 The LSP also publishes `VB062` for provably invalid conditional branch forms,
 `VB063` for `Case` outside `Select Case`, duplicate `Case Else`, or a branch
-after `Case Else`, `VB064` for parser-confirmed malformed `Open ... For
-<mode>` shapes, and `VB065` for provably malformed `TypeOf` expressions. These
+after `Case Else`, `VB064` for parser-confirmed malformed `Open ... For <mode>` shapes, and `VB065` for provably malformed `TypeOf` expressions. These
 compile-equivalent syntax diagnostics are unsuppressible and preflight-blocking;
 ambiguous parser recovery remains the generic `VB014` finding.
 


### PR DESCRIPTION
## Summary

- Fix the LSP command page so `<mode>` remains inside inline code.
- Prevent VitePress/Vue from interpreting it as an unclosed HTML element.

## Tests

- `pnpm docs:build`
- `pnpm docs:check`
- `pnpm format:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `VB064` description so the “Open … For <mode>” text appears on a single line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->