### PR TITLE
fix: avoid false-positive VB053 for duplicate TypeLib enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.30.1
+
+- Fixed `VB053` false positives for valid unqualified Excel/TypeLib enum
+  constants such as `xlCenter`, `xlThin`, and `xlContinuous` when metadata
+  contains the same name under multiple enum definitions.
 - Fixed `VBA225` false positives when a local, parameter, or module-level VBA
   binding such as `cells` shadows Excel's unqualified `Cells` function. The
   Procedure IR now gates the textual fallback, including propagated helper

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -1127,10 +1127,12 @@ Module` directives are also reported as duplicate same-kind declarations.
   or otherwise incomplete remain quiet. The canonical procedure resolver is
   shared by lint, analyze, LSP, Call Hierarchy, impact, and effect analysis;
   only a complete, certain project-local outcome is diagnosed.
-- `VB053`: a bare Enum member has multiple visible project or TypeLib
-  candidates with no lexical winner. Qualified members, unique candidates,
-  incomplete TypeLib/project snapshots, and unresolved conditional branches
-  remain quiet. The member identifier is the primary range.
+- `VB053`: a bare Enum member has multiple visible project candidates with no
+  lexical winner. TypeLib metadata is an external fallback, so duplicate
+  records for one globally exposed constant do not establish ambiguity.
+  Qualified members, unique candidates, incomplete TypeLib/project snapshots,
+  and unresolved conditional branches remain quiet. The member identifier is
+  the primary range.
 - `VB054`: `RaiseEvent` names an event that is not declared in the same object
   module. Only a complete object-module event set is considered; external or
   incomplete references remain quiet, and the event identifier is the primary

--- a/docs/specs/vba-resolution-diagnostics.md
+++ b/docs/specs/vba-resolution-diagnostics.md
@@ -14,8 +14,11 @@ external, built-in, dynamic, and incomplete outcomes. `VB052` reports only a
 provably project-local missing or non-callable call target. Bare unresolved
 names remain quiet because they may bind to a referenced library or late-bound
 value. `VB053` reports only an unqualified Enum member with multiple visible
-candidates and no same-module lexical winner. `VB054` reports an event name
-that is not declared in the same object module as the `RaiseEvent` statement.
+project declarations and no same-module lexical winner. TypeLib enum metadata
+is treated as an external fallback: duplicate records for one globally exposed
+constant do not establish a source-level ambiguity. `VB054` reports an event
+name that is not declared in the same object module as the `RaiseEvent`
+statement.
 
 All three rules are compile-equivalent errors, block source preflight, and are
 not inline-suppressible. They fail open for parser recovery, unresolved

--- a/internal/staticanalysis/rules/registry.json
+++ b/internal/staticanalysis/rules/registry.json
@@ -1786,7 +1786,7 @@
     {
       "id": "VB053",
       "title": "Ambiguous Enum member",
-      "description": "A bare Enum member reference has multiple visible project or type-library candidates and no unique lexical winner.",
+      "description": "A bare Enum member reference has multiple visible project candidates and no unique lexical winner.",
       "family": "lint",
       "category": "correctness",
       "evidence_class": "compile-equivalent",

--- a/internal/vba/procedureir/resolver.go
+++ b/internal/vba/procedureir/resolver.go
@@ -761,9 +761,11 @@ func (r SymbolResolver) ResolveSymbol(ref SymbolReference) SymbolResolution {
 }
 
 // ResolveEnumMember resolves a bare or qualified enum constant while
-// preserving all candidates. A bare lookup with more than one visible member
-// is ambiguous; callers should report that only when Complete is true and no
-// lexical winner exists.
+// preserving all candidates. Project enum declarations take precedence over
+// TypeLib metadata because only project declarations provide lexical evidence
+// that a bare name is ambiguous. External enum metadata can associate one
+// globally exposed constant with multiple enum groups, so external-only
+// multiplicity is reported as an external resolution rather than VB053.
 func (r SymbolResolver) ResolveEnumMember(ref EnumMemberReference) EnumResolution {
 	caller := callerModule(ref.Caller)
 	if caller == "" {
@@ -800,6 +802,14 @@ func (r SymbolResolver) ResolveEnumMember(ref EnumMemberReference) EnumResolutio
 			filtered = local
 		}
 	}
+	// Referenced-library constants are a fallback after project symbols. A
+	// TypeLib may describe the same globally usable name under several enum
+	// groups (or several generated library records); those records do not prove
+	// a source-level ambiguity. Keep project candidates when present and leave
+	// external-only collisions as an external, fail-open resolution.
+	if project := nonExternalEnumMembers(filtered); len(project) > 0 {
+		filtered = project
+	}
 	sort.SliceStable(filtered, func(i, j int) bool {
 		return resolverCandidateLess(filtered[i].Candidate, filtered[j].Candidate)
 	})
@@ -811,13 +821,43 @@ func (r SymbolResolver) ResolveEnumMember(ref EnumMemberReference) EnumResolutio
 		result.Status = ResolutionMatched
 		result.Candidates = entriesToCandidates(filtered)
 	default:
-		result.Status = ResolutionAmbiguous
+		if allExternalEnumMembers(filtered) {
+			result.Status = ResolutionExternal
+		} else {
+			result.Status = ResolutionAmbiguous
+		}
 		result.Candidates = entriesToCandidates(filtered)
 	}
 	if (!r.complete || hasUncertainEntries(filtered)) && result.Status != ResolutionMatched {
 		result.Status = ResolutionIncomplete
 	}
 	return result
+}
+
+func nonExternalEnumMembers(entries []resolverEntry) []resolverEntry {
+	result := make([]resolverEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !isExternalEnumMember(entry) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+func allExternalEnumMembers(entries []resolverEntry) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	for _, entry := range entries {
+		if !isExternalEnumMember(entry) {
+			return false
+		}
+	}
+	return true
+}
+
+func isExternalEnumMember(entry resolverEntry) bool {
+	return isEnumMemberKind(entry.Kind) && strings.EqualFold(strings.TrimSpace(entry.moduleKind), "external")
 }
 
 func resolverCandidateLess(a, b Candidate) bool {

--- a/internal/vba/procedureir/resolver_issue638_test.go
+++ b/internal/vba/procedureir/resolver_issue638_test.go
@@ -25,27 +25,25 @@ End Sub
 		{Name: "xlContinuous", Parent: "XlLineStyle", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
 		{Name: "xlContinuous", Parent: "XlBorderStyle", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
 	}))
-	seen := map[string]bool{}
+	seen := map[string]int{}
 	for _, procedure := range resolved.Procedures {
 		for _, access := range procedure.Accesses {
 			switch access.Name {
 			case "xlCenter", "xlThin", "xlContinuous":
-				seen[access.Name] = true
-				if access.Resolution.Status == ResolutionAmbiguous {
-					t.Fatalf("TypeLib constant %s resolved ambiguously: %#v", access.Name, access.Resolution)
+				seen[access.Name]++
+				if access.Resolution.Status != ResolutionExternal {
+					t.Fatalf("TypeLib constant %s status = %s, want external: %#v", access.Name, access.Resolution.Status, access.Resolution)
 				}
 			}
 		}
 	}
-	for _, name := range []string{"xlCenter", "xlThin", "xlContinuous"} {
-		if !seen[name] {
-			t.Fatalf("source did not retain enum-member access for %s: %#v", name, resolved.Procedures)
+	for name, want := range map[string]int{"xlCenter": 2, "xlThin": 2, "xlContinuous": 1} {
+		if got := seen[name]; got != want {
+			t.Fatalf("enum-member accesses for %s = %d, want %d: %#v", name, got, want, resolved.Procedures)
 		}
 	}
-	for _, diagnostic := range Diagnostics(resolved, true) {
-		if diagnostic.Code == "VB053" {
-			t.Fatalf("TypeLib constants produced VB053: %#v", diagnostic)
-		}
+	if diagnostics := Diagnostics(resolved, true); len(diagnostics) != 0 {
+		t.Fatalf("TypeLib constants produced diagnostics: %#v", diagnostics)
 	}
 }
 

--- a/internal/vba/procedureir/resolver_issue638_test.go
+++ b/internal/vba/procedureir/resolver_issue638_test.go
@@ -1,0 +1,76 @@
+package procedureir
+
+import "testing"
+
+func TestIssue638TypeLibEnumDuplicatesAreNotAmbiguous(t *testing.T) {
+	doc, err := BuildSource(BuildOptions{Path: "Main.bas", ModuleKind: "standard"}, []byte(`Public Sub Consume(ByVal value As Long)
+End Sub
+Public Sub TestAlignment()
+    Dim value As Long
+    value = xlCenter
+    value = xlThin
+    value = xlContinuous
+    Consume xlCenter
+    Call Consume(xlThin)
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(doc, NewResolver([]ResolverSymbol{
+		{Name: "xlCenter", Parent: "XlHAlign", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
+		{Name: "xlCenter", Parent: "XlHorizontalAlignment", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
+		{Name: "xlThin", Parent: "XlBorderWeight", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
+		{Name: "xlThin", Parent: "XlPattern", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
+		{Name: "xlContinuous", Parent: "XlLineStyle", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
+		{Name: "xlContinuous", Parent: "XlBorderStyle", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
+	}))
+	seen := map[string]bool{}
+	for _, procedure := range resolved.Procedures {
+		for _, access := range procedure.Accesses {
+			switch access.Name {
+			case "xlCenter", "xlThin", "xlContinuous":
+				seen[access.Name] = true
+				if access.Resolution.Status == ResolutionAmbiguous {
+					t.Fatalf("TypeLib constant %s resolved ambiguously: %#v", access.Name, access.Resolution)
+				}
+			}
+		}
+	}
+	for _, name := range []string{"xlCenter", "xlThin", "xlContinuous"} {
+		if !seen[name] {
+			t.Fatalf("source did not retain enum-member access for %s: %#v", name, resolved.Procedures)
+		}
+	}
+	for _, diagnostic := range Diagnostics(resolved, true) {
+		if diagnostic.Code == "VB053" {
+			t.Fatalf("TypeLib constants produced VB053: %#v", diagnostic)
+		}
+	}
+}
+
+func TestIssue638ProjectEnumAmbiguityRemainsProvableWithTypeLibMetadata(t *testing.T) {
+	doc, err := BuildSource(BuildOptions{Path: "Main.bas", ModuleKind: "standard"}, []byte(`Public Enum FirstState
+    Ready = 1
+End Enum
+Public Enum SecondState
+    Ready = 2
+End Enum
+Public Sub Run()
+    Dim value As Long
+    value = Ready
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(doc, NewResolver([]ResolverSymbol{
+		{Name: "Ready", Parent: "FirstState", Module: "Main", ModuleKind: "standard", Kind: "enum_member"},
+		{Name: "Ready", Parent: "SecondState", Module: "Main", ModuleKind: "standard", Kind: "enum_member"},
+		{Name: "Ready", Parent: "SomeExternalState", Module: "Excel", ModuleKind: "external", Kind: "enum_member"},
+	}))
+	diagnostics := Diagnostics(resolved, true)
+	if len(diagnostics) != 1 || diagnostics[0].Code != "VB053" {
+		t.Fatalf("diagnostics = %#v, want one VB053", diagnostics)
+	}
+}

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -110,7 +110,7 @@ default state, scope, precision, preflight behavior, and inline suppression.
 | `VBA243` | information / warning | A bulk or repeated `Range.Value` transfer may benefit from `Range.Value2` when Date/Currency coercion is not required.                        |
 | `VBA244` | information / warning | A confirmed recursive or cyclic procedure dependency was found; cycles with dangerous effects are elevated to `warning`.                      |
 | `VB052`  | error                 | Project-local call target is provably missing or known non-callable; blocks source preflight.                                                 |
-| `VB053`  | error                 | Bare Enum member has multiple visible candidates with no lexical winner; blocks source preflight.                                             |
+| `VB053`  | error                 | Bare Enum member has multiple visible project candidates with no lexical winner; blocks source preflight.                                     |
 | `VB054`  | error                 | `RaiseEvent` target is undeclared in the same object module; blocks source preflight.                                                         |
 | `VBA245` | warning               | A destructive or state-dependent file operation may receive an unsafe, relative, wildcard, overwritten, traversing, or external-input path.   |
 | `VBA246` | warning               | A recognized HTTP client may expose credentials, weaken TLS validation, log authorization data, or download and launch executable content.    |

--- a/vitepress/commands/lint.md
+++ b/vitepress/commands/lint.md
@@ -76,7 +76,7 @@ The summary below explains the lint findings in workflow terms.
 | `VB050` | error    | Declaration is invalid for the canonical module kind or has an invalid WithEvents/public-member shape; blocks source preflight.            |
 | `VB051` | error    | `Me` is used in a standard module; blocks source preflight.                                                                                |
 | `VB052` | error    | Project-local call target is provably missing or known non-callable; blocks source preflight.                                              |
-| `VB053` | error    | Bare Enum member has multiple visible candidates with no lexical winner; blocks source preflight.                                          |
+| `VB053` | error    | Bare Enum member has multiple visible project candidates with no lexical winner; blocks source preflight.                                  |
 | `VB054` | error    | `RaiseEvent` target is undeclared in the same object module; blocks source preflight.                                                      |
 | `VB059` | error    | Invalid explicit/standalone call parentheses, Function-expression call parentheses, or explicit Call target; blocks source preflight.      |
 | `VB060` | error    | Assignment to a `Const` value; blocks source preflight.                                                                                    |
@@ -139,12 +139,13 @@ target is local and either missing or a known non-callable declaration. Bare
 names that may bind to external libraries, built-ins, late-bound receivers,
 dynamic invocation (`Application.Run` / `CallByName`), or incomplete snapshots
 remain quiet. `VB053` reports an unqualified Enum member only when multiple
-complete visible candidates remain ambiguous; qualification, a unique lexical
-winner, and incomplete TypeLib/project state are fail-open. `VB054` reports an
-undeclared `RaiseEvent` identifier only against the complete event declarations
-of its containing object module. These three diagnostics are unsuppressible
-errors, block source preflight, and use the same resolver snapshot as `analyze`
-and LSP Full diagnostics.
+complete project candidates remain ambiguous; duplicate TypeLib records for a
+globally exposed constant are an external fallback and remain fail-open.
+Qualification, a unique lexical winner, and incomplete TypeLib/project state
+are also fail-open. `VB054` reports an undeclared `RaiseEvent` identifier only
+against the complete event declarations of its containing object module. These
+three diagnostics are unsuppressible errors, block source preflight, and use
+the same resolver snapshot as `analyze` and LSP Full diagnostics.
 
 `VB059` uses the CST and procedure context to separate compile-invalid call
 forms from `VB022`'s legal-but-confusing style warning. It reports missing

--- a/vitepress/commands/lsp.md
+++ b/vitepress/commands/lsp.md
@@ -92,8 +92,10 @@ keeps type-dependent `WithEvents` checks fail-open.
 
 The LSP publishes `VB052` for project-local calls whose canonical resolver
 proves a missing or known non-callable target, `VB053` for a bare Enum member
-with multiple complete visible candidates and no lexical winner, and `VB054`
-for an undeclared `RaiseEvent` target in the containing object module. These
+with multiple complete project candidates and no lexical winner, and `VB054`
+for an undeclared `RaiseEvent` target in the containing object module. Duplicate
+TypeLib records for one globally exposed constant remain an external,
+fail-open resolution. These
 compile-equivalent errors share the resolver snapshot and exact candidate and
 visibility rules used by batch `lint`/`analyze`, Call Hierarchy, impact, and
 effect propagation. Full diagnostics withhold them while the workspace index,

--- a/vitepress/reference/diagnostics.md
+++ b/vitepress/reference/diagnostics.md
@@ -1184,7 +1184,7 @@ Use [`xlflow rules`](../commands/rules) to inspect the same metadata from an ins
 
 ## VB053
 
-**Ambiguous Enum member.** A bare Enum member reference has multiple visible project or type-library candidates and no unique lexical winner.
+**Ambiguous Enum member.** A bare Enum member reference has multiple visible project candidates and no unique lexical winner.
 
 | Property                    | Value                    |
 | --------------------------- | ------------------------ |


### PR DESCRIPTION
## Summary

- Fixes #638 by treating duplicate external TypeLib enum metadata as
  fail-open instead of source-level ambiguity.
- Preserve `VB053` for genuinely ambiguous project enum members.
- Add regression coverage for unqualified Excel constants in assignments and
  procedure calls.
- Move the current unreleased entries into the `v0.30.1` changelog section.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/procedureir -run "Issue590|Issue638" -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/procedureir ./internal/lint ./internal/analyze ./internal/lspserver ./internal/staticanalysis/rules ./internal/vbadb ./internal/typedb -count=1`
- `rtk pnpm docs:generate-reference`
- `rtk pnpm docs:check`
- `rtk pnpm format:check`
- `rtk git diff --check`
- VBE oracle: `known-compile-accept`, `known-compile-reject`,
  `issue590-ambiguous-enum`, and `issue590-ambiguous-enum-valid` passed.
- `go test ./... -count=1` had one transient Windows
  `internal/coordination` subprocess failure (`TerminateProcess: Access is
  denied`); rerunning `./internal/coordination -count=1` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed false-positive `VB053` diagnostics when duplicate Enum members come only from external Excel/TypeLib metadata.
  - Preserved `VB053` reporting for genuinely ambiguous duplicate project-defined Enum members.
  - Clarified `VB054` detection so events must be declared in the same object module as the `RaiseEvent` statement.

- **Documentation**
  - Updated CLI, lint, LSP, and diagnostic references to explain the refined ambiguity behavior.
  - Added changelog notes for the fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->