### PR TITLE
perf(analyze): index project symbols for ByRef resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to xlflow will be documented in this file.
   `--json` stdout envelope. Added deterministic 100/500/1000-procedure scaling
   and real-world corpus benchmark guidance for comparing stage costs and
   allocations.
+- Improved batch ByRef call resolution by reusing parsed project symbols and
+  indexing exact and qualified-name lookups, avoiding a full project-symbol
+  scan for every call site while preserving ambiguity and visibility behavior.
 
 ## v0.30.1
 

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -109,7 +109,7 @@ type Analyzer struct {
 	typeDBResolutionIncomplete bool
 	visibleConstants           map[string]bool
 	visibleConstantValues      map[string]constexpr.Value
-	byRefSymbols               []intel.Symbol
+	byRefSymbolIndex           *intel.WorkspaceResolutionView
 	errorGuardAliases          map[string]bool
 	errorValueWrappers         map[string]bool
 	eventSafeProcedures        map[string]bool
@@ -518,14 +518,14 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	}
 	if needsByRefAnalysis {
 		finishStage = analysisstats.Measure(ctx, "project_symbols")
-		byRefSymbols, err := projectByRefSymbols(a.RootDir, a.Config)
-		finishStage(len(byRefSymbols), err)
+		byRefSymbolIndex, symbolCount, err := projectByRefSymbolIndex(ctx, a.RootDir, a.Config, a.PathFilter, parsedFiles)
+		finishStage(symbolCount, err)
 		if err != nil {
 			return Result{}, err
 		}
-		analysis.byRefSymbols = byRefSymbols
+		analysis.byRefSymbolIndex = byRefSymbolIndex
 		if recorder := analysisstats.FromContext(ctx); recorder != nil {
-			recorder.Add("project_symbol_count", uint64(len(byRefSymbols)))
+			recorder.Add("project_symbol_count", uint64(symbolCount))
 		}
 	}
 	findings := cycleFindings
@@ -782,35 +782,93 @@ func (a Analyzer) resolutionFinding(file parsedFile, diagnostic procedureir.Reso
 	return finding
 }
 
-// projectByRefSymbols builds the batch project's procedure index once. ByRef
-// diagnostics resolve every call through this immutable slice instead of
-// rediscovering the entire source tree through symbols.Inspect for each call
-// site.
-func projectByRefSymbols(rootDir string, cfg config.Config) ([]intel.Symbol, error) {
-	return (intel.Analyzer{RootDir: rootDir, Config: cfg}).WorkspaceSymbols(nil, "")
+// projectByRefSymbolIndex builds the batch project's immutable symbol index
+// once. A normal full-project analysis can reuse the already parsed documents;
+// a path-filtered analysis intentionally falls back to the complete workspace
+// collection because excluded modules remain valid project-local call targets.
+func projectByRefSymbolIndex(ctx context.Context, rootDir string, cfg config.Config, pathFilter func(string) bool, parsedFiles []parsedFile) (*intel.WorkspaceResolutionView, int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	var projectSymbols []intel.Symbol
+	if pathFilter != nil {
+		var err error
+		projectSymbols, err = (intel.Analyzer{RootDir: rootDir, Config: cfg}).WorkspaceSymbols(nil, "")
+		if err != nil {
+			return nil, 0, err
+		}
+	} else {
+		symbolAnalyzer := intel.Analyzer{RootDir: rootDir, Config: cfg}
+		seen := make(map[string]struct{}, len(parsedFiles))
+		for _, file := range parsedFiles {
+			if err := ctx.Err(); err != nil {
+				return nil, len(projectSymbols), err
+			}
+			_, included, err := symbols.SourceFileForPath(rootDir, cfg, file.Path)
+			if err != nil {
+				return nil, len(projectSymbols), err
+			}
+			if !included {
+				continue
+			}
+			key, err := projectByRefSourcePathKey(file.Path)
+			if err != nil {
+				return nil, len(projectSymbols), err
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			fileSymbols, err := symbolAnalyzer.DocumentSymbolsContext(ctx, file.intelDocument())
+			if err != nil {
+				return nil, len(projectSymbols), err
+			}
+			for _, symbol := range fileSymbols {
+				// WorkspaceSymbols uses IncludeLabels=false. Keep labels out of
+				// the batch index so the parsed-document reuse path preserves
+				// that historical candidate set.
+				switch strings.ToLower(strings.TrimSpace(symbol.Kind)) {
+				case "label", "line_number_label":
+					continue
+				}
+				// DocumentSymbolsContext also projects UserForm designer
+				// controls as field symbols. The workspace collection used by
+				// the old batch path contains source fields, but not those
+				// designer-only projections.
+				if strings.EqualFold(strings.TrimSpace(symbol.Kind), "field") && symbol.ModuleKind == "" && symbol.Visibility == "" && symbol.Parent == "" {
+					continue
+				}
+				projectSymbols = append(projectSymbols, symbol)
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, len(projectSymbols), err
+	}
+	return intel.NewWorkspaceResolutionView(projectSymbols), len(projectSymbols), nil
+}
+
+func projectByRefSourcePathKey(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	key := filepath.Clean(abs)
+	if os.PathSeparator == '\\' {
+		key = strings.ToLower(key)
+	}
+	return key, nil
 }
 
 func (a Analyzer) byRefWorkspaceSymbolQuery(_ []intel.Document, query intel.WorkspaceSymbolQuery) ([]intel.Symbol, error) {
-	needle := strings.ToLower(strings.TrimSpace(query.Text))
-	if needle == "" || (query.Mode != intel.WorkspaceSymbolQueryExact && query.Mode != intel.WorkspaceSymbolQueryQualified) {
+	if a.byRefSymbolIndex == nil || (query.Mode != intel.WorkspaceSymbolQueryExact && query.Mode != intel.WorkspaceSymbolQueryQualified) {
 		return nil, nil
 	}
-	out := make([]intel.Symbol, 0)
-	for _, sym := range a.byRefSymbols {
-		match := strings.EqualFold(sym.Name, needle)
-		if query.Mode == intel.WorkspaceSymbolQueryQualified {
-			qualified := strings.TrimSpace(sym.Module)
-			if qualified != "" {
-				qualified += "."
-			}
-			qualified += sym.Name
-			match = strings.EqualFold(qualified, needle)
-		}
-		if match {
-			out = append(out, sym)
-		}
-	}
-	return out, nil
+	return a.byRefSymbolIndex.Query(query), nil
 }
 
 func (a Analyzer) statefulExcelCallArgumentFindings(file parsedFile) []Finding {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -797,7 +797,7 @@ func projectByRefSymbolIndex(ctx context.Context, rootDir string, cfg config.Con
 	var projectSymbols []intel.Symbol
 	if pathFilter != nil {
 		var err error
-		projectSymbols, err = (intel.Analyzer{RootDir: rootDir, Config: cfg}).WorkspaceSymbols(nil, "")
+		projectSymbols, err = (intel.Analyzer{RootDir: rootDir, Config: cfg}).WorkspaceSymbolsContext(ctx, nil, "")
 		if err != nil {
 			return nil, 0, err
 		}

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -4679,6 +4679,74 @@ End Sub
 	}
 }
 
+func TestAnalyzerByRefPathFilterRetainsExcludedProjectCandidates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Receiver.bas", `Option Explicit
+Public Sub ReplaceText(ByRef target As String)
+End Sub
+`)
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim count As Long
+  receiver.ReplaceText count
+End Sub
+`)
+
+	findings, err := (Analyzer{
+		RootDir: dir,
+		Config:  config.Default(),
+		PathFilter: func(path string) bool {
+			return strings.EqualFold(filepath.Base(path), "Main.bas")
+		},
+	}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA228")
+	if len(got) != 1 || got[0].Line != 4 || !strings.Contains(got[0].Message, "requires String") {
+		t.Fatalf("path-filtered ByRef resolution lost excluded project candidate: %+v", got)
+	}
+}
+
+func TestAnalyzerByRefDoesNotIndexTestsAsProjectCandidates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim count As Long
+  TestHelper count
+End Sub
+`)
+	testsDir := filepath.Join(dir, "tests")
+	if err := os.MkdirAll(testsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testsDir, "Helper.bas"), []byte(`Option Explicit
+Public Sub TestHelper(ByRef target As String)
+End Sub
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA228"); len(got) != 0 {
+		t.Fatalf("test-only procedure became a project ByRef candidate: %+v", got)
+	}
+}
+
+func TestProjectByRefSymbolIndexHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, count, err := projectByRefSymbolIndex(ctx, t.TempDir(), config.Default(), nil, nil)
+	if !errors.Is(err, context.Canceled) || count != 0 {
+		t.Fatalf("canceled ByRef index build = (%d, %v), want (0, context.Canceled)", count, err)
+	}
+}
+
 func TestAnalyzerByRefSkipsAmbiguousCallsAndHonorsSuppression(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -3,10 +3,13 @@ package analyze
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
@@ -4745,6 +4748,47 @@ func TestProjectByRefSymbolIndexHonorsCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) || count != 0 {
 		t.Fatalf("canceled ByRef index build = (%d, %v), want (0, context.Canceled)", count, err)
 	}
+}
+
+func TestProjectByRefSymbolIndexHonorsCancellationDuringWorkspaceCollection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for i := 0; i < 32; i++ {
+		writeModule(t, dir, fmt.Sprintf("Module%02d.bas", i), "Public Sub Run()\nEnd Sub\n")
+	}
+	ctx := newCancelAfterContext(10)
+	_, count, err := projectByRefSymbolIndex(ctx, dir, config.Default(), func(string) bool { return true }, nil)
+	if !errors.Is(err, context.Canceled) || count != 0 {
+		t.Fatalf("canceled workspace collection = (%d, %v), want (0, context.Canceled)", count, err)
+	}
+}
+
+type cancelAfterContext struct {
+	context.Context
+	remaining atomic.Int32
+	done      chan struct{}
+	once      sync.Once
+}
+
+func newCancelAfterContext(checks int32) *cancelAfterContext {
+	ctx := &cancelAfterContext{Context: context.Background(), done: make(chan struct{})}
+	ctx.remaining.Store(checks)
+	return ctx
+}
+
+func (ctx *cancelAfterContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *cancelAfterContext) Err() error {
+	if err := ctx.Context.Err(); err != nil {
+		return err
+	}
+	if ctx.remaining.Add(-1) <= 0 {
+		ctx.once.Do(func() { close(ctx.done) })
+		return context.Canceled
+	}
+	return nil
 }
 
 func TestAnalyzerByRefSkipsAmbiguousCallsAndHonorsSuppression(t *testing.T) {

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -689,7 +689,33 @@ func (a Analyzer) RunnableProcedures(doc Document, cfg CodeLensConfig) ([]Runnab
 }
 
 func (a Analyzer) WorkspaceSymbols(open []Document, query string) ([]Symbol, error) {
-	return a.WorkspaceSymbolsQuery(open, WorkspaceSymbolQuery{Text: query, Mode: WorkspaceSymbolQueryContains})
+	return a.WorkspaceSymbolsContext(context.Background(), open, query)
+}
+
+// WorkspaceSymbolsContext is the cancellable variant of WorkspaceSymbols.
+// Cancellation is propagated through workspace discovery and symbol extraction.
+func (a Analyzer) WorkspaceSymbolsContext(ctx context.Context, open []Document, query string) ([]Symbol, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if a.WorkspaceSymbolQueryFunc != nil {
+		out, err := a.WorkspaceSymbolQueryFunc(open, WorkspaceSymbolQuery{Text: query, Mode: WorkspaceSymbolQueryContains})
+		if err != nil {
+			return nil, err
+		}
+		return out, ctx.Err()
+	}
+	if a.WorkspaceSymbolsFunc != nil {
+		out, err := a.WorkspaceSymbolsFunc(open, query)
+		if err != nil {
+			return nil, err
+		}
+		return out, ctx.Err()
+	}
+	return a.workspaceSymbolsContext(ctx, open, query)
 }
 
 func (a Analyzer) WorkspaceSymbolsQuery(open []Document, query WorkspaceSymbolQuery) ([]Symbol, error) {
@@ -703,7 +729,17 @@ func (a Analyzer) WorkspaceSymbolsQuery(open []Document, query WorkspaceSymbolQu
 }
 
 func (a Analyzer) workspaceSymbols(open []Document, query string) ([]Symbol, error) {
-	result, err := symbols.Inspect(symbols.Options{
+	return a.workspaceSymbolsContext(context.Background(), open, query)
+}
+
+func (a Analyzer) workspaceSymbolsContext(ctx context.Context, open []Document, query string) ([]Symbol, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	result, err := symbols.InspectContext(ctx, symbols.Options{
 		RootDir:        a.RootDir,
 		Config:         a.Config,
 		IncludePrivate: true,
@@ -714,19 +750,28 @@ func (a Analyzer) workspaceSymbols(open []Document, query string) ([]Symbol, err
 	}
 	openKeys := make(map[string]bool, len(open))
 	for _, doc := range open {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		for _, key := range a.workspacePathKeys(doc.Path) {
 			openKeys[key] = true
 		}
 	}
 	var out []Symbol
 	for _, file := range result.Files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if hasAnyPathKey(openKeys, a.workspacePathKeys(file.Path)) {
 			continue
 		}
 		out = append(out, symbolsFromFile(file, "")...)
 	}
 	for _, doc := range open {
-		docSyms, err := a.DocumentSymbols(doc)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		docSyms, err := a.DocumentSymbolsContext(ctx, doc)
 		if err != nil {
 			continue
 		}
@@ -751,7 +796,7 @@ func (a Analyzer) workspaceSymbols(open []Document, query string) ([]Symbol, err
 		}
 		return out[i].Name < out[j].Name
 	})
-	return out, nil
+	return out, ctx.Err()
 }
 
 func (a Analyzer) workspacePathKeys(path string) []string {

--- a/internal/vba/intel/workspace_resolution.go
+++ b/internal/vba/intel/workspace_resolution.go
@@ -21,7 +21,7 @@ type WorkspaceResolutionView struct {
 
 func NewWorkspaceResolutionView(symbols []Symbol) *WorkspaceResolutionView {
 	view := &WorkspaceResolutionView{
-		all:       append([]Symbol(nil), symbols...),
+		all:       cloneAnalysisSymbols(symbols),
 		exact:     make(map[string][]int),
 		qualified: make(map[string][]int),
 		module:    make(map[string][]int),
@@ -59,7 +59,7 @@ func (v *WorkspaceResolutionView) Query(query WorkspaceSymbolQuery) []Symbol {
 		indexes = v.kind[key]
 	case WorkspaceSymbolQueryPrefix:
 		if key == "" {
-			return append([]Symbol(nil), v.all...)
+			return cloneAnalysisSymbols(v.all)
 		}
 		start := sort.SearchStrings(v.exactKeys, key)
 		for i := start; i < len(v.exactKeys) && strings.HasPrefix(v.exactKeys[i], key); i++ {
@@ -67,7 +67,7 @@ func (v *WorkspaceResolutionView) Query(query WorkspaceSymbolQuery) []Symbol {
 		}
 	default:
 		if key == "" {
-			return append([]Symbol(nil), v.all...)
+			return cloneAnalysisSymbols(v.all)
 		}
 		for i, symbol := range v.all {
 			if strings.Contains(strings.ToLower(symbol.Name), key) || strings.Contains(strings.ToLower(qualifiedName(symbol.Module, symbol.Name)), key) {
@@ -91,7 +91,7 @@ func (v *WorkspaceResolutionView) Query(query WorkspaceSymbolQuery) []Symbol {
 		}
 		return result[i].Name < result[j].Name
 	})
-	return result
+	return cloneAnalysisSymbols(result)
 }
 
 func (a Analyzer) withRequestWorkspaceResolution(ctx context.Context, open []Document) Analyzer {

--- a/internal/vba/intel/workspace_resolution_test.go
+++ b/internal/vba/intel/workspace_resolution_test.go
@@ -2,6 +2,7 @@ package intel
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,10 +10,13 @@ import (
 )
 
 func TestWorkspaceResolutionViewQueriesIndexedSnapshot(t *testing.T) {
-	view := NewWorkspaceResolutionView([]Symbol{
-		{Name: "Run", Module: "Alpha", Kind: "sub", File: "a.bas"},
+	symbols := []Symbol{
+		{Name: "Run", Module: "Alpha", Kind: "sub", File: "a.bas", Parameters: []Parameter{{Name: "value", Type: "Long"}}},
 		{Name: "Runner", Module: "Beta", Kind: "function", File: "b.bas"},
-	})
+	}
+	view := NewWorkspaceResolutionView(symbols)
+	symbols[0].Name = "mutated input"
+	symbols[0].Parameters[0].Name = "mutated input"
 	tests := []struct {
 		query WorkspaceSymbolQuery
 		want  string
@@ -30,6 +34,46 @@ func TestWorkspaceResolutionViewQueriesIndexedSnapshot(t *testing.T) {
 	}
 	if got := view.Query(WorkspaceSymbolQuery{Text: "run", Mode: WorkspaceSymbolQueryPrefix}); len(got) != 2 {
 		t.Fatalf("prefix query returned %d symbols, want 2", len(got))
+	}
+	got := view.Query(WorkspaceSymbolQuery{Text: "run", Mode: WorkspaceSymbolQueryExact})
+	got[0].Name = "mutated"
+	got[0].Parameters[0].Name = "mutated"
+	got = view.Query(WorkspaceSymbolQuery{Text: "run", Mode: WorkspaceSymbolQueryExact})
+	if len(got) != 1 || got[0].Name != "Run" || got[0].Parameters[0].Name != "value" {
+		t.Fatalf("query result mutation changed immutable view: %+v", got)
+	}
+	duplicates := NewWorkspaceResolutionView([]Symbol{
+		{Name: "Run", Module: "Second", Kind: "sub", File: "z.bas"},
+		{Name: "Run", Module: "First", Kind: "sub", File: "a.bas"},
+	})
+	ordered := duplicates.Query(WorkspaceSymbolQuery{Text: "run", Mode: WorkspaceSymbolQueryExact})
+	if len(ordered) != 2 || ordered[0].File != "a.bas" || ordered[1].File != "z.bas" {
+		t.Fatalf("duplicate candidates are not deterministic: %+v", ordered)
+	}
+}
+
+func BenchmarkWorkspaceResolutionViewLookup(b *testing.B) {
+	for _, symbolCount := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("%d-symbols", symbolCount), func(b *testing.B) {
+			symbols := make([]Symbol, 0, symbolCount)
+			for i := 0; i < symbolCount; i++ {
+				symbols = append(symbols, Symbol{
+					Name:   fmt.Sprintf("Procedure%05d", i),
+					Module: fmt.Sprintf("Module%03d", i%100),
+					Kind:   "sub",
+					File:   fmt.Sprintf("Module%03d.bas", i%100),
+				})
+			}
+			view := NewWorkspaceResolutionView(symbols)
+			b.ReportAllocs()
+			b.ResetTimer()
+			resultCount := 0
+			for i := 0; i < b.N; i++ {
+				resultCount += len(view.Query(WorkspaceSymbolQuery{Text: "procedure00042", Mode: WorkspaceSymbolQueryExact}))
+				resultCount += len(view.Query(WorkspaceSymbolQuery{Text: "module042.procedure00042", Mode: WorkspaceSymbolQueryQualified}))
+			}
+			b.ReportMetric(float64(resultCount)/float64(b.N), "results/op")
+		})
 	}
 }
 

--- a/internal/vba/symbols/symbols.go
+++ b/internal/vba/symbols/symbols.go
@@ -132,6 +132,18 @@ type extractor struct {
 var attrRe = regexp.MustCompile(`(?i)^\s*Attribute\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$`)
 
 func Inspect(opts Options) (*Result, error) {
+	return InspectContext(context.Background(), opts)
+}
+
+// InspectContext is the cancellable variant of Inspect. Cancellation is
+// checked while discovering files, parsing each document, and walking symbols.
+func InspectContext(ctx context.Context, opts Options) (*Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	rootDir := opts.RootDir
 	if rootDir == "" {
 		rootDir = "."
@@ -146,7 +158,7 @@ func Inspect(opts Options) (*Result, error) {
 		displayRoot = "src"
 	}
 
-	files, err := discoverFiles(opts)
+	files, err := discoverFilesContext(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +174,15 @@ func Inspect(opts Options) (*Result, error) {
 	}
 	moduleFilter := strings.TrimSpace(opts.Module)
 	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		parsed, err := parser.ParseFile(file.path)
 		if err != nil {
+			return nil, err
+		}
+		if err := ctx.Err(); err != nil {
+			parsed.Close()
 			return nil, err
 		}
 		rel := displayPath(rootDir, file.path)
@@ -173,6 +192,7 @@ func Inspect(opts Options) (*Result, error) {
 			continue
 		}
 		ext := extractor{
+			ctx:         ctx,
 			opts:        opts,
 			rootDir:     rootDir,
 			source:      parsed.Source,
@@ -201,9 +221,12 @@ func Inspect(opts Options) (*Result, error) {
 			result.Summary.MissingNodes++
 		}
 		parsed.Close()
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 	}
 	result.Summary.Files = len(result.Files)
-	return result, nil
+	return result, ctx.Err()
 }
 
 // DiscoverSourceFiles returns the VBA files included by the configured source
@@ -415,9 +438,19 @@ func InspectParsedContext(ctx context.Context, opts SourceOptions, doc *vbaast.P
 }
 
 func discoverFiles(opts Options) ([]fileCandidate, error) {
+	return discoverFilesContext(context.Background(), opts)
+}
+
+func discoverFilesContext(ctx context.Context, opts Options) ([]fileCandidate, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(opts.Path) != "" {
 		root := resolvePath(opts.RootDir, opts.Path)
-		return collectFiles(root, opts)
+		return collectFilesContext(ctx, root, opts)
 	}
 	cfg := opts.Config
 	dirs := []struct {
@@ -435,7 +468,7 @@ func discoverFiles(opts Options) ([]fileCandidate, error) {
 		if strings.TrimSpace(dir.path) == "" {
 			continue
 		}
-		collected, err := collectFiles(filepath.Join(opts.RootDir, dir.path), opts)
+		collected, err := collectFilesContext(ctx, filepath.Join(opts.RootDir, dir.path), opts)
 		if err != nil {
 			return nil, err
 		}
@@ -456,13 +489,22 @@ func discoverFiles(opts Options) ([]fileCandidate, error) {
 			files = append(files, file)
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].path < files[j].path
 	})
 	return files, nil
 }
 
-func collectFiles(root string, opts Options) ([]fileCandidate, error) {
+func collectFilesContext(ctx context.Context, root string, opts Options) ([]fileCandidate, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	info, err := os.Stat(root)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -479,6 +521,9 @@ func collectFiles(root string, opts Options) ([]fileCandidate, error) {
 	}
 	files := make([]fileCandidate, 0)
 	err = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -496,6 +541,9 @@ func collectFiles(root string, opts Options) ([]fileCandidate, error) {
 		return nil
 	})
 	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	sort.Slice(files, func(i, j int) bool {


### PR DESCRIPTION
## Summary

- Replace per-call linear ByRef project-symbol scans with an immutable `intel.WorkspaceResolutionView` index for exact and qualified lookups.
- Reuse already parsed files and `AnalysisSnapshot` during normal full-project analysis, while preserving full-workspace candidates when `PathFilter` is used.
- Preserve case-insensitive lookup, visibility, module qualification, ambiguity, and output ordering; add defensive-copy, regression, and lookup benchmark coverage.
- Update the Unreleased changelog.

Part of #646. Closes #649.

## Performance

Compared with `origin/main` on the same Windows host (`12th Gen Intel(R) Core(TM) i7-12700`) using `BenchmarkSyntheticProject -benchtime=3x`:

| Project size | Total | ByRef stage | `project_symbols` |
| --- | ---: | ---: | ---: |
| 100 procedures | 4.76s -> 1.54s (-67.6%) | 67.7ms -> 8.3ms (-87.8%) | 108.4ms -> 21.9ms (-79.8%) |
| 500 procedures | 14.34s -> 7.99s (-44.3%) | 395.7ms -> 51.0ms (-87.1%) | 481.9ms -> 115.4ms (-76.0%) |
| 1000 procedures | 19.23s -> 14.95s (-22.3%) | 481.1ms -> 90.9ms (-81.1%) | 627.1ms -> 216.1ms (-65.5%) |

## Tests

- `rtk task lint`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/intel ./internal/analyze -count=1`
- `rtk task test`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^$' -bench '^BenchmarkSyntheticProject$' -benchmem -benchtime=3x -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/intel -run '^$' -bench '^BenchmarkWorkspaceResolutionViewLookup$' -benchmem -benchtime=1x -count=1`
- `rtk git diff --check`

VBE oracle and Excel COM E2E were not run because diagnostic semantics and Excel/VBIDE behavior are unchanged by this indexing-only optimization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved batch ByRef call resolution, especially in larger projects.
  * Reduced unnecessary symbol scanning while preserving accurate ambiguity and visibility handling.

* **Reliability**
  * Improved path-filtered resolution and exclusion of test-only procedures from project candidates.
  * Added cancellation support during indexing and symbol discovery.

* **Consistency**
  * Workspace lookup results are now isolated and returned in deterministic order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->