### PR TITLE
fix(lint): allow Friend procedures in document modules (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to xlflow will be documented in this file.
   interprocedural summaries and entry states through dependency worklists.
   Diagnostic output and conservative propagation semantics are unchanged.
 
+- Fixed `VB050` false positives for `Friend` procedures in worksheet and
+  `ThisWorkbook` document modules. `Friend` remains rejected in standard
+  modules, matching Excel/VBE behavior and issue #656.
 - Added opt-in `xlflow analyze --performance-log` batch-analyzer profiling.
   Stage timings, result counts, outcomes, and stable workload counters are
   written to stderr without changing analyzer findings, exit codes, or the

--- a/internal/lint/module_kind_diagnostics.go
+++ b/internal/lint/module_kind_diagnostics.go
@@ -73,9 +73,8 @@ func (w *moduleKindDiagnosticWalker) walk(node *tree_sitter.Node, state moduleWa
 		if strings.HasPrefix(kind, "conditional_") {
 			header = procedureHeaderNode(node)
 		}
-		if state.module && header != nil && strings.EqualFold(visibilityText(header, w.source), "Friend") &&
-			(w.moduleKind == "standard" || w.moduleKind == "document") {
-			w.add(header, declarationNameNode(header), "VB050", "invalid_friend_module", declarationNodeName(header, w.source), "Friend procedures are not valid in standard or document modules.")
+		if state.module && header != nil && strings.EqualFold(visibilityText(header, w.source), "Friend") && w.moduleKind == "standard" {
+			w.add(header, declarationNameNode(header), "VB050", "invalid_friend_module", declarationNodeName(header, w.source), "Friend procedures are not valid in standard modules.")
 		}
 		if strings.HasPrefix(kind, "conditional_") {
 			// The conditional procedure helper owns branch traversal. Its body

--- a/internal/lint/module_kind_diagnostics_test.go
+++ b/internal/lint/module_kind_diagnostics_test.go
@@ -17,7 +17,7 @@ func TestModuleKindDiagnosticsMatrix(t *testing.T) {
 		{"event standard", "standard", "Public Event Changed()\n", "VB050", 1},
 		{"event class", "class", "Public Event Changed()\n", "VB050", 0},
 		{"friend standard", "standard", "Friend Sub Run()\nEnd Sub\n", "VB050", 1},
-		{"friend document", "document", "Friend Sub Run()\nEnd Sub\n", "VB050", 1},
+		{"friend document", "document", "Friend Sub Run()\nEnd Sub\n", "VB050", 0},
 		{"friend class", "class", "Friend Sub Run()\nEnd Sub\n", "VB050", 0},
 		{"implements standard", "standard", "Implements IFoo\n", "VB050", 1},
 		{"implements class", "class", "Implements IFoo\n", "VB050", 0},

--- a/internal/lspserver/diagnostics_test.go
+++ b/internal/lspserver/diagnostics_test.go
@@ -604,6 +604,10 @@ func TestDiagnosticsDiscardsGenerationChangedImmediatelyBeforePublish(t *testing
 	ctx := diagnosticTestContext(notifications)
 	s.diagnostics = diagnosticVersionResult
 	uri := openDiagnosticsTestDocument(t, s, ctx, 1)
+	// didOpen launches diagnostics asynchronously. Wait for the initial
+	// publication before clearing the recorder so it cannot race with the
+	// generation-discard assertion below.
+	notifications.waitForCount(t, 1)
 	notifications.clear()
 
 	hookStarted := make(chan struct{})


### PR DESCRIPTION
## Summary

- Fix `VB050` false positives for `Friend` procedures in worksheet and `ThisWorkbook` document modules.
- Keep `Friend` rejected in standard modules and preserve the current `src/workbook` `.bas` layout.
- Add regression coverage and an Unreleased changelog entry for issue #656.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/lint ./internal/vba/symbols ./internal/oracle`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\test-vbe-oracle.ps1 --case invalid-friend-standard --case valid-module-document-worksheet --case valid-module-document-workbook --strict --timeout 5m`
- `rtk git diff --check`

The VBE oracle confirmed the standard-module rejection and worksheet/`ThisWorkbook` acceptance on Excel 16.0 build 17932 (x64, ja-JP), with cleanup confirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed false-positive `VB050` diagnostics for valid `Friend` procedures in worksheet and `ThisWorkbook` modules.
  - `Friend` procedures in standard modules continue to be flagged appropriately.

- **Documentation**
  - Added an entry to the unreleased changelog describing the diagnostic correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->