### PR TITLE
perf(analyze): reuse batch IR and CFG in Intel snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to xlflow will be documented in this file.
 - Improved batch ByRef call resolution by reusing parsed project symbols and
   indexing exact and qualified-name lookups, avoiding a full project-symbol
   scan for every call site while preserving ambiguity and visibility behavior.
+- Reused batch-built procedure IR and CFG artifacts in Intel diagnostics to
+  avoid rebuilding the same immutable file revision during `xlflow analyze`.
 
 ## v0.30.1
 

--- a/docs/adr/ADR-0021-procedure-analysis-ir.md
+++ b/docs/adr/ADR-0021-procedure-analysis-ir.md
@@ -51,10 +51,12 @@ Use `ast.Range` as the canonical source coordinate contract. LSP UTF-16
 conversion remains in the LSP adapter; the IR does not import LSP protocol
 types.
 
-Make the immutable `AnalysisSnapshot` the LSP ownership and cache boundary.
-Each snapshot lazily constructs syntax IR from its owned parsed document,
-supports concurrent readers, and returns defensive copies. A successor in the
-same open-document lifecycle may inherit completed Go-owned procedure fragments
+Make the immutable `AnalysisSnapshot` the ownership and cache boundary for
+editor and batch consumers. An editor snapshot lazily constructs syntax IR
+from its owned parsed document, while a batch snapshot may seed the same cache
+with an already-built IR for the exact immutable revision. Both paths support
+concurrent readers and return defensive copies. A successor in the same
+open-document lifecycle may inherit completed Go-owned procedure fragments
 keyed by procedure kind/name/ordinal, exact source hash, and module-context
 hash. Ranges are rebased from the fragment declaration start and document-wide
 declaration IDs are deterministically reassigned when materialized. In-flight,

--- a/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
+++ b/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
@@ -59,9 +59,11 @@ unresolved path. Consumers may request an explicit view, such as normal flow
 without exceptional edges, when the rule's contract calls for it; uncertainty
 within that selected view still participates.
 
-Cache the document CFG lazily on the immutable `AnalysisSnapshot`, using the
-same ownership, concurrency, retryable-cancellation, and defensive-copy
-contract as procedure IR. A successor in the same lifecycle may reuse a
+Cache the document CFG on the immutable `AnalysisSnapshot`, using the same
+ownership, concurrency, retryable-cancellation, and defensive-copy contract as
+procedure IR. Editor snapshots build it lazily from cached IR; batch snapshots
+may seed it with an already-built CFG for the exact immutable revision. A
+successor in the same lifecycle may reuse a
 completed procedure graph fragment when both its procedure source and module
 semantic context match. The module-context component is required because CFG
 assignment facts contain resolved symbol scopes. Source ranges are rebased to

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -227,7 +227,8 @@ Recovery acceptance belongs to the consumer:
 An `internal/vba/intel.AnalysisSnapshot` owns the syntax IR for one immutable
 document revision. The cache:
 
-- builds lazily from the snapshot-owned `ParsedDocument`;
+- builds lazily from the snapshot-owned `ParsedDocument`, or accepts a
+  caller-supplied immutable IR for the exact batch revision;
 - is safe for concurrent readers and performs at most one IR build per
   snapshot;
 - shares the same parsed document already used by snapshot symbols,
@@ -235,6 +236,10 @@ document revision. The cache:
 - returns defensive copies so callers cannot mutate cached slices or nested
   candidate data; and
 - is retired with the snapshot and never closes the parsed document itself.
+
+Batch analysis may construct the IR before creating the snapshot and seed it
+through `intel.NewAnalysisSnapshotWithArtifacts`. The snapshot deep-copies the
+IR at that boundary; parsed-document ownership remains unchanged.
 
 An incremental edit creates a new parsed-document snapshot and a new
 single-flight document result, but a successor within the same open lifecycle

--- a/docs/specs/vba-control-flow-graph.md
+++ b/docs/specs/vba-control-flow-graph.md
@@ -240,14 +240,18 @@ new public diagnostic ID.
 
 ## Snapshot Cache
 
-An `internal/vba/intel.AnalysisSnapshot` owns one lazy document CFG cache for
-its immutable revision. The cache:
+An `internal/vba/intel.AnalysisSnapshot` owns one document CFG cache for its
+immutable revision. Editor snapshots initialize it lazily; batch snapshots
+may seed it with a CFG built from the same revision's IR. The cache:
 
-- builds from the snapshot's cached procedure IR;
+- builds from the snapshot's cached procedure IR when it is not pre-seeded;
 - performs at most one build and caches either its result or error;
 - is safe for concurrent readers;
 - returns defensive copies; and
 - retires with the snapshot without retaining parser state.
+
+`NewAnalysisSnapshotWithArtifacts` deep-copies a supplied CFG at the snapshot
+boundary and keeps the existing cancellation and defensive-copy behavior.
 
 An incremental successor may reuse completed procedure graph fragments when the
 procedure source hash and module-context hash both match. Cached ranges are

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -413,7 +413,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		var intelDocument intel.Document
 		if needsTypedExcelAnalysis {
 			intelDocument = intel.Document{Path: file, Source: string(source), ModuleKind: moduleKind}
-			intelDocument.Snapshot = intel.NewAnalysisSnapshotWithParsedDocument(intelDocument, parsed)
+			intelDocument = batchIntelDocument(intelDocument, parsed, ir, controlFlow)
 		}
 		lines := normalizedSourceLines(string(source))
 		var rangeValueConstants map[string]int
@@ -1047,6 +1047,18 @@ func (file parsedFile) intelDocument() intel.Document {
 		return file.IntelDocument
 	}
 	return intel.Document{Path: file.Path, Source: string(file.Source), ModuleKind: file.ModuleKind}
+}
+
+// batchIntelDocument transfers the parser and already-built immutable
+// artifacts into the Intel snapshot used by batch diagnostics. Keeping this
+// boundary in one helper makes it explicit that batch preparation and Intel
+// analysis operate on the same document revision.
+func batchIntelDocument(doc intel.Document, parsed *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document) intel.Document {
+	doc.Snapshot = intel.NewAnalysisSnapshotWithArtifacts(doc, parsed, intel.AnalysisArtifacts{
+		ProcedureIR: ir,
+		ControlFlow: controlFlow,
+	})
+	return doc
 }
 
 func SourceNonShortCircuitObjectGuardFindings(rootDir, path string, cfg config.Config, source []byte) ([]Finding, error) {

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -3883,7 +3883,7 @@ End Sub
 	}
 }
 
-func TestBatchTypedExcelRulesReusePreparedParsedDocument(t *testing.T) {
+func TestBatchTypedExcelRulesReusePreparedAnalysisArtifacts(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Main.bas")
@@ -3901,8 +3901,13 @@ End Sub
 	if err != nil {
 		t.Fatal(err)
 	}
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{RootDir: dir, Path: path}, parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlFlow := vbacfg.BuildDocument(ir)
 	document := intel.Document{Path: path, Source: string(source)}
-	document.Snapshot = intel.NewAnalysisSnapshotWithParsedDocument(document, parsed)
+	document = batchIntelDocument(document, parsed, ir, controlFlow)
 	defer document.Snapshot.Retire()
 	db, err := vbadb.LoadBuiltin()
 	if err != nil {
@@ -3923,6 +3928,18 @@ End Sub
 	}
 	if got := document.Snapshot.ParseCount(); got != 1 {
 		t.Fatalf("shared VBA215/VBA218 snapshot parse count = %d, want 1", got)
+	}
+	if _, hit, err := document.Snapshot.ProcedureIR(func() (procedureir.DocumentIR, error) {
+		t.Fatal("seeded batch snapshot rebuilt procedure IR")
+		return procedureir.DocumentIR{}, nil
+	}); err != nil || !hit {
+		t.Fatalf("seeded procedure IR cache = (hit=%v, err=%v)", hit, err)
+	}
+	if _, hit, err := document.Snapshot.ControlFlowGraphs(func() (vbacfg.Document, error) {
+		t.Fatal("seeded batch snapshot rebuilt CFG")
+		return vbacfg.Document{}, nil
+	}); err != nil || !hit {
+		t.Fatalf("seeded CFG cache = (hit=%v, err=%v)", hit, err)
 	}
 }
 

--- a/internal/vba/cfg/cfg_test.go
+++ b/internal/vba/cfg/cfg_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
@@ -113,6 +114,44 @@ End Sub
 	if len(first.Graphs[0].Procedure.Parameters) != 0 ||
 		first.Graphs[0].Blocks[5].Statement.Text == "mutated input" {
 		t.Fatal("BuildDocument retained mutable input storage")
+	}
+}
+
+func TestCloneDeepCopiesProcedureSignatureRanges(t *testing.T) {
+	defaultRange := vbaast.Range{StartLine: 1, EndLine: 1, StartByte: 2, EndByte: 4}
+	boundsRange := vbaast.Range{StartLine: 2, EndLine: 2, StartByte: 5, EndByte: 8}
+	lowerRange := vbaast.Range{StartLine: 3, EndLine: 3, StartByte: 9, EndByte: 10}
+	upperRange := vbaast.Range{StartLine: 3, EndLine: 3, StartByte: 11, EndByte: 12}
+	procedureRange := vbaast.Range{StartLine: 1, EndLine: 4, StartByte: 0, EndByte: 20}
+	graph := Graph{Procedure: procedureir.ProcedureSymbol{
+		Parameters: []procedureir.Parameter{{
+			DefaultRange: &defaultRange,
+			BoundsRange:  &boundsRange,
+			ArrayBounds:  []procedureir.ArrayBound{{LowerRange: &lowerRange, UpperRange: &upperRange}},
+		}},
+		ArrayBounds:      []procedureir.ArrayBound{{LowerRange: &lowerRange, UpperRange: &upperRange}},
+		DeclarationRange: procedureRange,
+	}}
+	wantDefaultStart := graph.Procedure.Parameters[0].DefaultRange.StartByte
+	wantBoundsEnd := graph.Procedure.Parameters[0].BoundsRange.EndByte
+	wantParameterLowerStart := graph.Procedure.Parameters[0].ArrayBounds[0].LowerRange.StartByte
+	wantParameterUpperEnd := graph.Procedure.Parameters[0].ArrayBounds[0].UpperRange.EndByte
+	wantProcedureLowerStart := graph.Procedure.ArrayBounds[0].LowerRange.StartByte
+	wantProcedureUpperEnd := graph.Procedure.ArrayBounds[0].UpperRange.EndByte
+	clone := Clone(graph)
+	clone.Procedure.Parameters[0].DefaultRange.StartByte++
+	clone.Procedure.Parameters[0].BoundsRange.EndByte++
+	clone.Procedure.Parameters[0].ArrayBounds[0].LowerRange.StartByte++
+	clone.Procedure.Parameters[0].ArrayBounds[0].UpperRange.EndByte++
+	clone.Procedure.ArrayBounds[0].LowerRange.StartByte++
+	clone.Procedure.ArrayBounds[0].UpperRange.EndByte++
+	if graph.Procedure.Parameters[0].DefaultRange.StartByte != wantDefaultStart ||
+		graph.Procedure.Parameters[0].BoundsRange.EndByte != wantBoundsEnd ||
+		graph.Procedure.Parameters[0].ArrayBounds[0].LowerRange.StartByte != wantParameterLowerStart ||
+		graph.Procedure.Parameters[0].ArrayBounds[0].UpperRange.EndByte != wantParameterUpperEnd ||
+		graph.Procedure.ArrayBounds[0].LowerRange.StartByte != wantProcedureLowerStart ||
+		graph.Procedure.ArrayBounds[0].UpperRange.EndByte != wantProcedureUpperEnd {
+		t.Fatal("Clone shares procedure signature range storage")
 	}
 }
 

--- a/internal/vba/cfg/clone.go
+++ b/internal/vba/cfg/clone.go
@@ -19,7 +19,9 @@ func CloneDocument(in Document) Document {
 // Clone returns a deep copy of a graph.
 func Clone(in Graph) Graph {
 	out := in
-	out.Procedure.Parameters = append([]procedureir.Parameter(nil), in.Procedure.Parameters...)
+	out.Procedure.Parameters = cloneParameters(in.Procedure.Parameters)
+	out.Procedure.ArrayBounds = cloneArrayBounds(in.Procedure.ArrayBounds)
+	out.Procedure.ConditionalBranches = append([]procedureir.ConditionalBranch(nil), in.Procedure.ConditionalBranches...)
 	out.Blocks = make([]Block, len(in.Blocks))
 	for i := range in.Blocks {
 		out.Blocks[i] = in.Blocks[i]
@@ -44,6 +46,33 @@ func Clone(in Graph) Graph {
 	out.UnknownFlowSources = append([]BlockID(nil), in.UnknownFlowSources...)
 	out.ValidationFacts = append([]ValidationFact(nil), in.ValidationFacts...)
 	return out
+}
+
+func cloneParameters(in []procedureir.Parameter) []procedureir.Parameter {
+	out := append([]procedureir.Parameter(nil), in...)
+	for i := range out {
+		out[i].DefaultRange = cloneRangePointer(in[i].DefaultRange)
+		out[i].BoundsRange = cloneRangePointer(in[i].BoundsRange)
+		out[i].ArrayBounds = cloneArrayBounds(in[i].ArrayBounds)
+	}
+	return out
+}
+
+func cloneArrayBounds(in []procedureir.ArrayBound) []procedureir.ArrayBound {
+	out := append([]procedureir.ArrayBound(nil), in...)
+	for i := range out {
+		out[i].LowerRange = cloneRangePointer(in[i].LowerRange)
+		out[i].UpperRange = cloneRangePointer(in[i].UpperRange)
+	}
+	return out
+}
+
+func cloneRangePointer(in *vbaast.Range) *vbaast.Range {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func cloneExpression(in *procedureir.Expression) *procedureir.Expression {

--- a/internal/vba/intel/analysis_snapshot.go
+++ b/internal/vba/intel/analysis_snapshot.go
@@ -97,6 +97,20 @@ type AnalysisSnapshot struct {
 	retired atomic.Bool
 }
 
+// AnalysisArtifacts contains derived values that were built for the exact
+// document revision captured by an AnalysisSnapshot.  Batch analysis can
+// provide these values when it has already built them while preparing its
+// parsed input, allowing the snapshot to publish the same immutable values
+// without rebuilding them through its lazy loaders.
+//
+// The snapshot takes ownership of neither value: both are cloned at the
+// constructor boundary.  This keeps the caller free to continue using or
+// releasing its preparation buffers after construction.
+type AnalysisArtifacts struct {
+	ProcedureIR procedureir.DocumentIR
+	ControlFlow vbacfg.Document
+}
+
 // NewAnalysisSnapshot captures doc as an immutable analysis revision.
 func NewAnalysisSnapshot(doc Document) *AnalysisSnapshot {
 	source := doc.Source
@@ -187,6 +201,26 @@ func NewAnalysisSnapshotWithParsedDocument(doc Document, parsed *ast.ParsedDocum
 		snapshot.parsedDocument = parsed
 		snapshot.parseCount.Add(1)
 	}
+	return snapshot
+}
+
+// NewAnalysisSnapshotWithArtifacts captures doc and seeds it with a parsed
+// document, procedure IR, and control-flow graphs produced while preparing
+// this exact revision.  The parsed document is owned by the returned
+// snapshot, as with NewAnalysisSnapshotWithParsedDocument.  IR and CFG are
+// deep-copied at the snapshot boundary, then cached as completed values so
+// their first access is a cache hit and does not invoke its loader.
+func NewAnalysisSnapshotWithArtifacts(doc Document, parsed *ast.ParsedDocument, artifacts AnalysisArtifacts) *AnalysisSnapshot {
+	snapshot := NewAnalysisSnapshotWithParsedDocument(doc, parsed)
+	snapshot.procedureIR = procedureir.Clone(artifacts.ProcedureIR)
+	snapshot.procedureIRDone = true
+	snapshot.controlFlow = vbacfg.CloneDocument(artifacts.ControlFlow)
+	snapshot.controlFlowDone = true
+	// Seed the procedure-level store from the same cloned document values used
+	// by the completed caches.  This is what lets successor snapshots reuse
+	// unchanged fragments without rebuilding the batch's artifacts.
+	snapshot.seedProcedureArtifactsOwned(snapshot.procedureIR)
+	snapshot.seedCFGArtifactsOwned(snapshot.procedureIR, snapshot.controlFlow)
 	return snapshot
 }
 

--- a/internal/vba/intel/analysis_snapshot_artifacts_test.go
+++ b/internal/vba/intel/analysis_snapshot_artifacts_test.go
@@ -1,0 +1,181 @@
+package intel
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+func buildSnapshotArtifactsTestInput(t *testing.T, path, source string) (*vbaast.ParsedDocument, procedureir.DocumentIR, vbacfg.Document) {
+	t.Helper()
+	parsed, err := vbaast.ParseDocument(path, []byte(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{Path: path, ModuleKind: "standard"}, parsed)
+	if err != nil {
+		parsed.Close()
+		t.Fatal(err)
+	}
+	cfg, err := vbacfg.BuildDocumentContext(context.Background(), ir)
+	if err != nil {
+		parsed.Close()
+		t.Fatal(err)
+	}
+	return parsed, ir, cfg
+}
+
+func TestNewAnalysisSnapshotWithArtifactsSeedsCompletedCachesDefensively(t *testing.T) {
+	const source = "Sub Main()\n  Dim value As Long\n  value = 1\nEnd Sub\n"
+	path := "Main.bas"
+	parsed, ir, _ := buildSnapshotArtifactsTestInput(t, path, source)
+	defaultRange := vbaast.Range{StartLine: 2, EndLine: 2, StartByte: 14, EndByte: 15}
+	boundsRange := vbaast.Range{StartLine: 2, EndLine: 2, StartByte: 16, EndByte: 17}
+	lowerRange := vbaast.Range{StartLine: 2, EndLine: 2, StartByte: 18, EndByte: 19}
+	upperRange := vbaast.Range{StartLine: 2, EndLine: 2, StartByte: 20, EndByte: 21}
+	ir.Procedures[0].Symbol.Parameters = []procedureir.Parameter{{
+		DefaultRange: &defaultRange,
+		BoundsRange:  &boundsRange,
+		ArrayBounds:  []procedureir.ArrayBound{{LowerRange: &lowerRange, UpperRange: &upperRange}},
+	}}
+	cfg := vbacfg.BuildDocument(ir)
+	wantIR := procedureir.Clone(ir)
+	wantCFG := vbacfg.CloneDocument(cfg)
+	snapshot := NewAnalysisSnapshotWithArtifacts(
+		Document{Path: path, Source: source, ModuleKind: "standard", Version: 1},
+		parsed,
+		AnalysisArtifacts{ProcedureIR: ir, ControlFlow: cfg},
+	)
+	defer snapshot.Retire()
+
+	var irLoads, cfgLoads atomic.Int32
+	gotIR, hit, err := snapshot.ProcedureIR(func() (procedureir.DocumentIR, error) {
+		irLoads.Add(1)
+		return procedureir.DocumentIR{}, errors.New("seeded IR loader invoked")
+	})
+	if err != nil || !hit || !reflect.DeepEqual(gotIR, wantIR) {
+		t.Fatalf("seeded procedure IR = (equal=%v, hit=%v, err=%v)", reflect.DeepEqual(gotIR, wantIR), hit, err)
+	}
+	gotCFG, hit, err := snapshot.ControlFlowGraphs(func() (vbacfg.Document, error) {
+		cfgLoads.Add(1)
+		return vbacfg.Document{}, errors.New("seeded CFG loader invoked")
+	})
+	if err != nil || !hit || !reflect.DeepEqual(gotCFG, wantCFG) {
+		t.Fatalf("seeded control flow = (equal=%v, hit=%v, err=%v)", reflect.DeepEqual(gotCFG, wantCFG), hit, err)
+	}
+	if irLoads.Load() != 0 || cfgLoads.Load() != 0 {
+		t.Fatalf("seeded loaders called = (IR %d, CFG %d)", irLoads.Load(), cfgLoads.Load())
+	}
+
+	// Mutating the preparation values after construction must not affect the
+	// snapshot-owned caches.
+	ir.Procedures[0].Symbol.Name = "mutated input"
+	ir.Procedures[0].Statements[0].Text = "mutated input"
+	ir.Procedures[0].Symbol.Parameters[0].DefaultRange.StartByte++
+	ir.Procedures[0].Symbol.Parameters[0].BoundsRange.EndByte++
+	ir.Procedures[0].Symbol.Parameters[0].ArrayBounds[0].LowerRange.StartByte++
+	ir.Procedures[0].Symbol.Parameters[0].ArrayBounds[0].UpperRange.EndByte++
+	cfg.Graphs[0].Procedure.Name = "mutated input"
+	cfg.Graphs[0].Procedure.Parameters[0].DefaultRange.StartByte++
+	cfg.Graphs[0].Procedure.Parameters[0].BoundsRange.EndByte++
+	cfg.Graphs[0].Procedure.Parameters[0].ArrayBounds[0].LowerRange.StartByte++
+	cfg.Graphs[0].Procedure.Parameters[0].ArrayBounds[0].UpperRange.EndByte++
+	cfg.Graphs[0].Blocks[0].Kind = vbacfg.BlockUnknownExit
+	gotIR, _, err = snapshot.ProcedureIR(nil)
+	if err != nil || !reflect.DeepEqual(gotIR, wantIR) {
+		t.Fatalf("input mutation leaked into procedure IR = (equal=%v, err=%v)", reflect.DeepEqual(gotIR, wantIR), err)
+	}
+	gotCFG, _, err = snapshot.ControlFlowGraphs(nil)
+	if err != nil || !reflect.DeepEqual(gotCFG, wantCFG) {
+		t.Fatalf("input mutation leaked into control flow = (equal=%v, err=%v)", reflect.DeepEqual(gotCFG, wantCFG), err)
+	}
+
+	// Mutating one defensive getter result must not affect the next result.
+	gotIR.Procedures[0].Symbol.Parameters = append(gotIR.Procedures[0].Symbol.Parameters, procedureir.Parameter{Name: "mutated getter"})
+	gotIR.Procedures[0].Statements[0].Text = "mutated getter"
+	gotIR.Procedures[0].Symbol.Parameters[0].DefaultRange.StartByte++
+	gotCFG.Graphs[0].Procedure.Name = "mutated getter"
+	gotCFG.Graphs[0].Procedure.Parameters[0].DefaultRange.StartByte++
+	gotCFG.Graphs[0].Blocks[0].Kind = vbacfg.BlockUnknownExit
+	againIR, _, _ := snapshot.ProcedureIR(nil)
+	againCFG, _, _ := snapshot.ControlFlowGraphs(nil)
+	if !reflect.DeepEqual(againIR, wantIR) || !reflect.DeepEqual(againCFG, wantCFG) {
+		t.Fatal("mutating seeded getter result changed the snapshot cache")
+	}
+}
+
+func TestNewAnalysisSnapshotWithArtifactsCancellationPrecedesCacheHit(t *testing.T) {
+	const source = "Sub Main()\nEnd Sub\n"
+	parsed, ir, cfg := buildSnapshotArtifactsTestInput(t, "Main.bas", source)
+	snapshot := NewAnalysisSnapshotWithArtifacts(
+		Document{Path: "Main.bas", Source: source, ModuleKind: "standard", Version: 1},
+		parsed,
+		AnalysisArtifacts{ProcedureIR: ir, ControlFlow: cfg},
+	)
+	defer snapshot.Retire()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var loads atomic.Int32
+	_, hit, err := snapshot.ProcedureIRContext(ctx, func(context.Context) (procedureir.DocumentIR, error) {
+		loads.Add(1)
+		return procedureir.DocumentIR{}, nil
+	})
+	if !errors.Is(err, context.Canceled) || hit || loads.Load() != 0 {
+		t.Fatalf("pre-canceled seeded IR = (loads=%d, hit=%v, err=%v)", loads.Load(), hit, err)
+	}
+	_, hit, err = snapshot.ControlFlowGraphsContext(ctx, func(context.Context) (vbacfg.Document, error) {
+		loads.Add(1)
+		return vbacfg.Document{}, nil
+	})
+	if !errors.Is(err, context.Canceled) || hit || loads.Load() != 0 {
+		t.Fatalf("pre-canceled seeded CFG = (loads=%d, hit=%v, err=%v)", loads.Load(), hit, err)
+	}
+}
+
+func TestNewAnalysisSnapshotWithArtifactsSeedsSuccessorFragmentReuse(t *testing.T) {
+	const oldSource = "Sub A()\n  Dim value As Long\n  value = 1\nEnd Sub\nSub B()\n  Dim other As Long\n  other = 2\nEnd Sub\n"
+	const newSource = "Sub A()\n  Dim value As Long\n  value = 10\nEnd Sub\nSub B()\n  Dim other As Long\n  other = 2\nEnd Sub\n"
+	oldPath := "Module1.bas"
+	oldParsed, oldIR, oldCFG := buildSnapshotArtifactsTestInput(t, oldPath, oldSource)
+	oldSnapshot := NewAnalysisSnapshotWithArtifacts(
+		Document{Path: oldPath, Source: oldSource, ModuleKind: "standard", Version: 1},
+		oldParsed,
+		AnalysisArtifacts{ProcedureIR: oldIR, ControlFlow: oldCFG},
+	)
+	newParsed, err := vbaast.ParseDocument(oldPath, []byte(newSource))
+	if err != nil {
+		oldSnapshot.Retire()
+		t.Fatal(err)
+	}
+	newSnapshot := NewSuccessorAnalysisSnapshotWithParsedDocument(
+		Document{Path: oldPath, Source: newSource, ModuleKind: "standard", Version: 2},
+		newParsed,
+		oldSnapshot,
+	)
+	oldSnapshot.Retire()
+	defer newSnapshot.Retire()
+
+	newDoc := newSnapshot.Document()
+	newIR, err := procedureIRForDocumentContext(context.Background(), newDoc, ".", newParsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newCFG, err := controlFlowForDocumentContext(context.Background(), newDoc, newIR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := newSnapshot.ProcedureArtifactStats()
+	if stats.IRBuild != 1 || stats.IRReuse != 1 || stats.CFGBuild != 1 || stats.CFGReuse != 1 {
+		t.Fatalf("successor artifact stats = %+v, want one build and one reuse for both IR and CFG", stats)
+	}
+	if len(newIR.Procedures) != 2 || len(newCFG.Graphs) != 2 {
+		t.Fatalf("successor artifacts = (IR %d procedures, CFG %d graphs)", len(newIR.Procedures), len(newCFG.Graphs))
+	}
+}

--- a/internal/vba/intel/procedure_artifacts.go
+++ b/internal/vba/intel/procedure_artifacts.go
@@ -57,6 +57,18 @@ func astBase(entry ProcedureCatalogEntry) vbaast.Range {
 }
 
 func (s *AnalysisSnapshot) seedProcedureArtifacts(ir procedureir.DocumentIR) {
+	s.seedProcedureArtifactsWithClone(ir, true)
+}
+
+// seedProcedureArtifactsOwned indexes values already owned by the snapshot.
+// The document-level cache has performed the required deep copy at the
+// constructor boundary, so the private fragment store can reference those
+// immutable values without cloning every procedure a second time.
+func (s *AnalysisSnapshot) seedProcedureArtifactsOwned(ir procedureir.DocumentIR) {
+	s.seedProcedureArtifactsWithClone(ir, false)
+}
+
+func (s *AnalysisSnapshot) seedProcedureArtifactsWithClone(ir procedureir.DocumentIR, clone bool) {
 	if s == nil || s.artifacts == nil || ir.Parse.HasError || ir.Parse.HasMissing {
 		return
 	}
@@ -85,7 +97,10 @@ func (s *AnalysisSnapshot) seedProcedureArtifacts(ir procedureir.DocumentIR) {
 		if !ok {
 			continue
 		}
-		fragment := procedureIRFragment{base: procedure.Symbol.DeclarationRange, procedure: procedureir.CloneProcedureIR(procedure)}
+		if clone {
+			procedure = procedureir.CloneProcedureIR(procedure)
+		}
+		fragment := procedureIRFragment{base: procedure.Symbol.DeclarationRange, procedure: procedure}
 		for _, reference := range ir.TypeReferences {
 			if reference.Caller != nil && reference.Range.StartByte >= procedure.Symbol.DeclarationRange.StartByte && reference.Range.EndByte <= procedure.Symbol.DeclarationRange.EndByte {
 				fragment.typeReferences = append(fragment.typeReferences, reference)
@@ -196,6 +211,17 @@ func maskProcedureSet(source string, catalog ProcedureCatalog, keep map[Procedur
 }
 
 func (s *AnalysisSnapshot) seedCFGArtifacts(ir procedureir.DocumentIR, document vbacfg.Document) {
+	s.seedCFGArtifactsWithClone(ir, document, true)
+}
+
+// seedCFGArtifactsOwned indexes graphs already owned by the snapshot. Those
+// graphs are immutable behind the snapshot's completed cache, and every
+// incremental consumer clones before rebasing or returning them.
+func (s *AnalysisSnapshot) seedCFGArtifactsOwned(ir procedureir.DocumentIR, document vbacfg.Document) {
+	s.seedCFGArtifactsWithClone(ir, document, false)
+}
+
+func (s *AnalysisSnapshot) seedCFGArtifactsWithClone(ir procedureir.DocumentIR, document vbacfg.Document, clone bool) {
 	if s == nil || s.artifacts == nil || len(ir.Procedures) != len(document.Graphs) {
 		return
 	}
@@ -224,7 +250,10 @@ func (s *AnalysisSnapshot) seedCFGArtifacts(ir procedureir.DocumentIR, document 
 		if !ok {
 			continue
 		}
-		s.artifacts.cfg[key] = vbacfg.Clone(graph)
+		if clone {
+			graph = vbacfg.Clone(graph)
+		}
+		s.artifacts.cfg[key] = graph
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reuse the procedure IR and CFG already built by batch analysis when creating each Intel `AnalysisSnapshot`.
- Deep-copy artifacts at the snapshot boundary, seed procedure fragment caches, and preserve cancellation, successor reuse, diagnostics, and LSP behavior.
- Update the related ADR/specification documents and the Unreleased changelog entry.

## Benchmark

`BenchmarkSyntheticProject` on Windows (12th Gen Intel Core i7-12700), three-run means comparing the rebased `origin/main` with this branch:

| Procedures | `stage_analyze_total` before | after | Change |
| ---: | ---: | ---: | ---: |
| 100 | 0.916 s | 0.873 s | 4.7% faster |
| 500 | 4.648 s | 4.460 s | 4.0% faster |
| 1000 | 9.503 s | 9.143 s | 3.8% faster |

Allocations decreased by about 1.4–1.6% in bytes/op and 5.1–5.3% in allocs/op. The seeded snapshot tests also verify that the IR/CFG loaders are not called on the first access.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/intel ./internal/vba/cfg ./internal/analyze -count=1`
- `rtk task test`
- `rtk task lint`

Closes #651
Part of #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved `xlflow analyze` efficiency by reusing prepared analysis results for the same file revision.
  - Reduced repeated processing when multiple diagnostics inspect the same VBA content.

- **Reliability**
  - Strengthened analysis-result isolation to prevent changes in one analysis from affecting another.
  - Preserved correct handling of updated file revisions and cancellation behavior.

- **Documentation**
  - Updated analysis and control-flow documentation to describe caching and reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->