### PR TITLE
perf(analyze): compute ByRef diagnostics once per file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to xlflow will be documented in this file.
   adjacency, and reachability indexes for analyzer graph queries. CFG semantics
   and diagnostic output are unchanged.
 
+- Improved batch ByRef analysis by computing each file revision once and
+  reusing the typed diagnostics for both runtime-safety and compile-equivalent
+  projections. Diagnostic output and the `VBA206`/`VBA228` contracts are
+  unchanged.
+
 - Improved `VBA202` batch analysis scalability by gating object analysis behind
   the rule, reusing per-procedure CFG/object-flow artifacts, and propagating
   interprocedural summaries and entry states through dependency worklists.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -261,6 +261,14 @@ type parsedFile struct {
 	DataFlowModuleBindings    map[string]bool
 }
 
+// batchByRefDiagnostics records the result of the one ByRef analysis pass
+// performed for a file revision. The computed bit distinguishes an analyzed
+// file with no findings from callers that still need the Intel fallback.
+type batchByRefDiagnostics struct {
+	computed    bool
+	diagnostics []intel.Diagnostic
+}
+
 type sourceProcedure struct {
 	Kind             string
 	ProcedureKind    procedureir.ProcedureKind
@@ -619,11 +627,12 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		findings = append(findings, contractFindings...)
 		finishStage(len(statefulFindings)+len(contractFindings), nil)
 		finishStage = analysisstats.Measure(ctx, "byref_diagnostics")
-		byRefFindings := analysis.byRefArgumentFindings(file)
+		byRefDiagnostics := analysis.byRefArgumentDiagnosticsContext(ctx, file)
+		byRefFindings := analysis.byRefArgumentFindings(file, byRefDiagnostics.diagnostics)
 		findings = append(findings, byRefFindings...)
 		finishStage(len(byRefFindings), nil)
 		finishStage = analysisstats.Measure(ctx, "compile_equivalent_diagnostics")
-		compileFindings, filePreflightFindings := analysis.compileEquivalentFindingsContext(ctx, file)
+		compileFindings, filePreflightFindings := analysis.compileEquivalentFindingsContext(ctx, file, byRefDiagnostics)
 		finishStage(len(compileFindings)+len(filePreflightFindings), ctx.Err())
 		if err := ctx.Err(); err != nil {
 			return Result{}, err
@@ -646,9 +655,9 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	return result, nil
 }
 
-func (a Analyzer) byRefArgumentFindings(file parsedFile) []Finding {
-	if a.typeDB == nil {
-		return nil
+func (a Analyzer) byRefArgumentDiagnosticsContext(ctx context.Context, file parsedFile) batchByRefDiagnostics {
+	if a.typeDB == nil || ctx.Err() != nil {
+		return batchByRefDiagnostics{computed: true}
 	}
 	diagnostics := (intel.Analyzer{
 		RootDir:                    a.RootDir,
@@ -656,7 +665,11 @@ func (a Analyzer) byRefArgumentFindings(file parsedFile) []Finding {
 		DB:                         a.typeDB,
 		TypeDBResolutionIncomplete: a.typeDBResolutionIncomplete,
 		WorkspaceSymbolQueryFunc:   a.byRefWorkspaceSymbolQuery,
-	}).ByRefArgumentDiagnostics(file.intelDocument())
+	}).ByRefArgumentDiagnosticsContext(ctx, file.intelDocument())
+	return batchByRefDiagnostics{computed: true, diagnostics: diagnostics}
+}
+
+func (a Analyzer) byRefArgumentFindings(file parsedFile, diagnostics []intel.Diagnostic) []Finding {
 	if len(diagnostics) == 0 {
 		return nil
 	}
@@ -693,11 +706,11 @@ func (a Analyzer) byRefArgumentFindings(file parsedFile) []Finding {
 }
 
 func (a Analyzer) compileEquivalentFindings(file parsedFile) ([]Finding, []Finding) {
-	return a.compileEquivalentFindingsContext(context.Background(), file)
+	return a.compileEquivalentFindingsContext(context.Background(), file, batchByRefDiagnostics{})
 }
 
-func (a Analyzer) compileEquivalentFindingsContext(ctx context.Context, file parsedFile) ([]Finding, []Finding) {
-	diagnostics := (intel.Analyzer{
+func (a Analyzer) compileEquivalentFindingsContext(ctx context.Context, file parsedFile, byRefDiagnostics batchByRefDiagnostics) ([]Finding, []Finding) {
+	intelAnalyzer := intel.Analyzer{
 		RootDir:                    a.RootDir,
 		Config:                     a.Config,
 		DB:                         a.typeDB,
@@ -705,7 +718,13 @@ func (a Analyzer) compileEquivalentFindingsContext(ctx context.Context, file par
 		WorkspaceSymbolQueryFunc:   a.byRefWorkspaceSymbolQuery,
 		VisibleConstants:           a.visibleConstants,
 		ConstantValues:             a.visibleConstantValues,
-	}).CompileEquivalentDiagnosticsContext(ctx, file.intelDocument())
+	}
+	var diagnostics []intel.Diagnostic
+	if byRefDiagnostics.computed {
+		diagnostics = intelAnalyzer.CompileEquivalentDiagnosticsContextWithByRefDiagnostics(ctx, file.intelDocument(), byRefDiagnostics.diagnostics)
+	} else {
+		diagnostics = intelAnalyzer.CompileEquivalentDiagnosticsContext(ctx, file.intelDocument())
+	}
 	if len(diagnostics) == 0 {
 		return nil, nil
 	}

--- a/internal/analyze/profiling_test.go
+++ b/internal/analyze/profiling_test.go
@@ -66,6 +66,7 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 	for _, name := range []string{
 		"file_count", "procedure_count", "statement_count", "expression_count",
 		"call_site_count", "cfg_block_count", "cfg_edge_count", "project_symbol_count",
+		"byref_diagnostic_passes",
 	} {
 		if _, ok := counterByName[name]; !ok {
 			t.Fatalf("missing counter %q: %+v", name, counters)
@@ -73,6 +74,9 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 	}
 	if counterByName["file_count"] != 1 || counterByName["procedure_count"] != 1 {
 		t.Fatalf("workload counters = %+v", counters)
+	}
+	if counterByName["byref_diagnostic_passes"] != 1 {
+		t.Fatalf("ByRef analysis passes = %d, want one per file revision", counterByName["byref_diagnostic_passes"])
 	}
 }
 func TestBatchAnalysisSkipsVBA202ContextWhenDisabled(t *testing.T) {

--- a/internal/vba/intel/byref.go
+++ b/internal/vba/intel/byref.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	staticrules "github.com/harumiWeb/xlflow/internal/staticanalysis/rules"
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 )
 
 var (
@@ -25,6 +26,9 @@ func (a Analyzer) ByRefArgumentDiagnostics(doc Document) []Diagnostic {
 
 // ByRefArgumentDiagnosticsContext is the cancellable form used by realtime LSP analysis.
 func (a Analyzer) ByRefArgumentDiagnosticsContext(ctx context.Context, doc Document) []Diagnostic {
+	if recorder := analysisstats.FromContext(ctx); recorder != nil {
+		recorder.Add("byref_diagnostic_passes", 1)
+	}
 	// Resolve calls in the current module directly from its immutable snapshot.
 	// A newly opened document's workspace overlay is intentionally absent while
 	// background analysis is pending, but file-local diagnostics must still be

--- a/internal/vba/intel/byref_compile_equivalent_test.go
+++ b/internal/vba/intel/byref_compile_equivalent_test.go
@@ -1,0 +1,35 @@
+package intel
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCompileEquivalentDiagnosticsWithPrecomputedByRefDiagnostics(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+Public Sub NeedsLong(ByRef value As Long)
+End Sub
+Public Sub Run()
+    Dim text As String
+    NeedsLong text
+End Sub
+`,
+	}
+
+	ctx := context.Background()
+	want := analyzer.CompileEquivalentDiagnosticsContext(ctx, doc)
+	byRef := analyzer.ByRefArgumentDiagnosticsContext(ctx, doc)
+	got := analyzer.CompileEquivalentDiagnosticsContextWithByRefDiagnostics(ctx, doc, byRef)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("precomputed ByRef compile-equivalent diagnostics changed:\n got: %+v\nwant: %+v", got, want)
+	}
+	if diagnostics := diagnosticsByCode(got, "VBA228"); len(diagnostics) != 1 {
+		t.Fatalf("precomputed ByRef diagnostics = %+v, want one VBA228", diagnostics)
+	}
+}

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -240,30 +240,38 @@ func (a Analyzer) DiagnosticsContext(ctx context.Context, doc Document) []Diagno
 // project the same semantic findings that the LSP exposes, without importing
 // the full editor diagnostic pipeline a second time.
 func (a Analyzer) CompileEquivalentDiagnosticsContext(ctx context.Context, doc Document) []Diagnostic {
+	return a.compileEquivalentDiagnosticsContext(ctx, doc, nil, false)
+}
+
+// CompileEquivalentDiagnosticsContextWithByRefDiagnostics projects compile-
+// equivalent diagnostics using a ByRef result that was already computed for
+// the same document revision. Batch analysis uses this entry point so the
+// expensive project-local call resolution is shared with the normal ByRef
+// diagnostic projection.
+func (a Analyzer) CompileEquivalentDiagnosticsContextWithByRefDiagnostics(ctx context.Context, doc Document, byRefDiagnostics []Diagnostic) []Diagnostic {
+	return a.compileEquivalentDiagnosticsContext(ctx, doc, byRefDiagnostics, true)
+}
+
+func (a Analyzer) compileEquivalentDiagnosticsContext(ctx context.Context, doc Document, byRefDiagnostics []Diagnostic, byRefDiagnosticsReady bool) []Diagnostic {
 	if ctx.Err() != nil {
 		return nil
 	}
 	var out []Diagnostic
-	for _, diagnostic := range a.argumentDiagnosticsContext(ctx, doc) {
-		if isCompileEquivalentDiagnostic(diagnostic.Code) {
-			out = append(out, diagnostic)
+	appendCompileEquivalent := func(diagnostics []Diagnostic) {
+		for _, diagnostic := range diagnostics {
+			if isCompileEquivalentDiagnostic(diagnostic.Code) {
+				out = append(out, diagnostic)
+			}
 		}
 	}
-	for _, diagnostic := range a.ByRefArgumentDiagnosticsContext(ctx, doc) {
-		if isCompileEquivalentDiagnostic(diagnostic.Code) {
-			out = append(out, diagnostic)
-		}
+	appendCompileEquivalent(a.argumentDiagnosticsContext(ctx, doc))
+	if byRefDiagnosticsReady {
+		appendCompileEquivalent(byRefDiagnostics)
+	} else {
+		appendCompileEquivalent(a.ByRefArgumentDiagnosticsContext(ctx, doc))
 	}
-	for _, diagnostic := range a.assignmentDiagnosticsContext(ctx, doc) {
-		if isCompileEquivalentDiagnostic(diagnostic.Code) {
-			out = append(out, diagnostic)
-		}
-	}
-	for _, diagnostic := range a.LocalTypeNameDiagnosticsContext(ctx, doc) {
-		if isCompileEquivalentDiagnostic(diagnostic.Code) {
-			out = append(out, diagnostic)
-		}
-	}
+	appendCompileEquivalent(a.assignmentDiagnosticsContext(ctx, doc))
+	appendCompileEquivalent(a.LocalTypeNameDiagnosticsContext(ctx, doc))
 	// Control-flow legality is projected from the same procedure IR/CFG used
 	// by lint. Batch analyze/preflight does not run the full lint adapter, so
 	// build the shared artifacts here and retain the exact byte ranges.

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -87,6 +87,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `builtin_like`
 - `button_not_found`
 - `by_kind`
+- `byref_diagnostic_passes`
 - `byref_diagnostics`
 - `byref_modifier`
 - `byref_parameter_count`


### PR DESCRIPTION
## Summary

- Compute ByRef diagnostics once per file revision during batch analysis.
- Reuse the precomputed typed diagnostics for the compile-equivalent projection.
- Preserve the existing `VBA206` and `VBA228` diagnostic contracts and add regression/profiling coverage.
- Part of #646; closes #650.

## Performance

Benchmark: `BenchmarkSyntheticProject/1000-procedures`, `-benchtime=1x -count 3`, Windows i7-12700. Medians from `origin/main` (`57aa4f6b`) to this branch (`104a9f1a`):

- `compile_equivalent_diagnostics`: 197.1 ms -> 153.1 ms (22.4% reduction)
- `analyze_total`: 9.143 s -> 9.033 s (1.2% reduction)
- ByRef passes: 21 passes for 21 files (one pass per file revision)

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/analyze ./internal/vba/intel -count=1`
- `rtk task lint`
- Baseline and post-change benchmark commands listed above

The earlier full `./...` run encountered two timing-sensitive tests under parallel load; both passed when rerun individually. The changed packages and repository lint pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch ByRef analysis efficiency by avoiding repeated diagnostic processing for each file revision.
  * Preserved existing diagnostic output and `VBA206`/`VBA228` behavior.
* **Documentation**
  * Added an Unreleased changelog entry describing the analysis improvements.
  * Updated the error-code inventory with the `byref_diagnostic_passes` metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->