### PR TITLE
fix(analyze): avoid false-positive VB029 receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.30.2
+
 - Fixed LSP `VB029` false positives for declared UDT member receivers and VBA
   built-in functions used in member chains such as `GetObject(...).ExecQuery(...)`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed LSP `VB029` false positives for declared UDT member receivers and VBA
+  built-in functions used in member chains such as `GetObject(...).ExecQuery(...)`.
+
 - Added bounded parallel execution for independent per-file batch analysis
   stages. Findings remain deterministic, cancellation is preserved, and large
   synthetic projects show substantial wall-clock reductions.

--- a/internal/cli/coordination_test.go
+++ b/internal/cli/coordination_test.go
@@ -225,8 +225,12 @@ func TestWorkbookCoordinationWaitsThenRunsHandlerOnce(t *testing.T) {
 	}
 	rootDir, manager, identity, owner := setupHeldCoordinationLock(t, "run")
 	var stdout, stderr bytes.Buffer
-	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: time.Second, stdout: &stdout, stderr: &stderr, coordination: manager}
-	time.AfterFunc(150*time.Millisecond, func() { _ = owner.Release() })
+	// Leave ample room for timer delivery and metadata publication on loaded
+	// Windows CI runners while still proving the waiter acquires after release.
+	const releaseDelay = 500 * time.Millisecond
+	const waitBudget = 3 * time.Second
+	a := &app{cwd: rootDir, json: true, wait: true, waitTimeout: waitBudget, stdout: &stdout, stderr: &stderr, coordination: manager}
+	time.AfterFunc(releaseDelay, func() { _ = owner.Release() })
 	runs := 0
 	err := a.withWorkbookCoordination(context.Background(), "push", []string{identity.CanonicalPath}, func() error {
 		runs++

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -2323,16 +2323,17 @@ func (a Analyzer) unresolvedMemberReceiverDiagnosticsContext(ctx context.Context
 			return nil
 		}
 		code := stripLineComment(line)
+		offset := byteOffsetForDocumentPosition(doc, Position{Line: lineNo, Character: utf16Len(line)})
 		for _, call := range callsOnLine(code) {
 			receiver, _, ok := splitCallTarget(call.Target)
 			if !ok || strings.TrimSpace(receiver) == "" || strings.HasPrefix(strings.TrimSpace(receiver), ".") {
 				continue
 			}
-			if _, ok := a.resolveDocumentExpressionTypeAt(doc, receiver, byteOffsetForDocumentPosition(doc, Position{Line: lineNo, Character: utf16Len(line)})); ok {
+			if _, ok := a.resolveDocumentExpressionTypeAt(doc, receiver, offset); ok {
 				continue
 			}
 			base := memberReceiverBase(receiver)
-			if base == "" || strings.EqualFold(base, "Me") || a.knownModuleOrNamespaceReceiver(doc, base) {
+			if base == "" || strings.EqualFold(base, "Me") || a.knownMemberReceiverBase(doc, base, offset) {
 				continue
 			}
 			key := fmt.Sprintf("%d:%s", lineNo, strings.ToLower(base))
@@ -2344,6 +2345,23 @@ func (a Analyzer) unresolvedMemberReceiverDiagnosticsContext(ctx context.Context
 		}
 	}
 	return out
+}
+
+// knownMemberReceiverBase separates an unresolved member chain from an
+// actually undeclared receiver. VB029 only has enough evidence to report the
+// latter: a declared UDT/Object variable may have members that this analyzer
+// cannot resolve, and a VBA.Global function may return a late-bound object.
+func (a Analyzer) knownMemberReceiverBase(doc Document, base string, offset int) bool {
+	if a.knownModuleOrNamespaceReceiver(doc, base) {
+		return true
+	}
+	if a.DB != nil {
+		if _, ok := a.DB.ResolveMember("VBA.Global", base); ok {
+			return true
+		}
+	}
+	_, ok := a.visibleSymbolTypeInfoAtContext(doc, base, offset, nil)
+	return ok
 }
 
 func (a Analyzer) unknownMemberDiagnosticsContext(ctx context.Context, doc Document) []Diagnostic {

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -2180,6 +2180,54 @@ End Sub
 	}
 }
 
+func TestDiagnosticsDoNotReportDeclaredUDTMemberReceiver(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path:       filepath.Join(t.TempDir(), "CDPContext.cls"),
+		ModuleKind: "class",
+		Source: `Option Explicit
+
+Private Type cacheResultCDP
+    response As Object
+    Limit As Long
+End Type
+
+Private ResultCDP_Tab As cacheResultCDP
+
+Private Sub AddResult(ByVal id As Long, ByVal RawJson As String)
+    If ResultCDP_Tab.response.Count + 1 > ResultCDP_Tab.Limit Then
+        ResultCDP_Tab.response.RemoveAll
+    End If
+    ResultCDP_Tab.response.Add id, RawJson
+End Sub
+`,
+	}
+
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VB029"); len(diagnostics) != 0 {
+		t.Fatalf("declared UDT member receiver should not produce VB029: %+v", diagnostics)
+	}
+}
+
+func TestDiagnosticsTreatBuiltinFunctionAsKnownMemberReceiver(t *testing.T) {
+	analyzer := newTestAnalyzer(t)
+	doc := Document{
+		Path: filepath.Join(t.TempDir(), "Main.bas"),
+		Source: `Option Explicit
+
+Private Sub FindProcess()
+    Dim proc As Object
+    For Each proc In GetObject("winmgmts:").ExecQuery("Select * from Win32_Process")
+        Debug.Print proc.Name
+    Next proc
+End Sub
+`,
+	}
+
+	if diagnostics := diagnosticsByCode(analyzer.Diagnostics(doc), "VB029"); len(diagnostics) != 0 {
+		t.Fatalf("VBA.GetObject member chain should not produce VB029: %+v", diagnostics)
+	}
+}
+
 func TestDiagnosticsResolveMeInWorkbookDocumentModules(t *testing.T) {
 	root := t.TempDir()
 	analyzer := newTestAnalyzer(t)


### PR DESCRIPTION
## Summary

- Fix LSP `VB029` false positives when a declared UDT or object receiver has a member that the analyzer cannot resolve.
- Treat `VBA.Global` built-in functions such as `GetObject` as known receivers in member chains.
- Add regression coverage for `ResultCDP_Tab.response.Add` and `GetObject(...).ExecQuery(...)`.
- Closes #659.

## Tests

- `rtk proxy powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/... -count=1`
- `rtk proxy powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/lint -count=1`
- `rtk pnpm format:check`
- `rtk git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false VB029 undeclared-identifier diagnostics for member receivers declared through user-defined types.
  * Fixed diagnostics for VBA built-in functions used in member chains, including `GetObject(...).ExecQuery(...)`.
  * Updated the Unreleased changelog with these corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->