### PR TITLE
perf(cfg): make canonical IsReachable queries zero-allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Reduced repeated canonical CFG `IsReachable` query cost by reading cached
+  reachability membership directly instead of cloning the full reachable set;
+  default and `NormalOnly` semantics are unchanged.
+
 ## v0.30.2
 
 - Fixed LSP `VB029` false positives for declared UDT member receivers and VBA

--- a/docs/specs/vba-control-flow-graph.md
+++ b/docs/specs/vba-control-flow-graph.md
@@ -173,6 +173,10 @@ established before that path diverges.
 Built graphs retain immutable per-revision query indexes. Statement-to-block
 lookups and incoming/outgoing edge traversal use these indexes, and the default
 and `NormalOnly` reachability sets are computed once when the graph is built.
+`IsReachable` reads membership directly from the matching cached set for these
+canonical views without materializing a defensive copy. APIs that materialize
+reachability data continue to receive independently owned copies, and a future
+filter view without a cached set must use the general reachability path.
 Graph value copies may share the index because it is read-only. `Clone`, graph
 rebasing, and edge-changing transformations rebuild the index with their
 independent graph storage. A Graph literal without an index builds a temporary

--- a/internal/vba/cfg/cfg_test.go
+++ b/internal/vba/cfg/cfg_test.go
@@ -166,20 +166,90 @@ func TestQueryIndexInvalidatesReachabilityInputs(t *testing.T) {
 	if got, want := graph.Reachable(EdgeFilter{}), []BlockID{1, 2}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("initial Reachable() = %v, want %v", got, want)
 	}
+	if !graph.IsReachable(2, EdgeFilter{}) || graph.IsReachable(4, EdgeFilter{}) {
+		t.Fatal("initial IsReachable() did not use the initial index")
+	}
 
 	graph.Entry = 4
 	if got, want := graph.Reachable(EdgeFilter{}), []BlockID{4}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Reachable() after Entry change = %v, want %v", got, want)
+	}
+	if !graph.IsReachable(4, EdgeFilter{}) || graph.IsReachable(2, EdgeFilter{}) {
+		t.Fatal("IsReachable() used stale Entry reachability")
 	}
 
 	graph.UnknownFlowSources = []BlockID{4}
 	if got, want := graph.Reachable(EdgeFilter{}), []BlockID{2, 3, 4}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Reachable() after UnknownFlowSources change = %v, want %v", got, want)
 	}
+	if !graph.IsReachable(3, EdgeFilter{}) {
+		t.Fatal("IsReachable() used stale UnknownFlowSources reachability")
+	}
 
 	graph.UnknownExit = 5
 	if got, want := graph.Reachable(EdgeFilter{}), []BlockID{2, 4, 5}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Reachable() after UnknownExit change = %v, want %v", got, want)
+	}
+	if !graph.IsReachable(5, EdgeFilter{}) || graph.IsReachable(3, EdgeFilter{}) {
+		t.Fatal("IsReachable() used stale UnknownExit reachability")
+	}
+}
+
+func TestIsReachableUsesCanonicalFilterViews(t *testing.T) {
+	t.Parallel()
+	graph := Graph{
+		Blocks: []Block{
+			{ID: 1, Kind: BlockEntry},
+			{ID: 2, Kind: BlockStatement},
+			{ID: 3, Kind: BlockExceptionalExit},
+		},
+		Edges: []Edge{
+			{ID: 1, From: 1, To: 2, Class: EdgeNormal},
+			{ID: 2, From: 1, To: 3, Class: EdgeExceptional},
+		},
+		Entry: 1,
+	}
+	graph.query = buildQueryIndex(graph)
+
+	if !graph.IsReachable(2, EdgeFilter{}) {
+		t.Fatal("default reachability lost normal flow")
+	}
+	if !graph.IsReachable(3, EdgeFilter{}) {
+		t.Fatal("default reachability lost exceptional flow")
+	}
+	if graph.IsReachable(3, EdgeFilter{NormalOnly: true}) {
+		t.Fatal("NormalOnly reachability included exceptional flow")
+	}
+	if graph.IsReachable(99, EdgeFilter{}) {
+		t.Fatal("unknown block was reported reachable")
+	}
+}
+
+func TestIsReachableCanonicalQueriesDoNotAllocate(t *testing.T) {
+	graph := benchmarkQueryGraph(1000)
+	tests := []struct {
+		name   string
+		target BlockID
+		filter EdgeFilter
+		want   bool
+	}{
+		{name: "default/true", target: 1000, filter: EdgeFilter{}, want: true},
+		{name: "normal-only/false", target: 3, filter: EdgeFilter{NormalOnly: true}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			var got bool
+			allocations := testing.AllocsPerRun(1000, func() {
+				got = graph.IsReachable(test.target, test.filter)
+			})
+			if allocations != 0 {
+				t.Fatalf("IsReachable(%d, %+v) allocated %.2f times, want zero", test.target, test.filter, allocations)
+			}
+			if got != test.want {
+				t.Fatalf("IsReachable(%d, %+v) = %v, want %v", test.target, test.filter, got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/vba/cfg/query.go
+++ b/internal/vba/cfg/query.go
@@ -79,6 +79,10 @@ func (g Graph) Reachable(filter EdgeFilter) []BlockID {
 
 // IsReachable reports whether target is reachable from Entry.
 func (g Graph) IsReachable(target BlockID, filter EdgeFilter) bool {
+	index := g.queryIndexes()
+	if reachable, ok := index.cachedReachable(filter); ok {
+		return reachable[target]
+	}
 	return g.reachableWithout(filter, nil)[target]
 }
 
@@ -353,10 +357,9 @@ func (g Graph) CleanupGuaranteed(cleanupStatementIDs []int, selection ExitSelect
 func (g Graph) reachableWithout(filter EdgeFilter, removed map[BlockID]bool) map[BlockID]bool {
 	index := g.queryIndexes()
 	if removed == nil {
-		if filter.NormalOnly {
-			return cloneBlockSet(index.reachableNormal)
+		if reachable, ok := index.cachedReachable(filter); ok {
+			return cloneBlockSet(reachable)
 		}
-		return cloneBlockSet(index.reachableAll)
 	}
 	seen := physicalReachableWithIndex(g, index, filter, removed)
 	if g.unknownFlowReached(seen) {

--- a/internal/vba/cfg/query_benchmark_test.go
+++ b/internal/vba/cfg/query_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	benchmarkBlockSink       Block
+	benchmarkIsReachableSink bool
 	benchmarkReachableSink   []BlockID
 	benchmarkPredecessorSink []BlockID
 )
@@ -32,6 +33,37 @@ func BenchmarkCFGQuery(b *testing.B) {
 				benchmarkPredecessorSink = legacyPredecessors(graph, BlockID(size+5), EdgeFilter{}, benchmarkSet(benchmarkReachableSink))
 			}
 		})
+	}
+}
+
+func BenchmarkCFGIsReachable(b *testing.B) {
+	for _, size := range []int{100, 1000, 5000} {
+		graph := benchmarkQueryGraph(size)
+		for _, test := range []struct {
+			name   string
+			filter EdgeFilter
+		}{
+			{name: "default", filter: EdgeFilter{}},
+			{name: "normal-only", filter: EdgeFilter{NormalOnly: true}},
+		} {
+			test := test
+			b.Run("indexed/"+test.name+"/"+benchmarkSizeName(size), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					target := BlockID(i%size + 6)
+					benchmarkIsReachableSink = graph.IsReachable(target, test.filter)
+				}
+			})
+			b.Run("defensive-copy/"+test.name+"/"+benchmarkSizeName(size), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					target := BlockID(i%size + 6)
+					benchmarkIsReachableSink = legacyIsReachable(graph, target, test.filter)
+				}
+			})
+		}
 	}
 }
 
@@ -70,7 +102,10 @@ func benchmarkQueryGraph(size int) Graph {
 	for i := 0; i < size; i++ {
 		blocks = append(blocks, Block{ID: BlockID(i + 6), Kind: BlockStatement, StatementID: i + 1})
 	}
-	edges := []Edge{{From: 1, To: 6, Class: EdgeNormal}}
+	edges := []Edge{
+		{From: 1, To: 6, Class: EdgeNormal},
+		{From: 6, To: 3, Class: EdgeExceptional},
+	}
 	for i := 0; i < size; i++ {
 		from := BlockID(i + 6)
 		if i+1 < size {
@@ -84,6 +119,10 @@ func benchmarkQueryGraph(size int) Graph {
 	graph := Graph{Blocks: blocks, Edges: edges, Entry: 1, NormalExit: 2, ExceptionalExit: 3, TerminationExit: 4, UnknownExit: 5}
 	graph.query = buildQueryIndex(graph)
 	return graph
+}
+
+func legacyIsReachable(g Graph, target BlockID, filter EdgeFilter) bool {
+	return g.reachableWithout(filter, nil)[target]
 }
 
 func benchmarkSet(ids []BlockID) map[BlockID]bool {

--- a/internal/vba/cfg/query_index.go
+++ b/internal/vba/cfg/query_index.go
@@ -62,6 +62,20 @@ func (g Graph) queryIndexes() *queryIndex {
 	return buildQueryIndex(g)
 }
 
+// cachedReachable returns the immutable reachability set for a canonical
+// filter view. Keep the filter cases explicit so a future filter variant does
+// not accidentally reuse the conservative default set.
+func (index *queryIndex) cachedReachable(filter EdgeFilter) (map[BlockID]bool, bool) {
+	switch filter {
+	case EdgeFilter{}:
+		return index.reachableAll, true
+	case EdgeFilter{NormalOnly: true}:
+		return index.reachableNormal, true
+	default:
+		return nil, false
+	}
+}
+
 func (index *queryIndex) matches(g Graph) bool {
 	if index.blocksLen != len(g.Blocks) || index.edgesLen != len(g.Edges) {
 		return false


### PR DESCRIPTION
## Summary

- Make canonical `Graph.IsReachable` queries read cached reachability membership directly instead of cloning the full reachable set.
- Preserve conservative default and `NormalOnly` semantics, defensive-copy behavior for materialized reachability APIs, and a general fallback for unsupported filter views.
- Add index-invalidation and zero-allocation regressions plus repeated-query benchmarks for 100, 1,000, and 5,000 block graphs.

Closes #668

## Benchmark

- Indexed default and `NormalOnly` queries report `0 B/op` and `0 allocs/op` at all tested graph sizes.
- At 5,000 blocks, indexed queries run at about 24 ns/op, while the defensive-copy baseline uses about 148 KB/op and 18 allocs/op.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/cfg -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/cfg -run '^$' -bench 'BenchmarkCFGIsReachable$' -benchmem -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./... -count=1`
- `rtk task lint`
- `rtk pnpm format:check`
- `rtk git diff --check`
