### PR TITLE
perf(analyze): add large single-module profiling and monster-module benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added canonical large-single-module analyzer performance telemetry for
+  `xlflow analyze --performance-log`, including aggregate workload counters and
+  maximum file/procedure dimensions. Profiling remains opt-in and stderr-only;
+  analyzer findings, exit codes, and `--json` output remain compatible. Added
+  developer-only synthetic and ROneCOne benchmark guidance.
+
 - Fixed false positives in the shared `VBA227`/`VBA249` array-use scan when a
   qualified member call such as `Application.OnTime(...)` or
   `driver_.TableToArray(...)` shares its name with a local scalar or

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -186,12 +186,28 @@ tasks:
       - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only$' -benchmem -benchtime=1x -count 2
         platforms: [linux, darwin]
 
+  bench:corpus-ronecone:
+    desc: Benchmark the single-project ROneCOne analyzer stress fixture
+    cmds:
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count 2
+        platforms: [windows]
+      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count 2
+        platforms: [linux, darwin]
+
   bench:analyze:
     desc: Benchmark synthetic batch analysis scaling and object worklist metrics
     cmds:
       - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/analyze -run '^TestSyntheticBenchmarkFixtureScale$' -bench '^Benchmark(SyntheticProject|ObjectAnalysisWorklist)$' -benchmem -benchtime=1x -count 1
         platforms: [windows]
       - cmd: rtk go test ./internal/analyze -run '^TestSyntheticBenchmarkFixtureScale$' -bench '^Benchmark(SyntheticProject|ObjectAnalysisWorklist)$' -benchmem -benchtime=1x -count 1
+        platforms: [linux, darwin]
+
+  bench:analyze-single-module:
+    desc: Benchmark deterministic large single-module analyzer workloads
+    cmds:
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/analyze -run '^TestSingleModuleBenchmarkFixtureScale$' -bench '^BenchmarkSingleModuleSynthetic$' -benchmem -benchtime=1x -count 1
+        platforms: [windows]
+      - cmd: rtk go test ./internal/analyze -run '^TestSingleModuleBenchmarkFixtureScale$' -bench '^BenchmarkSingleModuleSynthetic$' -benchmem -benchtime=1x -count 1
         platforms: [linux, darwin]
 
   verify:security:

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -284,6 +284,8 @@ The performance output also reports workload counters in stable order. Aggregate
 workload counters are `file_count`, `procedure_count`, `statement_count`,
 `expression_count`, `call_site_count`, `cfg_block_count`, `cfg_edge_count`, and
 `project_symbol_count`, `line_count`, and `module_declaration_count`.
+`line_count` uses physical source lines and does not count a terminal newline as
+an additional empty line.
 Analyzer worklist counters such as `object_summary_evaluations`,
 `object_entry_flow_evaluations`, and `byref_diagnostic_passes` may also be
 reported when those subsystems run.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -274,19 +274,28 @@ data to the `--json` stdout envelope. A record uses the fixed operation name
 count, result count, and outcome (`ok`, `error`, or `canceled`). The measured
 stages are `source_discovery`, `file_read`, `parse`, `procedure_ir`, `cfg`,
 `effect_summaries`, `object_procedure_summaries`, `object_entry_states`,
-`project_context`, `project_symbols`, `typedb_load`,
-`project_wide_diagnostics`, `file_procedure_diagnostics`, `byref_diagnostics`,
-`compile_equivalent_diagnostics`, and `suppression_finalization`; the complete
-operation is reported as `analyze_total`.
+`project_context`, `project_context_indexes`, `project_symbols`, `typedb_load`,
+`project_wide_diagnostics`, `procedure_local_diagnostics`, `byref_diagnostics`,
+`typed_excel_diagnostics`, `compile_equivalent_diagnostics`, and
+`suppression_and_finalize`; the complete operation is reported as
+`analyze_total`. These are the canonical CLI labels.
 
-The performance output also reports workload counters in stable order:
-`file_count`, `procedure_count`, `statement_count`, `expression_count`,
-`call_site_count`, `cfg_block_count`, `cfg_edge_count`, and
-`project_symbol_count`. Counters describe the analyzed workload and are not
-diagnostics. When the flag is absent, analysis does not start a timer or emit
-performance records. The flag is valid only on `analyze`; `check` does not
-forward or expose analyzer profiling. Findings, warning order, preflight
-results, exit codes, and JSON output are identical with and without the flag.
+The performance output also reports workload counters in stable order. Aggregate
+workload counters are `file_count`, `procedure_count`, `statement_count`,
+`expression_count`, `call_site_count`, `cfg_block_count`, `cfg_edge_count`, and
+`project_symbol_count`, `line_count`, and `module_declaration_count`.
+Analyzer worklist counters such as `object_summary_evaluations`,
+`object_entry_flow_evaluations`, and `byref_diagnostic_passes` may also be
+reported when those subsystems run.
+Large-single-module dimensions are reported by the maximum counters
+`max_lines_per_file`, `max_procedures_per_file`,
+`max_calls_per_file`, `max_statements_per_procedure`,
+`max_cfg_blocks_per_procedure`, and `max_cfg_edges_per_procedure`. Counters
+describe the analyzed workload and are not diagnostics. When the flag is
+absent, analysis does not start a timer or emit performance records. The flag
+is valid only on `analyze`; `check` does not forward or expose analyzer
+profiling. Findings, warning order, preflight results, exit codes, and JSON
+output are identical with and without the flag.
 
 For `VBA222`, an unresolved external type is reported only when the project and
 TypeLib resolution view is complete. Missing, empty, malformed, or partial

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -778,46 +778,61 @@ Do not parallelize VBE cases or infer a hang from the broad `go test ./...`
 duration; Excel/COM tests have a materially different runtime profile from
 the Excel-free corpus checks.
 
-### Batch analyzer stage profiling and scaling benchmarks
+### Batch analyzer stage profiling and large single-module benchmarks
 
-Issue #647 adds a separate batch-analyzer profiling path. The opt-in
-`xlflow analyze --performance-log` flag emits stage timings, result counts, and
-workload counters to stderr while leaving analyzer findings and JSON stdout
-unchanged. The records are intended for same-machine comparisons and are not
-CI timing thresholds. The stage names and counter names are stable so a profile
-can be compared across analyzer changes; use the `outcome` field to distinguish
+Issue #671 adds a separate profiling path for unusually large VBA modules. The
+opt-in `xlflow analyze --performance-log` flag emits canonical stage timings,
+result counts, outcomes, and workload counters to stderr while leaving analyzer
+findings and JSON stdout unchanged. The records are intended for same-machine
+comparisons and are not CI timing thresholds. Use `outcome` to distinguish
 successful, failed, and canceled stages.
 
-Run the deterministic synthetic scaling benchmark and the real-world corpus
-hotspot benchmark with the repository tasks:
+The aggregate counters describe total project work, including files,
+procedures, statements, expressions, call sites, CFG blocks/edges, and project
+symbols, lines, and module declarations. Subsystem worklist counters may also
+be present when object or ByRef analysis runs. The maximum counters describe
+the largest single-file or single-procedure dimensions: `max_lines_per_file`,
+`max_procedures_per_file`, `max_calls_per_file`,
+`max_statements_per_procedure`, `max_cfg_blocks_per_procedure`, and
+`max_cfg_edges_per_procedure`. These counters are workload measurements, not
+diagnostics. The canonical stage labels include `parse`, `procedure_ir`, `cfg`,
+`effect_summaries`, `project_context`, `project_wide_diagnostics`,
+`procedure_local_diagnostics`, and `suppression_and_finalize`.
+
+Run the deterministic synthetic benchmark and the real-world corpus hotspot
+benchmark with the repository tasks:
 
 ```powershell
 rtk task bench:analyze
+rtk task bench:analyze-single-module
 rtk task bench:corpus
 ```
 
-`bench:analyze` generates its 100-, 500-, and 1,000-procedure projects outside
-the timed region. The generated projects use multiple modules, project-local
-calls, ByRef-heavy calls, object state flow, and branching CFGs so stage
-scaling can be compared against a known workload. It also runs the
-`BenchmarkObjectAnalysisWorklist` reverse-ordered object-return chain, whose
-`counter_object_summary_evaluations` and `counter_object_entry_flow_evaluations`
-metrics expose propagation work separately from parsing and diagnostics.
-`bench:corpus` runs the
-existing `BenchmarkRealWorldCorpus` `std-vba` and `ronecone` analyze-only
-sub-benchmarks. Both tasks use `-benchmem -benchtime=1x`; on Windows they run
-through `scripts/dev/go.ps1` to keep CGO and tree-sitter toolchain selection
-consistent. The benchmark output should retain `ns/op`, allocations, findings,
-and the `stage_*` / `counter_*` benchmark metrics derived from the attached
-analysis recorder; these are Go benchmark metrics, not stderr records from
+`bench:analyze` retains the existing multi-module and object-worklist baselines.
+`bench:analyze-single-module` keeps fixture generation outside the timed region
+and covers single-module scales around 500, 1,000, and 2,000 procedures,
+including large call graphs, declaration sets, and CFGs. `bench:corpus` runs the checked-in
+`std-vba` and `ronecone` analyze-only sub-benchmarks. These tasks use
+`-benchmem -benchtime=1x`; on Windows they run through `scripts/dev/go.ps1` to
+keep CGO and tree-sitter toolchain selection consistent. Benchmark output should
+retain wall time (`ns/op`), allocations, findings, workload dimensions, and the
+`stage_*` / `counter_*` metrics derived from the attached analysis recorder;
+these are Go benchmark metrics, not stderr records from
 `analyze --performance-log`.
 
-Do not use absolute elapsed-time assertions to fail CI. For a useful before /
-after comparison, keep the Go version, machine, power state, benchmark filter,
-and sample count constant, and report any unusually slow run with its complete
-command and environment. Benchmark generation is test-only infrastructure and
-must not run from ordinary `analyze`, `check`, corpus snapshot, or Excel/VBE
-oracle workflows.
+ROneCOne profiling is developer-only and must be selected explicitly as a leaf
+benchmark; it is Excel/COM-free and is not part of ordinary `go test ./...`:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count 2
+```
+
+On Linux or macOS, use the same command with `rtk go test` instead of the
+Windows wrapper. Keep the Go version, machine, power state, benchmark filter,
+and sample count constant for before/after comparisons, and report unusually
+slow runs with the complete command and environment. Benchmark generation is
+test-only infrastructure and must not run from ordinary `analyze`, `check`,
+corpus snapshot, or Excel/VBE oracle workflows.
 
 ## Verification requirements
 

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -526,8 +526,8 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	} else {
 		finishStage(0, nil)
 		if recorder := analysisstats.FromContext(ctx); recorder != nil {
-			recorder.Add("object_summary_evaluations", 0)
-			recorder.Add("object_entry_flow_evaluations", 0)
+			recorder.AddSum("object_summary_evaluations", 0)
+			recorder.AddSum("object_entry_flow_evaluations", 0)
 		}
 	}
 	finishStage = analysisstats.Measure(ctx, "object_entry_states")
@@ -535,8 +535,8 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		objectAnalysis.buildEntryStates()
 		finishStage(len(objectAnalysis.entries), nil)
 		if recorder := analysisstats.FromContext(ctx); recorder != nil {
-			recorder.Add("object_summary_evaluations", uint64(objectAnalysis.summaryEvaluations))
-			recorder.Add("object_entry_flow_evaluations", uint64(objectAnalysis.entryFlowEvaluations))
+			recorder.AddSum("object_summary_evaluations", uint64(objectAnalysis.summaryEvaluations))
+			recorder.AddSum("object_entry_flow_evaluations", uint64(objectAnalysis.entryFlowEvaluations))
 		}
 	} else {
 		finishStage(0, nil)
@@ -561,7 +561,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 			})
 		}
 	}
-	finishStage = analysisstats.Measure(ctx, "project_context")
+	finishStage = analysisstats.Measure(ctx, "project_context_indexes")
 	analysis.visibleConstants = projectVisibleConstants(parsedFiles, analysis.typeDB)
 	analysis.visibleConstantValues = projectConstantValues(parsedFiles, analysis.typeDB)
 	if dictionaryCollectionAnalysisEnabled(analysis.Config.Analyze) {
@@ -598,7 +598,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		}
 		analysis.byRefSymbolIndex = byRefSymbolIndex
 		if recorder := analysisstats.FromContext(ctx); recorder != nil {
-			recorder.Add("project_symbol_count", uint64(symbolCount))
+			recorder.AddSum("project_symbol_count", uint64(symbolCount))
 		}
 	}
 	findings := cycleFindings
@@ -644,7 +644,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		findings = append(findings, fileResult.findings...)
 		preflightFindings = append(preflightFindings, fileResult.preflight...)
 	}
-	finishStage = analysisstats.Measure(ctx, "suppression_finalization")
+	finishStage = analysisstats.Measure(ctx, "suppression_and_finalize")
 	sortFindings(findings)
 	directives, directiveWarnings, err := suppression.DirectivesForFiles(a.RootDir, files)
 	if err != nil {
@@ -735,7 +735,7 @@ sendJobs:
 }
 
 func (a Analyzer) analyzeParsedFileBounded(ctx context.Context, file parsedFile, analysisCtx analysisContext, projectEffects effects.ProjectSummary, publicAPITypeIndex *apiTypeIndex) ([]Finding, []Finding, error) {
-	finishStage := analysisstats.Measure(ctx, "file_procedure_diagnostics")
+	finishStage := analysisstats.Measure(ctx, "procedure_local_diagnostics")
 	var findings []Finding
 	readErr := file.Parsed.Read(func(view vbaast.ParsedView) error {
 		if err := ctx.Err(); err != nil {
@@ -761,7 +761,7 @@ func (a Analyzer) analyzeParsedFileBounded(ctx context.Context, file parsedFile,
 	// The typed VBA215/VBA218 analysis uses the same snapshot-owned parsed
 	// document. Run it after the tree callback releases its exclusive read
 	// lease so the snapshot can reuse that parse without re-entering it.
-	finishStage = analysisstats.Measure(ctx, "file_procedure_diagnostics")
+	finishStage = analysisstats.Measure(ctx, "typed_excel_diagnostics")
 	statefulFindings, err := a.statefulExcelCallArgumentFindingsContext(ctx, file)
 	if err != nil {
 		finishStage(0, err)
@@ -1841,17 +1841,38 @@ func recordBatchWorkload(ctx context.Context, files []parsedFile) {
 	if recorder == nil {
 		return
 	}
-	recorder.Add("file_count", uint64(len(files)))
+	recorder.AddSum("file_count", uint64(len(files)))
+	// Seed maximum dimensions so an empty project still reports a complete
+	// workload shape with zero values.
+	for _, name := range []string{
+		"max_lines_per_file", "max_procedures_per_file", "max_calls_per_file",
+		"max_statements_per_procedure", "max_cfg_blocks_per_procedure",
+		"max_cfg_edges_per_procedure",
+	} {
+		recorder.AddMax(name, 0)
+	}
 	for _, file := range files {
-		recorder.Add("procedure_count", uint64(len(file.IR.Procedures)))
+		recorder.AddSum("line_count", uint64(len(file.Lines)))
+		recorder.AddSum("module_declaration_count", uint64(len(file.IR.Declarations)))
+		procedureCount := len(file.IR.Procedures)
+		recorder.AddSum("procedure_count", uint64(procedureCount))
+		recorder.AddMax("max_lines_per_file", uint64(len(file.Lines)))
+		recorder.AddMax("max_procedures_per_file", uint64(procedureCount))
+		callsPerFile := 0
 		for _, procedure := range file.IR.Procedures {
-			recorder.Add("statement_count", uint64(len(procedure.Statements)))
-			recorder.Add("expression_count", uint64(len(procedure.Expressions)))
-			recorder.Add("call_site_count", uint64(len(procedure.Calls)))
+			statementCount := len(procedure.Statements)
+			recorder.AddSum("statement_count", uint64(statementCount))
+			recorder.AddSum("expression_count", uint64(len(procedure.Expressions)))
+			callsPerFile += len(procedure.Calls)
+			recorder.AddSum("call_site_count", uint64(len(procedure.Calls)))
+			recorder.AddMax("max_statements_per_procedure", uint64(statementCount))
 		}
+		recorder.AddMax("max_calls_per_file", uint64(callsPerFile))
 		for _, graph := range file.CFG.Graphs {
-			recorder.Add("cfg_block_count", uint64(len(graph.Blocks)))
-			recorder.Add("cfg_edge_count", uint64(len(graph.Edges)))
+			recorder.AddMax("max_cfg_blocks_per_procedure", uint64(len(graph.Blocks)))
+			recorder.AddMax("max_cfg_edges_per_procedure", uint64(len(graph.Edges)))
+			recorder.AddSum("cfg_block_count", uint64(len(graph.Blocks)))
+			recorder.AddSum("cfg_edge_count", uint64(len(graph.Edges)))
 		}
 	}
 }

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -1852,11 +1852,12 @@ func recordBatchWorkload(ctx context.Context, files []parsedFile) {
 		recorder.AddMax(name, 0)
 	}
 	for _, file := range files {
-		recorder.AddSum("line_count", uint64(len(file.Lines)))
+		lineCount := physicalSourceLineCount(file.Lines)
+		recorder.AddSum("line_count", uint64(lineCount))
 		recorder.AddSum("module_declaration_count", uint64(len(file.IR.Declarations)))
 		procedureCount := len(file.IR.Procedures)
 		recorder.AddSum("procedure_count", uint64(procedureCount))
-		recorder.AddMax("max_lines_per_file", uint64(len(file.Lines)))
+		recorder.AddMax("max_lines_per_file", uint64(lineCount))
 		recorder.AddMax("max_procedures_per_file", uint64(procedureCount))
 		callsPerFile := 0
 		for _, procedure := range file.IR.Procedures {
@@ -3863,6 +3864,14 @@ func normalizedSourceLines(source string) []string {
 	source = strings.ReplaceAll(source, "\r\n", "\n")
 	source = strings.ReplaceAll(source, "\r", "\n")
 	return strings.Split(source, "\n")
+}
+
+func physicalSourceLineCount(lines []string) int {
+	count := len(lines)
+	if count > 0 && lines[count-1] == "" {
+		count--
+	}
+	return count
 }
 
 // worksheetLogicalStatement joins only explicit continuation lines for the

--- a/internal/analyze/benchmark_test.go
+++ b/internal/analyze/benchmark_test.go
@@ -413,7 +413,7 @@ func inspectSingleModuleBenchmarkFixture(tb testing.TB, root, path, source strin
 	if err != nil {
 		tb.Fatalf("build single-module benchmark IR: %v", err)
 	}
-	fixture.lines = len(normalizedSourceLines(source))
+	fixture.lines = physicalSourceLineCount(normalizedSourceLines(source))
 	fixture.procedures = len(ir.Procedures)
 	for _, declaration := range ir.Declarations {
 		if declaration.Scope == procedureir.ScopeModule || declaration.Scope == procedureir.ScopeProject {

--- a/internal/analyze/benchmark_test.go
+++ b/internal/analyze/benchmark_test.go
@@ -56,6 +56,51 @@ func BenchmarkSyntheticProject(b *testing.B) {
 	}
 }
 
+// BenchmarkSingleModuleSynthetic measures the pathological single-file shapes
+// that do not get represented by project-scale fixtures with many modules.
+// Every source file and its workload metadata are prepared before the timer
+// starts so the timed region contains only analyzer work.
+func BenchmarkSingleModuleSynthetic(b *testing.B) {
+	for _, workload := range singleModuleBenchmarkWorkloads() {
+		workload := workload
+		b.Run(workload.benchmarkName(), func(b *testing.B) {
+			root := b.TempDir()
+			fixture := writeSingleModuleBenchmarkProject(b, root, workload)
+
+			// Keep the benchmark independent of any developer-generated TypeLib
+			// database. A missing database is a valid, deterministic analyzer
+			// configuration for this fixture.
+			b.Setenv(typedb.EnvDir, filepath.Join(b.TempDir(), "typelib"))
+			cfg := config.Default()
+			recorder := analysisstats.NewRecorder()
+			recordSingleModuleBenchmarkDimensions(recorder, fixture)
+			ctx := analysisstats.WithRecorder(context.Background(), recorder)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			findings := 0
+			warnings := 0
+			for i := 0; i < b.N; i++ {
+				result, err := (Analyzer{RootDir: root, Config: cfg}).RunResultContext(ctx)
+				if err != nil {
+					b.Fatalf("analyze single-module %s fixture: %v", workload.benchmarkName(), err)
+				}
+				findings += len(result.Findings)
+				warnings += len(result.Warnings)
+			}
+			b.StopTimer()
+
+			b.ReportMetric(float64(fixture.lines), "lines/op")
+			b.ReportMetric(float64(fixture.procedures), "procedures/op")
+			b.ReportMetric(float64(fixture.moduleDeclarations), "module-declarations/op")
+			b.ReportMetric(float64(fixture.calls), "calls/op")
+			b.ReportMetric(float64(findings)/float64(b.N), "findings/op")
+			b.ReportMetric(float64(warnings)/float64(b.N), "warnings/op")
+			reportAnalysisRecorderMetrics(b, recorder, b.N)
+		})
+	}
+}
+
 // BenchmarkObjectAnalysisWorklist isolates the object-summary and entry-state
 // stages on a deliberately reverse-ordered object-return chain. The source is
 // parsed and its IR/CFG are constructed before timing starts so the benchmark
@@ -172,6 +217,238 @@ func TestSyntheticBenchmarkFixtureScale(t *testing.T) {
 	}
 }
 
+// TestSingleModuleBenchmarkFixtureScale keeps the single-file workload matrix
+// visible to ordinary tests without running the expensive analyzer benchmark.
+func TestSingleModuleBenchmarkFixtureScale(t *testing.T) {
+	for _, workload := range singleModuleBenchmarkWorkloads() {
+		workload := workload
+		t.Run(workload.benchmarkName(), func(t *testing.T) {
+			fixture := writeSingleModuleBenchmarkProject(t, t.TempDir(), workload)
+			if fixture.sourcePath == "" || fixture.lines == 0 {
+				t.Fatalf("single-module %s fixture has no source metadata: %+v", workload.benchmarkName(), fixture)
+			}
+			if fixture.procedures == 0 {
+				t.Fatalf("single-module %s fixture has no procedures", workload.benchmarkName())
+			}
+			if fixture.moduleCount != 1 {
+				t.Fatalf("single-module %s fixture contains %d modules, want 1", workload.benchmarkName(), fixture.moduleCount)
+			}
+			if fixture.procedures != workload.expectedProcedures() {
+				t.Fatalf("single-module %s procedures = %d, want %d", workload.benchmarkName(), fixture.procedures, workload.expectedProcedures())
+			}
+			if fixture.moduleDeclarations != workload.expectedModuleDeclarations() {
+				t.Fatalf("single-module %s declarations = %d, want %d", workload.benchmarkName(), fixture.moduleDeclarations, workload.expectedModuleDeclarations())
+			}
+			if fixture.calls != workload.expectedCalls() {
+				t.Fatalf("single-module %s calls = %d, want %d", workload.benchmarkName(), fixture.calls, workload.expectedCalls())
+			}
+		})
+	}
+}
+
+type singleModuleBenchmarkWorkload struct {
+	shape string
+	size  int
+}
+
+func singleModuleBenchmarkWorkloads() []singleModuleBenchmarkWorkload {
+	workloads := make([]singleModuleBenchmarkWorkload, 0, 17)
+	for _, shape := range []string{"independent", "chain", "declarations"} {
+		for _, size := range []int{500, 1000, 2000} {
+			workloads = append(workloads, singleModuleBenchmarkWorkload{shape: shape, size: size})
+		}
+	}
+	for _, shape := range []string{"dense", "cyclic"} {
+		for _, size := range []int{500, 1000} {
+			workloads = append(workloads, singleModuleBenchmarkWorkload{shape: shape, size: size})
+		}
+	}
+	for _, size := range []int{100, 500, 1000, 2000} {
+		workloads = append(workloads, singleModuleBenchmarkWorkload{shape: "cfg-independent", size: size})
+	}
+	return workloads
+}
+
+func (w singleModuleBenchmarkWorkload) benchmarkName() string {
+	unit := "procedures"
+	switch w.shape {
+	case "declarations":
+		unit = "declarations"
+	case "cfg-independent":
+		unit = "branches"
+	}
+	return fmt.Sprintf("%s/%d-%s", w.shape, w.size, unit)
+}
+
+func (w singleModuleBenchmarkWorkload) expectedProcedures() int {
+	switch w.shape {
+	case "declarations", "cfg-independent":
+		return 1
+	default:
+		return w.size
+	}
+}
+
+func (w singleModuleBenchmarkWorkload) expectedModuleDeclarations() int {
+	switch w.shape {
+	case "declarations":
+		return w.size
+	default:
+		return 0
+	}
+}
+
+func (w singleModuleBenchmarkWorkload) expectedCalls() int {
+	switch w.shape {
+	case "chain":
+		return w.size - 1
+	case "dense":
+		const fanout = 8
+		calls := 0
+		for index := 0; index < w.size; index++ {
+			remaining := w.size - index - 1
+			if remaining > fanout {
+				remaining = fanout
+			}
+			calls += remaining
+		}
+		return calls
+	case "cyclic":
+		return w.size
+	default:
+		return 0
+	}
+}
+
+type singleModuleBenchmarkFixture struct {
+	sourcePath         string
+	moduleCount        int
+	lines              int
+	procedures         int
+	moduleDeclarations int
+	calls              int
+	maxStatements      int
+	maxCFGBlocks       int
+	maxCFGEdges        int
+}
+
+func writeSingleModuleBenchmarkProject(tb testing.TB, root string, workload singleModuleBenchmarkWorkload) singleModuleBenchmarkFixture {
+	tb.Helper()
+	srcDir := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		tb.Fatalf("create single-module benchmark source directory: %v", err)
+	}
+	path := filepath.Join(srcDir, "Monster.bas")
+	source := singleModuleBenchmarkSource(workload)
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		tb.Fatalf("write single-module %s fixture: %v", workload.benchmarkName(), err)
+	}
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		tb.Fatalf("read single-module benchmark source directory: %v", err)
+	}
+
+	fixture := singleModuleBenchmarkFixture{sourcePath: path, moduleCount: len(entries)}
+	inspectSingleModuleBenchmarkFixture(tb, root, path, source, &fixture)
+	return fixture
+}
+
+func singleModuleBenchmarkSource(workload singleModuleBenchmarkWorkload) string {
+	var source strings.Builder
+	source.WriteString("Option Explicit\n\n")
+	switch workload.shape {
+	case "independent":
+		for index := 0; index < workload.size; index++ {
+			fmt.Fprintf(&source, "Private Sub Independent%04d()\n    Dim value As Long\n    value = %d\nEnd Sub\n\n", index, index)
+		}
+	case "chain":
+		for index := 0; index < workload.size; index++ {
+			fmt.Fprintf(&source, "Private Sub Chain%04d()\n", index)
+			if index+1 < workload.size {
+				fmt.Fprintf(&source, "    Call Chain%04d\n", index+1)
+			} else {
+				source.WriteString("    Dim value As Long\n    value = 1\n")
+			}
+			source.WriteString("End Sub\n\n")
+		}
+	case "dense":
+		const fanout = 8
+		for index := 0; index < workload.size; index++ {
+			fmt.Fprintf(&source, "Private Sub Dense%04d()\n", index)
+			for offset := 1; offset <= fanout && index+offset < workload.size; offset++ {
+				fmt.Fprintf(&source, "    Call Dense%04d\n", index+offset)
+			}
+			if index+1 >= workload.size {
+				source.WriteString("    Dim value As Long\n    value = 1\n")
+			}
+			source.WriteString("End Sub\n\n")
+		}
+	case "cyclic":
+		for index := 0; index < workload.size; index++ {
+			fmt.Fprintf(&source, "Private Sub Cyclic%04d()\n    Call Cyclic%04d\nEnd Sub\n\n", index, (index+1)%workload.size)
+		}
+	case "declarations":
+		for index := 0; index < workload.size; index++ {
+			fmt.Fprintf(&source, "Private Const ModuleConst%04d As Long = %d\n", index, index)
+		}
+		source.WriteString("\nPrivate Sub ReadModuleDeclaration()\n    Dim value As Long\n    value = ModuleConst0000\nEnd Sub\n")
+	case "cfg-independent":
+		source.WriteString("Private Sub IndependentLargeCFG(ByRef value As Long)\n")
+		for index := 0; index < workload.size; index++ {
+			fmt.Fprintf(&source, "    If value = %d Then\n        value = value + 1\n    Else\n        value = value - 1\n    End If\n", index)
+		}
+		source.WriteString("End Sub\n")
+	}
+	return source.String()
+}
+
+func inspectSingleModuleBenchmarkFixture(tb testing.TB, root, path, source string, fixture *singleModuleBenchmarkFixture) {
+	tb.Helper()
+	doc, err := vbaast.ParseDocument(path, []byte(source))
+	if err != nil {
+		tb.Fatalf("parse single-module benchmark source: %v", err)
+	}
+	defer doc.Close()
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{RootDir: root, Path: path, ModuleKind: "standard"}, doc)
+	if err != nil {
+		tb.Fatalf("build single-module benchmark IR: %v", err)
+	}
+	fixture.lines = len(normalizedSourceLines(source))
+	fixture.procedures = len(ir.Procedures)
+	for _, declaration := range ir.Declarations {
+		if declaration.Scope == procedureir.ScopeModule || declaration.Scope == procedureir.ScopeProject {
+			fixture.moduleDeclarations++
+		}
+	}
+	for _, procedure := range ir.Procedures {
+		if len(procedure.Statements) > fixture.maxStatements {
+			fixture.maxStatements = len(procedure.Statements)
+		}
+		fixture.calls += len(procedure.Calls)
+	}
+	controlFlow := vbacfg.BuildDocument(ir)
+	for _, graph := range controlFlow.Graphs {
+		if len(graph.Blocks) > fixture.maxCFGBlocks {
+			fixture.maxCFGBlocks = len(graph.Blocks)
+		}
+		if len(graph.Edges) > fixture.maxCFGEdges {
+			fixture.maxCFGEdges = len(graph.Edges)
+		}
+	}
+}
+
+func recordSingleModuleBenchmarkDimensions(recorder *analysisstats.Recorder, fixture singleModuleBenchmarkFixture) {
+	if recorder == nil {
+		return
+	}
+	recorder.AddMax("max_lines_per_file", uint64(fixture.lines))
+	recorder.AddMax("max_procedures_per_file", uint64(fixture.procedures))
+	recorder.AddMax("max_calls_per_file", uint64(fixture.calls))
+	recorder.AddMax("max_statements_per_procedure", uint64(fixture.maxStatements))
+	recorder.AddMax("max_cfg_blocks_per_procedure", uint64(fixture.maxCFGBlocks))
+	recorder.AddMax("max_cfg_edges_per_procedure", uint64(fixture.maxCFGEdges))
+}
+
 type syntheticBenchmarkModule struct {
 	name       string
 	source     string
@@ -285,6 +562,10 @@ func reportAnalysisRecorderMetrics(b *testing.B, recorder *analysisstats.Recorde
 	}
 	for _, counter := range counters {
 		metricName := "counter_" + strings.ReplaceAll(counter.Name, "-", "_")
+		if strings.HasPrefix(counter.Name, "max_") {
+			b.ReportMetric(float64(counter.Value), metricName)
+			continue
+		}
 		b.ReportMetric(float64(counter.Value)/float64(iterations), metricName+"/op")
 	}
 }

--- a/internal/analyze/profiling_test.go
+++ b/internal/analyze/profiling_test.go
@@ -18,7 +18,7 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 	if err := os.MkdirAll(modules, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	source := "Option Explicit\nPublic Sub Run(ByRef target As Long)\n  Dim value As Long\n  value = 1\n  target = value\nEnd Sub\n"
+	source := "Option Explicit\nPrivate moduleValue As Long\nPublic Sub Run(ByRef target As Long)\n  Dim value As Long\n  value = 1\n  target = value\nEnd Sub\n"
 	if err := os.WriteFile(filepath.Join(modules, "Main.bas"), []byte(source), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -47,9 +47,9 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 	for _, name := range []string{
 		"source_discovery", "file_read", "parse", "procedure_ir", "cfg",
 		"effect_summaries", "object_procedure_summaries", "object_entry_states",
-		"project_context", "typedb_load", "project_symbols", "project_wide_diagnostics",
-		"file_procedure_diagnostics", "byref_diagnostics", "compile_equivalent_diagnostics",
-		"suppression_finalization", "analyze_total",
+		"project_context", "project_context_indexes", "typedb_load", "project_symbols", "project_wide_diagnostics",
+		"procedure_local_diagnostics", "typed_excel_diagnostics", "byref_diagnostics", "compile_equivalent_diagnostics",
+		"suppression_and_finalize", "analyze_total",
 	} {
 		stage, ok := stageByName[name]
 		if !ok {
@@ -66,7 +66,9 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 	for _, name := range []string{
 		"file_count", "procedure_count", "statement_count", "expression_count",
 		"call_site_count", "cfg_block_count", "cfg_edge_count", "project_symbol_count",
-		"byref_diagnostic_passes",
+		"byref_diagnostic_passes", "line_count", "module_declaration_count",
+		"max_lines_per_file", "max_procedures_per_file", "max_calls_per_file",
+		"max_statements_per_procedure", "max_cfg_blocks_per_procedure", "max_cfg_edges_per_procedure",
 	} {
 		if _, ok := counterByName[name]; !ok {
 			t.Fatalf("missing counter %q: %+v", name, counters)
@@ -74,6 +76,18 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 	}
 	if counterByName["file_count"] != 1 || counterByName["procedure_count"] != 1 {
 		t.Fatalf("workload counters = %+v", counters)
+	}
+	if counterByName["line_count"] != uint64(len(normalizedSourceLines(source))) ||
+		counterByName["max_lines_per_file"] != uint64(len(normalizedSourceLines(source))) ||
+		counterByName["module_declaration_count"] != 1 ||
+		counterByName["max_procedures_per_file"] != 1 ||
+		counterByName["max_calls_per_file"] != 0 {
+		t.Fatalf("line/module maximum counters = %+v", counters)
+	}
+	if counterByName["max_statements_per_procedure"] == 0 ||
+		counterByName["max_cfg_blocks_per_procedure"] == 0 ||
+		counterByName["max_cfg_edges_per_procedure"] == 0 {
+		t.Fatalf("procedure maximum counters = %+v", counters)
 	}
 	if counterByName["byref_diagnostic_passes"] != 1 {
 		t.Fatalf("ByRef analysis passes = %d, want one per file revision", counterByName["byref_diagnostic_passes"])

--- a/internal/analyze/profiling_test.go
+++ b/internal/analyze/profiling_test.go
@@ -12,6 +12,25 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 )
 
+func TestPhysicalSourceLineCount(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+		want   int
+	}{
+		{name: "empty", source: "", want: 0},
+		{name: "without terminal newline", source: "Option Explicit", want: 1},
+		{name: "with terminal newline", source: "Option Explicit\n", want: 1},
+		{name: "with trailing blank line", source: "Option Explicit\n\n", want: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := physicalSourceLineCount(normalizedSourceLines(test.source)); got != test.want {
+				t.Fatalf("physicalSourceLineCount(%q) = %d, want %d", test.source, got, test.want)
+			}
+		})
+	}
+}
+
 func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) {
 	root := t.TempDir()
 	modules := filepath.Join(root, "src", "modules")
@@ -77,8 +96,9 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 	if counterByName["file_count"] != 1 || counterByName["procedure_count"] != 1 {
 		t.Fatalf("workload counters = %+v", counters)
 	}
-	if counterByName["line_count"] != uint64(len(normalizedSourceLines(source))) ||
-		counterByName["max_lines_per_file"] != uint64(len(normalizedSourceLines(source))) ||
+	wantLineCount := uint64(len(normalizedSourceLines(source)) - 1)
+	if counterByName["line_count"] != wantLineCount ||
+		counterByName["max_lines_per_file"] != wantLineCount ||
 		counterByName["module_declaration_count"] != 1 ||
 		counterByName["max_procedures_per_file"] != 1 ||
 		counterByName["max_calls_per_file"] != 0 {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/lint"
 	"github.com/harumiWeb/xlflow/internal/output"
 	"github.com/harumiWeb/xlflow/internal/typedb"
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 	"github.com/harumiWeb/xlflow/internal/vbafmt"
 	"github.com/xuri/excelize/v2"
 )
@@ -753,14 +754,56 @@ func TestAnalyzePerformanceLogFlagIsOptInAndPreservesJSON(t *testing.T) {
 		`operation="analyze/stage"`, `stage="source_discovery"`, `stage="parse"`,
 		`stage="procedure_ir"`, `stage="cfg"`, `stage="effect_summaries"`,
 		`stage="object_procedure_summaries"`, `stage="object_entry_states"`,
-		`stage="project_context"`, `stage="typedb_load"`, `stage="project_symbols"`,
-		`stage="project_wide_diagnostics"`, `stage="file_procedure_diagnostics"`,
-		`stage="byref_diagnostics"`, `stage="compile_equivalent_diagnostics"`,
-		`stage="suppression_finalization"`, `stage="analyze_total"`,
-		`operation="analyze/counter"`, `counter="file_count"`, `counter="procedure_count"`,
+		`stage="project_context"`, `stage="typedb_load"`, `stage="project_context_indexes"`,
+		`stage="project_symbols"`,
+		`stage="project_wide_diagnostics"`, `stage="procedure_local_diagnostics"`,
+		`stage="typed_excel_diagnostics"`, `stage="byref_diagnostics"`,
+		`stage="compile_equivalent_diagnostics"`,
+		`stage="suppression_and_finalize"`, `stage="analyze_total"`,
+		`operation="analyze/counter"`, `counter="file_count"`, `counter="line_count"`,
+		`counter="module_declaration_count"`, `counter="procedure_count"`,
+		`counter="max_lines_per_file"`, `counter="max_procedures_per_file"`,
+		`counter="max_calls_per_file"`, `counter="max_statements_per_procedure"`,
+		`counter="max_cfg_blocks_per_procedure"`, `counter="max_cfg_edges_per_procedure"`,
 	} {
 		if !strings.Contains(profiledStderr, expected) {
 			t.Fatalf("performance output missing %q:\n%s", expected, profiledStderr)
+		}
+	}
+}
+
+func TestWriteAnalyzePerformanceReportsWorkloadCounters(t *testing.T) {
+	recorder := analysisstats.NewRecorder()
+	recorder.Record(analysisstats.Stage{Name: "procedure_local_diagnostics", Elapsed: time.Millisecond, Outcome: "ok", ResultCount: 2})
+	recorder.Record(analysisstats.Stage{Name: "procedure_local_diagnostics", Elapsed: 2 * time.Millisecond, Outcome: "error", ResultCount: 3})
+	recorder.Record(analysisstats.Stage{Name: "suppression_and_finalize", Elapsed: time.Millisecond, Outcome: "ok", ResultCount: 1})
+	for _, name := range []string{
+		"file_count", "procedure_count", "statement_count", "expression_count",
+		"call_site_count", "cfg_block_count", "cfg_edge_count", "project_symbol_count",
+	} {
+		recorder.AddSum(name, 1)
+	}
+	for _, name := range []string{
+		"max_lines_per_file", "max_procedures_per_file", "max_calls_per_file",
+		"max_statements_per_procedure", "max_cfg_blocks_per_procedure", "max_cfg_edges_per_procedure",
+	} {
+		recorder.AddMax(name, 1)
+	}
+
+	var stderr bytes.Buffer
+	writeAnalyzePerformance(&stderr, recorder)
+	output := stderr.String()
+	for _, expected := range []string{
+		`stage="procedure_local_diagnostics" elapsed_ms=3.000`,
+		`calls=2 result_count=5 outcome="error"`,
+		`stage="suppression_and_finalize"`,
+		`counter="file_count"`, `counter="procedure_count"`,
+		`counter="max_lines_per_file"`, `counter="max_procedures_per_file"`,
+		`counter="max_calls_per_file"`, `counter="max_statements_per_procedure"`,
+		`counter="max_cfg_blocks_per_procedure"`, `counter="max_cfg_edges_per_procedure"`,
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("performance output missing %q:\n%s", expected, output)
 		}
 	}
 }

--- a/internal/staticanalysis/corpus/benchmark_test.go
+++ b/internal/staticanalysis/corpus/benchmark_test.go
@@ -127,6 +127,10 @@ func reportCorpusAnalysisRecorderMetrics(b *testing.B, recorder *analysisstats.R
 	}
 	for _, counter := range counters {
 		metricName := "counter_" + strings.ReplaceAll(counter.Name, "-", "_")
+		if strings.HasPrefix(counter.Name, "max_") {
+			b.ReportMetric(float64(counter.Value), metricName)
+			continue
+		}
 		b.ReportMetric(float64(counter.Value)/float64(iterations), metricName+"/op")
 	}
 }

--- a/internal/vba/analysisstats/recorder.go
+++ b/internal/vba/analysisstats/recorder.go
@@ -104,11 +104,33 @@ func combinedOutcome(current, next string) string {
 }
 
 func (r *Recorder) Add(name string, value uint64) {
+	r.AddSum(name, value)
+}
+
+// AddSum adds value to an additive counter. Add is retained as a compatibility
+// alias for existing instrumentation callers.
+func (r *Recorder) AddSum(name string, value uint64) {
 	if r == nil {
 		return
 	}
 	r.mu.Lock()
 	r.counters[name] += value
+	r.mu.Unlock()
+}
+
+// AddMax records the greatest value observed for a maximum counter. Maximum
+// workload dimensions are intentionally separate from additive counters so
+// repeated observations do not turn a per-file or per-procedure maximum into
+// a sum.
+func (r *Recorder) AddMax(name string, value uint64) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	current, ok := r.counters[name]
+	if !ok || value > current {
+		r.counters[name] = value
+	}
 	r.mu.Unlock()
 }
 

--- a/internal/vba/analysisstats/recorder_test.go
+++ b/internal/vba/analysisstats/recorder_test.go
@@ -34,8 +34,12 @@ func TestTotalsAggregateStagesAndSortCounters(t *testing.T) {
 	recorder.Record(Stage{Name: "cfg", Elapsed: 2 * time.Millisecond, Outcome: "ok", ResultCount: 2})
 	recorder.Record(Stage{Name: "parse", Elapsed: 3 * time.Millisecond, Outcome: "error", ResultCount: 4})
 	recorder.Add("procedure_count", 3)
-	recorder.Add("file_count", 1)
-	recorder.Add("procedure_count", 2)
+	recorder.AddSum("file_count", 1)
+	recorder.AddSum("procedure_count", 2)
+	recorder.AddMax("max_lines_per_file", 11)
+	recorder.AddMax("max_lines_per_file", 7)
+	recorder.AddMax("max_procedures_per_file", 2)
+	recorder.AddMax("max_procedures_per_file", 5)
 
 	stages, counters := recorder.Totals()
 	if len(stages) != 2 {
@@ -47,7 +51,12 @@ func TestTotalsAggregateStagesAndSortCounters(t *testing.T) {
 	if got := stages[1]; got.Name != "cfg" || got.Calls != 1 || got.Outcome != "ok" {
 		t.Fatalf("cfg total = %+v", got)
 	}
-	wantCounters := []Counter{{Name: "file_count", Value: 1}, {Name: "procedure_count", Value: 5}}
+	wantCounters := []Counter{
+		{Name: "file_count", Value: 1},
+		{Name: "max_lines_per_file", Value: 11},
+		{Name: "max_procedures_per_file", Value: 5},
+		{Name: "procedure_count", Value: 5},
+	}
 	if !reflect.DeepEqual(counters, wantCounters) {
 		t.Fatalf("counters = %+v, want %+v", counters, wantCounters)
 	}

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -63,17 +63,33 @@ cost. It writes line-oriented records to stderr, so it is safe to combine with
 count, result count, and an `ok`, `error`, or `canceled` outcome. The measured
 stages cover source discovery and reading, parsing, procedure IR and CFG
 construction, effect and object summaries, project context and symbols,
-TypeLib loading, project-wide and file/procedure diagnostics, ByRef and
-compile-equivalent diagnostics, suppression finalization, and the complete
-`analyze_total` operation.
+TypeLib loading, project-wide and procedure-local diagnostics, typed Excel,
+ByRef, and compile-equivalent diagnostics, suppression/finalization, and the
+complete `analyze_total` operation. The canonical stage labels include
+`project_context_indexes`, `procedure_local_diagnostics`,
+`typed_excel_diagnostics`, and `suppression_and_finalize`.
 
-The performance output includes stable workload counters: `file_count`,
-`procedure_count`, `statement_count`, `expression_count`, `call_site_count`,
-`cfg_block_count`, `cfg_edge_count`, and `project_symbol_count`. Counters are
-workload measurements, not findings. Timings vary by machine and Go toolchain;
-use them for same-environment comparisons rather than fixed pass/fail limits.
+The performance output includes stable aggregate workload counters:
+`file_count`, `procedure_count`, `statement_count`, `expression_count`,
+`call_site_count`, `cfg_block_count`, `cfg_edge_count`, and
+`project_symbol_count`, `line_count`, and `module_declaration_count`.
+Subsystem worklist counters such as `object_summary_evaluations`,
+`object_entry_flow_evaluations`, and `byref_diagnostic_passes` may also appear.
+Large-module profiles also expose maximum dimensions:
+`max_lines_per_file`, `max_procedures_per_file`, `max_calls_per_file`,
+`max_statements_per_procedure`, `max_cfg_blocks_per_procedure`, and
+`max_cfg_edges_per_procedure`. Counters are workload measurements, not
+findings. Timings vary by machine and Go toolchain; use them for same-
+environment comparisons rather than fixed pass/fail limits.
 The flag does not change findings, their order, exit status, or the JSON schema.
 `check` has no performance-log option.
+
+For reproducible developer measurements, use `rtk task bench:analyze-single-module`
+for the synthetic large-module workloads, `rtk task bench:analyze` for the
+existing multi-module baselines, and `rtk task bench:corpus` for the checked-in
+real-world corpus. The explicit ROneCOne leaf benchmark command and its
+developer-only execution boundary are documented in the
+[static-analysis corpus specification](https://github.com/harumiWeb/xlflow/blob/main/docs/specs/static-analysis-corpus.md).
 
 ## Rules
 

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -73,6 +73,8 @@ The performance output includes stable aggregate workload counters:
 `file_count`, `procedure_count`, `statement_count`, `expression_count`,
 `call_site_count`, `cfg_block_count`, `cfg_edge_count`, and
 `project_symbol_count`, `line_count`, and `module_declaration_count`.
+`line_count` uses physical source lines and excludes a terminal newline from the
+count.
 Subsystem worklist counters such as `object_summary_evaluations`,
 `object_entry_flow_evaluations`, and `byref_diagnostic_passes` may also appear.
 Large-module profiles also expose maximum dimensions:

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -404,7 +404,6 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `file_input`
 - `file_operation`
 - `file_picker`
-- `file_procedure_diagnostics`
 - `file_read`
 - `files_changed`
 - `files_to_change`
@@ -558,6 +557,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `like_pattern`
 - `likely_cause`
 - `line_continuation`
+- `line_count`
 - `line_number_label`
 - `line_number_literal`
 - `line_number_statement`
@@ -603,11 +603,17 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `manifest_path`
 - `manual_quoting`
 - `max_age_days`
+- `max_calls_per_file`
+- `max_cfg_blocks_per_procedure`
+- `max_cfg_edges_per_procedure`
 - `max_cols`
 - `max_concurrent`
 - `max_count`
+- `max_lines_per_file`
 - `max_nesting_depth`
+- `max_procedures_per_file`
 - `max_rows`
+- `max_statements_per_procedure`
 - `max_total_size_mb`
 - `may_raise`
 - `member_access`
@@ -636,6 +642,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `module_already_exists`
 - `module_ambiguous`
 - `module_declaration_after_procedure`
+- `module_declaration_count`
 - `module_install_failed`
 - `module_kind`
 - `module_mutation_failed`
@@ -780,6 +787,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `procedure_ir_reuses`
 - `procedure_ir_singleflight`
 - `procedure_kind`
+- `procedure_local_diagnostics`
 - `procedure_modifier`
 - `procedure_name`
 - `procedure_name_constant`
@@ -798,6 +806,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `project_config`
 - `project_config_missing`
 - `project_context`
+- `project_context_indexes`
 - `project_count`
 - `project_create`
 - `project_init`
@@ -1003,7 +1012,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `sub_declaration`
 - `supported_severities`
 - `suppresses_errors`
-- `suppression_finalization`
+- `suppression_and_finalize`
 - `symbols_singleflight`
 - `sync_source`
 - `systemprofile_desktop`
@@ -1058,6 +1067,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `type_preprocessor_else`
 - `type_preprocessor_elseif`
 - `type_preprocessor_if`
+- `typed_excel_diagnostics`
 - `typedb_load`
 - `udt_byval`
 - `udt_optional`


### PR DESCRIPTION
## Summary

- Add opt-in analyzer workload telemetry with additive counters and maximum single-file/procedure dimensions.
- Add canonical stage coverage for parsing, IR/CFG construction, propagation, project context, diagnostics, and finalization.
- Add deterministic single-module benchmarks for 500, 1,000, and 2,000-procedure workloads, including call graphs, cycles, declaration-heavy modules, and large CFGs.
- Expose explicit developer-only ROneCOne profiling and preserve analyzer findings, JSON output, and normal execution behavior.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/analysisstats ./internal/analyze ./internal/cli ./internal/staticanalysis/corpus -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^TestSingleModuleBenchmarkFixtureScale$' -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=1`
- `rtk golangci-lint run ./internal/analyze/...`
- `rtk pnpm docs:check`
- Representative single-module benchmark smoke and `git diff --check` passed.

The full heavy 17-case `bench:analyze-single-module` matrix was not run; its fixture-scale test covers all matrix entries.

Closes #671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded `analyze --performance-log` output with detailed analysis stages, workload totals, and maximum file, procedure, call, and CFG dimensions.
  * Added aggregate and maximum performance counters while preserving findings, exit codes, stderr-only profiling, and `--json` compatibility.
  * Added reproducible benchmark commands for large single-module and corpus analysis workloads.

* **Documentation**
  * Updated CLI and static-analysis documentation with metric definitions and benchmark guidance.
  * Refreshed the error-code inventory with current diagnostic codes and naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->