### PR TITLE
perf(analyze): replace repeated line-to-procedure scans with indexed module facts

### DIFF
--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -2023,7 +2023,7 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 		if a.Config.Analyze.DetectRangeFindNothingCheck {
 			findings = append(findings, a.rangeFindFindings(file, proc, lineNo, stmt, findAssignments, guardedFinds)...)
 		}
-		if a.Config.Analyze.DetectObjectArrayComparison {
+		if a.Config.Analyze.DetectObjectArrayComparison && objectNothingEqualityLineIsExecutable(proc, lineNo, stmt) {
 			findings = append(findings, a.objectArrayComparisonFindings(file, proc, lineNo, stmt, decls)...)
 		}
 		_ = lower
@@ -2661,12 +2661,42 @@ func dictionaryIterationValueUse(stmt, item string, decls declarationScope) bool
 
 func (a Analyzer) objectArrayComparisonFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls declarationScope) []Finding {
 	var findings []Finding
+	reported := make(map[string]bool)
 	decls.forEach(func(key string, decl sourceDeclaration) {
 		if decl.Object && objectNothingEqualityComparisonExists(stmt, key) {
 			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", decl.Name+" is compared to Nothing with =.", "Object references must be compared with Is Nothing, not the scalar equality operator.", "Use `If "+decl.Name+" Is Nothing Then` or `If Not "+decl.Name+" Is Nothing Then`."))
+			reported[key] = true
 		}
 	})
+	for _, declaration := range proc.Declarations {
+		if declaration.Scope != procedureir.ScopeParameter || !sourceDeclarationIsObject(declaration, declaration.Type) {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(declaration.Name))
+		if reported[key] || !objectNothingEqualityComparisonExists(stmt, key) {
+			continue
+		}
+		findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", declaration.Name+" is compared to Nothing with =.", "Object references must be compared with Is Nothing, not the scalar equality operator.", "Use `If "+declaration.Name+" Is Nothing Then` or `If Not "+declaration.Name+" Is Nothing Then`."))
+		reported[key] = true
+	}
 	return findings
+}
+
+func objectNothingEqualityLineIsExecutable(proc sourceProcedure, lineNo int, stmt string) bool {
+	lower := strings.ToLower(strings.TrimSpace(stmt))
+	if lineNo == proc.StartLine && isProcedureHeaderLine(lower) {
+		return false
+	}
+	for _, parameter := range proc.Params {
+		if !parameter.Optional || parameter.Range.StartLine == 0 || lineNo < parameter.Range.StartLine || lineNo > parameter.Range.EndLine {
+			continue
+		}
+		// Optional defaults belong to the procedure declaration, not to an
+		// executable object comparison. Keep the later `If ad = Nothing` line
+		// eligible by limiting this to the parameter's source range.
+		return false
+	}
+	return true
 }
 
 func objectNothingEqualityComparisonExists(stmt, name string) bool {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -278,7 +278,10 @@ type parsedFile struct {
 	// ModuleDeclarations is the module-scope declaration projection paired with
 	// Procedures. It is materialized once during batch/realtime file setup and
 	// reused by rule stages that solve array and object state.
-	ModuleDeclarations          map[string]sourceDeclaration
+	ModuleDeclarations map[string]sourceDeclaration
+	// ModuleFacts owns the immutable module declaration and procedure ownership
+	// indexes shared by all rule stages for this file revision.
+	ModuleFacts                 *moduleAnalysisFacts
 	Parsed                      *vbaast.ParsedDocument
 	IntelDocument               intel.Document
 	RangeValueModuleConstants   map[string]int
@@ -503,7 +506,8 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	for i := range parsedFiles {
 		procedures := sourceProceduresFromIR(parsedFiles[i].IR, parsedFiles[i].CFG)
 		parsedFiles[i].Procedures = procedures
-		parsedFiles[i].ModuleDeclarations = moduleDeclarations(parsedFiles[i].Lines, procedures)
+		parsedFiles[i].ModuleFacts = buildModuleAnalysisFacts(parsedFiles[i].Lines, parsedFiles[i].IR, procedures)
+		parsedFiles[i].ModuleDeclarations = parsedFiles[i].ModuleFacts.moduleDeclarations
 	}
 	if err := ctx.Err(); err != nil {
 		return Result{}, err
@@ -1260,6 +1264,8 @@ func SourceNonShortCircuitObjectGuardFindingsParsedContext(ctx context.Context, 
 			IR:         ir,
 			Procedures: procedures,
 		}
+		file.ModuleFacts = buildModuleAnalysisFacts(file.Lines, file.IR, procedures)
+		file.ModuleDeclarations = file.ModuleFacts.moduleDeclarations
 		analyzer := Analyzer{RootDir: rootDir, Config: cfg}
 		var scanErr error
 		findings, scanErr = analyzer.vba212ScanWithContext(ctx, file, procedures, nil, vba212Context{})
@@ -1410,11 +1416,12 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 			IR:                        ir,
 			CFG:                       controlFlow,
 			Procedures:                procedures,
-			ModuleDeclarations:        moduleDeclarations(lines, procedures),
 			RangeValueModuleConstants: rangeValueConstants,
 			ConstantValues:            constantValues,
 			DataFlowModuleBindings:    dataFlowModuleBindings,
 		}
+		file.ModuleFacts = buildModuleAnalysisFacts(file.Lines, file.IR, procedures)
+		file.ModuleDeclarations = file.ModuleFacts.moduleDeclarations
 		if cfg.Analyze.DetectArrayLifecycleSafety || cfg.Analyze.DetectRedimPreserveDimension || cfg.Analyze.DetectObjectArrayComparison || cfg.Analyze.DetectDeterministicRuntimeErrors {
 			file.ArrayOptionBase = optionBase(lines)
 			file.ArrayOptionBaseSet = true
@@ -1534,13 +1541,8 @@ func (a Analyzer) sourceRealtimeProcedureFindingsContext(ctx context.Context, fi
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	decls := cloneDeclarations(moduleDecls)
-	for key, decl := range procedureDeclarations(file.Lines, proc) {
-		decls[key] = decl
-	}
-	for _, param := range proc.Params {
-		decls[strings.ToLower(param.Name)] = sourceDeclaration{Name: param.Name, Type: param.Type, Line: proc.StartLine, Object: isObjectType(param.Type), Parameter: true}
-	}
+	decls := newDeclarationScope(file, proc)
+	decls.module = moduleDecls
 	findAssignments := map[string]rangeFindAssignmentInfo{}
 	guardedFinds := map[string]bool{}
 	withStack := make([]withInfo, 0)
@@ -1919,13 +1921,8 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	if err := cancelCtx.Err(); err != nil {
 		return nil, err
 	}
-	decls := cloneDeclarations(moduleDecls)
-	for key, decl := range procedureDeclarations(file.Lines, proc) {
-		decls[key] = decl
-	}
-	for _, param := range proc.Params {
-		decls[strings.ToLower(param.Name)] = sourceDeclaration{Name: param.Name, Type: param.Type, Line: proc.StartLine, Object: isObjectType(param.Type), Parameter: true}
-	}
+	decls := newDeclarationScope(file, proc)
+	decls.module = moduleDecls
 	shadowedVBA205 := vba205ShadowedIdentifiers(proc, decls, ctx)
 	withStack := make([]withInfo, 0)
 	findAssignments := map[string]rangeFindAssignmentInfo{}
@@ -2014,12 +2011,12 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 			}
 			if cm := callAssignRe.FindStringSubmatch(stmt); len(cm) > 0 {
 				callee := strings.ToLower(lastName(cm[2]))
-				if typ, ok := decls[target]; ok && typ.Object && isObjectType(ctx.functionReturns[callee]) {
+				if typ, ok := decls.lookup(target); ok && typ.Object && isObjectType(ctx.functionReturns[callee]) {
 					findings = append(findings, a.objectSetFinding(file, proc, lineNo, "VBA102", m[1], ctx.functionReturns[callee]))
 					continue
 				}
 			}
-			if decl, ok := decls[target]; ok && decl.Object {
+			if decl, ok := decls.lookup(target); ok && decl.Object {
 				findings = append(findings, a.objectSetFinding(file, proc, lineNo, "VBA101", m[1], decl.Type))
 			}
 		}
@@ -2174,7 +2171,10 @@ func (file parsedFile) moduleDecls() map[string]sourceDeclaration {
 	if file.ModuleDeclarations != nil {
 		return file.ModuleDeclarations
 	}
-	return moduleDeclarations(file.Lines, file.procedureProjection())
+	if facts := file.moduleAnalysisFacts(); facts != nil {
+		return facts.moduleDeclarations
+	}
+	return nil
 }
 
 func procedureEffectIdentity(document procedureir.DocumentIR, symbol procedureir.ProcedureSymbol) effects.ProcedureIdentity {
@@ -2276,47 +2276,39 @@ func isProcedureHeaderLine(lower string) bool {
 }
 
 func moduleDeclarations(lines []string, procedures []sourceProcedure) map[string]sourceDeclaration {
-	decls := map[string]sourceDeclaration{}
-	for i := 0; i < len(lines); i++ {
-		lineNo := i + 1
-		if lineInAnyProcedure(lineNo, procedures) {
-			continue
-		}
-		stmt := normalizedCodeLine(lines[i])
-		lower := strings.ToLower(stmt)
-		if !strings.HasPrefix(lower, "dim ") && !strings.HasPrefix(lower, "static ") && !strings.HasPrefix(lower, "private ") && !strings.HasPrefix(lower, "public ") {
-			continue
-		}
-		m := declRe.FindStringSubmatch(stmt)
-		if len(m) == 0 {
-			continue
-		}
-		for _, part := range splitArgs(m[1]) {
-			name, typ, array, newExpr := declarationNameAndType(part)
-			if name == "" {
-				continue
-			}
-			decls[strings.ToLower(name)] = sourceDeclaration{Name: name, Type: typ, Line: lineNo, Object: isObjectType(typ), Array: array, NewExpression: newExpr}
-		}
-	}
-	return decls
+	facts := buildModuleAnalysisFacts(lines, procedureir.DocumentIR{}, procedures)
+	return facts.moduleDeclarations
 }
 
+// lineInAnyProcedure is retained for package-local compatibility. Normal
+// analysis uses moduleAnalysisFacts.procedureLineOwners; this helper handles
+// the already-sorted procedure projection with a binary search and preserves
+// the old behavior for synthetic unsorted callers.
 func lineInAnyProcedure(line int, procedures []sourceProcedure) bool {
-	for _, proc := range procedures {
-		if proc.StartLine <= line && line <= proc.EndLine {
-			return true
+	if len(procedures) == 0 {
+		return false
+	}
+	sorted := true
+	for index := 1; index < len(procedures); index++ {
+		if procedures[index].StartLine < procedures[index-1].StartLine {
+			sorted = false
+			break
 		}
 	}
-	return false
-}
-
-func cloneDeclarations(decls map[string]sourceDeclaration) map[string]sourceDeclaration {
-	clone := make(map[string]sourceDeclaration, len(decls))
-	for key, decl := range decls {
-		clone[key] = decl
+	if !sorted {
+		for _, procedure := range procedures {
+			if procedure.StartLine <= line && line <= procedure.EndLine {
+				return true
+			}
+		}
+		return false
 	}
-	return clone
+	index := sort.Search(len(procedures), func(index int) bool { return procedures[index].StartLine > line })
+	if index == 0 {
+		return false
+	}
+	procedure := procedures[index-1]
+	return procedure.StartLine <= line && line <= procedure.EndLine
 }
 
 func declarationNameAndType(text string) (string, string, bool, bool) {
@@ -2347,7 +2339,7 @@ func declarationNameAndType(text string) (string, string, bool, bool) {
 	return cleanIdentifier(nameFields[0]), typ, array, newExpr
 }
 
-func (a Analyzer) legacyMemberMismatchFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls map[string]sourceDeclaration, withStack []withInfo) []Finding {
+func (a Analyzer) legacyMemberMismatchFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls declarationScope, withStack []withInfo) []Finding {
 	all := a.memberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)
 	filtered := all[:0]
 	for _, finding := range all {
@@ -2358,7 +2350,7 @@ func (a Analyzer) legacyMemberMismatchFindings(file parsedFile, proc sourceProce
 	return filtered
 }
 
-func (a Analyzer) memberMismatchFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls map[string]sourceDeclaration, withStack []withInfo) []Finding {
+func (a Analyzer) memberMismatchFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls declarationScope, withStack []withInfo) []Finding {
 	var findings []Finding
 	if currentWith, ok := currentWithInfo(withStack); ok {
 		if m := withMemberRe.FindStringSubmatch(stmt); len(m) > 0 {
@@ -2368,7 +2360,7 @@ func (a Analyzer) memberMismatchFindings(file parsedFile, proc sourceProcedure, 
 		}
 	}
 	for _, m := range memberRe.FindAllStringSubmatch(stmt, -1) {
-		if decl, ok := decls[strings.ToLower(m[1])]; ok {
+		if decl, ok := decls.lookup(m[1]); ok {
 			if rule, ok := invalidMemberRuleFor(decl.Type, m[2]); ok {
 				findings = append(findings, a.memberFinding(file, proc, lineNo, m[1], decl.Type, m[2], rule))
 			}
@@ -2475,11 +2467,11 @@ func vba205NonExecutableStatement(stmt string) bool {
 		strings.HasPrefix(lower, "declare ")
 }
 
-func vba205ShadowedIdentifiers(proc sourceProcedure, decls map[string]sourceDeclaration, ctx analysisContext) map[string]bool {
-	shadowed := make(map[string]bool, len(decls)+len(proc.Accesses)+len(proc.Declarations)+len(ctx.procedures))
-	for name := range decls {
+func vba205ShadowedIdentifiers(proc sourceProcedure, decls declarationScope, ctx analysisContext) map[string]bool {
+	shadowed := make(map[string]bool, decls.len()+len(proc.Accesses)+len(proc.Declarations)+len(ctx.procedures))
+	decls.forEach(func(name string, _ sourceDeclaration) {
 		shadowed[strings.ToLower(name)] = true
-	}
+	})
 	for _, declaration := range proc.Declarations {
 		switch declaration.Scope {
 		case procedureir.ScopeParameter, procedureir.ScopeLocal, procedureir.ScopeModule, procedureir.ScopeProject:
@@ -2551,20 +2543,15 @@ type dictionaryIterationLoop struct {
 // iteration whose control variable is subsequently used as an object. VBA
 // iterates Dictionary keys, so ordinary key usage must remain silent.
 func (a Analyzer) dictionaryIterationValueUsageFindings(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration) []Finding {
-	decls := cloneDeclarations(moduleDecls)
-	for key, decl := range procedureDeclarations(file.Lines, proc) {
-		decls[key] = decl
-	}
-	for _, param := range proc.Params {
-		decls[strings.ToLower(param.Name)] = sourceDeclaration{Name: param.Name, Type: param.Type, Line: proc.StartLine, Object: isObjectType(param.Type), Parameter: true}
-	}
+	decls := newDeclarationScope(file, proc)
+	decls.module = moduleDecls
 
 	declaredDictionaries := map[string]bool{}
-	for key, decl := range decls {
+	decls.forEach(func(key string, decl sourceDeclaration) {
 		if isDictionaryType(decl.Type) {
 			declaredDictionaries[key] = true
 		}
-	}
+	})
 	inferredDictionaries := map[string]bool{}
 	var loops []*dictionaryIterationLoop
 	var findings []Finding
@@ -2650,7 +2637,7 @@ func isDictionaryType(typ string) bool {
 	}
 }
 
-func dictionaryIterationValueUse(stmt, item string, decls map[string]sourceDeclaration) bool {
+func dictionaryIterationValueUse(stmt, item string, decls declarationScope) bool {
 	if match := withRe.FindStringSubmatch(stmt); len(match) > 1 && strings.EqualFold(cleanIdentifier(match[1]), item) {
 		return true
 	}
@@ -2664,7 +2651,7 @@ func dictionaryIterationValueUse(stmt, item string, decls map[string]sourceDecla
 	if len(match) == 0 {
 		return false
 	}
-	target, ok := decls[strings.ToLower(match[1])]
+	target, ok := decls.lookup(match[1])
 	if !ok || !target.Object {
 		return false
 	}
@@ -2672,13 +2659,13 @@ func dictionaryIterationValueUse(stmt, item string, decls map[string]sourceDecla
 	return strings.EqualFold(cleanIdentifier(rhs), itemKey)
 }
 
-func (a Analyzer) objectArrayComparisonFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls map[string]sourceDeclaration) []Finding {
+func (a Analyzer) objectArrayComparisonFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, decls declarationScope) []Finding {
 	var findings []Finding
-	for key, decl := range decls {
+	decls.forEach(func(key string, decl sourceDeclaration) {
 		if decl.Object && objectNothingEqualityComparisonExists(stmt, key) {
 			findings = append(findings, a.simpleFinding(file, proc, lineNo, "VBA209", "warning", decl.Name+" is compared to Nothing with =.", "Object references must be compared with Is Nothing, not the scalar equality operator.", "Use `If "+decl.Name+" Is Nothing Then` or `If Not "+decl.Name+" Is Nothing Then`."))
 		}
-	}
+	})
 	return findings
 }
 
@@ -3979,7 +3966,7 @@ func referencedTraceHelpers(code string) []string {
 	return helpers
 }
 
-func resolveWithInfo(expr string, decls map[string]sourceDeclaration) withInfo {
+func resolveWithInfo(expr string, decls declarationScope) withInfo {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
 		return withInfo{}
@@ -3990,7 +3977,7 @@ func resolveWithInfo(expr string, decls map[string]sourceDeclaration) withInfo {
 		base = base[:idx]
 	}
 	base = lastName(strings.TrimSpace(strings.TrimPrefix(base, "Set ")))
-	if decl, ok := decls[strings.ToLower(base)]; ok {
+	if decl, ok := decls.lookup(base); ok {
 		info.Target = base
 		info.Type = decl.Type
 	}

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -6867,6 +6867,36 @@ End Sub
 	}
 }
 
+func TestAnalyzerVBA227DoesNotPropagateModuleSetupIntoShadowedArrayParameter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private values() As Long
+
+Private Sub SetupValues()
+  ReDim values(0 To 1)
+End Sub
+
+Private Sub Consume(ByRef values() As Long)
+  If UBound(values) > 0 Then Debug.Print values(0)
+End Sub
+
+Public Sub Run()
+  Dim other() As Long
+  SetupValues
+  Consume other
+End Sub
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA227"); len(got) != 2 || got[0].Procedure != "Consume" || got[1].Procedure != "Consume" {
+		t.Fatalf("module allocation must not initialize a shadowing array parameter: %+v", got)
+	}
+}
+
 func TestAnalyzerVBA227KeepsPublicByRefArrayCallsConservative(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -7414,6 +7444,38 @@ End Sub
 	got := findingsByCode(findings, "VBA227")
 	if len(got) != 2 || got[0].Procedure != "Unsafe" || got[1].Procedure != "Unsafe" {
 		t.Fatalf("only the unguarded Resume Next probe should remain unsafe: %+v", got)
+	}
+}
+
+func TestAnalyzerVBA227RecognizesCheckedResumeNextBoundsProbe(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Sub Consume(ByVal body As Variant)
+  Dim bytes() As Byte
+  If IsArray(body) Then
+    bytes = body
+  Else
+    bytes = StrConv(CStr(body), vbFromUnicode)
+  End If
+  Dim cb As Long
+  cb = 0
+  On Error Resume Next
+  cb = UBound(bytes) - LBound(bytes) + 1
+  On Error GoTo fail
+  If cb <= 0 Then Exit Sub
+  Debug.Print bytes(LBound(bytes))
+  Exit Sub
+fail:
+End Sub
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA227"); len(got) != 0 {
+		t.Fatalf("a successful bounds probe must prove the later indexed access safe: %+v", got)
 	}
 }
 

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -5090,6 +5090,28 @@ End Sub
 	}
 }
 
+func TestAnalyzerObjectNothingComparisonIgnoresOptionalParameterDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Function Load(Optional ad As mscorlib.AppDomain = Nothing) As Object
+  If ad = Nothing Then
+    Set ad = New Collection
+  End If
+  Set Load = ad
+End Function
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA209")
+	if len(got) != 1 || got[0].Line != 3 || !strings.Contains(got[0].Message, "ad") {
+		t.Fatalf("optional default must be ignored while executable comparison remains reported: %+v", got)
+	}
+}
+
 func TestVBA209BatchAndRealtimeResultsMatch(t *testing.T) {
 	dir := t.TempDir()
 	source := `Option Explicit
@@ -7476,6 +7498,46 @@ End Sub
 	}
 	if got := findingsByCode(findings, "VBA227"); len(got) != 0 {
 		t.Fatalf("a successful bounds probe must prove the later indexed access safe: %+v", got)
+	}
+}
+
+func TestAnalyzerVBA227RejectsUnprovenResumeNextCapacityGuard(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Sub Stale(ByRef values() As Byte)
+  Dim capacity As Long
+  capacity = 1
+  On Error Resume Next
+  capacity = UBound(values) - LBound(values) + 1
+  On Error GoTo 0
+  If capacity <= 0 Then Exit Sub
+  Debug.Print values(LBound(values))
+End Sub
+
+Private Sub GotoGuard(ByRef values() As Byte)
+  Dim capacity As Long
+  capacity = 0
+  On Error Resume Next
+  capacity = UBound(values) - LBound(values) + 1
+  On Error GoTo 0
+  If capacity <= 0 Then GoTo done
+  Debug.Print values(LBound(values))
+done:
+End Sub
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA227")
+	seen := map[string]bool{}
+	for _, finding := range got {
+		seen[finding.Procedure] = true
+	}
+	if !seen["Stale"] || !seen["GotoGuard"] {
+		t.Fatalf("unproven Resume Next guards must not suppress indexed access: %+v", got)
 	}
 }
 

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -6919,6 +6919,27 @@ End Sub
 	}
 }
 
+func TestArrayModuleEntryStateDoesNotInitializeShadowingParameter(t *testing.T) {
+	t.Parallel()
+	moduleDecls := map[string]sourceDeclaration{
+		"values": {Name: "values", Type: "Byte", Array: true},
+	}
+	proc := sourceProcedure{
+		Name: "Consume", Module: "Main", StartLine: 1, EndLine: 2,
+		Params: []parameterInfo{{Name: "values", Type: "Byte()", Passing: "ByRef", ValueShape: procedureir.ValueShapeDynamicArray}},
+	}
+	file := parsedFile{
+		Lines:              []string{"Private Sub Consume(ByRef values() As Byte)", "End Sub"},
+		ModuleDeclarations: moduleDecls,
+	}
+	variables := arrayVariables(file, proc, moduleDecls)
+	entries := arrayModuleEntryStates{arrayProcedureKey(proc): {"values": true}}
+	state := applyArrayModuleEntryState(arrayInitialState(variables), file, proc, variables, moduleDecls, entries)
+	if state["values"].kind == arrayAllocated {
+		t.Fatalf("module entry allocation must not initialize a shadowing parameter: %+v", state["values"])
+	}
+}
+
 func TestAnalyzerVBA227KeepsPublicByRefArrayCallsConservative(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -7538,6 +7559,44 @@ End Sub
 	}
 	if !seen["Stale"] || !seen["GotoGuard"] {
 		t.Fatalf("unproven Resume Next guards must not suppress indexed access: %+v", got)
+	}
+}
+
+func TestAnalyzerVBA227RejectsStaticCapacityAfterFailedProbe(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Sub StaticCapacity(ByRef values() As Byte)
+  Static capacity As Long
+  On Error Resume Next
+  capacity = UBound(values) - LBound(values) + 1
+  On Error GoTo 0
+  If capacity <= 0 Then Exit Sub
+  Debug.Print values(LBound(values))
+End Sub
+
+Public Sub Run()
+  Dim allocated() As Byte
+  Dim unallocated() As Byte
+  ReDim allocated(0 To 0)
+  StaticCapacity allocated
+  StaticCapacity unallocated
+End Sub
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := false
+	for _, finding := range findingsByCode(findings, "VBA227") {
+		if finding.Procedure == "StaticCapacity" {
+			seen = true
+			break
+		}
+	}
+	if !seen {
+		t.Fatalf("a Static capacity value must not validate a later failed UBound probe: %+v", findings)
 	}
 }
 

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -122,6 +122,8 @@ var (
 	arrayOnErrorGotoZeroRe    = regexp.MustCompile(`(?i)^\s*on\s+error\s+goto\s+0\s*$`)
 	arrayErrNumberFailureRe   = regexp.MustCompile(`(?i)^\s*if\s+err\.number\s*<>\s*0\s+then\s*$`)
 	arrayCapacityProbeRe      = regexp.MustCompile(`(?i)^\s*([A-Za-z_]\w*)\s*=\s*ubound\s*\(\s*([A-Za-z_]\w*)\s*\)\s*\+\s*1\s*$`)
+	arrayBoundsProbeRe        = regexp.MustCompile(`(?i)^\s*([A-Za-z_]\w*)\s*=\s*ubound\s*\(\s*([A-Za-z_]\w*)\s*\)\s*-\s*lbound\s*\(\s*([A-Za-z_]\w*)\s*\)\s*\+\s*1\s*$`)
+	arrayCheckedProbeExitRe   = regexp.MustCompile(`(?i)^\s*if\s+([A-Za-z_]\w*)\s*(?:<=|=)\s*0\s+then\s+(?:exit\s+(?:sub|function|property)|goto\s+[A-Za-z_]\w*)\s*$`)
 	arrayCapacityIfRe         = regexp.MustCompile(`(?i)^\s*if\s+.+\s*>\s*([A-Za-z_]\w*)\s+then\s*$`)
 	arrayForZeroToCountRe     = regexp.MustCompile(`(?i)^\s*for\s+[A-Za-z_]\w*\s*=\s*0\s+to\s+[A-Za-z_]\w*\s*-\s*1\s*$`)
 	arrayLabelRe              = regexp.MustCompile(`(?i)^\s*([A-Za-z_]\w*)\s*:\s*$`)
@@ -517,6 +519,12 @@ func arrayResumeNextCapacityGuards(file parsedFile, proc sourceProcedure, variab
 				targetName = strings.ToLower(match[2])
 				break
 			}
+			if match := arrayBoundsProbeRe.FindStringSubmatch(text); len(match) == 4 && strings.EqualFold(match[2], match[3]) {
+				probeIndex = candidate
+				capacityName = strings.ToLower(match[1])
+				targetName = strings.ToLower(match[2])
+				break
+			}
 		}
 		if probeIndex < 0 {
 			continue
@@ -524,6 +532,29 @@ func arrayResumeNextCapacityGuards(file parsedFile, proc sourceProcedure, variab
 		variable, known := variables[targetName]
 		if !known || !variable.isArray {
 			continue
+		}
+		if restoreIndex, restoreText, ok := nextNonEmpty(probeIndex + 1); ok &&
+			(arrayOnErrorGotoZeroRe.MatchString(restoreText) || arrayOnErrorGotoRe.MatchString(restoreText)) {
+			if checkIndex, checkText, ok := nextNonEmpty(restoreIndex + 1); ok {
+				if match := arrayCheckedProbeExitRe.FindStringSubmatch(checkText); len(match) == 2 && strings.EqualFold(match[1], capacityName) {
+					indexStartLine := checkIndex + 2
+					indexEndLine := end
+					for candidate := indexStartLine - 1; candidate < end; candidate++ {
+						text := lineText(candidate)
+						if erase := arrayEraseRe.FindStringSubmatch(text); len(erase) == 2 && strings.EqualFold(strings.TrimSpace(erase[1]), targetName) {
+							indexEndLine = candidate
+							break
+						}
+					}
+					guards = append(guards, arrayResumeNextCapacityGuard{
+						target:         targetName,
+						probeLine:      probeIndex + 1,
+						indexStartLine: indexStartLine,
+						indexEndLine:   indexEndLine,
+					})
+					continue
+				}
+			}
 		}
 		errIndex, errText, ok := nextNonEmpty(probeIndex + 1)
 		if !ok || !arrayErrNumberFailureRe.MatchString(errText) {
@@ -658,6 +689,10 @@ func arrayResumeNextCapacityIndexApplies(guards []arrayResumeNextCapacityGuard, 
 		}
 	}
 	return false
+}
+
+func arrayResumeNextCapacityProofApplies(guards []arrayResumeNextCapacityGuard, name string, line int) bool {
+	return arrayResumeNextCapacityProbeApplies(guards, name, line) || arrayResumeNextCapacityIndexApplies(guards, name, line)
 }
 
 // walkArrayCFG owns the common allocation-state worklist used by both the
@@ -1995,7 +2030,8 @@ func applyArrayModuleCallEffects(state arrayFlowState, file parsedFile, proc sou
 	if !ok {
 		return state
 	}
-	localDeclarations := file.procedureDeclarationsFor(proc)
+	declarations := newDeclarationScope(file, proc)
+	declarations.module = moduleDecls
 	updated := cloneArrayState(state)
 	markArgument := func(name string) {
 		name = strings.ToLower(cleanIdentifier(name))
@@ -2010,7 +2046,7 @@ func applyArrayModuleCallEffects(state arrayFlowState, file parsedFile, proc sou
 	}
 	markModule := func(name string) {
 		name = strings.ToLower(cleanIdentifier(name))
-		if _, shadowed := localDeclarations[name]; shadowed {
+		if declarations.shadowsModule(name) {
 			return
 		}
 		declaration, declared := moduleDecls[name]
@@ -2121,11 +2157,12 @@ func applyArrayInternalStorageConfiguration(state arrayFlowState, file parsedFil
 	if len(arrays) == 0 {
 		return state
 	}
-	localDeclarations := file.procedureDeclarationsFor(proc)
+	declarations := newDeclarationScope(file, proc)
+	declarations.module = moduleDecls
 	updated := cloneArrayState(state)
 	for name := range arrays {
 		name = strings.ToLower(cleanIdentifier(name))
-		if _, shadowed := localDeclarations[name]; shadowed {
+		if declarations.shadowsModule(name) {
 			continue
 		}
 		declaration, declared := moduleDecls[name]
@@ -2219,11 +2256,12 @@ func applyArrayModuleConfigurationBranch(state arrayFlowState, statement *proced
 	if len(arrays) == 0 {
 		return state
 	}
-	localDeclarations := file.procedureDeclarationsFor(proc)
+	declarations := newDeclarationScope(file, proc)
+	declarations.module = moduleDecls
 	updated := cloneArrayState(state)
 	for name := range arrays {
 		name = strings.ToLower(cleanIdentifier(name))
-		if _, shadowed := localDeclarations[name]; shadowed {
+		if declarations.shadowsModule(name) {
 			continue
 		}
 		declaration, declared := moduleDecls[name]
@@ -2306,9 +2344,12 @@ func arrayModuleAllocationSummaryForProcedure(file parsedFile, proc sourceProced
 	if len(moduleArrays) == 0 || proc.Graph == nil {
 		return nil
 	}
-	localDeclarations := file.procedureDeclarationsFor(proc)
-	for name := range localDeclarations {
-		delete(moduleArrays, name)
+	declarations := newDeclarationScope(file, proc)
+	declarations.module = moduleDecls
+	for name := range moduleArrays {
+		if declarations.shadowsModule(name) {
+			delete(moduleArrays, name)
+		}
 	}
 	idempotentSetupArrays := arrayModuleIdempotentSetupArrays(file, proc, moduleDecls)
 	allocated := map[string]bool{}
@@ -2630,10 +2671,11 @@ func applyArrayModuleInitializationState(state arrayFlowState, file parsedFile, 
 	if strings.EqualFold(strings.TrimSpace(proc.Name), initializer) {
 		return state
 	}
-	localDeclarations := file.procedureDeclarationsFor(proc)
+	declarations := newDeclarationScope(file, proc)
+	declarations.module = moduleDecls
 	updated := cloneArrayState(state)
 	for name := range initializationStates[file.Path] {
-		if _, shadowed := localDeclarations[name]; shadowed {
+		if declarations.shadowsModule(name) {
 			continue
 		}
 		declaration, ok := moduleDecls[name]
@@ -2780,8 +2822,12 @@ func arrayModuleNamesForProcedure(file parsedFile, proc sourceProcedure, moduleD
 			moduleArrays[strings.ToLower(name)] = true
 		}
 	}
-	for name := range file.procedureDeclarationsFor(proc) {
-		delete(moduleArrays, name)
+	declarations := newDeclarationScope(file, proc)
+	declarations.module = moduleDecls
+	for name := range moduleArrays {
+		if declarations.shadowsModule(name) {
+			delete(moduleArrays, name)
+		}
 	}
 	return moduleArrays
 }
@@ -3499,7 +3545,7 @@ func (a Analyzer) arrayTransfer(file parsedFile, proc sourceProcedure, ctx analy
 			continue
 		}
 		if value.kind != arrayAllocated || !value.knownArray {
-			if arrayResumeNextCapacityProbeApplies(capacityGuards, name, line) {
+			if arrayResumeNextCapacityProofApplies(capacityGuards, name, line) {
 				// A recognized Resume Next capacity probe deliberately catches
 				// this bounds failure before its fallback allocation branch.
 				continue

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -123,7 +123,7 @@ var (
 	arrayErrNumberFailureRe   = regexp.MustCompile(`(?i)^\s*if\s+err\.number\s*<>\s*0\s+then\s*$`)
 	arrayCapacityProbeRe      = regexp.MustCompile(`(?i)^\s*([A-Za-z_]\w*)\s*=\s*ubound\s*\(\s*([A-Za-z_]\w*)\s*\)\s*\+\s*1\s*$`)
 	arrayBoundsProbeRe        = regexp.MustCompile(`(?i)^\s*([A-Za-z_]\w*)\s*=\s*ubound\s*\(\s*([A-Za-z_]\w*)\s*\)\s*-\s*lbound\s*\(\s*([A-Za-z_]\w*)\s*\)\s*\+\s*1\s*$`)
-	arrayCheckedProbeExitRe   = regexp.MustCompile(`(?i)^\s*if\s+([A-Za-z_]\w*)\s*(?:<=|=)\s*0\s+then\s+(?:exit\s+(?:sub|function|property)|goto\s+[A-Za-z_]\w*)\s*$`)
+	arrayCheckedProbeExitRe   = regexp.MustCompile(`(?i)^\s*if\s+([A-Za-z_]\w*)\s*(?:<=|=)\s*0\s+then\s+exit\s+(?:sub|function|property)\s*$`)
 	arrayCapacityIfRe         = regexp.MustCompile(`(?i)^\s*if\s+.+\s*>\s*([A-Za-z_]\w*)\s+then\s*$`)
 	arrayForZeroToCountRe     = regexp.MustCompile(`(?i)^\s*for\s+[A-Za-z_]\w*\s*=\s*0\s+to\s+[A-Za-z_]\w*\s*-\s*1\s*$`)
 	arrayLabelRe              = regexp.MustCompile(`(?i)^\s*([A-Za-z_]\w*)\s*:\s*$`)
@@ -533,26 +533,28 @@ func arrayResumeNextCapacityGuards(file parsedFile, proc sourceProcedure, variab
 		if !known || !variable.isArray {
 			continue
 		}
-		if restoreIndex, restoreText, ok := nextNonEmpty(probeIndex + 1); ok &&
-			(arrayOnErrorGotoZeroRe.MatchString(restoreText) || arrayOnErrorGotoRe.MatchString(restoreText)) {
-			if checkIndex, checkText, ok := nextNonEmpty(restoreIndex + 1); ok {
-				if match := arrayCheckedProbeExitRe.FindStringSubmatch(checkText); len(match) == 2 && strings.EqualFold(match[1], capacityName) {
-					indexStartLine := checkIndex + 2
-					indexEndLine := end
-					for candidate := indexStartLine - 1; candidate < end; candidate++ {
-						text := lineText(candidate)
-						if erase := arrayEraseRe.FindStringSubmatch(text); len(erase) == 2 && strings.EqualFold(strings.TrimSpace(erase[1]), targetName) {
-							indexEndLine = candidate
-							break
+		if arrayResumeNextCapacityStartsAtZero(file, proc, variables, index, capacityName) {
+			if restoreIndex, restoreText, ok := nextNonEmpty(probeIndex + 1); ok &&
+				(arrayOnErrorGotoZeroRe.MatchString(restoreText) || arrayOnErrorGotoRe.MatchString(restoreText)) {
+				if checkIndex, checkText, ok := nextNonEmpty(restoreIndex + 1); ok {
+					if match := arrayCheckedProbeExitRe.FindStringSubmatch(checkText); len(match) == 2 && strings.EqualFold(match[1], capacityName) {
+						indexStartLine := checkIndex + 2
+						indexEndLine := end
+						for candidate := indexStartLine - 1; candidate < end; candidate++ {
+							text := lineText(candidate)
+							if erase := arrayEraseRe.FindStringSubmatch(text); len(erase) == 2 && strings.EqualFold(strings.TrimSpace(erase[1]), targetName) {
+								indexEndLine = candidate
+								break
+							}
 						}
+						guards = append(guards, arrayResumeNextCapacityGuard{
+							target:         targetName,
+							probeLine:      probeIndex + 1,
+							indexStartLine: indexStartLine,
+							indexEndLine:   indexEndLine,
+						})
+						continue
 					}
-					guards = append(guards, arrayResumeNextCapacityGuard{
-						target:         targetName,
-						probeLine:      probeIndex + 1,
-						indexStartLine: indexStartLine,
-						indexEndLine:   indexEndLine,
-					})
-					continue
 				}
 			}
 		}
@@ -646,6 +648,76 @@ func arrayResumeNextCapacityGuards(file parsedFile, proc sourceProcedure, variab
 		})
 	}
 	return guards
+}
+
+// arrayResumeNextCapacityStartsAtZero proves the only state that makes a
+// Resume Next bounds probe safe to use as a guard: a failed assignment must
+// leave the capacity at zero. A stale positive value would make `If capacity
+// <= 0 Then Exit ...` incorrectly accept an unallocated array.
+func arrayResumeNextCapacityStartsAtZero(file parsedFile, proc sourceProcedure, variables map[string]arrayVariable, resumeIndex int, capacityName string) bool {
+	start := max(0, proc.StartLine-1)
+	lineText := func(index int) string {
+		if index < 0 || index >= len(file.Lines) {
+			return ""
+		}
+		return strings.TrimSpace(normalizedCodeLine(file.Lines[index]))
+	}
+	for index := resumeIndex - 1; index >= start; index-- {
+		text := lineText(index)
+		if text == "" {
+			continue
+		}
+		if rhs, assigned := arrayScalarAssignment(text, capacityName); assigned {
+			return strings.TrimSpace(rhs) == "0"
+		}
+		break
+	}
+
+	variable, known := variables[strings.ToLower(cleanIdentifier(capacityName))]
+	if !known || variable.parameter || variable.isArray || variable.isVariant || !variable.knownScalar {
+		return false
+	}
+	declarationLine := 0
+	for _, declaration := range proc.Declarations {
+		if declaration.Scope != procedureir.ScopeLocal || !strings.EqualFold(cleanIdentifier(declaration.Name), cleanIdentifier(capacityName)) || declaration.IsArray || !arrayKnownScalarType(declaration.Type) {
+			continue
+		}
+		declarationLine = declaration.Range.StartLine
+		break
+	}
+	if declarationLine == 0 || declarationLine > resumeIndex+1 {
+		return false
+	}
+	for index := start; index < resumeIndex; index++ {
+		text := lineText(index)
+		if text == "" || index+1 == declarationLine {
+			continue
+		}
+		if _, assigned := arrayScalarAssignment(text, capacityName); assigned || strings.Contains(strings.ToLower(text), strings.ToLower(cleanIdentifier(capacityName))) {
+			return false
+		}
+	}
+	return true
+}
+
+func arrayScalarAssignment(text, name string) (string, bool) {
+	name = strings.ToLower(cleanIdentifier(name))
+	if name == "" {
+		return "", false
+	}
+	statements := strings.Split(text, ":")
+	for index := len(statements) - 1; index >= 0; index-- {
+		statement := statements[index]
+		if strings.TrimSpace(statement) == "" {
+			continue
+		}
+		lhs, rhs, indexed, assigned := arrayAssignment(strings.TrimSpace(statement))
+		if assigned && !indexed && strings.EqualFold(cleanIdentifier(lhs), name) {
+			return rhs, true
+		}
+		break
+	}
+	return "", false
 }
 
 func arraySourceIfEnd(lines []string, start, end int) int {

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -55,6 +55,7 @@ type arrayVariable struct {
 	knownScalar bool
 	fixed       bool
 	parameter   bool
+	static      bool
 	paramArray  bool
 	dimensions  []arrayDimension
 }
@@ -155,7 +156,7 @@ func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, 
 	initial := arrayInitialState(variables)
 	initial = applyArrayInternalStorageConfiguration(initial, file, proc, variables, moduleDecls, ctx.arrayModuleConfigurations[file.Path])
 	initial = applyArrayByRefEntryStates(initial, proc, variables, ctx.arrayByRefEntryStates, ctx.arrayByRefEntryConditions)
-	initial = applyArrayModuleEntryState(initial, proc, variables, moduleDecls, ctx.arrayModuleEntryStates)
+	initial = applyArrayModuleEntryState(initial, file, proc, variables, moduleDecls, ctx.arrayModuleEntryStates)
 	// Constant bounds are scoped to the current procedure. Resolve them once
 	// for this CFG walk so every ReDim transfer shares the same table without
 	// repeatedly reparsing the module and procedure declarations.
@@ -175,7 +176,7 @@ func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, 
 		vba227Initial := arrayInitialState(vba227Variables)
 		vba227Initial = applyArrayInternalStorageConfiguration(vba227Initial, file, proc, vba227Variables, moduleDecls, ctx.arrayModuleConfigurations[file.Path])
 		vba227Initial = applyArrayByRefEntryStates(vba227Initial, proc, vba227Variables, ctx.arrayByRefEntryStates, ctx.arrayByRefEntryConditions)
-		vba227Initial = applyArrayModuleEntryState(vba227Initial, proc, vba227Variables, moduleDecls, ctx.arrayModuleEntryStates)
+		vba227Initial = applyArrayModuleEntryState(vba227Initial, file, proc, vba227Variables, moduleDecls, ctx.arrayModuleEntryStates)
 		for _, finding := range a.arrayVBA227LinearFindings(file, proc, ctx, vba227Variables, vba227Initial, constants, capacityGuards) {
 			if finding.Code == "VBA227" {
 				findings = append(findings, finding)
@@ -218,7 +219,7 @@ func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, 
 		vba227Initial := arrayInitialState(vba227Variables)
 		vba227Initial = applyArrayInternalStorageConfiguration(vba227Initial, file, proc, vba227Variables, moduleDecls, ctx.arrayModuleConfigurations[file.Path])
 		vba227Initial = applyArrayByRefEntryStates(vba227Initial, proc, vba227Variables, ctx.arrayByRefEntryStates, ctx.arrayByRefEntryConditions)
-		vba227Initial = applyArrayModuleEntryState(vba227Initial, proc, vba227Variables, moduleDecls, ctx.arrayModuleEntryStates)
+		vba227Initial = applyArrayModuleEntryState(vba227Initial, file, proc, vba227Variables, moduleDecls, ctx.arrayModuleEntryStates)
 		vba227CapacityGuards := arrayResumeNextCapacityGuards(file, proc, vba227Variables)
 		walkArrayCFGWithSourceLines(&vba227Graph, file.Lines, vba227Initial, func(text string, line int, in arrayFlowState) arrayFlowState {
 			out, issues := a.arrayVBA227Transfer(file, proc, ctx, vba227Variables, in, text, line, constants, vba227CapacityGuards)
@@ -655,6 +656,10 @@ func arrayResumeNextCapacityGuards(file parsedFile, proc sourceProcedure, variab
 // leave the capacity at zero. A stale positive value would make `If capacity
 // <= 0 Then Exit ...` incorrectly accept an unallocated array.
 func arrayResumeNextCapacityStartsAtZero(file parsedFile, proc sourceProcedure, variables map[string]arrayVariable, resumeIndex int, capacityName string) bool {
+	variable, known := variables[strings.ToLower(cleanIdentifier(capacityName))]
+	if known && variable.static {
+		return false
+	}
 	start := max(0, proc.StartLine-1)
 	lineText := func(index int) string {
 		if index < 0 || index >= len(file.Lines) {
@@ -673,7 +678,6 @@ func arrayResumeNextCapacityStartsAtZero(file parsedFile, proc sourceProcedure, 
 		break
 	}
 
-	variable, known := variables[strings.ToLower(cleanIdentifier(capacityName))]
 	if !known || variable.parameter || variable.isArray || variable.isVariant || !variable.knownScalar {
 		return false
 	}
@@ -2815,7 +2819,7 @@ func inferArrayModuleEntryStates(a Analyzer, files []parsedFile, ctx analysisCon
 			variables := procedure.variables
 			initial := arrayInitialState(variables)
 			initial = applyArrayModuleInitializationState(initial, procedure.file, procedure.proc, variables, procedure.moduleDecls, initializationStates)
-			initial = applyArrayModuleEntryState(initial, procedure.proc, variables, procedure.moduleDecls, entries)
+			initial = applyArrayModuleEntryState(initial, procedure.file, procedure.proc, variables, procedure.moduleDecls, entries)
 			initial = applyArrayInternalStorageConfiguration(initial, procedure.file, procedure.proc, variables, procedure.moduleDecls, ctx.arrayModuleConfigurations[procedure.file.Path])
 
 			recordCall := func(call procedureir.CallSite, state arrayFlowState) {
@@ -2904,13 +2908,18 @@ func arrayModuleNamesForProcedure(file parsedFile, proc sourceProcedure, moduleD
 	return moduleArrays
 }
 
-func applyArrayModuleEntryState(state arrayFlowState, proc sourceProcedure, variables map[string]arrayVariable, moduleDecls map[string]sourceDeclaration, entries arrayModuleEntryStates) arrayFlowState {
+func applyArrayModuleEntryState(state arrayFlowState, file parsedFile, proc sourceProcedure, variables map[string]arrayVariable, moduleDecls map[string]sourceDeclaration, entries arrayModuleEntryStates) arrayFlowState {
 	allocated := entries[arrayProcedureKey(proc)]
 	if len(allocated) == 0 {
 		return state
 	}
+	declarations := newDeclarationScope(file, proc)
+	declarations.module = moduleDecls
 	updated := cloneArrayState(state)
 	for name := range allocated {
+		if declarations.shadowsModule(name) {
+			continue
+		}
 		declaration, declared := moduleDecls[name]
 		variable, known := variables[name]
 		if !declared || !declaration.Array || declaration.Parameter || !known || !variable.isArray {
@@ -3005,7 +3014,7 @@ func inferArrayByRefEntryStates(a Analyzer, files []parsedFile, ctx analysisCont
 			initial := arrayInitialState(variables)
 			initial = applyArrayModuleInitializationState(initial, file, proc, variables, moduleDecls, moduleInitializationStates)
 			initial = applyArrayByRefEntryStates(initial, proc, variables, entries, ctx.arrayByRefEntryConditions)
-			initial = applyArrayModuleEntryState(initial, proc, variables, moduleDecls, ctx.arrayModuleEntryStates)
+			initial = applyArrayModuleEntryState(initial, file, proc, variables, moduleDecls, ctx.arrayModuleEntryStates)
 			initial = applyArrayInternalStorageConfiguration(initial, file, proc, variables, moduleDecls, ctx.arrayModuleConfigurations[file.Path])
 			visit := func(text string, line int, in arrayFlowState) arrayFlowState {
 				var eligible []arrayByRefCallCandidate
@@ -3784,7 +3793,7 @@ func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 		// Treat them exactly like an explicit Variant so array-sensitive rules
 		// do not turn an unresolved value into a false scalar proof.
 		isVariant := typeName == "" || strings.EqualFold(typeName, "Variant")
-		variable := arrayVariable{name: decl.Name, typ: decl.Type, isArray: decl.Array, isVariant: isVariant, isObject: decl.Object, knownScalar: !isVariant && arrayKnownScalarType(typeName), parameter: decl.Parameter, paramArray: decl.ParamArray}
+		variable := arrayVariable{name: decl.Name, typ: decl.Type, isArray: decl.Array, isVariant: isVariant, isObject: decl.Object, knownScalar: !isVariant && arrayKnownScalarType(typeName), parameter: decl.Parameter, static: decl.Static, paramArray: decl.ParamArray}
 		if decl.Array {
 			variable.dimensions, variable.fixed = declarationDimensions(file.Lines, decl.Line, decl.Name, base)
 			if len(decl.Dimensions) > 0 {

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -132,27 +132,6 @@ var (
 )
 
 func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration) []Finding {
-	// Array-shape enrichment is local to this rule. Do not mutate the shared
-	// declaration map used by object, Excel, and dictionary analyses later in
-	// the same module; doing so can change unrelated findings for subsequent
-	// procedures.
-	moduleDecls = cloneDeclarations(moduleDecls)
-	// Keep module-level Const/Enum declarations visible to the shared shape
-	// lattice; the historical text scanner only indexed Dim/Static/visibility
-	// declarations.
-	for _, declaration := range file.IR.Declarations {
-		key := strings.ToLower(declaration.Name)
-		if key == "" {
-			continue
-		}
-		if _, exists := moduleDecls[key]; exists {
-			continue
-		}
-		moduleDecls[key] = sourceDeclaration{
-			Name: declaration.Name, Type: declaration.Type, Line: declaration.Range.StartLine,
-			Object: declaration.IsObject, Array: declaration.IsArray,
-		}
-	}
 	variables := arrayVariables(file, proc, moduleDecls)
 	capacityGuards := arrayResumeNextCapacityGuards(file, proc, variables)
 	objectArrayDiagnosticsApplicable := false
@@ -2016,7 +1995,7 @@ func applyArrayModuleCallEffects(state arrayFlowState, file parsedFile, proc sou
 	if !ok {
 		return state
 	}
-	localDeclarations := procedureDeclarations(file.Lines, proc)
+	localDeclarations := file.procedureDeclarationsFor(proc)
 	updated := cloneArrayState(state)
 	markArgument := func(name string) {
 		name = strings.ToLower(cleanIdentifier(name))
@@ -2142,7 +2121,7 @@ func applyArrayInternalStorageConfiguration(state arrayFlowState, file parsedFil
 	if len(arrays) == 0 {
 		return state
 	}
-	localDeclarations := procedureDeclarations(file.Lines, proc)
+	localDeclarations := file.procedureDeclarationsFor(proc)
 	updated := cloneArrayState(state)
 	for name := range arrays {
 		name = strings.ToLower(cleanIdentifier(name))
@@ -2240,7 +2219,7 @@ func applyArrayModuleConfigurationBranch(state arrayFlowState, statement *proced
 	if len(arrays) == 0 {
 		return state
 	}
-	localDeclarations := procedureDeclarations(file.Lines, proc)
+	localDeclarations := file.procedureDeclarationsFor(proc)
 	updated := cloneArrayState(state)
 	for name := range arrays {
 		name = strings.ToLower(cleanIdentifier(name))
@@ -2327,7 +2306,7 @@ func arrayModuleAllocationSummaryForProcedure(file parsedFile, proc sourceProced
 	if len(moduleArrays) == 0 || proc.Graph == nil {
 		return nil
 	}
-	localDeclarations := procedureDeclarations(file.Lines, proc)
+	localDeclarations := file.procedureDeclarationsFor(proc)
 	for name := range localDeclarations {
 		delete(moduleArrays, name)
 	}
@@ -2651,7 +2630,7 @@ func applyArrayModuleInitializationState(state arrayFlowState, file parsedFile, 
 	if strings.EqualFold(strings.TrimSpace(proc.Name), initializer) {
 		return state
 	}
-	localDeclarations := procedureDeclarations(file.Lines, proc)
+	localDeclarations := file.procedureDeclarationsFor(proc)
 	updated := cloneArrayState(state)
 	for name := range initializationStates[file.Path] {
 		if _, shadowed := localDeclarations[name]; shadowed {
@@ -2801,7 +2780,7 @@ func arrayModuleNamesForProcedure(file parsedFile, proc sourceProcedure, moduleD
 			moduleArrays[strings.ToLower(name)] = true
 		}
 	}
-	for name := range procedureDeclarations(file.Lines, proc) {
+	for name := range file.procedureDeclarationsFor(proc) {
 		delete(moduleArrays, name)
 	}
 	return moduleArrays
@@ -3653,10 +3632,8 @@ func (a Analyzer) arrayTransfer(file parsedFile, proc sourceProcedure, ctx analy
 }
 
 func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration) map[string]arrayVariable {
-	decls := cloneDeclarations(moduleDecls)
-	for key, decl := range procedureDeclarations(file.Lines, proc) {
-		decls[key] = decl
-	}
+	decls := newDeclarationScope(file, proc)
+	decls.module = moduleDecls
 	base := arrayOptionBase(file)
 	// The legacy line scanner intentionally ignores Const and Enum syntax.
 	// Fill those gaps from the shared procedure IR so a known scalar constant
@@ -3666,19 +3643,16 @@ func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 		if key == "" {
 			continue
 		}
-		if _, exists := decls[key]; exists {
-			continue
-		}
-		decls[key] = sourceDeclaration{
+		decls.addExtraIfMissing(key, sourceDeclaration{
 			Name: declaration.Name, Type: declaration.Type, Line: declaration.Range.StartLine,
 			Object: declaration.IsObject, Array: declaration.IsArray,
 			Fixed:      declaration.ValueShape == procedureir.ValueShapeFixedArray,
 			Dimensions: parameterArrayDimensions(declaration.ArrayBounds, base),
-		}
+		})
 	}
 	for _, param := range proc.Params {
 		array := param.ParamArray || strings.Contains(param.Type, "()") || param.ValueShape == procedureir.ValueShapeFixedArray || param.ValueShape == procedureir.ValueShapeDynamicArray
-		decls[strings.ToLower(param.Name)] = sourceDeclaration{
+		decls.parameters[strings.ToLower(param.Name)] = sourceDeclaration{
 			Name: param.Name, Type: param.Type, Array: array,
 			Fixed:      param.ValueShape == procedureir.ValueShapeFixedArray,
 			Dimensions: parameterArrayDimensions(param.ArrayBounds, base),
@@ -3686,7 +3660,7 @@ func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 		}
 	}
 	variables := map[string]arrayVariable{}
-	for key, decl := range decls {
+	decls.forEach(func(key string, decl sourceDeclaration) {
 		typeName := strings.TrimSpace(decl.Type)
 		// VBA declarations without an As clause are implicit Variant values.
 		// Treat them exactly like an explicit Variant so array-sensitive rules
@@ -3706,7 +3680,7 @@ func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 			}
 		}
 		variables[key] = variable
-	}
+	})
 	return variables
 }
 

--- a/internal/analyze/declaration_scope.go
+++ b/internal/analyze/declaration_scope.go
@@ -47,6 +47,23 @@ func (scope declarationScope) lookup(name string) (sourceDeclaration, bool) {
 	return declaration, ok
 }
 
+func (scope declarationScope) shadowsModule(name string) bool {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		return false
+	}
+	if _, ok := scope.parameters[key]; ok {
+		return true
+	}
+	if _, ok := scope.local[key]; ok {
+		return true
+	}
+	if _, ok := scope.extra[key]; ok {
+		return true
+	}
+	return false
+}
+
 func (scope *declarationScope) addExtraIfMissing(name string, declaration sourceDeclaration) {
 	if scope == nil {
 		return

--- a/internal/analyze/declaration_scope.go
+++ b/internal/analyze/declaration_scope.go
@@ -1,0 +1,130 @@
+package analyze
+
+import "strings"
+
+// declarationScope layers procedure-local declarations over immutable module
+// declarations. Keeping the layers separate avoids copying a large module
+// declaration map for every procedure while preserving ordinary map lookup
+// semantics for callers that need the merged view.
+type declarationScope struct {
+	module     map[string]sourceDeclaration
+	extra      map[string]sourceDeclaration
+	local      map[string]sourceDeclaration
+	parameters map[string]sourceDeclaration
+}
+
+func newDeclarationScope(file parsedFile, proc sourceProcedure) declarationScope {
+	scope := declarationScope{
+		module:     file.moduleDecls(),
+		local:      file.procedureDeclarationsFor(proc),
+		parameters: make(map[string]sourceDeclaration, len(proc.Params)),
+	}
+	for _, parameter := range proc.Params {
+		name := strings.ToLower(strings.TrimSpace(parameter.Name))
+		if name == "" {
+			continue
+		}
+		scope.parameters[name] = sourceDeclaration{
+			Name: parameter.Name, Type: parameter.Type, Line: proc.StartLine,
+			Object: isObjectType(parameter.Type), Parameter: true,
+		}
+	}
+	return scope
+}
+
+func (scope declarationScope) lookup(name string) (sourceDeclaration, bool) {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if declaration, ok := scope.parameters[key]; ok {
+		return declaration, true
+	}
+	if declaration, ok := scope.local[key]; ok {
+		return declaration, true
+	}
+	if declaration, ok := scope.extra[key]; ok {
+		return declaration, true
+	}
+	declaration, ok := scope.module[key]
+	return declaration, ok
+}
+
+func (scope *declarationScope) addExtraIfMissing(name string, declaration sourceDeclaration) {
+	if scope == nil {
+		return
+	}
+	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		return
+	}
+	if _, exists := scope.lookup(key); exists {
+		return
+	}
+	if scope.extra == nil {
+		scope.extra = make(map[string]sourceDeclaration)
+	}
+	scope.extra[key] = declaration
+}
+
+// addProcedureIRDeclaration preserves procedure declarations recovered by the
+// IR when the source scanner cannot represent them. Procedure declarations
+// shadow module declarations, while parameters remain the highest-priority
+// layer in lookup and iteration.
+func (scope *declarationScope) addProcedureIRDeclaration(declaration sourceDeclaration) {
+	if scope == nil {
+		return
+	}
+	key := strings.ToLower(strings.TrimSpace(declaration.Name))
+	if key == "" {
+		return
+	}
+	if _, exists := scope.local[key]; exists {
+		return
+	}
+	if scope.extra == nil {
+		scope.extra = make(map[string]sourceDeclaration)
+	}
+	scope.extra[key] = declaration
+}
+
+// forEach visits the effective merged scope without allocating a merged map.
+// Overlay order matches map construction in the former implementation:
+// module, procedure declarations, IR-only extras, and parameters.
+func (scope declarationScope) forEach(visit func(string, sourceDeclaration)) {
+	if visit == nil {
+		return
+	}
+	for key, declaration := range scope.module {
+		if _, shadowed := scope.local[key]; shadowed {
+			continue
+		}
+		if _, shadowed := scope.extra[key]; shadowed {
+			continue
+		}
+		if _, shadowed := scope.parameters[key]; shadowed {
+			continue
+		}
+		visit(key, declaration)
+	}
+	for key, declaration := range scope.extra {
+		if _, shadowed := scope.local[key]; shadowed {
+			continue
+		}
+		if _, shadowed := scope.parameters[key]; shadowed {
+			continue
+		}
+		visit(key, declaration)
+	}
+	for key, declaration := range scope.local {
+		if _, shadowed := scope.parameters[key]; shadowed {
+			continue
+		}
+		visit(key, declaration)
+	}
+	for key, declaration := range scope.parameters {
+		visit(key, declaration)
+	}
+}
+
+func (scope declarationScope) len() int {
+	count := len(scope.module) + len(scope.extra) + len(scope.local) + len(scope.parameters)
+	return count
+}

--- a/internal/analyze/dictionary_collection_safety.go
+++ b/internal/analyze/dictionary_collection_safety.go
@@ -348,7 +348,7 @@ func dcInitialState(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 	for key, decl := range moduleDecls {
 		add(key, decl, false)
 	}
-	for key, decl := range procedureDeclarations(file.Lines, proc) {
+	for key, decl := range file.procedureDeclarationsFor(proc) {
 		add(key, decl, true)
 	}
 	for _, param := range proc.Params {

--- a/internal/analyze/hardcoded_secrets.go
+++ b/internal/analyze/hardcoded_secrets.go
@@ -65,9 +65,10 @@ func (a Analyzer) hardcodedSecretFindings(file parsedFile, procedures []sourcePr
 		}
 	}
 
+	facts := file.moduleAnalysisFacts()
 	for lineNo, rawLine := range file.Lines {
 		line := lineNo + 1
-		if lineInAnyProcedure(line, procedures) {
+		if facts != nil && facts.lineInProcedure(line) {
 			continue
 		}
 		code := strings.TrimSpace(gui.StripComment(rawLine))

--- a/internal/analyze/module_facts.go
+++ b/internal/analyze/module_facts.go
@@ -1,0 +1,157 @@
+package analyze
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+// moduleAnalysisFacts contains the immutable, file-local facts shared by the
+// source rules. It is built once for a parsed file revision and is safe to
+// retain on parsedFile values copied into worker goroutines.
+type moduleAnalysisFacts struct {
+	moduleDeclarations  map[string]sourceDeclaration
+	procedureLineOwners []int
+	procedureDecls      map[int]map[string]sourceDeclaration
+}
+
+func buildModuleAnalysisFacts(lines []string, document procedureir.DocumentIR, procedures []sourceProcedure) *moduleAnalysisFacts {
+	facts := &moduleAnalysisFacts{
+		moduleDeclarations:  make(map[string]sourceDeclaration),
+		procedureLineOwners: make([]int, len(lines)+1),
+		procedureDecls:      make(map[int]map[string]sourceDeclaration, len(procedures)),
+	}
+	for line := range facts.procedureLineOwners {
+		facts.procedureLineOwners[line] = -1
+	}
+
+	ordered := append([]sourceProcedure(nil), procedures...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].StartLine != ordered[j].StartLine {
+			return ordered[i].StartLine < ordered[j].StartLine
+		}
+		return ordered[i].StartByte < ordered[j].StartByte
+	})
+	coveredThrough := 0
+	for index, procedure := range ordered {
+		start := procedure.StartLine
+		if start < 1 {
+			start = 1
+		}
+		end := procedure.EndLine
+		if end > len(lines) {
+			end = len(lines)
+		}
+		if end >= start && end > coveredThrough {
+			fillStart := start
+			if fillStart <= coveredThrough {
+				fillStart = coveredThrough + 1
+			}
+			for line := fillStart; line <= end; line++ {
+				facts.procedureLineOwners[line] = index
+			}
+			coveredThrough = end
+		}
+		facts.procedureDecls[procedure.StartByte] = procedureDeclarations(lines, procedure)
+	}
+
+	if !document.Parse.HasError && !document.Parse.HasMissing && len(document.Declarations) > 0 {
+		for _, declaration := range document.Declarations {
+			if !isSourceModuleDeclaration(declaration) {
+				continue
+			}
+			if converted, ok := sourceDeclarationFromIR(declaration); ok {
+				facts.moduleDeclarations[strings.ToLower(converted.Name)] = converted
+			}
+		}
+	} else {
+		facts.moduleDeclarations = moduleDeclarationsFromSource(lines, facts.procedureLineOwners)
+	}
+	return facts
+}
+
+func isSourceModuleDeclaration(declaration procedureir.Declaration) bool {
+	if declaration.Scope != procedureir.ScopeModule && declaration.Scope != procedureir.ScopeProject {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(declaration.Kind)) {
+	case "variable", "module_variable", "field", "withevents_field", "variable_declaration", "const", "constant", "const_declaration":
+		return true
+	default:
+		return false
+	}
+}
+
+func sourceDeclarationFromIR(declaration procedureir.Declaration) (sourceDeclaration, bool) {
+	name := strings.TrimSpace(declaration.Name)
+	if name == "" {
+		return sourceDeclaration{}, false
+	}
+	return sourceDeclaration{
+		Name:          name,
+		Type:          declaration.Type,
+		Line:          declaration.Range.StartLine,
+		Object:        declaration.IsObject,
+		Array:         declaration.IsArray,
+		Fixed:         declaration.ValueShape == procedureir.ValueShapeFixedArray,
+		NewExpression: strings.HasPrefix(strings.ToLower(strings.TrimSpace(declaration.Type)), "new "),
+	}, true
+}
+
+func (facts *moduleAnalysisFacts) lineInProcedure(line int) bool {
+	return facts != nil && line >= 0 && line < len(facts.procedureLineOwners) && facts.procedureLineOwners[line] >= 0
+}
+
+func (facts *moduleAnalysisFacts) procedureDeclarations(procedure sourceProcedure) map[string]sourceDeclaration {
+	if facts == nil {
+		return nil
+	}
+	return facts.procedureDecls[procedure.StartByte]
+}
+
+func moduleDeclarationsFromSource(lines []string, procedureLineOwners []int) map[string]sourceDeclaration {
+	decls := make(map[string]sourceDeclaration)
+	for lineNo, rawLine := range lines {
+		line := lineNo + 1
+		if line >= 0 && line < len(procedureLineOwners) && procedureLineOwners[line] >= 0 {
+			continue
+		}
+		stmt := normalizedCodeLine(rawLine)
+		lower := strings.ToLower(stmt)
+		if !strings.HasPrefix(lower, "dim ") && !strings.HasPrefix(lower, "static ") && !strings.HasPrefix(lower, "private ") && !strings.HasPrefix(lower, "public ") {
+			continue
+		}
+		match := declRe.FindStringSubmatch(stmt)
+		if len(match) == 0 {
+			continue
+		}
+		for _, part := range splitArgs(match[1]) {
+			name, typ, array, newExpression := declarationNameAndType(part)
+			if name == "" {
+				continue
+			}
+			decls[strings.ToLower(name)] = sourceDeclaration{
+				Name: name, Type: typ, Line: line, Object: isObjectType(typ),
+				Array: array, NewExpression: newExpression,
+			}
+		}
+	}
+	return decls
+}
+
+func (file parsedFile) moduleAnalysisFacts() *moduleAnalysisFacts {
+	if file.ModuleFacts != nil {
+		return file.ModuleFacts
+	}
+	return buildModuleAnalysisFacts(file.Lines, file.IR, file.procedureProjection())
+}
+
+func (file parsedFile) procedureDeclarationsFor(proc sourceProcedure) map[string]sourceDeclaration {
+	if facts := file.moduleAnalysisFacts(); facts != nil {
+		if declarations := facts.procedureDeclarations(proc); declarations != nil {
+			return declarations
+		}
+	}
+	return procedureDeclarations(file.Lines, proc)
+}

--- a/internal/analyze/module_facts.go
+++ b/internal/analyze/module_facts.go
@@ -88,15 +88,33 @@ func sourceDeclarationFromIR(declaration procedureir.Declaration) (sourceDeclara
 	if name == "" {
 		return sourceDeclaration{}, false
 	}
+	typ := strings.TrimSpace(declaration.Type)
+	newExpression := strings.HasPrefix(strings.ToLower(typ), "new ")
+	if newExpression {
+		typ = strings.TrimSpace(typ[4:])
+	}
 	return sourceDeclaration{
-		Name:          name,
-		Type:          declaration.Type,
-		Line:          declaration.Range.StartLine,
-		Object:        declaration.IsObject,
+		Name: name,
+		Type: typ,
+		Line: declaration.Range.StartLine,
+		// Preserve known object types and IR object classifications, except for
+		// MSForms controls. Form controls are initialized by the form runtime and
+		// are not reliable roots for this rule; treating them as ordinary nullable
+		// objects caused false positives in the corpus.
+		Object:        sourceDeclarationIsObject(declaration, typ),
 		Array:         declaration.IsArray,
 		Fixed:         declaration.ValueShape == procedureir.ValueShapeFixedArray,
-		NewExpression: strings.HasPrefix(strings.ToLower(strings.TrimSpace(declaration.Type)), "new "),
+		NewExpression: newExpression,
 	}, true
+}
+
+func sourceDeclarationIsObject(declaration procedureir.Declaration, typ string) bool {
+	return (declaration.IsObject || isObjectType(typ)) && !isMSFormsControlType(typ)
+}
+
+func isMSFormsControlType(typ string) bool {
+	typ = strings.ToLower(strings.TrimSpace(typ))
+	return strings.HasPrefix(typ, "msforms.")
 }
 
 func (facts *moduleAnalysisFacts) lineInProcedure(line int) bool {

--- a/internal/analyze/module_facts_test.go
+++ b/internal/analyze/module_facts_test.go
@@ -21,6 +21,26 @@ func TestModuleAnalysisFactsUsesIRDeclarationsAndIndexedProcedureOwnership(t *te
 			Name: "moduleObject", Type: "Object", IsObject: true,
 			Scope: procedureir.ScopeModule, Kind: "variable",
 			Range: vbaast.Range{StartLine: 1, EndLine: 1},
+		}, {
+			Name: "newWorksheet", Type: " New Worksheet ", IsObject: true,
+			Scope: procedureir.ScopeModule, Kind: "variable",
+			Range: vbaast.Range{StartLine: 1, EndLine: 1},
+		}, {
+			Name: "table", Type: "ListObject",
+			Scope: procedureir.ScopeModule, Kind: "variable",
+			Range: vbaast.Range{StartLine: 1, EndLine: 1},
+		}, {
+			Name: "control", Type: "MSForms.Label", IsObject: true,
+			Scope: procedureir.ScopeModule, Kind: "variable",
+			Range: vbaast.Range{StartLine: 1, EndLine: 1},
+		}, {
+			Name: "customObject", Type: "TThis", IsObject: true,
+			Scope: procedureir.ScopeModule, Kind: "variable",
+			Range: vbaast.Range{StartLine: 1, EndLine: 1},
+		}, {
+			Name: "externalObject", Type: "mscorlib.AppDomain", IsObject: true,
+			Scope: procedureir.ScopeModule, Kind: "variable",
+			Range: vbaast.Range{StartLine: 1, EndLine: 1},
 		}},
 	}
 
@@ -33,6 +53,21 @@ func TestModuleAnalysisFactsUsesIRDeclarationsAndIndexedProcedureOwnership(t *te
 	}
 	if _, ok := facts.moduleDeclarations["moduleobject"]; !ok {
 		t.Fatalf("module declarations = %#v, want moduleObject", facts.moduleDeclarations)
+	}
+	if declaration := facts.moduleDeclarations["newworksheet"]; declaration.Type != "Worksheet" || !declaration.NewExpression {
+		t.Fatalf("normalized As New declaration = %#v, want Worksheet/NewExpression", declaration)
+	}
+	if declaration := facts.moduleDeclarations["table"]; !declaration.Object {
+		t.Fatalf("IR ListObject declaration = %#v, want object declaration", declaration)
+	}
+	if declaration := facts.moduleDeclarations["control"]; declaration.Object {
+		t.Fatalf("dotted form-control declaration = %#v, want non-object declaration", declaration)
+	}
+	if declaration := facts.moduleDeclarations["customobject"]; !declaration.Object {
+		t.Fatalf("unqualified custom declaration = %#v, want object declaration", declaration)
+	}
+	if declaration := facts.moduleDeclarations["externalobject"]; !declaration.Object {
+		t.Fatalf("qualified external declaration = %#v, want object declaration", declaration)
 	}
 	if _, ok := facts.moduleDeclarations["localvalue"]; ok {
 		t.Fatalf("procedure-local declaration leaked into module declarations: %#v", facts.moduleDeclarations)
@@ -80,10 +115,22 @@ func TestDeclarationScopeLayersWithoutModuleMapCopy(t *testing.T) {
 	if declaration, ok := scope.lookup("VALUE"); !ok || declaration.Type != "String" || !declaration.Parameter {
 		t.Fatalf("parameter overlay = %#v, %v", declaration, ok)
 	}
+	module["moduleonly"] = sourceDeclaration{Name: "moduleOnly", Type: "String"}
+	if declaration, ok := scope.lookup("moduleOnly"); !ok || declaration.Type != "String" {
+		t.Fatalf("scope must retain module map reference: %#v, %v", declaration, ok)
+	}
 	seen := map[string]sourceDeclaration{}
 	scope.forEach(func(key string, declaration sourceDeclaration) { seen[key] = declaration })
-	if len(seen) != 2 || seen["value"].Type != "String" || seen["moduleonly"].Type != "Long" {
+	if len(seen) != 2 || seen["value"].Type != "String" || seen["moduleonly"].Type != "String" {
 		t.Fatalf("effective declaration scope = %#v, want parameter shadowing without duplication", seen)
+	}
+	arrayScope := newDeclarationScope(file, sourceProcedure{
+		StartLine: 1,
+		EndLine:   1,
+		Params:    []parameterInfo{{Name: "moduleOnly", Type: "Long()"}},
+	})
+	if !arrayScope.shadowsModule("moduleOnly") {
+		t.Fatalf("parameter declaration should shadow module array names")
 	}
 }
 

--- a/internal/analyze/module_facts_test.go
+++ b/internal/analyze/module_facts_test.go
@@ -60,6 +60,8 @@ func TestModuleAnalysisFactsUsesIRDeclarationsAndIndexedProcedureOwnership(t *te
 	if declaration := facts.moduleDeclarations["table"]; !declaration.Object {
 		t.Fatalf("IR ListObject declaration = %#v, want object declaration", declaration)
 	}
+	// MSForms controls are runtime-initialized and excluded, while other
+	// IR-marked external objects such as mscorlib.AppDomain remain objects.
 	if declaration := facts.moduleDeclarations["control"]; declaration.Object {
 		t.Fatalf("dotted form-control declaration = %#v, want non-object declaration", declaration)
 	}

--- a/internal/analyze/module_facts_test.go
+++ b/internal/analyze/module_facts_test.go
@@ -1,0 +1,151 @@
+package analyze
+
+import (
+	"testing"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+func TestModuleAnalysisFactsUsesIRDeclarationsAndIndexedProcedureOwnership(t *testing.T) {
+	lines := []string{
+		"Dim moduleObject As Object",
+		"Public Sub First()",
+		"    Dim localValue As Long",
+		"End Sub",
+		"Private Const moduleConst As Long = 1",
+	}
+	procedures := []sourceProcedure{{StartLine: 2, EndLine: 4, StartByte: 10}}
+	document := procedureir.DocumentIR{
+		Declarations: []procedureir.Declaration{{
+			Name: "moduleObject", Type: "Object", IsObject: true,
+			Scope: procedureir.ScopeModule, Kind: "variable",
+			Range: vbaast.Range{StartLine: 1, EndLine: 1},
+		}},
+	}
+
+	facts := buildModuleAnalysisFacts(lines, document, procedures)
+	if _, ok := moduleDeclarations(lines, procedures)["moduleobject"]; !ok {
+		t.Fatalf("compatibility module declarations omitted moduleObject")
+	}
+	if !lineInAnyProcedure(2, procedures) || lineInAnyProcedure(1, procedures) {
+		t.Fatalf("compatibility procedure ownership helper disagrees with indexed facts")
+	}
+	if _, ok := facts.moduleDeclarations["moduleobject"]; !ok {
+		t.Fatalf("module declarations = %#v, want moduleObject", facts.moduleDeclarations)
+	}
+	if _, ok := facts.moduleDeclarations["localvalue"]; ok {
+		t.Fatalf("procedure-local declaration leaked into module declarations: %#v", facts.moduleDeclarations)
+	}
+	if facts.lineInProcedure(1) || !facts.lineInProcedure(2) || !facts.lineInProcedure(4) || facts.lineInProcedure(5) {
+		t.Fatalf("procedure line ownership = %#v, want only lines 2-4", facts.procedureLineOwners)
+	}
+	if got := facts.procedureDeclarations(procedures[0]); got["localvalue"].Name != "localValue" {
+		t.Fatalf("cached procedure declarations = %#v, want localValue", got)
+	}
+}
+
+func TestModuleAnalysisFactsFallsBackToSourceForIncompleteIR(t *testing.T) {
+	lines := []string{
+		"Private obj As Object",
+		"Private Sub Run()",
+		"    Dim localValue As Long",
+		"End Sub",
+	}
+	procedures := []sourceProcedure{{StartLine: 2, EndLine: 4, StartByte: 10}}
+	facts := buildModuleAnalysisFacts(lines, procedureir.DocumentIR{Parse: procedureir.ParseSummary{HasMissing: true}}, procedures)
+	if declaration := facts.moduleDeclarations["obj"]; !declaration.Object {
+		t.Fatalf("source fallback declaration = %#v, want object declaration", declaration)
+	}
+	if _, ok := facts.moduleDeclarations["localvalue"]; ok {
+		t.Fatalf("source fallback included procedure-local declaration: %#v", facts.moduleDeclarations)
+	}
+}
+
+func TestDeclarationScopeLayersWithoutModuleMapCopy(t *testing.T) {
+	module := map[string]sourceDeclaration{
+		"value":      {Name: "value", Type: "Object", Object: true},
+		"moduleonly": {Name: "moduleOnly", Type: "Long"},
+	}
+	proc := sourceProcedure{
+		StartLine: 1,
+		EndLine:   1,
+		Params:    []parameterInfo{{Name: "value", Type: "String"}},
+	}
+	file := parsedFile{ModuleDeclarations: module, Lines: []string{""}}
+	scope := newDeclarationScope(file, proc)
+	if len(scope.module) == 0 || scope.module["value"].Type != "Object" {
+		t.Fatalf("scope module layer = %#v, want original module map", scope.module)
+	}
+	if declaration, ok := scope.lookup("VALUE"); !ok || declaration.Type != "String" || !declaration.Parameter {
+		t.Fatalf("parameter overlay = %#v, %v", declaration, ok)
+	}
+	seen := map[string]sourceDeclaration{}
+	scope.forEach(func(key string, declaration sourceDeclaration) { seen[key] = declaration })
+	if len(seen) != 2 || seen["value"].Type != "String" || seen["moduleonly"].Type != "Long" {
+		t.Fatalf("effective declaration scope = %#v, want parameter shadowing without duplication", seen)
+	}
+}
+
+func TestVBA212DeclarationScopeRetainsIRProcedureDeclarations(t *testing.T) {
+	module := map[string]sourceDeclaration{"service": {Name: "service", Type: "ModuleService"}}
+	proc := sourceProcedure{
+		StartLine: 1,
+		EndLine:   1,
+		StartByte: 1,
+		Declarations: []procedureir.Declaration{{
+			Name: "service", Type: "LocalService", Scope: procedureir.ScopeLocal,
+		}},
+	}
+	scope := declarationScope{module: module}
+	addVBA212ProcedureIRDeclarations(&scope, proc)
+	if declaration, ok := scope.lookup("service"); !ok || declaration.Type != "LocalService" {
+		t.Fatalf("IR procedure declaration = %#v, %v; want local shadowing module", declaration, ok)
+	}
+	legacy := vba212DeclarationIndexes([]string{"Sub Run()"}, []sourceProcedure{proc})
+	if declaration, ok := legacy[proc.StartByte]["service"]; !ok || declaration.Type != "LocalService" {
+		t.Fatalf("legacy VBA212 declaration index = %#v, %v; want local shadowing module", declaration, ok)
+	}
+}
+
+var benchmarkModuleFactsSink *moduleAnalysisFacts
+
+func BenchmarkModuleAnalysisFacts(b *testing.B) {
+	for _, workload := range []struct {
+		name         string
+		procedures   int
+		declarations int
+	}{
+		{name: "small", procedures: 8, declarations: 4},
+		{name: "hundreds", procedures: 500, declarations: 32},
+		{name: "thousands", procedures: 2000, declarations: 2000},
+	} {
+		workload := workload
+		b.Run(workload.name, func(b *testing.B) {
+			lines := make([]string, workload.procedures*3)
+			procedures := make([]sourceProcedure, 0, workload.procedures)
+			for index := 0; index < workload.procedures; index++ {
+				start := index*3 + 1
+				lines[start-1] = "Private Sub Run" + strconvItoa(index) + "()"
+				lines[start] = "    Dim localValue As Long"
+				lines[start+1] = "End Sub"
+				procedures = append(procedures, sourceProcedure{StartLine: start, EndLine: start + 2, StartByte: index + 1})
+			}
+			declarations := make([]procedureir.Declaration, 0, workload.declarations)
+			for index := 0; index < workload.declarations; index++ {
+				declarations = append(declarations, procedureir.Declaration{
+					Name: "ModuleValue" + strconvItoa(index), Type: "Long", Scope: procedureir.ScopeModule,
+					Kind: "variable", Range: vbaast.Range{StartLine: index + 1, EndLine: index + 1},
+				})
+			}
+			document := procedureir.DocumentIR{Declarations: declarations}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for index := 0; index < b.N; index++ {
+				benchmarkModuleFactsSink = buildModuleAnalysisFacts(lines, document, procedures)
+			}
+			b.ReportMetric(float64(workload.procedures), "procedures/op")
+			b.ReportMetric(float64(workload.declarations), "declarations/op")
+		})
+	}
+}

--- a/internal/analyze/object_use_before_set.go
+++ b/internal/analyze/object_use_before_set.go
@@ -548,10 +548,15 @@ func (analysis *objectAnalysisContext) buildEntryStates() map[string]map[string]
 			}
 			if strings.EqualFold(callee.proc.Module, caller.proc.Module) {
 				for name, declaration := range callee.moduleDecls {
-					if declaration.Object {
-						fieldKey := (objectVariable{Scope: procedureir.ScopeModule, Name: name}).key()
-						contributions[fieldKey] = blockState[fieldKey]
+					if !declaration.Object {
+						continue
 					}
+					binding, scope, ok := objectDeclarationBinding(name, caller.declarations)
+					if !ok || scope != procedureir.ScopeModule || !binding.Object {
+						continue
+					}
+					fieldKey := (objectVariable{Scope: procedureir.ScopeModule, Name: name}).key()
+					contributions[fieldKey] = blockState[fieldKey]
 				}
 			}
 			if !entryCall.evaluated || !objectBoolMapEqual(entryCall.contributions, contributions) {
@@ -801,7 +806,7 @@ func (a Analyzer) objectUseBeforeSetIRFindingsPlan(plan *objectProcedurePlan, su
 		if !objectMemberReceiver(expressions, statements, access) {
 			continue
 		}
-		declaration, ok := objectDeclarationFor(access.Name, access.Scope, declarations)
+		declaration, scope, ok := objectDeclarationBinding(access.Name, declarations)
 		// `As New` is guaranteed to produce a value on first use.  A normal
 		// Static declaration, however, has module-lifetime state and may still
 		// be Nothing on its first read; it therefore remains in the analysis.
@@ -815,10 +820,7 @@ func (a Analyzer) objectUseBeforeSetIRFindingsPlan(plan *objectProcedurePlan, su
 		if declaration.Array && access.Mode == procedureir.AccessWrite {
 			continue
 		}
-		variable := objectVariable{Scope: access.Scope, Name: access.Name}
-		if access.Scope == procedureir.ScopeUnresolved {
-			variable.Scope = procedureir.ScopeLocal
-		}
+		variable := objectVariable{Scope: scope, Name: access.Name}
 		key := variable.key()
 		block, ok := plan.flowGraph.BlockForStatement(access.StatementID)
 		if !ok || !plan.reachable[block.ID] {
@@ -1234,7 +1236,7 @@ func objectStateFlowPlan(plan *objectProcedurePlan, summaries map[string]objectP
 				if edge.Class == vbacfg.EdgeExceptional || edge.Uncertain || objectFlowForEachZeroIteration(flowContext, edge) {
 					state = result.in[edge.From]
 				}
-				state = objectFlowApplyGuard(state, flowContext, edge)
+				state = objectFlowApplyGuard(state, flowContext, edge, plan.declarations)
 				incoming = append(incoming, state)
 			}
 			if len(incoming) == 0 {
@@ -1300,7 +1302,7 @@ func objectClassLifecycleAssignedPlan(plan *objectProcedurePlan, variable object
 // `obj Is Nothing`/`Not obj Is Nothing` condition.  Compound boolean
 // expressions are deliberately ignored; VBA212 remains responsible for
 // short-circuit/eager Boolean diagnostics and this analysis stays conservative.
-func objectFlowApplyGuard(state map[string]bool, flowContext objectFlowContext, edge vbacfg.Edge) map[string]bool {
+func objectFlowApplyGuard(state map[string]bool, flowContext objectFlowContext, edge vbacfg.Edge, declarations declarationScope) map[string]bool {
 	if edge.Kind != vbacfg.EdgeBranchTrue && edge.Kind != vbacfg.EdgeBranchFalse {
 		return state
 	}
@@ -1321,7 +1323,7 @@ func objectFlowApplyGuard(state map[string]bool, flowContext objectFlowContext, 
 		}
 	}
 	if name, expected, equals, ok := objectTypeNameGuard(text); ok {
-		key := objectGuardVariableKey(name, state)
+		key := objectGuardVariableKey(name, state, declarations)
 		if key == "" {
 			return state
 		}
@@ -1351,7 +1353,7 @@ func objectFlowApplyGuard(state map[string]bool, flowContext objectFlowContext, 
 	if name == "" || strings.ContainsAny(name, " .()") {
 		return state
 	}
-	key := objectGuardVariableKey(name, state)
+	key := objectGuardVariableKey(name, state, declarations)
 	if key == "" {
 		return state
 	}
@@ -1407,9 +1409,19 @@ func objectFlowExceptionalOnlyFrom(flowContext objectFlowContext, blockID vbacfg
 	return true
 }
 
-func objectGuardVariableKey(name string, state map[string]bool) string {
+func objectGuardVariableKey(name string, state map[string]bool, declarations declarationScope) string {
 	name = cleanIdentifier(strings.TrimSpace(name))
 	if name == "" {
+		return ""
+	}
+	if declaration, scope, ok := objectDeclarationBinding(name, declarations); ok {
+		if !declaration.Object {
+			return ""
+		}
+		key := (objectVariable{Scope: scope, Name: name}).key()
+		if _, exists := state[key]; exists {
+			return key
+		}
 		return ""
 	}
 	for _, scope := range []procedureir.SymbolScope{procedureir.ScopeLocal, procedureir.ScopeParameter, procedureir.ScopeModule} {
@@ -1530,15 +1542,7 @@ func objectFlowTarget(proc sourceProcedure, statement procedureir.Statement, dec
 		if objectIndexedReceiverWrite(flowContext.calls[statement.ID], access) {
 			continue
 		}
-		var declaration sourceDeclaration
-		var scope procedureir.SymbolScope
-		var ok bool
-		if access.Scope == procedureir.ScopeUnresolved {
-			declaration, scope, ok = objectDeclarationBinding(access.Name, declarations)
-		} else {
-			declaration, ok = objectDeclarationFor(access.Name, access.Scope, declarations)
-			scope = access.Scope
-		}
+		declaration, scope, ok := objectDeclarationBinding(access.Name, declarations)
 		if !ok || !declaration.Object {
 			continue
 		}
@@ -1901,12 +1905,8 @@ func objectExcelMemberFactoryAssigned(call procedureir.CallSite, declarations de
 }
 
 func objectDeclarationByName(name string, declarations declarationScope) (sourceDeclaration, bool) {
-	for _, scope := range []procedureir.SymbolScope{procedureir.ScopeLocal, procedureir.ScopeParameter, procedureir.ScopeModule} {
-		if declaration, ok := objectDeclarationFor(name, scope, declarations); ok {
-			return declaration, true
-		}
-	}
-	return sourceDeclaration{}, false
+	declaration, _, ok := objectDeclarationBinding(name, declarations)
+	return declaration, ok
 }
 
 func excelObjectUseType(typ string) bool {
@@ -1980,6 +1980,10 @@ func applyObjectCallEffects(call procedureir.CallSite, state map[string]bool, va
 		}
 		for name, assigned := range summary.ModuleAssigned {
 			if !summary.ModuleWritten[name] {
+				continue
+			}
+			binding, scope, ok := objectDeclarationBinding(name, declarations)
+			if !ok || scope != procedureir.ScopeModule || !binding.Object {
 				continue
 			}
 			variable := objectVariable{Scope: procedureir.ScopeModule, Name: name}

--- a/internal/analyze/object_use_before_set.go
+++ b/internal/analyze/object_use_before_set.go
@@ -1960,7 +1960,11 @@ func applyObjectCallEffects(call procedureir.CallSite, state map[string]bool, va
 		if strings.TrimSpace(name) == "" {
 			name = call.Callee.Member
 		}
-		for _, summary := range objectSummaryCandidatesForDirectCall(call.Module, name, call.File, summaries) {
+		matches := objectSummaryCandidatesForDirectCall(call.Module, name, call.File, summaries)
+		if len(matches) != 1 {
+			matches = nil
+		}
+		for _, summary := range matches {
 			if !strings.EqualFold(strings.TrimSpace(call.Caller.QualifiedName), strings.TrimSpace(summary.QualifiedName)) {
 				candidates = append(candidates, summary)
 			}

--- a/internal/analyze/object_use_before_set.go
+++ b/internal/analyze/object_use_before_set.go
@@ -303,9 +303,6 @@ func (analysis *objectAnalysisContext) buildObjectDependencies() {
 				// propagation keeps the self edge so recursive summaries converge.
 				continue
 			}
-			if call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 {
-				continue
-			}
 			callee := analysis.plans[calleeKey]
 			if callee == nil || caller.proc.Graph == nil {
 				continue
@@ -398,23 +395,43 @@ func uniqueStrings(values []string) []string {
 }
 
 func (analysis *objectAnalysisContext) objectCalleeKey(call procedureir.CallSite) (string, bool) {
-	if call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 {
+	if call.Resolution.Status == procedureir.ResolutionMatched && len(call.Resolution.Candidates) == 1 {
+		candidate := call.Resolution.Candidates[0]
+		key := objectSummaryKey(candidate.File, candidate.QualifiedName, candidate.Kind, candidate.Line)
+		if _, ok := analysis.plans[key]; ok {
+			return key, true
+		}
+		var match string
+		for candidateKey, plan := range analysis.plans {
+			if !strings.EqualFold(plan.proc.Module+"."+plan.proc.Name, candidate.QualifiedName) && !strings.EqualFold(objectProcedureQualifiedName(plan.proc), candidate.QualifiedName) {
+				continue
+			}
+			if candidate.Kind != "" && !strings.EqualFold(string(plan.proc.ProcedureKind), candidate.Kind) {
+				continue
+			}
+			if candidate.Line > 0 && plan.proc.StartLine != candidate.Line {
+				continue
+			}
+			if match != "" {
+				return "", false
+			}
+			match = candidateKey
+		}
+		return match, match != ""
+	}
+	if call.Callee.Receiver != nil && !objectIsCurrentModuleReceiver(call) {
 		return "", false
 	}
-	candidate := call.Resolution.Candidates[0]
-	key := objectSummaryKey(candidate.File, candidate.QualifiedName, candidate.Kind, candidate.Line)
-	if _, ok := analysis.plans[key]; ok {
-		return key, true
+	name := strings.TrimSpace(call.Callee.BaseName)
+	if name == "" {
+		name = strings.TrimSpace(call.Callee.Member)
+	}
+	if name == "" || strings.TrimSpace(call.Module) == "" {
+		return "", false
 	}
 	var match string
 	for candidateKey, plan := range analysis.plans {
-		if !strings.EqualFold(plan.proc.Module+"."+plan.proc.Name, candidate.QualifiedName) && !strings.EqualFold(objectProcedureQualifiedName(plan.proc), candidate.QualifiedName) {
-			continue
-		}
-		if candidate.Kind != "" && !strings.EqualFold(string(plan.proc.ProcedureKind), candidate.Kind) {
-			continue
-		}
-		if candidate.Line > 0 && plan.proc.StartLine != candidate.Line {
+		if !strings.EqualFold(strings.TrimSpace(plan.proc.Module), strings.TrimSpace(call.Module)) || !strings.EqualFold(cleanIdentifier(plan.proc.Name), cleanIdentifier(name)) {
 			continue
 		}
 		if match != "" {
@@ -423,6 +440,10 @@ func (analysis *objectAnalysisContext) objectCalleeKey(call procedureir.CallSite
 		match = candidateKey
 	}
 	return match, match != ""
+}
+
+func objectIsCurrentModuleReceiver(call procedureir.CallSite) bool {
+	return call.Callee.Receiver != nil && strings.EqualFold(cleanIdentifier(strings.TrimSpace(*call.Callee.Receiver)), "me")
 }
 
 func (analysis *objectAnalysisContext) buildSummaries() map[string]objectProcedureSummary {
@@ -838,10 +859,16 @@ func (a Analyzer) objectUseBeforeSetIRFindingsPlan(plan *objectProcedurePlan, su
 		if name == "" {
 			continue
 		}
-		variable := objectFlowVariableForName(name, flow.vars)
+		declaration, scope, ok := objectDeclarationBinding(name, declarations)
+		if !ok || !declaration.Object || declaration.NewExpression || declaration.Array {
+			continue
+		}
+		variable := objectVariable{Scope: scope, Name: name}
 		key := variable.key()
-		declaration, ok := objectDeclarationFor(name, variable.Scope, declarations)
-		if !ok || !declaration.Object || declaration.NewExpression || declaration.Array || reported[key] {
+		if reported[key] {
+			continue
+		}
+		if _, exists := flow.vars[key]; !exists {
 			continue
 		}
 		block, ok := plan.flowGraph.BlockForStatement(call.StatementID)
@@ -1137,6 +1164,26 @@ func objectDeclarationFor(name string, scope procedureir.SymbolScope, declaratio
 		}
 	}
 	return declarations.lookup(key)
+}
+
+func objectDeclarationBinding(name string, declarations declarationScope) (sourceDeclaration, procedureir.SymbolScope, bool) {
+	key := strings.ToLower(cleanIdentifier(name))
+	if key == "" {
+		return sourceDeclaration{}, procedureir.ScopeUnresolved, false
+	}
+	if declaration, ok := declarations.parameters[key]; ok {
+		return declaration, procedureir.ScopeParameter, true
+	}
+	if declaration, ok := declarations.local[key]; ok {
+		return declaration, procedureir.ScopeLocal, true
+	}
+	if declaration, ok := declarations.extra[key]; ok {
+		return declaration, procedureir.ScopeLocal, true
+	}
+	if declaration, ok := declarations.module[key]; ok {
+		return declaration, procedureir.ScopeModule, true
+	}
+	return sourceDeclaration{}, procedureir.ScopeUnresolved, false
 }
 
 func objectStateFlowPlan(plan *objectProcedurePlan, summaries map[string]objectProcedureSummary, options objectFlowOptions) objectFlowResult {
@@ -1483,23 +1530,23 @@ func objectFlowTarget(proc sourceProcedure, statement procedureir.Statement, dec
 		if objectIndexedReceiverWrite(flowContext.calls[statement.ID], access) {
 			continue
 		}
-		declaration, ok := objectDeclarationFor(access.Name, access.Scope, declarations)
+		var declaration sourceDeclaration
+		var scope procedureir.SymbolScope
+		var ok bool
+		if access.Scope == procedureir.ScopeUnresolved {
+			declaration, scope, ok = objectDeclarationBinding(access.Name, declarations)
+		} else {
+			declaration, ok = objectDeclarationFor(access.Name, access.Scope, declarations)
+			scope = access.Scope
+		}
 		if !ok || !declaration.Object {
 			continue
-		}
-		scope := access.Scope
-		if scope == procedureir.ScopeUnresolved {
-			scope = procedureir.ScopeLocal
 		}
 		return objectVariable{Scope: scope, Name: access.Name}, true
 	}
 	if statement.Target != nil && statement.Target.Kind != procedureir.ExpressionCall && statement.Target.Kind != procedureir.ExpressionMember && !objectIndexedTargetCall(flowContext.calls[statement.ID], statement.Target.Text) {
 		name := cleanIdentifier(strings.TrimSpace(statement.Target.Text))
-		if declaration, ok := objectDeclarationFor(name, procedureir.ScopeLocal, declarations); ok && declaration.Object {
-			scope := procedureir.ScopeLocal
-			if declaration.Parameter {
-				scope = procedureir.ScopeParameter
-			}
+		if declaration, scope, ok := objectDeclarationBinding(name, declarations); ok && declaration.Object {
 			return objectVariable{Scope: scope, Name: name}, true
 		}
 	}
@@ -1554,14 +1601,14 @@ func objectExpressionAssigned(proc sourceProcedure, expression procedureir.Expre
 		}
 	case procedureir.ExpressionIdentifier:
 		name := cleanIdentifier(text)
-		for _, scope := range []procedureir.SymbolScope{procedureir.ScopeLocal, procedureir.ScopeParameter, procedureir.ScopeModule} {
-			if value, exists := state[objectVariable{Scope: scope, Name: name}.key()]; exists {
-				// Stop at the first lexical binding even when it is currently
-				// Nothing; a same-named module field must not initialize a shadowing
-				// local object.
-				return value
+		declaration, scope, ok := objectDeclarationBinding(name, declarations)
+		if !ok || !declaration.Object {
+			if isObjectType(proc.ReturnType) && strings.EqualFold(name, cleanIdentifier(proc.Name)) {
+				return state[(objectVariable{Scope: procedureir.ScopeLocal, Name: name}).key()]
 			}
+			return false
 		}
+		return state[(objectVariable{Scope: scope, Name: name}).key()]
 	case procedureir.ExpressionCall:
 		for _, call := range proc.Calls {
 			if call.StatementID != statementID || (call.ExpressionID != 0 && call.ExpressionID != expression.ID) {
@@ -1573,6 +1620,9 @@ func objectExpressionAssigned(proc sourceProcedure, expression procedureir.Expre
 		}
 		return objectConstructorCallText(lower)
 	case procedureir.ExpressionMember:
+		if objectExcelMemberExpressionAssigned(expression.Text, proc, declarations) {
+			return true
+		}
 		// A member rooted at an intrinsic workbook/application object is a
 		// non-Nothing factory value.  For a user object, the member may itself be
 		// Nothing; keep the assignment nullable and report a later dereference.
@@ -1601,6 +1651,11 @@ func objectConstructorCallText(text string) bool {
 func objectCallReturnsAssigned(proc sourceProcedure, statementID int, call procedureir.CallSite, state map[string]bool, flowContext objectFlowContext, declarations declarationScope, summaries map[string]objectProcedureSummary) bool {
 	if objectConstructorCallText(strings.ToLower(call.Callee.Text)) || strings.EqualFold(call.Callee.BaseName, "CreateObject") || strings.EqualFold(call.Callee.BaseName, "GetObject") {
 		return true
+	}
+	if call.Callee.Receiver == nil {
+		if summary, ok := objectDirectCallSummary(proc, call, summaries); ok {
+			return summary.ReturnAssigned
+		}
 	}
 	if call.Callee.Receiver != nil {
 		// Excel object factories such as Worksheets(1) and Range("A1") are
@@ -1653,6 +1708,80 @@ func objectCallReturnsAssigned(proc sourceProcedure, statementID int, call proce
 	return ok && summary.ReturnAssigned
 }
 
+func objectDirectCallSummary(proc sourceProcedure, call procedureir.CallSite, summaries map[string]objectProcedureSummary) (objectProcedureSummary, bool) {
+	if call.Callee.Receiver != nil || strings.TrimSpace(call.Callee.BaseName) == "" {
+		return objectProcedureSummary{}, false
+	}
+	matches := objectSummaryCandidatesForDirectCall(proc.Module, call.Callee.BaseName, call.File, summaries)
+	if len(matches) == 0 {
+		return objectProcedureSummary{}, false
+	}
+	returnAssigned := true
+	for _, summary := range matches {
+		returnAssigned = returnAssigned && summary.ReturnAssigned
+	}
+	return objectProcedureSummary{ReturnAssigned: returnAssigned}, true
+}
+
+func objectSummaryCandidatesForDirectCall(module, name, callFile string, summaries map[string]objectProcedureSummary) []objectProcedureSummary {
+	name = strings.TrimSpace(name)
+	if strings.TrimSpace(module) == "" || name == "" {
+		return nil
+	}
+	allMatches := make([]objectProcedureSummary, 0, 1)
+	for _, summary := range summaries {
+		if !strings.EqualFold(strings.TrimSpace(summary.Module), strings.TrimSpace(module)) || !strings.EqualFold(lastName(summary.QualifiedName), name) {
+			continue
+		}
+		allMatches = append(allMatches, summary)
+	}
+	if len(allMatches) == 0 {
+		return nil
+	}
+	// A project may contain a WIP copy of a module with the same VB_Name. The
+	// call site file identifies the lexical function in that case; do not let
+	// an unrelated duplicate affect object state. If the file is unavailable,
+	// only a unique module/name match is safe to use.
+	if normalizedCallFile := normalizedObjectSummaryFile(callFile); normalizedCallFile != "" {
+		fileMatches := make([]objectProcedureSummary, 0, len(allMatches))
+		for _, summary := range allMatches {
+			if objectSummaryFilesMatch(normalizedCallFile, summary.File) {
+				fileMatches = append(fileMatches, summary)
+			}
+		}
+		if len(fileMatches) > 0 {
+			return fileMatches
+		}
+	}
+	if len(allMatches) == 1 {
+		return allMatches
+	}
+	return nil
+}
+
+func normalizedObjectSummaryFile(file string) string {
+	file = filepath.ToSlash(filepath.Clean(strings.TrimSpace(file)))
+	file = strings.TrimPrefix(file, "./")
+	if file == "." {
+		return ""
+	}
+	return file
+}
+
+func objectSummaryFilesMatch(callFile, summaryFile string) bool {
+	callFile = normalizedObjectSummaryFile(callFile)
+	summaryFile = normalizedObjectSummaryFile(summaryFile)
+	if callFile == "" || summaryFile == "" {
+		return false
+	}
+	if strings.EqualFold(callFile, summaryFile) {
+		return true
+	}
+	callFile = strings.ToLower(callFile)
+	summaryFile = strings.ToLower(summaryFile)
+	return strings.HasSuffix(callFile, "/"+summaryFile) || strings.HasSuffix(summaryFile, "/"+callFile)
+}
+
 func objectReceiverReturnSummary(call procedureir.CallSite, declarations declarationScope, summaries map[string]objectProcedureSummary) (objectProcedureSummary, bool) {
 	return objectReceiverReturnSummaryIndexed(call, declarations, summaries, nil)
 }
@@ -1701,11 +1830,14 @@ func objectExcelMemberChainAssigned(call procedureir.CallSite, state map[string]
 		return false
 	}
 	root := cleanIdentifier(strings.TrimSpace(strings.SplitN(parts[0], "(", 2)[0]))
-	if root == "" || !objectNameDefinitelyAssigned(root, state) {
+	if root == "" {
 		return false
 	}
-	declaration, ok := objectDeclarationByName(root, declarations)
+	declaration, scope, ok := objectDeclarationBinding(root, declarations)
 	if !ok || !excelObjectUseType(declaration.Type) {
+		return false
+	}
+	if !state[(objectVariable{Scope: scope, Name: root}).key()] {
 		return false
 	}
 	for _, part := range parts[1:] {
@@ -1714,6 +1846,36 @@ func objectExcelMemberChainAssigned(call procedureir.CallSite, state map[string]
 		}
 	}
 	return excelObjectUseMember(call.Callee.Member)
+}
+
+func objectExcelMemberExpressionAssigned(text string, proc sourceProcedure, declarations declarationScope) bool {
+	parts := strings.Split(strings.TrimSpace(text), ".")
+	if len(parts) < 2 {
+		return false
+	}
+	root := cleanIdentifier(strings.TrimSpace(strings.SplitN(parts[0], "(", 2)[0]))
+	if root == "" {
+		return false
+	}
+	declaration, _, ok := objectDeclarationBinding(root, declarations)
+	if !ok || !excelObjectUseType(declaration.Type) {
+		for _, irDeclaration := range proc.Declarations {
+			if strings.EqualFold(cleanIdentifier(irDeclaration.Name), root) && isObjectType(irDeclaration.Type) {
+				declaration = sourceDeclaration{Type: irDeclaration.Type}
+				ok = true
+				break
+			}
+		}
+	}
+	if !ok || !excelObjectUseType(declaration.Type) {
+		return false
+	}
+	for _, part := range parts[1:] {
+		if !excelObjectFactoryMember(part) {
+			return false
+		}
+	}
+	return true
 }
 
 func objectExcelMemberFactoryAssigned(call procedureir.CallSite, declarations declarationScope) bool {
@@ -1738,17 +1900,6 @@ func objectExcelMemberFactoryAssigned(call procedureir.CallSite, declarations de
 	return excelObjectFactoryMember(call.Callee.Member)
 }
 
-func objectNameDefinitelyAssigned(name string, state map[string]bool) bool {
-	name = cleanIdentifier(strings.TrimSpace(name))
-	for _, scope := range []procedureir.SymbolScope{procedureir.ScopeLocal, procedureir.ScopeParameter, procedureir.ScopeModule} {
-		key := (objectVariable{Scope: scope, Name: name}).key()
-		if value, exists := state[key]; exists {
-			return value
-		}
-	}
-	return false
-}
-
 func objectDeclarationByName(name string, declarations declarationScope) (sourceDeclaration, bool) {
 	for _, scope := range []procedureir.SymbolScope{procedureir.ScopeLocal, procedureir.ScopeParameter, procedureir.ScopeModule} {
 		if declaration, ok := objectDeclarationFor(name, scope, declarations); ok {
@@ -1771,7 +1922,7 @@ func excelObjectUseType(typ string) bool {
 func excelObjectUseMember(member string) bool {
 	member = strings.ToLower(cleanIdentifier(strings.TrimSpace(strings.SplitN(member, "(", 2)[0])))
 	switch member {
-	case "application", "worksheets", "sheets", "range", "cells", "rows", "columns", "shapes", "parent", "resize", "offset", "addshape", "selection", "usedrange", "interior", "borders", "font", "textframe", "characters", "fill", "line", "controls", "add":
+	case "application", "workbooks", "worksheets", "sheets", "range", "cells", "rows", "columns", "shapes", "parent", "resize", "offset", "addshape", "selection", "usedrange", "interior", "borders", "font", "textframe", "characters", "fill", "line", "controls", "add":
 		return true
 	default:
 		return false
@@ -1781,7 +1932,7 @@ func excelObjectUseMember(member string) bool {
 func excelObjectFactoryMember(member string) bool {
 	member = strings.ToLower(cleanIdentifier(strings.TrimSpace(strings.SplitN(member, "(", 2)[0])))
 	switch member {
-	case "application", "worksheets", "sheets", "range", "cells", "rows", "columns", "shapes", "usedrange", "interior", "borders", "font", "textframe", "characters", "fill", "line", "controls", "add", "addshape", "parent", "resize", "offset":
+	case "application", "workbooks", "worksheets", "sheets", "range", "cells", "rows", "columns", "shapes", "usedrange", "interior", "borders", "font", "textframe", "characters", "fill", "line", "controls", "add", "addshape", "parent", "resize", "offset":
 		return true
 	default:
 		return false
@@ -1800,6 +1951,16 @@ func applyObjectCallEffects(call procedureir.CallSite, state map[string]bool, va
 	var candidates []objectProcedureSummary
 	if call.Resolution.Status == procedureir.ResolutionMatched && len(call.Resolution.Candidates) == 1 {
 		if summary, ok := objectSummaryForCandidate(call.Resolution.Candidates[0], summaries); ok {
+			if !strings.EqualFold(strings.TrimSpace(call.Caller.QualifiedName), strings.TrimSpace(summary.QualifiedName)) {
+				candidates = append(candidates, summary)
+			}
+		}
+	} else if call.ExpressionID == 0 && (call.Callee.Receiver == nil || objectIsCurrentModuleReceiver(call)) {
+		name := call.Callee.BaseName
+		if strings.TrimSpace(name) == "" {
+			name = call.Callee.Member
+		}
+		for _, summary := range objectSummaryCandidatesForDirectCall(call.Module, name, call.File, summaries) {
 			if !strings.EqualFold(strings.TrimSpace(call.Caller.QualifiedName), strings.TrimSpace(summary.QualifiedName)) {
 				candidates = append(candidates, summary)
 			}
@@ -1831,14 +1992,11 @@ func applyObjectCallEffects(call procedureir.CallSite, state map[string]bool, va
 		if name == "" {
 			continue
 		}
-		variable := objectVariable{Scope: actual.scope, Name: name}
-		if variable.Scope == procedureir.ScopeUnresolved {
-			variable = objectFlowVariableForName(name, vars)
-		}
-		declaration, ok := objectDeclarationFor(name, variable.Scope, declarations)
+		declaration, scope, ok := objectDeclarationBinding(name, declarations)
 		if !ok || !declaration.Object {
 			continue
 		}
+		variable := objectVariable{Scope: scope, Name: name}
 		if _, exists := vars[variable.key()]; !exists {
 			continue
 		}
@@ -1898,7 +2056,6 @@ func applyObjectCallEffects(call procedureir.CallSite, state map[string]bool, va
 type objectCallActual struct {
 	expressionID  int
 	text          string
-	scope         procedureir.SymbolScope
 	parenthesized bool
 }
 
@@ -1920,7 +2077,20 @@ func objectCallParameterAssigned(proc sourceProcedure, declarations declarationS
 		if name == "" {
 			return false, true
 		}
-		variable := objectFlowVariableForName(name, vars)
+		declaration, scope, ok := objectDeclarationBinding(name, declarations)
+		if !ok && proc.Name != "" && strings.EqualFold(name, cleanIdentifier(proc.Name)) && isObjectType(proc.ReturnType) {
+			// A function's return slot is an object binding even though it is not
+			// represented by a source Dim declaration. Keep it aligned with the
+			// special return-slot handling in objectFlowTarget.
+			variable := objectVariable{Scope: procedureir.ScopeLocal, Name: name}
+			if _, exists := vars[variable.key()]; exists {
+				return state[variable.key()], true
+			}
+		}
+		if !ok || !declaration.Object {
+			return false, false
+		}
+		variable := objectVariable{Scope: scope, Name: name}
 		if _, exists := vars[variable.key()]; !exists {
 			return false, false
 		}
@@ -1948,19 +2118,9 @@ func objectCallActuals(call procedureir.CallSite, expressions map[int]procedurei
 			}
 			expression = nested
 		}
-		actuals = append(actuals, objectCallActual{expressionID: expression.ID, text: expression.Text, scope: procedureir.ScopeUnresolved, parenthesized: parenthesized})
+		actuals = append(actuals, objectCallActual{expressionID: expression.ID, text: expression.Text, parenthesized: parenthesized})
 	}
 	return actuals
-}
-
-func objectFlowVariableForName(name string, vars map[string]objectVariable) objectVariable {
-	for _, scope := range []procedureir.SymbolScope{procedureir.ScopeLocal, procedureir.ScopeParameter, procedureir.ScopeModule} {
-		variable := objectVariable{Scope: scope, Name: name}
-		if _, ok := vars[variable.key()]; ok {
-			return variable
-		}
-	}
-	return objectVariable{Scope: procedureir.ScopeLocal, Name: name}
 }
 
 func objectFormalIndex(call procedureir.CallSite, summary objectProcedureSummary, actualIndex int) int {

--- a/internal/analyze/object_use_before_set.go
+++ b/internal/analyze/object_use_before_set.go
@@ -55,7 +55,7 @@ type objectProcedurePlan struct {
 	file           parsedFile
 	proc           sourceProcedure
 	moduleDecls    map[string]sourceDeclaration
-	declarations   map[string]sourceDeclaration
+	declarations   declarationScope
 	procedureDecls map[string]sourceDeclaration
 
 	flowProc    sourceProcedure
@@ -177,8 +177,8 @@ func newObjectProcedurePlan(file parsedFile, proc sourceProcedure, moduleDecls m
 		file:           file,
 		proc:           proc,
 		moduleDecls:    moduleDecls,
-		declarations:   objectFlowDeclarations(file.Lines, proc, moduleDecls),
-		procedureDecls: procedureDeclarations(file.Lines, proc),
+		declarations:   objectFlowDeclarations(file, proc, moduleDecls),
+		procedureDecls: file.procedureDeclarationsFor(proc),
 		reachable:      map[vbacfg.BlockID]bool{},
 		vars:           map[string]objectVariable{},
 	}
@@ -191,19 +191,22 @@ func newObjectProcedurePlan(file parsedFile, proc sourceProcedure, moduleDecls m
 		}
 		plan.flowContext = newObjectFlowContext(plan.flowProc)
 	}
-	for key, declaration := range plan.declarations {
-		if !declaration.Object {
-			continue
+	addObjectVariables := func(scope procedureir.SymbolScope, declarations map[string]sourceDeclaration) {
+		for _, declaration := range declarations {
+			if !declaration.Object {
+				continue
+			}
+			variable := objectVariable{Scope: scope, Name: declaration.Name}
+			plan.vars[variable.key()] = variable
 		}
-		scope := procedureir.ScopeModule
-		if declaration.Parameter {
-			scope = procedureir.ScopeParameter
-		} else if _, local := plan.procedureDecls[key]; local {
-			scope = procedureir.ScopeLocal
-		}
-		variable := objectVariable{Scope: scope, Name: declaration.Name}
-		plan.vars[variable.key()] = variable
 	}
+	// Keep the module layer shared. Local and parameter layers are small and
+	// are enumerated independently so shadowed bindings still get distinct
+	// object-flow variables without copying the module declaration map.
+	addObjectVariables(procedureir.ScopeModule, plan.declarations.module)
+	addObjectVariables(procedureir.ScopeLocal, plan.declarations.extra)
+	addObjectVariables(procedureir.ScopeLocal, plan.declarations.local)
+	addObjectVariables(procedureir.ScopeParameter, plan.declarations.parameters)
 	if isObjectType(proc.ReturnType) {
 		variable := objectVariable{Scope: procedureir.ScopeLocal, Name: proc.Name}
 		plan.vars[variable.key()] = variable
@@ -1116,48 +1119,24 @@ func newObjectFlowContext(proc sourceProcedure) objectFlowContext {
 	return context
 }
 
-func objectFlowDeclarations(lines []string, proc sourceProcedure, moduleDecls map[string]sourceDeclaration) map[string]sourceDeclaration {
-	declarations := map[string]sourceDeclaration{}
-	localDecls := procedureDeclarations(lines, proc)
-	for key, declaration := range moduleDecls {
-		key = strings.ToLower(key)
-		if _, shadowed := localDecls[key]; shadowed {
-			declarations["@module:"+key] = declaration
-			continue
-		}
-		declarations[key] = declaration
-	}
-	for key, declaration := range localDecls {
-		declarations[strings.ToLower(key)] = declaration
-	}
-	for _, parameter := range proc.Params {
-		declaration := sourceDeclaration{
-			Name: parameter.Name, Type: parameter.Type, Object: isObjectType(parameter.Type), Parameter: true,
-		}
-		key := strings.ToLower(parameter.Name)
-		if _, shadowed := declarations[key]; shadowed {
-			declarations["@parameter:"+key] = declaration
-		} else {
-			declarations[key] = declaration
-		}
-	}
+func objectFlowDeclarations(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration) declarationScope {
+	declarations := newDeclarationScope(file, proc)
+	declarations.module = moduleDecls
 	return declarations
 }
 
-func objectDeclarationFor(name string, scope procedureir.SymbolScope, declarations map[string]sourceDeclaration) (sourceDeclaration, bool) {
+func objectDeclarationFor(name string, scope procedureir.SymbolScope, declarations declarationScope) (sourceDeclaration, bool) {
 	key := strings.ToLower(cleanIdentifier(name))
-	if scope == procedureir.ScopeModule {
-		if declaration, ok := declarations["@module:"+key]; ok {
+	switch scope {
+	case procedureir.ScopeModule:
+		declaration, ok := declarations.module[key]
+		return declaration, ok
+	case procedureir.ScopeParameter:
+		if declaration, ok := declarations.parameters[key]; ok {
 			return declaration, true
 		}
 	}
-	if scope == procedureir.ScopeParameter {
-		if declaration, ok := declarations["@parameter:"+key]; ok {
-			return declaration, true
-		}
-	}
-	declaration, ok := declarations[key]
-	return declaration, ok
+	return declarations.lookup(key)
 }
 
 func objectStateFlowPlan(plan *objectProcedurePlan, summaries map[string]objectProcedureSummary, options objectFlowOptions) objectFlowResult {
@@ -1456,7 +1435,7 @@ func objectFlowAssigned(state map[string]bool, variable objectVariable) bool {
 	return state[variable.key()]
 }
 
-func objectFlowTransfer(file parsedFile, proc sourceProcedure, block vbacfg.Block, input map[string]bool, vars map[string]objectVariable, declarations map[string]sourceDeclaration, summaries map[string]objectProcedureSummary, flowContext objectFlowContext) map[string]bool {
+func objectFlowTransfer(file parsedFile, proc sourceProcedure, block vbacfg.Block, input map[string]bool, vars map[string]objectVariable, declarations declarationScope, summaries map[string]objectProcedureSummary, flowContext objectFlowContext) map[string]bool {
 	state := cloneObjectState(input)
 	statement := block.Statement
 	if statement == nil {
@@ -1489,7 +1468,7 @@ func objectFlowTransfer(file parsedFile, proc sourceProcedure, block vbacfg.Bloc
 	return state
 }
 
-func objectFlowTarget(proc sourceProcedure, statement procedureir.Statement, declarations map[string]sourceDeclaration, flowContext objectFlowContext) (objectVariable, bool) {
+func objectFlowTarget(proc sourceProcedure, statement procedureir.Statement, declarations declarationScope, flowContext objectFlowContext) (objectVariable, bool) {
 	for _, access := range flowContext.accesses[statement.ID] {
 		if access.Mode != procedureir.AccessWrite && access.Mode != procedureir.AccessReadWrite {
 			continue
@@ -1549,7 +1528,7 @@ func objectIndexedTargetCall(calls []procedureir.CallSite, targetText string) bo
 	return false
 }
 
-func objectFlowValueAssigned(proc sourceProcedure, statement procedureir.Statement, state map[string]bool, flowContext objectFlowContext, declarations map[string]sourceDeclaration, summaries map[string]objectProcedureSummary) bool {
+func objectFlowValueAssigned(proc sourceProcedure, statement procedureir.Statement, state map[string]bool, flowContext objectFlowContext, declarations declarationScope, summaries map[string]objectProcedureSummary) bool {
 	value := statement.Value
 	if value == nil {
 		return false
@@ -1557,7 +1536,7 @@ func objectFlowValueAssigned(proc sourceProcedure, statement procedureir.Stateme
 	return objectExpressionAssigned(proc, *value, state, flowContext, declarations, summaries, statement.ID)
 }
 
-func objectExpressionAssigned(proc sourceProcedure, expression procedureir.Expression, state map[string]bool, flowContext objectFlowContext, declarations map[string]sourceDeclaration, summaries map[string]objectProcedureSummary, statementID int) bool {
+func objectExpressionAssigned(proc sourceProcedure, expression procedureir.Expression, state map[string]bool, flowContext objectFlowContext, declarations declarationScope, summaries map[string]objectProcedureSummary, statementID int) bool {
 	expressions := flowContext.expressions
 	text := strings.TrimSpace(expression.Text)
 	lower := strings.ToLower(text)
@@ -1619,7 +1598,7 @@ func objectConstructorCallText(text string) bool {
 	return strings.HasPrefix(text, "createobject(") || strings.HasPrefix(text, "getobject(")
 }
 
-func objectCallReturnsAssigned(proc sourceProcedure, statementID int, call procedureir.CallSite, state map[string]bool, flowContext objectFlowContext, declarations map[string]sourceDeclaration, summaries map[string]objectProcedureSummary) bool {
+func objectCallReturnsAssigned(proc sourceProcedure, statementID int, call procedureir.CallSite, state map[string]bool, flowContext objectFlowContext, declarations declarationScope, summaries map[string]objectProcedureSummary) bool {
 	if objectConstructorCallText(strings.ToLower(call.Callee.Text)) || strings.EqualFold(call.Callee.BaseName, "CreateObject") || strings.EqualFold(call.Callee.BaseName, "GetObject") {
 		return true
 	}
@@ -1674,11 +1653,11 @@ func objectCallReturnsAssigned(proc sourceProcedure, statementID int, call proce
 	return ok && summary.ReturnAssigned
 }
 
-func objectReceiverReturnSummary(call procedureir.CallSite, declarations map[string]sourceDeclaration, summaries map[string]objectProcedureSummary) (objectProcedureSummary, bool) {
+func objectReceiverReturnSummary(call procedureir.CallSite, declarations declarationScope, summaries map[string]objectProcedureSummary) (objectProcedureSummary, bool) {
 	return objectReceiverReturnSummaryIndexed(call, declarations, summaries, nil)
 }
 
-func objectReceiverReturnSummaryIndexed(call procedureir.CallSite, declarations map[string]sourceDeclaration, summaries map[string]objectProcedureSummary, receiverSummaryKeys map[string][]string) (objectProcedureSummary, bool) {
+func objectReceiverReturnSummaryIndexed(call procedureir.CallSite, declarations declarationScope, summaries map[string]objectProcedureSummary, receiverSummaryKeys map[string][]string) (objectProcedureSummary, bool) {
 	if call.Callee.Receiver == nil || call.Callee.Member == "" {
 		return objectProcedureSummary{}, false
 	}
@@ -1712,7 +1691,7 @@ func objectReceiverReturnSummaryIndexed(call procedureir.CallSite, declarations 
 	return match, found
 }
 
-func objectExcelMemberChainAssigned(call procedureir.CallSite, state map[string]bool, declarations map[string]sourceDeclaration) bool {
+func objectExcelMemberChainAssigned(call procedureir.CallSite, state map[string]bool, declarations declarationScope) bool {
 	if call.Callee.Receiver == nil {
 		return false
 	}
@@ -1737,7 +1716,7 @@ func objectExcelMemberChainAssigned(call procedureir.CallSite, state map[string]
 	return excelObjectUseMember(call.Callee.Member)
 }
 
-func objectExcelMemberFactoryAssigned(call procedureir.CallSite, declarations map[string]sourceDeclaration) bool {
+func objectExcelMemberFactoryAssigned(call procedureir.CallSite, declarations declarationScope) bool {
 	if call.Callee.Receiver == nil {
 		return false
 	}
@@ -1770,7 +1749,7 @@ func objectNameDefinitelyAssigned(name string, state map[string]bool) bool {
 	return false
 }
 
-func objectDeclarationByName(name string, declarations map[string]sourceDeclaration) (sourceDeclaration, bool) {
+func objectDeclarationByName(name string, declarations declarationScope) (sourceDeclaration, bool) {
 	for _, scope := range []procedureir.SymbolScope{procedureir.ScopeLocal, procedureir.ScopeParameter, procedureir.ScopeModule} {
 		if declaration, ok := objectDeclarationFor(name, scope, declarations); ok {
 			return declaration, true
@@ -1809,7 +1788,7 @@ func excelObjectFactoryMember(member string) bool {
 	}
 }
 
-func applyObjectCallEffects(call procedureir.CallSite, state map[string]bool, vars map[string]objectVariable, declarations map[string]sourceDeclaration, expressions map[int]procedureir.Expression, summaries map[string]objectProcedureSummary) {
+func applyObjectCallEffects(call procedureir.CallSite, state map[string]bool, vars map[string]objectVariable, declarations declarationScope, expressions map[int]procedureir.Expression, summaries map[string]objectProcedureSummary) {
 	// Unresolved calls embedded in expressions (for example TypeName(obj) or
 	// StrComp(TypeName(obj), ...)) consume values but do not provide a reliable
 	// ByRef mutation contract.  Only statement-level unresolved calls can affect
@@ -1927,7 +1906,7 @@ func objectProcedureAllowsParameterEntry(proc sourceProcedure) bool {
 	return strings.EqualFold(strings.TrimSpace(proc.Visibility), "private")
 }
 
-func objectCallParameterAssigned(proc sourceProcedure, declarations map[string]sourceDeclaration, call procedureir.CallSite, summary objectProcedureSummary, formalIndex int, actuals []objectCallActual, state map[string]bool, vars map[string]objectVariable, flowContext objectFlowContext, summaries map[string]objectProcedureSummary) (bool, bool) {
+func objectCallParameterAssigned(proc sourceProcedure, declarations declarationScope, call procedureir.CallSite, summary objectProcedureSummary, formalIndex int, actuals []objectCallActual, state map[string]bool, vars map[string]objectVariable, flowContext objectFlowContext, summaries map[string]objectProcedureSummary) (bool, bool) {
 	for actualIndex, actual := range actuals {
 		if objectFormalIndex(call, summary, actualIndex) != formalIndex {
 			continue

--- a/internal/analyze/object_use_before_set_issue448_test.go
+++ b/internal/analyze/object_use_before_set_issue448_test.go
@@ -861,6 +861,63 @@ func TestObjectCallEffectsSkipsAmbiguousDirectSummaries(t *testing.T) {
 	}
 }
 
+func TestObjectFlowUsesLexicalBindingForVariantShadows(t *testing.T) {
+	t.Parallel()
+	module := map[string]sourceDeclaration{
+		"sharedsheet": {Name: "sharedSheet", Type: "Worksheet", Object: true},
+	}
+	moduleVariable := objectVariable{Scope: procedureir.ScopeModule, Name: "sharedSheet"}
+	moduleSummary := objectProcedureSummary{
+		File: "src/Main.bas", Module: "Main", QualifiedName: "Main.Initialize",
+		ModuleAssigned: map[string]bool{"sharedsheet": false},
+		ModuleWritten:  map[string]bool{"sharedsheet": true},
+	}
+	actualSummary := objectProcedureSummary{
+		File: "src/Main.bas", Module: "Main", QualifiedName: "Main.Touch",
+		Params:        []objectParameterSummary{{Name: "value", Object: true, ByRef: true}},
+		ByRefAssigned: map[int]bool{0: false},
+		ByRefWritten:  map[int]bool{0: true},
+	}
+	expressions := map[int]procedureir.Expression{
+		1: {ID: 1, Kind: procedureir.ExpressionIdentifier, Text: "sharedSheet"},
+	}
+	call := procedureir.CallSite{
+		File: "src/Main.bas", Module: "Main", Caller: procedureir.ProcedureRef{QualifiedName: "Main.Run"},
+		Callee: procedureir.Callee{BaseName: "Initialize"},
+	}
+	actualCall := procedureir.CallSite{
+		File: "src/Main.bas", Module: "Main", Caller: procedureir.ProcedureRef{QualifiedName: "Main.Run"},
+		Callee:    procedureir.Callee{BaseName: "Touch"},
+		Arguments: procedureir.Arguments{Count: 1, ExpressionIDs: []int{1}},
+	}
+	for _, test := range []struct {
+		name       string
+		local      map[string]sourceDeclaration
+		parameters map[string]sourceDeclaration
+	}{
+		{name: "local", local: map[string]sourceDeclaration{"sharedsheet": {Name: "sharedSheet", Type: "Variant"}}},
+		{name: "parameter", parameters: map[string]sourceDeclaration{"sharedsheet": {Name: "sharedSheet", Type: "Variant", Parameter: true}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			declarations := declarationScope{module: module, local: test.local, parameters: test.parameters}
+			state := map[string]bool{moduleVariable.key(): true}
+			vars := map[string]objectVariable{moduleVariable.key(): moduleVariable}
+			applyObjectCallEffects(call, state, vars, declarations, nil, map[string]objectProcedureSummary{"initialize": moduleSummary})
+			if !state[moduleVariable.key()] {
+				t.Fatalf("initialized module object was changed through a shadowed Variant: %+v", state)
+			}
+			applyObjectCallEffects(actualCall, state, vars, declarations, expressions, map[string]objectProcedureSummary{"touch": actualSummary})
+			if !state[moduleVariable.key()] {
+				t.Fatalf("ByRef actual resolution selected the module object through a shadowed Variant: %+v", state)
+			}
+			assigned, present := objectCallParameterAssigned(sourceProcedure{Name: "Run"}, declarations, actualCall, actualSummary, 0, objectCallActuals(actualCall, expressions), state, vars, objectFlowContext{expressions: expressions}, map[string]objectProcedureSummary{})
+			if assigned || present {
+				t.Fatalf("entry-call actual resolution selected a shadowed Variant: assigned=%v present=%v", assigned, present)
+			}
+		})
+	}
+}
+
 func TestVBA202Issue448PreservesObjectStateAcrossUnresolvedPrivateByValCall(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/object_use_before_set_issue448_test.go
+++ b/internal/analyze/object_use_before_set_issue448_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 func TestVBA202Issue448TracksObjectStateAcrossCFGAndCalls(t *testing.T) {
@@ -319,6 +320,31 @@ End Sub
 	got := findingsByCode(findings, "VBA202")
 	if len(got) != 1 || got[0].Procedure != "Shadow" {
 		t.Fatalf("shadowing local should remain nullable despite module initialization: %+v", got)
+	}
+}
+
+func TestVBA202Issue448DoesNotUseModuleObjectForVariantShadow(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private sharedSheet As Worksheet
+
+Public Sub LocalShadow()
+  Dim sharedSheet As Variant
+  Debug.Print sharedSheet.Cells(1, 1)
+End Sub
+
+Public Sub ParameterShadow(ByVal sharedSheet As Variant)
+  Debug.Print sharedSheet.Cells(1, 1)
+End Sub
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA202"); len(got) != 0 {
+		t.Fatalf("Variant shadows must not resolve to the module object: %+v", got)
 	}
 }
 
@@ -725,5 +751,137 @@ End Sub
 	got := findingsByCode(findings, "VBA202")
 	if len(got) != 2 || got[0].Procedure != "ErrorPath" || got[1].Procedure != "EarlyGoto" {
 		t.Fatalf("error and early-exit paths should warn while initialized indexed writes stay safe: %+v", got)
+	}
+}
+
+func TestVBA202Issue448RecognizesExcelFactoryFunctionResult(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private remoteWorkbook As Workbook
+
+Private Function createRemoteWorkbook() As Workbook
+  Dim app As Application: Set app = CreateObject("Excel.Application")
+  Set createRemoteWorkbook = app.Workbooks.Add
+End Function
+
+Public Sub Run()
+  Set remoteWorkbook = createRemoteWorkbook()
+  Call remoteWorkbook.Application.Run("TimerMain.StartTimer")
+End Sub
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA202"); len(got) != 0 {
+		t.Fatalf("Excel factory function result should establish the object before use: %+v", got)
+	}
+}
+
+func TestVBA202Issue448TracksInitializedFunctionReturnThroughByRefCall(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Sub Append(ByRef output As Collection, ByVal input As Collection)
+  Call output.Add(input)
+End Sub
+
+Private Function Values() As Collection
+  Dim input As Collection
+  Set input = New Collection
+  Set Values = New Collection
+  Call Append(Values, input)
+End Function
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA202"); len(got) != 0 {
+		t.Fatalf("an initialized function return passed to a private ByRef helper should be safe: %+v", got)
+	}
+}
+
+func TestObjectDirectCallSummaryUsesCallFileForDuplicateModules(t *testing.T) {
+	t.Parallel()
+	call := procedureir.CallSite{
+		File:   "../../src/stdTimer.cls",
+		Module: "stdTimer",
+		Callee: procedureir.Callee{BaseName: "createRemoteWorkbook"},
+	}
+	summary, ok := objectDirectCallSummary(sourceProcedure{Module: "stdTimer"}, call, map[string]objectProcedureSummary{
+		"primary": {
+			File:           "src/stdTimer.cls",
+			Module:         "stdTimer",
+			QualifiedName:  "stdTimer.createRemoteWorkbook",
+			ReturnAssigned: true,
+		},
+		"wip": {
+			File:           "src/WIP/stdTimer.cls",
+			Module:         "stdTimer",
+			QualifiedName:  "stdTimer.createRemoteWorkbook",
+			ReturnAssigned: false,
+		},
+	})
+	if !ok || !summary.ReturnAssigned {
+		t.Fatalf("same-file function summary = %+v, ok=%v; want assigned primary summary", summary, ok)
+	}
+}
+
+func TestVBA202Issue448PreservesObjectStateAcrossUnresolvedPrivateByValCall(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Private Sub Touch(ByVal values As Collection)
+  Call values.Add("callee")
+End Sub
+
+Public Sub Run()
+  Dim values As Collection
+  Set values = New Collection
+  Call Touch(values)
+  Call values.Add("caller")
+End Sub
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA202"); len(got) != 0 {
+		t.Fatalf("a private ByVal object call must preserve the caller's reference: %+v", got)
+	}
+}
+
+func TestVBA202Issue448TracksModuleInitializationThroughMeCall(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeClass(t, dir, "Main.cls", `Attribute VB_Name = "Main"
+Option Explicit
+Private target As Worksheet
+
+Private Sub InitializeTarget()
+  Set target = ThisWorkbook.Worksheets(1)
+End Sub
+
+Private Sub UseTarget()
+  Debug.Print target.Name
+End Sub
+
+Public Sub Run()
+  If target Is Nothing Then Me.InitializeTarget
+  Call UseTarget
+End Sub
+`)
+
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA202"); len(got) != 0 {
+		t.Fatalf("Me initializer should establish the module object before the private helper: %+v", got)
 	}
 }

--- a/internal/analyze/object_use_before_set_issue448_test.go
+++ b/internal/analyze/object_use_before_set_issue448_test.go
@@ -831,6 +831,36 @@ func TestObjectDirectCallSummaryUsesCallFileForDuplicateModules(t *testing.T) {
 	}
 }
 
+func TestObjectCallEffectsSkipsAmbiguousDirectSummaries(t *testing.T) {
+	t.Parallel()
+	value := objectVariable{Scope: procedureir.ScopeParameter, Name: "value"}
+	call := procedureir.CallSite{
+		File: "src/Main.bas", Module: "Main",
+		Caller:    procedureir.ProcedureRef{QualifiedName: "Main.Run"},
+		Callee:    procedureir.Callee{BaseName: "Touch"},
+		Arguments: procedureir.Arguments{Count: 1, ExpressionIDs: []int{1}},
+	}
+	declarations := declarationScope{parameters: map[string]sourceDeclaration{
+		"value": {Name: "value", Type: "Collection", Object: true, Parameter: true},
+	}}
+	vars := map[string]objectVariable{value.key(): value}
+	expressions := map[int]procedureir.Expression{
+		1: {ID: 1, Kind: procedureir.ExpressionIdentifier, Text: "value"},
+	}
+	summary := func() objectProcedureSummary {
+		return objectProcedureSummary{
+			File: "src/Main.bas", Module: "Main", QualifiedName: "Main.Touch",
+			Params: []objectParameterSummary{{Name: "value", Object: true, ByRef: true}},
+		}
+	}
+	summaries := map[string]objectProcedureSummary{"first": summary(), "second": summary()}
+	state := map[string]bool{value.key(): true}
+	applyObjectCallEffects(call, state, vars, declarations, expressions, summaries)
+	if state[value.key()] {
+		t.Fatalf("ambiguous direct summaries must not preserve a nullable ByRef object state: %+v", state)
+	}
+}
+
 func TestVBA202Issue448PreservesObjectStateAcrossUnresolvedPrivateByValCall(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/vba212.go
+++ b/internal/analyze/vba212.go
@@ -19,7 +19,7 @@ type vba212Context struct {
 	projectEffects effects.ProjectSummary
 	userDefined    map[string]bool
 	getterEffects  map[string]bool
-	declarations   map[int]map[string]sourceDeclaration
+	declarations   map[int]declarationScope
 }
 
 type vba212Guard struct {
@@ -58,7 +58,7 @@ func (a Analyzer) vba212ScanWithContext(ctx context.Context, file parsedFile, pr
 	procedures = append([]sourceProcedure(nil), procedures...)
 	sortSourceProcedures(procedures)
 	if scanCtx.declarations == nil {
-		scanCtx.declarations = vba212DeclarationIndexes(file.Lines, procedures)
+		scanCtx.declarations = vba212DeclarationIndexesForFile(file, procedures)
 	}
 	summaries := scanCtx.projectEffects.All()
 	if len(summaries) == 0 && file.Root != nil && vba212SourceMayHaveGetter(file) {
@@ -169,23 +169,57 @@ func sortSourceProcedures(procedures []sourceProcedure) {
 	}
 }
 
-func vba212DeclarationIndexes(lines []string, procedures []sourceProcedure) map[int]map[string]sourceDeclaration {
-	moduleDecls := moduleDeclarations(lines, procedures)
-	indexes := make(map[int]map[string]sourceDeclaration, len(procedures))
+func vba212DeclarationScopes(lines []string, procedures []sourceProcedure) map[int]declarationScope {
+	facts := buildModuleAnalysisFacts(lines, procedureir.DocumentIR{}, procedures)
+	indexes := make(map[int]declarationScope, len(procedures))
 	for _, proc := range procedures {
-		decls := make(map[string]sourceDeclaration, len(moduleDecls)+len(proc.Declarations)+len(proc.Params))
-		for name, decl := range moduleDecls {
-			decls[name] = decl
-		}
-		for _, decl := range proc.Declarations {
-			decls[strings.ToLower(decl.Name)] = sourceDeclaration{Name: decl.Name, Type: decl.Type}
-		}
-		for _, param := range proc.Params {
-			decls[strings.ToLower(param.Name)] = sourceDeclaration{Name: param.Name, Type: param.Type, Parameter: true}
-		}
-		indexes[proc.StartByte] = decls
+		scope := declarationScope{module: facts.moduleDeclarations, local: facts.procedureDeclarations(proc), parameters: vba212Parameters(proc)}
+		addVBA212ProcedureIRDeclarations(&scope, proc)
+		indexes[proc.StartByte] = scope
 	}
 	return indexes
+}
+
+// vba212DeclarationIndexes retains the historical merged-map helper for
+// package-local callers. The analyzer itself uses vba212DeclarationScopes so
+// module declarations remain shared across procedures.
+func vba212DeclarationIndexes(lines []string, procedures []sourceProcedure) map[int]map[string]sourceDeclaration {
+	scopes := vba212DeclarationScopes(lines, procedures)
+	indexes := make(map[int]map[string]sourceDeclaration, len(scopes))
+	for start, scope := range scopes {
+		merged := make(map[string]sourceDeclaration, scope.len())
+		scope.forEach(func(key string, declaration sourceDeclaration) { merged[key] = declaration })
+		indexes[start] = merged
+	}
+	return indexes
+}
+
+func vba212DeclarationIndexesForFile(file parsedFile, procedures []sourceProcedure) map[int]declarationScope {
+	indexes := make(map[int]declarationScope, len(procedures))
+	for _, proc := range procedures {
+		scope := newDeclarationScope(file, proc)
+		addVBA212ProcedureIRDeclarations(&scope, proc)
+		indexes[proc.StartByte] = scope
+	}
+	return indexes
+}
+
+func addVBA212ProcedureIRDeclarations(scope *declarationScope, proc sourceProcedure) {
+	for _, declaration := range proc.Declarations {
+		scope.addProcedureIRDeclaration(sourceDeclaration{Name: declaration.Name, Type: declaration.Type})
+	}
+}
+
+func vba212Parameters(proc sourceProcedure) map[string]sourceDeclaration {
+	parameters := make(map[string]sourceDeclaration, len(proc.Params))
+	for _, parameter := range proc.Params {
+		key := strings.ToLower(strings.TrimSpace(parameter.Name))
+		if key == "" {
+			continue
+		}
+		parameters[key] = sourceDeclaration{Name: parameter.Name, Type: parameter.Type, Parameter: true}
+	}
+	return parameters
 }
 
 type vba212NodeKey struct {
@@ -507,7 +541,7 @@ func vba212ResolvedGetter(node *tree_sitter.Node, source []byte, file parsedFile
 	return scanCtx.getterEffects[strings.ToLower(typ)+"\x00"+memberName]
 }
 
-func vba212ReceiverType(receiver *tree_sitter.Node, source []byte, file parsedFile, proc sourceProcedure, declarationIndexes map[int]map[string]sourceDeclaration) string {
+func vba212ReceiverType(receiver *tree_sitter.Node, source []byte, file parsedFile, proc sourceProcedure, declarationIndexes map[int]declarationScope) string {
 	path := vba212AccessPath(receiver, source)
 	if path == "" {
 		return ""
@@ -523,7 +557,7 @@ func vba212ReceiverType(receiver *tree_sitter.Node, source []byte, file parsedFi
 		return file.Module
 	}
 	decls := declarationIndexes[proc.StartByte]
-	if decl, ok := decls[strings.ToLower(root)]; ok {
+	if decl, ok := decls.lookup(root); ok {
 		return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(decl.Type), "New "))
 	}
 	return ""

--- a/testdata/static-analysis-corpus/snapshots/analyze/self/legal-viewer.jsonl
+++ b/testdata/static-analysis-corpus/snapshots/analyze/self/legal-viewer.jsonl
@@ -267,7 +267,6 @@
 {"project":"self/legal-viewer","file":"src/modules/modLawSearch.bas","surface":"analyze","code":"VBA202","severity":"warning","line":418,"column":0}
 {"project":"self/legal-viewer","file":"src/modules/modLawSearch.bas","surface":"analyze","code":"VBA202","severity":"warning","line":875,"column":0}
 {"project":"self/legal-viewer","file":"src/modules/modLawSearch.bas","surface":"analyze","code":"VBA225","severity":"warning","line":890,"column":0}
-{"project":"self/legal-viewer","file":"src/modules/modLawSearch.bas","surface":"analyze","code":"VBA202","severity":"warning","line":1005,"column":0}
 {"project":"self/legal-viewer","file":"src/modules/modLawTableParser.bas","surface":"analyze","code":"VBA225","severity":"warning","line":15,"column":0}
 {"project":"self/legal-viewer","file":"src/modules/modLawTableParser.bas","surface":"analyze","code":"VBA202","severity":"warning","line":17,"column":0}
 {"project":"self/legal-viewer","file":"src/modules/modLawTableParser.bas","surface":"analyze","code":"VBA244","severity":"information","line":89,"column":14}

--- a/testdata/static-analysis-corpus/snapshots/analyze/third_party/std-vba.jsonl
+++ b/testdata/static-analysis-corpus/snapshots/analyze/third_party/std-vba.jsonl
@@ -37,6 +37,7 @@
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":52,"column":22}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":60,"column":10}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":60,"column":10}
+{"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA209","severity":"warning","line":82,"column":0}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":104,"column":21}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":116,"column":61}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":116,"column":61}
@@ -548,7 +549,6 @@
 {"project":"third_party/std-vba","file":"src/WIP/stdDictionary/trick/stdDictionary.cls","surface":"analyze","code":"VBA206","severity":"warning","line":914,"column":5}
 {"project":"third_party/std-vba","file":"src/WIP/stdDictionary/trick/stdDictionary.cls","surface":"analyze","code":"VBA206","severity":"warning","line":924,"column":5}
 {"project":"third_party/std-vba","file":"src/WIP/stdEndpoint.cls","surface":"analyze","code":"VBA202","severity":"warning","line":50,"column":0}
-{"project":"third_party/std-vba","file":"src/WIP/stdEndpoint.cls","surface":"analyze","code":"VBA202","severity":"warning","line":51,"column":0}
 {"project":"third_party/std-vba","file":"src/WIP/stdEnumProvider/STD_Types_IniVariantEnum.bas","surface":"analyze","code":"VBA206","severity":"warning","line":83,"column":9}
 {"project":"third_party/std-vba","file":"src/WIP/stdEnumProvider/STD_Types_IniVariantEnum.bas","surface":"analyze","code":"VBA206","severity":"warning","line":103,"column":15}
 {"project":"third_party/std-vba","file":"src/WIP/stdEnumProvider/STD_Types_IniVariantEnum.bas","surface":"analyze","code":"VBA206","severity":"warning","line":110,"column":15}
@@ -882,7 +882,6 @@
 {"project":"third_party/std-vba","file":"src/WIP/stdTable/stdXLTableRow.cls","surface":"analyze","code":"VBA202","severity":"warning","line":138,"column":0}
 {"project":"third_party/std-vba","file":"src/WIP/stdTable/stdXLTableRow.cls","surface":"analyze","code":"VBA202","severity":"warning","line":142,"column":0}
 {"project":"third_party/std-vba","file":"src/WIP/stdTimer.cls","surface":"analyze","code":"VBA206","severity":"warning","line":132,"column":12}
-{"project":"third_party/std-vba","file":"src/WIP/stdTimer.cls","surface":"analyze","code":"VBA202","severity":"warning","line":133,"column":0}
 {"project":"third_party/std-vba","file":"src/WIP/stdTimer.cls","surface":"analyze","code":"VB045","severity":"error","line":134,"column":12}
 {"project":"third_party/std-vba","file":"src/WIP/stdTimer.cls","surface":"analyze","code":"VBA249","severity":"error","line":157,"column":0}
 {"project":"third_party/std-vba","file":"src/WIP/stdTimer.cls","surface":"analyze","code":"VBA244","severity":"information","line":165,"column":17}
@@ -1033,6 +1032,7 @@
 {"project":"third_party/std-vba","file":"src/stdClipboard.cls","surface":"analyze","code":"VBA249","severity":"error","line":279,"column":0}
 {"project":"third_party/std-vba","file":"src/stdClipboard.cls","surface":"analyze","code":"VBA227","severity":"warning","line":282,"column":0}
 {"project":"third_party/std-vba","file":"src/stdClipboard.cls","surface":"analyze","code":"VBA227","severity":"warning","line":282,"column":0}
+{"project":"third_party/std-vba","file":"src/stdClipboard.cls","surface":"analyze","code":"VBA227","severity":"warning","line":301,"column":0}
 {"project":"third_party/std-vba","file":"src/stdClipboard.cls","surface":"analyze","code":"VBA227","severity":"warning","line":301,"column":0}
 {"project":"third_party/std-vba","file":"src/stdClipboard.cls","surface":"analyze","code":"VBA227","severity":"warning","line":308,"column":0}
 {"project":"third_party/std-vba","file":"src/stdEnumerator.cls","surface":"analyze","code":"VBA202","severity":"warning","line":316,"column":0}
@@ -1448,6 +1448,7 @@
 {"project":"third_party/std-vba","file":"src/stdTimer.cls","surface":"analyze","code":"VBA202","severity":"warning","line":98,"column":0}
 {"project":"third_party/std-vba","file":"src/stdTimer.cls","surface":"analyze","code":"VBA214","severity":"warning","line":108,"column":0}
 {"project":"third_party/std-vba","file":"src/stdTimer.cls","surface":"analyze","code":"VBA236","severity":"warning","line":119,"column":0}
+{"project":"third_party/std-vba","file":"src/stdTimer.cls","surface":"analyze","code":"VBA202","severity":"warning","line":172,"column":0}
 {"project":"third_party/std-vba","file":"src/stdWebSocket.cls","surface":"analyze","code":"VBA202","severity":"warning","line":93,"column":0}
 {"project":"third_party/std-vba","file":"src/stdWebSocket.cls","surface":"analyze","code":"VBA202","severity":"warning","line":94,"column":0}
 {"project":"third_party/std-vba","file":"src/stdWebSocket.cls","surface":"analyze","code":"VBA202","severity":"warning","line":130,"column":0}
@@ -1487,9 +1488,6 @@
 {"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA214","severity":"warning","line":2079,"column":0}
 {"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA214","severity":"warning","line":2129,"column":0}
 {"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA214","severity":"warning","line":2129,"column":0}
-{"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA227","severity":"warning","line":2143,"column":0}
-{"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA227","severity":"warning","line":2143,"column":0}
-{"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA227","severity":"warning","line":2152,"column":0}
 {"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA214","severity":"warning","line":2161,"column":0}
 {"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA206","severity":"warning","line":2189,"column":27}
 {"project":"third_party/std-vba","file":"src/stdWebView.cls","surface":"analyze","code":"VBA214","severity":"warning","line":2250,"column":0}
@@ -1552,6 +1550,7 @@
 {"project":"third_party/std-vba","file":"tests/lib/Test.cls","surface":"analyze","code":"VBA202","severity":"warning","line":111,"column":0}
 {"project":"third_party/std-vba","file":"tests/lib/Test.cls","surface":"analyze","code":"VBA244","severity":"warning","line":133,"column":6}
 {"project":"third_party/std-vba","file":"tests/lib/Test.cls","surface":"analyze","code":"VBA214","severity":"warning","line":159,"column":0}
+{"project":"third_party/std-vba","file":"tests/lib/Test.cls","surface":"analyze","code":"VBA202","severity":"warning","line":166,"column":0}
 {"project":"third_party/std-vba","file":"tests/lib/xlsProjectBuilder.cls","surface":"analyze","code":"VBA244","severity":"information","line":94,"column":28}
 {"project":"third_party/std-vba","file":"tests/stdCallbackTests.bas","surface":"analyze","code":"VBA240","severity":"warning","line":10,"column":0}
 {"project":"third_party/std-vba","file":"tests/stdEnumeratorTests.bas","surface":"analyze","code":"VBA214","severity":"warning","line":92,"column":0}

--- a/testdata/static-analysis-corpus/snapshots/analyze/third_party/std-vba.jsonl
+++ b/testdata/static-analysis-corpus/snapshots/analyze/third_party/std-vba.jsonl
@@ -37,7 +37,7 @@
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":52,"column":22}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":60,"column":10}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":60,"column":10}
-{"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA209","severity":"warning","line":82,"column":0}
+{"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA209","severity":"warning","line":83,"column":0}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":104,"column":21}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":116,"column":61}
 {"project":"third_party/std-vba","file":"src/WIP/STD_Runtimes_CLR.cls","surface":"analyze","code":"VBA206","severity":"warning","line":116,"column":61}


### PR DESCRIPTION
## Summary

- Add reusable per-file module facts with IR-backed module declarations, indexed procedure ownership, and cached procedure-local declarations.
- Layer shared module declarations with procedure-local declarations and parameters to avoid rebuilding the full module map for each procedure.
- Reuse the shared scope in VBA212, object-use-before-set, array, dictionary, and related analyzer paths while preserving incomplete-source fallbacks.

Closes #672

## Tests

- `$env:CC='C:\TDM-GCC-64\bin\gcc.exe'; $env:CXX='C:\TDM-GCC-64\bin\g++.exe'; go test ./internal/analyze -count=1`
- `$env:CC='C:\TDM-GCC-64\bin\gcc.exe'; $env:CXX='C:\TDM-GCC-64\bin\g++.exe'; go test ./internal/lspserver -run '^TestJSONRPCPublishesAnalyzerDiagnostics$' -count=1`
- `$env:CC='C:\TDM-GCC-64\bin\gcc.exe'; $env:CXX='C:\TDM-GCC-64\bin\g++.exe'; go test ./... -p 1 -count=1`
- `$env:CC='C:\TDM-GCC-64\bin\gcc.exe'; $env:CXX='C:\TDM-GCC-64\bin\g++.exe'; go test ./internal/analyze -run '^$' -bench '^BenchmarkModuleAnalysisFacts$' -benchmem -benchtime=1x -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of declarations across modules, procedures, parameters, and local scopes.
  * Reduced false positives involving shadowed names, object references, `With` blocks, arrays, dictionaries, and procedure ownership.
  * Improved object-flow analysis for Excel factory results, function returns, module calls, and initialized objects.
  * Refined VBA202, VBA209, and VBA227 findings, including optional parameters and ambiguous calls.
  * Increased accuracy when parsed information is incomplete.

* **Performance**
  * Reused analysis results across batch and realtime processing for more efficient scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->