### PR TITLE
perf(callgraph): index matched procedure candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Improved project-local call graph construction by indexing canonical
+  procedure candidate identities, avoiding a full procedure-node scan for each
+  uniquely matched call while preserving conservative resolution behavior.
+
 - Added canonical large-single-module analyzer performance telemetry for
   `xlflow analyze --performance-log`, including aggregate workload counters and
   maximum file/procedure dimensions. Profiling remains opt-in and stderr-only;

--- a/internal/vba/callgraph/callgraph.go
+++ b/internal/vba/callgraph/callgraph.go
@@ -167,14 +167,13 @@ type AmbiguousTargetError struct{ Candidates []Node }
 func (e *AmbiguousTargetError) Error() string { return "impact target is ambiguous" }
 
 type graph struct {
-	nodes              map[string]Node
-	byQualified        map[string][]string
-	byName             map[string][]string
-	byCandidate        map[procedureIdentity]string
-	candidateConflicts map[procedureIdentity]struct{}
-	out                map[string][]Edge
-	in                 map[string][]Edge
-	uncertain          map[string][]calls.Call
+	nodes       map[string]Node
+	byQualified map[string][]string
+	byName      map[string][]string
+	byCandidate map[procedureIdentity]candidateIndexEntry
+	out         map[string][]Edge
+	in          map[string][]Edge
+	uncertain   map[string][]calls.Call
 }
 
 // procedureIdentity contains the fields that a uniquely resolved call
@@ -186,6 +185,15 @@ type procedureIdentity struct {
 	kind          string
 	file          string
 	line          int
+}
+
+// candidateIndexEntry retains every graph node in a normalized identity
+// bucket. Most buckets contain one node and therefore avoid a slice
+// allocation; alternates are retained only for normalized collisions and are
+// checked against the original identity fields during lookup.
+type candidateIndexEntry struct {
+	first      string
+	alternates []string
 }
 
 func Analyze(input *calls.Result, request Request) (Result, error) {
@@ -304,7 +312,7 @@ func AnalyzeSnapshot(input Snapshot, request Request) (Result, error) {
 }
 
 func build(input Snapshot) graph {
-	g := graph{nodes: map[string]Node{}, byQualified: map[string][]string{}, byName: map[string][]string{}, byCandidate: map[procedureIdentity]string{}, candidateConflicts: map[procedureIdentity]struct{}{}, out: map[string][]Edge{}, in: map[string][]Edge{}, uncertain: map[string][]calls.Call{}}
+	g := graph{nodes: map[string]Node{}, byQualified: map[string][]string{}, byName: map[string][]string{}, byCandidate: map[procedureIdentity]candidateIndexEntry{}, out: map[string][]Edge{}, in: map[string][]Edge{}, uncertain: map[string][]calls.Call{}}
 	moduleKinds := map[string]string{}
 	for _, sym := range input.Symbols {
 		if sym.Kind == "module" {
@@ -332,27 +340,24 @@ func build(input Snapshot) graph {
 	// The candidate index is populated immediately below and has one entry per
 	// procedure in the common case. Reserve that capacity after the node pass so
 	// map growth does not become part of the matched-call hot path.
-	g.byCandidate = make(map[procedureIdentity]string, len(g.nodes))
+	g.byCandidate = make(map[procedureIdentity]candidateIndexEntry, len(g.nodes))
 	for qualified := range g.byQualified {
 		sort.Strings(g.byQualified[qualified])
 	}
 	for name := range g.byName {
 		sort.Strings(g.byName[name])
 	}
-	// Build the candidate identity index once for this graph snapshot. Keep a
-	// separate conflict set so the common unique-identity case does not allocate
-	// a one-element slice for every procedure.
+	// Build the candidate identity index once for this graph snapshot. Keep all
+	// normalized collisions so an exact raw-file match can still be selected.
 	for key, node := range g.nodes {
 		identity := procedureIdentityForNode(node)
-		if _, conflict := g.candidateConflicts[identity]; conflict {
-			continue
+		entry, exists := g.byCandidate[identity]
+		if !exists {
+			entry.first = key
+		} else {
+			entry.alternates = append(entry.alternates, key)
 		}
-		if _, exists := g.byCandidate[identity]; exists {
-			delete(g.byCandidate, identity)
-			g.candidateConflicts[identity] = struct{}{}
-			continue
-		}
-		g.byCandidate[identity] = key
+		g.byCandidate[identity] = entry
 	}
 	for _, call := range input.Calls {
 		if call.Caller == nil {
@@ -406,22 +411,36 @@ func procedureIdentityForCandidate(candidate calls.Candidate) procedureIdentity 
 	}
 }
 
-// candidateKey returns a callee only when its canonical identity is unique
-// and the original comparison used by the graph builder still succeeds.
-// Rechecking the original values is important because normalization is an
-// index optimization, not a change to call-resolution semantics.
+// candidateKey narrows a candidate to its canonical identity bucket, then
+// rechecks the original comparison used by the graph builder. Normalized path
+// collisions may contain a valid exact match, while multiple exact matches
+// remain ambiguous and must not become a confirmed edge.
 func (g graph) candidateKey(candidate calls.Candidate) string {
 	identity := procedureIdentityForCandidate(candidate)
-	if _, conflict := g.candidateConflicts[identity]; conflict {
+	entry, ok := g.byCandidate[identity]
+	if !ok {
 		return ""
 	}
-	key, ok := g.byCandidate[identity]
-	node, nodeOK := g.nodes[key]
-	if !ok || !nodeOK || !strings.EqualFold(node.ID.QualifiedName, candidate.QualifiedName) ||
-		node.ID.Kind != candidate.Kind || node.ID.File != candidate.File || node.ID.Line != candidate.Line {
-		return ""
+	match := ""
+	if g.candidateNodeMatches(entry.first, candidate) {
+		match = entry.first
 	}
-	return key
+	for _, key := range entry.alternates {
+		if !g.candidateNodeMatches(key, candidate) {
+			continue
+		}
+		if match != "" {
+			return ""
+		}
+		match = key
+	}
+	return match
+}
+
+func (g graph) candidateNodeMatches(key string, candidate calls.Candidate) bool {
+	node, ok := g.nodes[key]
+	return ok && strings.EqualFold(node.ID.QualifiedName, candidate.QualifiedName) &&
+		node.ID.Kind == candidate.Kind && node.ID.File == candidate.File && node.ID.Line == candidate.Line
 }
 
 func normalizeProcedureFile(file string) string {

--- a/internal/vba/callgraph/callgraph.go
+++ b/internal/vba/callgraph/callgraph.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/harumiWeb/xlflow/internal/vba/calls"
 )
@@ -165,12 +167,25 @@ type AmbiguousTargetError struct{ Candidates []Node }
 func (e *AmbiguousTargetError) Error() string { return "impact target is ambiguous" }
 
 type graph struct {
-	nodes       map[string]Node
-	byQualified map[string][]string
-	byName      map[string][]string
-	out         map[string][]Edge
-	in          map[string][]Edge
-	uncertain   map[string][]calls.Call
+	nodes              map[string]Node
+	byQualified        map[string][]string
+	byName             map[string][]string
+	byCandidate        map[procedureIdentity]string
+	candidateConflicts map[procedureIdentity]struct{}
+	out                map[string][]Edge
+	in                 map[string][]Edge
+	uncertain          map[string][]calls.Call
+}
+
+// procedureIdentity contains the fields that a uniquely resolved call
+// candidate must match before it can become a confirmed graph edge. The file
+// component is normalized for indexing, while build still rechecks the
+// original file string below to preserve the historical exact-file match.
+type procedureIdentity struct {
+	qualifiedName string
+	kind          string
+	file          string
+	line          int
 }
 
 func Analyze(input *calls.Result, request Request) (Result, error) {
@@ -289,7 +304,7 @@ func AnalyzeSnapshot(input Snapshot, request Request) (Result, error) {
 }
 
 func build(input Snapshot) graph {
-	g := graph{nodes: map[string]Node{}, byQualified: map[string][]string{}, byName: map[string][]string{}, out: map[string][]Edge{}, in: map[string][]Edge{}, uncertain: map[string][]calls.Call{}}
+	g := graph{nodes: map[string]Node{}, byQualified: map[string][]string{}, byName: map[string][]string{}, byCandidate: map[procedureIdentity]string{}, candidateConflicts: map[procedureIdentity]struct{}{}, out: map[string][]Edge{}, in: map[string][]Edge{}, uncertain: map[string][]calls.Call{}}
 	moduleKinds := map[string]string{}
 	for _, sym := range input.Symbols {
 		if sym.Kind == "module" {
@@ -314,11 +329,30 @@ func build(input Snapshot) graph {
 		g.byQualified[qualified] = append(g.byQualified[qualified], key)
 		g.byName[strings.ToLower(node.Name)] = append(g.byName[strings.ToLower(node.Name)], key)
 	}
+	// The candidate index is populated immediately below and has one entry per
+	// procedure in the common case. Reserve that capacity after the node pass so
+	// map growth does not become part of the matched-call hot path.
+	g.byCandidate = make(map[procedureIdentity]string, len(g.nodes))
 	for qualified := range g.byQualified {
 		sort.Strings(g.byQualified[qualified])
 	}
 	for name := range g.byName {
 		sort.Strings(g.byName[name])
+	}
+	// Build the candidate identity index once for this graph snapshot. Keep a
+	// separate conflict set so the common unique-identity case does not allocate
+	// a one-element slice for every procedure.
+	for key, node := range g.nodes {
+		identity := procedureIdentityForNode(node)
+		if _, conflict := g.candidateConflicts[identity]; conflict {
+			continue
+		}
+		if _, exists := g.byCandidate[identity]; exists {
+			delete(g.byCandidate, identity)
+			g.candidateConflicts[identity] = struct{}{}
+			continue
+		}
+		g.byCandidate[identity] = key
 	}
 	for _, call := range input.Calls {
 		if call.Caller == nil {
@@ -333,13 +367,7 @@ func build(input Snapshot) graph {
 			continue
 		}
 		candidate := call.Resolution.Candidates[0]
-		calleeKey := ""
-		for key, node := range g.nodes {
-			if strings.EqualFold(node.ID.QualifiedName, candidate.QualifiedName) && node.ID.Kind == candidate.Kind && node.ID.File == candidate.File && node.ID.Line == candidate.Line {
-				calleeKey = key
-				break
-			}
-		}
+		calleeKey := g.candidateKey(candidate)
 		if calleeKey == "" {
 			continue
 		}
@@ -358,6 +386,92 @@ func build(input Snapshot) graph {
 		sort.Slice(g.in[key], func(i, j int) bool { return edgeKey(g.in[key][i]) < edgeKey(g.in[key][j]) })
 	}
 	return g
+}
+
+func procedureIdentityForNode(node Node) procedureIdentity {
+	return procedureIdentity{
+		qualifiedName: foldEqualFold(node.ID.QualifiedName),
+		kind:          node.ID.Kind,
+		file:          normalizeProcedureFile(node.ID.File),
+		line:          node.ID.Line,
+	}
+}
+
+func procedureIdentityForCandidate(candidate calls.Candidate) procedureIdentity {
+	return procedureIdentity{
+		qualifiedName: foldEqualFold(candidate.QualifiedName),
+		kind:          candidate.Kind,
+		file:          normalizeProcedureFile(candidate.File),
+		line:          candidate.Line,
+	}
+}
+
+// candidateKey returns a callee only when its canonical identity is unique
+// and the original comparison used by the graph builder still succeeds.
+// Rechecking the original values is important because normalization is an
+// index optimization, not a change to call-resolution semantics.
+func (g graph) candidateKey(candidate calls.Candidate) string {
+	identity := procedureIdentityForCandidate(candidate)
+	if _, conflict := g.candidateConflicts[identity]; conflict {
+		return ""
+	}
+	key, ok := g.byCandidate[identity]
+	node, nodeOK := g.nodes[key]
+	if !ok || !nodeOK || !strings.EqualFold(node.ID.QualifiedName, candidate.QualifiedName) ||
+		node.ID.Kind != candidate.Kind || node.ID.File != candidate.File || node.ID.Line != candidate.Line {
+		return ""
+	}
+	return key
+}
+
+func normalizeProcedureFile(file string) string {
+	if strings.TrimSpace(file) == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(file))
+}
+
+// foldEqualFold returns a canonical key for Go's Unicode simple-fold
+// equivalence. strings.ToLower is insufficient for a few simple-fold cycles
+// (for example, Kelvin sign), so canonicalize each rune through its complete
+// unicode.SimpleFold cycle. This keeps indexing lossless while retaining the
+// final strings.EqualFold guard in candidateKey.
+func foldEqualFold(value string) string {
+	ascii := true
+	needsUpper := false
+	for i := 0; i < len(value); i++ {
+		if value[i] >= utf8.RuneSelf {
+			ascii = false
+			break
+		}
+		if value[i] >= 'a' && value[i] <= 'z' {
+			needsUpper = true
+		}
+	}
+	if ascii {
+		if !needsUpper {
+			return value
+		}
+		folded := []byte(value)
+		for i, char := range folded {
+			if char >= 'a' && char <= 'z' {
+				folded[i] -= 'a' - 'A'
+			}
+		}
+		return string(folded)
+	}
+	var folded strings.Builder
+	folded.Grow(len(value))
+	for _, r := range value {
+		canonical := r
+		for next := unicode.SimpleFold(r); next != r; next = unicode.SimpleFold(next) {
+			if next < canonical {
+				canonical = next
+			}
+		}
+		folded.WriteRune(canonical)
+	}
+	return folded.String()
 }
 
 // AnalyzeReachability walks the confirmed project call graph from explicit

--- a/internal/vba/callgraph/callgraph_bench_test.go
+++ b/internal/vba/callgraph/callgraph_bench_test.go
@@ -1,0 +1,117 @@
+package callgraph
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/vba/calls"
+)
+
+// benchmarkGraphSink keeps the graph produced by each iteration observable so
+// the benchmark measures build rather than an optimized-away result.
+var benchmarkGraphSink graph
+
+func BenchmarkBuildProcedures(b *testing.B) {
+	for _, procedures := range []int{500, 1000, 2000} {
+		input := benchmarkSnapshot(procedures, 500, false)
+		b.Run(fmt.Sprintf("procedures_%d_calls_500", procedures), func(b *testing.B) {
+			benchmarkBuild(b, input)
+		})
+	}
+}
+
+func BenchmarkBuildMatchedCalls(b *testing.B) {
+	const procedures = 2000
+	for _, matchedCalls := range []int{500, 1000, 2000} {
+		input := benchmarkSnapshot(procedures, matchedCalls, false)
+		b.Run(fmt.Sprintf("procedures_%d_calls_%d", procedures, matchedCalls), func(b *testing.B) {
+			benchmarkBuild(b, input)
+		})
+	}
+}
+
+func BenchmarkBuildSameNameModules(b *testing.B) {
+	const procedures = 2000
+	const matchedCalls = 2000
+	input := benchmarkSnapshot(procedures, matchedCalls, true)
+	benchmarkBuild(b, input)
+}
+
+func benchmarkBuild(b *testing.B, input Snapshot) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkGraphSink = build(input)
+	}
+}
+
+// benchmarkSnapshot builds all fixture data before the benchmark timer starts.
+// When sameName is false, each procedure has a distinct name in one large
+// module. When it is true, every module contains a procedure named Worker, so
+// candidate identity must distinguish same-named procedures across files.
+func benchmarkSnapshot(procedures, matchedCalls int, sameName bool) Snapshot {
+	if procedures < 1 {
+		procedures = 1
+	}
+	if matchedCalls < 0 {
+		matchedCalls = 0
+	}
+	if matchedCalls > procedures {
+		matchedCalls = procedures
+	}
+
+	snapshot := Snapshot{
+		Symbols: make([]Symbol, procedures),
+		Calls:   make([]calls.Call, matchedCalls),
+	}
+	for i := 0; i < procedures; i++ {
+		module, file, name := "Main", "Main.bas", fmt.Sprintf("Procedure%04d", i)
+		if sameName {
+			module = fmt.Sprintf("Module%04d", i)
+			file = module + ".bas"
+			name = "Worker"
+		}
+		snapshot.Symbols[i] = Symbol{
+			Name:       name,
+			Kind:       "sub",
+			Module:     module,
+			ModuleKind: "standard",
+			File:       file,
+			Line:       i + 1,
+			Column:     1,
+		}
+	}
+	for i := 0; i < matchedCalls; i++ {
+		callerIndex := i
+		calleeIndex := (i + 1) % procedures
+		callerModule, callerFile, callerName := benchmarkProcedureIdentity(callerIndex, sameName)
+		calleeModule, calleeFile, calleeName := benchmarkProcedureIdentity(calleeIndex, sameName)
+		snapshot.Calls[i] = calls.Call{
+			CallSite: calls.CallSite{
+				File:   callerFile,
+				Module: callerModule,
+				Caller: &calls.Caller{Name: callerName, Kind: "sub", QualifiedName: callerModule + "." + callerName},
+			},
+			Resolution: calls.Resolution{
+				Status: "matched",
+				Candidates: []calls.Candidate{{
+					QualifiedName: calleeModule + "." + calleeName,
+					Kind:          "sub",
+					File:          calleeFile,
+					Line:          calleeIndex + 1,
+				}},
+			},
+		}
+	}
+	return snapshot
+}
+
+func benchmarkProcedureIdentity(index int, sameName bool) (module, file, name string) {
+	module, file, name = "Main", "Main.bas", fmt.Sprintf("Procedure%04d", index)
+	if sameName {
+		module = fmt.Sprintf("Module%04d", index)
+		file = module + ".bas"
+		name = "Worker"
+	}
+	return module, file, name
+}

--- a/internal/vba/callgraph/callgraph_test.go
+++ b/internal/vba/callgraph/callgraph_test.go
@@ -451,6 +451,39 @@ func TestBuildIndexesCandidateIdentityWithoutChangingMatches(t *testing.T) {
 	}
 }
 
+func TestBuildSelectsExactCandidateFromNormalizedFileCollision(t *testing.T) {
+	input := Snapshot{
+		Symbols: []Symbol{
+			{Name: "Caller", Kind: "sub", Module: "Main", File: "Main.bas", Line: 1, Column: 1},
+			{Name: "Target", Kind: "sub", Module: "M", File: "src/M.bas", Line: 5, Column: 1},
+			{Name: "Target", Kind: "sub", Module: "M", File: "src/./M.bas", Line: 5, Column: 2},
+		},
+		Calls: []calls.Call{
+			matched("Main", "Main.bas", "Caller", "M", "src/M.bas", "Target", 5, 2),
+			matched("Main", "Main.bas", "Caller", "M", "src/./M.bas", "Target", 5, 3),
+		},
+	}
+
+	g := build(input)
+	callerKey, ok := g.lookupCallerKey("Main.Caller", "sub", "Main.bas")
+	if !ok {
+		t.Fatal("caller was not indexed")
+	}
+	if got := len(g.out[callerKey]); got != 2 {
+		t.Fatalf("confirmed edges = %d, want 2", got)
+	}
+	files := map[string]int{}
+	for _, edge := range g.out[callerKey] {
+		if edge.Callee.File != "src/M.bas" && edge.Callee.File != "src/./M.bas" {
+			t.Fatalf("unexpected callee file = %q", edge.Callee.File)
+		}
+		files[edge.Callee.File]++
+	}
+	if files["src/M.bas"] != 1 || files["src/./M.bas"] != 1 {
+		t.Fatalf("normalized collision targets = %#v, want one edge per raw file", files)
+	}
+}
+
 func TestBuildIndexesPropertyAccessorKinds(t *testing.T) {
 	input := Snapshot{
 		Symbols: []Symbol{

--- a/internal/vba/callgraph/callgraph_test.go
+++ b/internal/vba/callgraph/callgraph_test.go
@@ -382,6 +382,151 @@ func TestAnalyzeReachabilityTreatsAmbiguousRootsAsPossible(t *testing.T) {
 	}
 }
 
+func TestBuildIndexesCandidateIdentityWithoutChangingMatches(t *testing.T) {
+	input := Snapshot{
+		Symbols: []Symbol{
+			{Name: "Caller", Kind: "sub", Module: "Main", File: "Main.bas", Line: 1, Column: 1},
+			// Kelvin sign and ASCII k are EqualFold-equivalent but have different
+			// lower-case representations. The index must retain that match.
+			{Name: "Karget", Kind: "sub", Module: "M", File: "M.bas", Line: 5, Column: 1},
+			// Same qualified name and declaration line in different files must
+			// remain distinct candidate identities.
+			{Name: "Target", Kind: "sub", Module: "M", File: "M.bas", Line: 8, Column: 1},
+			{Name: "Target", Kind: "sub", Module: "M", File: "Other.bas", Line: 8, Column: 1},
+			// Different columns make these distinct graph nodes but the candidate
+			// identity is not unique, so no edge may be inferred.
+			{Name: "Collision", Kind: "sub", Module: "M", File: "M.bas", Line: 11, Column: 1},
+			{Name: "Collision", Kind: "sub", Module: "M", File: "M.bas", Line: 11, Column: 2},
+		},
+		Calls: []calls.Call{
+			matched("Main", "Main.bas", "Caller", "M", "M.bas", "karget", 5, 2),
+			matched("Main", "Main.bas", "Caller", "M", "Other.bas", "Target", 8, 3),
+			// These candidates have the same qualified name but fail one of the
+			// exact identity fields that the old graph scan checked.
+			matchedKind("Main", "Main.bas", "Caller", "sub", "M", "M.bas", "Target", "function", 8, 4),
+			matched("Main", "Main.bas", "Caller", "M", "Missing.bas", "Target", 8, 5),
+			// File normalization is only an index aid; the historical exact file
+			// comparison must still reject a cleaned-but-different candidate.
+			matched("Main", "Main.bas", "Caller", "M", ".\\M.bas", "Target", 8, 6),
+			matched("Main", "Main.bas", "Caller", "M", "M.bas", "Target", 9, 6),
+			matched("Main", "Main.bas", "Caller", "M", "M.bas", "Collision", 11, 7),
+			calls.Call{CallSite: calls.CallSite{File: "Main.bas", Module: "Main", Caller: &calls.Caller{Name: "Caller", Kind: "sub", QualifiedName: "Main.Caller"}, Range: vbaast.Range{StartLine: 8}}, Resolution: calls.Resolution{Status: "ambiguous", Candidates: []calls.Candidate{{QualifiedName: "M.Target", Kind: "sub", File: "M.bas", Line: 8}}}},
+		},
+	}
+
+	g := build(input)
+	callerKey, callerOK := g.lookupCallerKey("Main.Caller", "sub", "Main.bas")
+	if !callerOK {
+		t.Fatal("caller was not indexed")
+	}
+	if got := len(g.out[callerKey]); got != 2 {
+		t.Fatalf("confirmed edges = %d, want 2", got)
+	}
+	if got := g.out[callerKey][0].Callee.QualifiedName; got != "M.Karget" {
+		t.Fatalf("first edge callee = %q, want Unicode EqualFold target", got)
+	}
+	if got := g.out[callerKey][1].Callee.File; got != "Other.bas" {
+		t.Fatalf("second edge file = %q, want Other.bas", got)
+	}
+	if got := len(g.uncertain[callerKey]); got != 1 {
+		t.Fatalf("non-matched calls recorded as uncertain = %d, want 1", got)
+	}
+
+	permuted := input
+	permuted.Symbols = append([]Symbol(nil), input.Symbols...)
+	permuted.Calls = append([]calls.Call(nil), input.Calls...)
+	for left, right := 0, len(permuted.Symbols)-1; left < right; left, right = left+1, right-1 {
+		permuted.Symbols[left], permuted.Symbols[right] = permuted.Symbols[right], permuted.Symbols[left]
+	}
+	for left, right := 0, len(permuted.Calls)-1; left < right; left, right = left+1, right-1 {
+		permuted.Calls[left], permuted.Calls[right] = permuted.Calls[right], permuted.Calls[left]
+	}
+	permutedGraph := build(permuted)
+	permutedCallerKey, permutedCallerOK := permutedGraph.lookupCallerKey("Main.Caller", "sub", "Main.bas")
+	if !permutedCallerOK {
+		t.Fatal("caller was not indexed after input permutation")
+	}
+	if got := edgeKeys(permutedGraph.out[permutedCallerKey]); !reflect.DeepEqual(got, edgeKeys(g.out[callerKey])) {
+		t.Fatalf("edge ordering changed after input permutation: first=%v permuted=%v", edgeKeys(g.out[callerKey]), got)
+	}
+}
+
+func TestBuildIndexesPropertyAccessorKinds(t *testing.T) {
+	input := Snapshot{
+		Symbols: []Symbol{
+			{Name: "Caller", Kind: "sub", Module: "Main", File: "Main.bas", Line: 1, Column: 1},
+			{Name: "Value", Kind: "property_get", Module: "Thing", File: "Thing.cls", Line: 5, Column: 1},
+			{Name: "Value", Kind: "property_let", Module: "Thing", File: "Thing.cls", Line: 10, Column: 1},
+			{Name: "Value", Kind: "property_set", Module: "Thing", File: "Thing.cls", Line: 15, Column: 1},
+		},
+		Calls: []calls.Call{
+			matchedKind("Main", "Main.bas", "Caller", "sub", "Thing", "Thing.cls", "Value", "property_get", 5, 2),
+			matchedKind("Main", "Main.bas", "Caller", "sub", "Thing", "Thing.cls", "Value", "property_let", 10, 3),
+			matchedKind("Main", "Main.bas", "Caller", "sub", "Thing", "Thing.cls", "Value", "property_set", 15, 4),
+		},
+	}
+
+	g := build(input)
+	callerKey, ok := g.lookupCallerKey("Main.Caller", "sub", "Main.bas")
+	if !ok {
+		t.Fatal("caller was not indexed")
+	}
+	if got := len(g.out[callerKey]); got != 3 {
+		t.Fatalf("property accessor edges = %d, want 3", got)
+	}
+	gotKinds := make([]string, 0, len(g.out[callerKey]))
+	for _, edge := range g.out[callerKey] {
+		gotKinds = append(gotKinds, edge.Callee.Kind)
+	}
+	if want := []string{"property_get", "property_let", "property_set"}; !reflect.DeepEqual(gotKinds, want) {
+		t.Fatalf("property accessor kinds = %v, want %v", gotKinds, want)
+	}
+}
+
+func TestBuildKeepsNonMatchedResolutionStatusesUnconnected(t *testing.T) {
+	statuses := []string{"ambiguous", "unresolved", "external", "builtin_like", "member_call", "dynamic", "incomplete"}
+	input := Snapshot{
+		Symbols: []Symbol{
+			{Name: "Caller", Kind: "sub", Module: "Main", File: "Main.bas", Line: 1, Column: 1},
+			{Name: "Target", Kind: "sub", Module: "M", File: "M.bas", Line: 2, Column: 1},
+		},
+		Calls: make([]calls.Call, 0, len(statuses)),
+	}
+	for i, status := range statuses {
+		input.Calls = append(input.Calls, calls.Call{
+			CallSite: calls.CallSite{
+				File: "Main.bas", Module: "Main",
+				Caller: &calls.Caller{Name: "Caller", Kind: "sub", QualifiedName: "Main.Caller"},
+				Range:  vbaast.Range{StartLine: i + 2},
+			},
+			Resolution: calls.Resolution{
+				Status:     status,
+				Candidates: []calls.Candidate{{QualifiedName: "M.Target", Kind: "sub", File: "M.bas", Line: 2}},
+			},
+		})
+	}
+
+	g := build(input)
+	callerKey, ok := g.lookupCallerKey("Main.Caller", "sub", "Main.bas")
+	if !ok {
+		t.Fatal("caller was not resolved")
+	}
+	if got := len(g.out[callerKey]); got != 0 {
+		t.Fatalf("non-matched statuses created %d edges", got)
+	}
+	if got := len(g.uncertain[callerKey]); got != len(statuses) {
+		t.Fatalf("uncertain calls = %d, want %d", got, len(statuses))
+	}
+}
+
+func edgeKeys(edges []Edge) []string {
+	keys := make([]string, len(edges))
+	for i, edge := range edges {
+		keys[i] = edgeKey(edge)
+	}
+	return keys
+}
+
 func TestAnalyzeReachabilityHandlesRecursiveDiamondWithoutDuplicates(t *testing.T) {
 	input := &calls.Result{
 		Symbols: []symbols.Symbol{


### PR DESCRIPTION
## Summary

- Index canonical project-local procedure candidate identities once per call-graph snapshot.
- Replace the matched, uniquely resolved call-site full-node scan with an average O(1) lookup while preserving the exact qualified-name, kind, file, and declaration-line checks.
- Retain every candidate in a normalized identity bucket, so normalized path collisions still select the one exact raw-file match; multiple exact matches remain unconnected.
- Preserve conservative behavior for ambiguous, unresolved, external, dynamic/member, incomplete, and colliding identities; retain deterministic edge ordering.
- Add regression tests, scaling benchmarks, and an Unreleased changelog entry.

Closes #673
Parent issue: #670

## Performance

Environment: Windows amd64, Intel i7-12700, Go 1.26.6. Values are medians of five 1-second samples with the same fixture and `-cpu=1`; baseline is the pre-index implementation and optimized is this branch after the normalized-path collision fix.

| Workload | ns/op (baseline -> optimized) | B/op (baseline -> optimized) | allocs/op (baseline -> optimized) | Speedup / improvement |
| --- | ---: | ---: | ---: | ---: |
| 500 procedures / 500 calls | 5,398,878 -> 1,483,119 | 1,280,437 -> 1,411,062 | 18,321 -> 19,326 | 3.64x / 72.5% |
| 1,000 procedures / 500 calls | 10,792,673 -> 2,116,801 | 1,920,603 -> 2,169,760 | 25,338 -> 26,845 | 5.10x / 80.4% |
| 2,000 procedures / 500 calls | 21,079,099 -> 3,474,907 | 3,200,928 -> 3,687,131 | 39,365 -> 41,876 | 6.07x / 83.5% |
| 2,000 procedures / 500 matched calls | 21,141,500 -> 3,496,110 | 3,200,926 -> 3,687,132 | 39,365 -> 41,876 | 6.05x / 83.5% |
| 2,000 procedures / 1,000 matched calls | 38,768,988 -> 4,420,744 | 3,865,705 -> 4,363,902 | 51,375 -> 54,386 | 8.77x / 88.6% |
| 2,000 procedures / 2,000 matched calls | 72,462,036 -> 6,325,989 | 5,195,244 -> 5,717,433 | 75,393 -> 79,403 | 11.45x / 91.3% |
| Same-name modules, 2,000 procedures / 2,000 calls | 63,189,279 -> 6,223,229 | 5,052,757 -> 5,574,944 | 73,377 -> 77,387 | 10.15x / 90.2% |

Benchmark command:

```text
rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/callgraph -run '^$' -bench '^BenchmarkBuild' -benchmem -benchtime=1s -count=5 -cpu=1
```

With calls fixed at 500, optimized construction grows from 1.48 ms to 3.47 ms as procedures grow from 500 to 2,000, while baseline grows from 5.40 ms to 21.08 ms. With procedures fixed at 2,000, optimized construction grows from 3.50 ms to 6.33 ms as matched calls grow from 500 to 2,000, showing that lookup no longer scales as procedures × calls.

## Diagnostics

- Pre- and post-change corpus snapshots have no diagnostic delta.
- Two post-change verify-only runs completed successfully with unchanged diagnostic counts; no snapshot diff was produced.
- No false-positive remediation, snapshot update, or forbidden-ledger update was required.

## Tests

- `rtk task test`
- `rtk task lint`
- `rtk pnpm format:check`
- `rtk git diff --check`
- `rtk task corpus:test` (two verify-only runs after the review fix)
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/callgraph -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^TestVBA244' -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/lspserver -run '^TestJSONRPCPublishesAnalyzerDiagnostics$' -count=1`
