### PR TITLE
docs(skill): add object-model traps reference

### DIFF
--- a/internal/agentskill/skill_test.go
+++ b/internal/agentskill/skill_test.go
@@ -15,6 +15,7 @@ var referenceFiles = []string{
 	"xlflow-ui.md",
 	"recovery.md",
 	"code-analysis.md",
+	"object-model-traps.md",
 }
 
 func requireContains(t *testing.T, body string, wants ...string) {
@@ -94,6 +95,7 @@ func TestInstallUsesProviderDefaultTarget(t *testing.T) {
 		"## Dispatch to Specialized References",
 		"[recovery.md](references/recovery.md)",
 		"[code-analysis.md](references/code-analysis.md)",
+		"[object-model-traps.md](references/object-model-traps.md)",
 		"## Evidence of Completion",
 	)
 	requireBefore(t, installed, "xlflow lint --json", "xlflow push --fast --session --no-save --json")

--- a/internal/agentskill/templates/xlflow/SKILL.md
+++ b/internal/agentskill/templates/xlflow/SKILL.md
@@ -221,7 +221,7 @@ that Excel not stay open.
 | Runtime or compile diagnostics that do not identify the cause              | [debugging.md](references/debugging.md)         |
 | Recovery-required state or uncertain workbook termination                  | [recovery.md](references/recovery.md)           |
 | Callers, callees, dependencies, refactors, blast radius, or affected tests | [code-analysis.md](references/code-analysis.md) |
-| Lookups over unsorted data, criteria strings, structural inserts, or sorting | [object-model-traps.md](references/object-model-traps.md) |
+| Approximate lookups, criteria strings, `Insert`/`Delete` and partial shifts, merged cells under a shift, mixed-type sorting, or `WorksheetFunction` versus VBA (`Round`, `Trim`) | [object-model-traps.md](references/object-model-traps.md) |
 
 Use the reference before editing when its subject changes source authority,
 safety, test selection, or the evidence needed to prove the task.

--- a/internal/agentskill/templates/xlflow/SKILL.md
+++ b/internal/agentskill/templates/xlflow/SKILL.md
@@ -221,6 +221,7 @@ that Excel not stay open.
 | Runtime or compile diagnostics that do not identify the cause              | [debugging.md](references/debugging.md)         |
 | Recovery-required state or uncertain workbook termination                  | [recovery.md](references/recovery.md)           |
 | Callers, callees, dependencies, refactors, blast radius, or affected tests | [code-analysis.md](references/code-analysis.md) |
+| Lookups over unsorted data, criteria strings, structural inserts, or sorting | [object-model-traps.md](references/object-model-traps.md) |
 
 Use the reference before editing when its subject changes source authority,
 safety, test selection, or the evidence needed to prove the task.

--- a/internal/agentskill/templates/xlflow/references/object-model-traps.md
+++ b/internal/agentskill/templates/xlflow/references/object-model-traps.md
@@ -1,0 +1,188 @@
+# Excel Object-Model Traps Reference
+
+Load this reference when correctness depends on Excel's runtime behavior rather
+than on the source: lookups over data whose order you do not control, criteria
+strings, inserting or deleting cells under existing formulas or merges, sorting
+mixed-type columns, or any call that exists under both `WorksheetFunction` and
+VBA.
+
+Every trap here shares one property: the source is not wrong on its face. Static
+analysis cannot separate the correct use from the silent defect, because the
+answer depends on the data. Where a lint rule can catch a mistake, you do not
+need to remember it. These are what is left.
+
+Each entry states when to care, what fails quietly, what to do instead, how to
+prove it, and how far the statement reaches.
+
+## Approximate Lookup Over Unsorted Data
+
+**Trigger.** `Match`, `VLookup`, `HLookup` or `Lookup` with approximate matching
+— the default — against a range whose sort order you have not established in
+the same procedure.
+
+**Risk.** No error is raised and no `#N/A` is returned. A position comes back
+that looks like an answer and is not the nearest value. The result may also be
+correct by accident on the data you tested with, and wrong on the data your user
+has.
+
+**Safe rule.** Either sort the range ascending immediately before the lookup, or
+pass exact matching explicitly: `Match(key, rng, 0)`, `VLookup(key, tbl, 2,
+False)`. Prefer exact matching unless a banded or bucketed lookup is genuinely
+intended. Do not rely on any particular wrong answer.
+
+**Proof.** Write a test that fills a range out of order, performs the lookup, and
+asserts the position you require. Run it with `xlflow test --session --no-save
+--json`. If it passes only because the data happened to be arranged a certain
+way, arrange it differently and watch it fail.
+
+**Scope / provenance.** Excel documents approximate matching as requiring
+ascending order, and documents nothing about unsorted input. Observed on Excel
+16 (Windows 11, ja-JP): with `A1:A5` holding `10, 50, 20, 40, 30`,
+`WorksheetFunction.Match(35, Range("A1:A5"), 1)` returns `3` — the cell holding
+`20`, not the nearest value at or below the key. That is consistent with a
+binary search reporting where it stopped, but treat it as an observation of one
+implementation, not as a contract. Descending approximate matching over shuffled
+input was not stable enough to state at all.
+
+## Criteria Comparisons Are Not Symmetric
+
+**Trigger.** `CountIf`, `SumIf`, `AverageIf` and their `*Ifs` forms, or
+`AutoFilter`, given a criteria string — especially against a column that mixes
+numbers with text that spells numbers.
+
+**Risk.** `"<>20"` does not count what `"=20"` leaves out. Both can be right at
+once and the totals will not reconcile, with no error to notice.
+
+**Safe rule.** Do not derive one criterion from another by negation. When a
+column may hold text that looks numeric, either normalise the column before
+counting, or state the comparison you actually mean and verify both halves
+against the row count.
+
+**Proof.** Build a range holding the text `"20"`, the number `20`, and the text
+`"20.0"`, then assert `CountIf` for `"=20"`, `"<>20"` and `">=20"` in one test.
+Three cells and five matches is the signal.
+
+**Scope / provenance.** Observed on Excel 16 (Windows 11, ja-JP): `"=20"` counts
+3, `"<>20"` counts 2, `">=20"` counts 1. Equality coerces text that spells a
+number; the ordering operators do not. Excel documents criteria loosely enough
+that this is worth verifying on your own version before depending on either
+number.
+
+## Insert And Delete Move Absolute References
+
+**Trigger.** `Range.Insert`, `Range.Delete`, `Rows.Insert`, `Columns.Delete`, or
+any structural edit above or across a range that existing formulas refer to.
+
+**Risk.** "Absolute means fixed" is a reasonable rule carried over from copying
+formulas, and it is wrong here. `$A$2` is unchanged by a copy and becomes `$A$3`
+when a row is inserted above it. Formulas keep pointing at the value they meant,
+which is usually what you want — but if your code assumed the address text was
+stable, it is now reading a different cell.
+
+**Safe rule.** Never assume an address literal survives a structural edit. Re-read
+addresses after inserting or deleting, or refer to the data through a defined
+name or a table column, which are maintained across the edit.
+
+**Safe rule for ranges.** A range argument resizes rather than shifts. An insert
+inside `SUM(A1:A3)` gives `SUM(A1:A4)`; a deletion across it gives `SUM(A1:A2)`;
+only a range removed in its entirety becomes `#REF!`. Do not treat the absence of
+`#REF!` as evidence that a formula still covers what it used to.
+
+**Proof.** Snapshot formulas with `xlflow formulas pull --json` before and after
+the structural edit and compare the regions that matter. The snapshot reads the
+saved file, so run `xlflow save --json` first.
+
+**Scope / provenance.** This is documented Excel behavior for reference
+adjustment; it is listed here because the sensible reading of "absolute" points
+the other way, not because it is undocumented.
+
+## A Partial Shift Divides Formulas And Merges Oppositely
+
+**Trigger.** `Range.Insert` or `Range.Delete` with `xlShiftDown` or `xlShiftRight`
+over a band narrower than the region it crosses — that is, any partial shift on a
+sheet holding merged cells or multi-column formula ranges.
+
+**Risk.** The same containment test produces opposite outcomes. A range that
+reaches past the shifted band is left alone; a merge that the band only half
+covers is taken apart. Code that reasons about one will be wrong about the other.
+
+**Safe rule.** Before a partial shift, establish which merges the band intersects
+and decide explicitly whether losing them is acceptable. If it is not, shift whole
+rows or columns instead, or unmerge and re-merge deliberately. Verify merges after
+the edit rather than assuming they survived.
+
+**Proof.** After the shift, assert both halves in one test: the formula that
+should be untouched and the merge that should not be. `xlflow formulas pull
+--json` covers the formula side; read `MergeArea` for the merge side.
+
+**Scope / provenance.** Observed on Excel 16 (Windows 11, ja-JP):
+`Range("B2").Insert xlShiftDown` rewrites `B3`, leaves `C3` alone, and leaves
+`SUM(A1:C3)` alone because that range reaches past column B — while a merge only
+half covered by the same band is broken. The formula half follows from documented
+reference adjustment; the merge half is an observation.
+
+## Sorting Orders By Kind Before Value
+
+**Trigger.** `Range.Sort` or `AutoFilter` sorting over a column that may hold more
+than one type, or any `Sort` call that omits `Header`.
+
+**Risk.** Two silent failures. Values do not interleave: all numbers come before
+all text, which comes before Booleans, so a "sorted" column can look shuffled to
+a user reading values. And `Header` defaults to `xlNo`, so an omitted argument
+sorts the header row in with the data.
+
+**Safe rule.** Pass `Header:=xlYes` explicitly whenever the range includes a
+header row — do not rely on Excel guessing. Normalise a mixed column to one type
+before sorting if the user expects values to interleave.
+
+**Safe rule for blanks.** Blanks sort to the bottom in both directions. A
+descending sort does not bring them to the top, so "the last row is blank" is not
+a reliable end-of-data test after sorting.
+
+**Proof.** Sort a column holding a number, a text value, a Boolean and a blank,
+then assert the resulting order cell by cell.
+
+**Scope / provenance.** Excel documents the type ordering and the `Header`
+default. Observed to hold on Excel 16 (Windows 11, ja-JP). Locale affects text
+collation, so assert on the type grouping rather than on the order of specific
+strings if the workbook may run elsewhere.
+
+## The Same Name Is Two Different Functions
+
+**Trigger.** Any call that exists in both places: `Round`, `Trim`, and others
+reachable as both `WorksheetFunction.X` and a VBA built-in.
+
+**Risk.** Both answers are correct in their own language, which is what makes the
+pair dangerous in one file. A refactor that adds or removes the
+`WorksheetFunction` qualifier changes the result without changing the intent, and
+nothing in the diff looks like a behavior change.
+
+| expression          | `WorksheetFunction`        | VBA                    |
+| ------------------- | -------------------------- | ---------------------- |
+| `Round(2.5, 0)`     | `3` — half away from zero  | `2` — half to even     |
+| `Trim("  a   b  ")` | `a b` — inner runs collapse | `a   b` — ends only   |
+
+**Safe rule.** Choose the rounding rule the requirement states, and write it so
+the choice is visible: qualify the call and say why in a comment, or wrap it in a
+named helper. Never change a qualifier during unrelated cleanup. For whitespace,
+`Trim` and `WorksheetFunction.Trim` are not interchangeable at all — pick by
+whether inner runs must collapse.
+
+**Proof.** Assert the boundary case directly: `Round(2.5, 0)` and `Round(3.5, 0)`
+in one test tell you which rule is in force.
+
+**Scope / provenance.** Both behaviors are documented in their own references;
+they are listed here because the collision is easy to miss and expensive to find.
+Observed on Excel 16 (Windows 11, ja-JP).
+
+## Safety Rules
+
+- Treat any approximate lookup over data you did not just sort as unverified.
+- Do not derive a criteria string by negating another one.
+- Re-read addresses after a structural edit; do not trust an address literal
+  across `Insert` or `Delete`.
+- Check merges after a partial shift, separately from checking formulas.
+- Pass `Header` explicitly to every `Sort` over a range that has one.
+- Prove the boundary case whenever a rounding or trimming rule matters.
+- When an entry above is marked as an observation, verify it on the target Excel
+  version before writing code that depends on the specific value.

--- a/internal/agentskill/templates/xlflow/references/object-model-traps.md
+++ b/internal/agentskill/templates/xlflow/references/object-model-traps.md
@@ -20,10 +20,11 @@ prove it, and how far the statement reaches.
 — the default — against a range whose sort order you have not established in
 the same procedure.
 
-**Risk.** No error is raised and no `#N/A` is returned. A position comes back
-that looks like an answer and is not the nearest value. The result may also be
-correct by accident on the data you tested with, and wrong on the data your user
-has.
+**Risk.** A key below every value in the range returns `#N/A` in a formula, and
+raises at the `WorksheetFunction` call — that case is at least loud. The
+dangerous one is a key inside the range: a position comes back with no error and
+no `#N/A`, and it is not the nearest value. The result may also be correct by
+accident on the data you tested with, and wrong on the data your user has.
 
 **Safe rule.** Either sort the range ascending immediately before the lookup, or
 pass exact matching explicitly: `Match(key, rng, 0)`, `VLookup(key, tbl, 2,
@@ -31,9 +32,11 @@ False)`. Prefer exact matching unless a banded or bucketed lookup is genuinely
 intended. Do not rely on any particular wrong answer.
 
 **Proof.** Write a test that fills a range out of order, performs the lookup, and
-asserts the position you require. Run it with `xlflow test --session --no-save
---json`. If it passes only because the data happened to be arranged a certain
-way, arrange it differently and watch it fail.
+asserts the position you require, then run it through the session proof loop in
+SKILL.md (`session start` → `push --fast --session --no-save` → `test --session
+--no-save` → `save --session` → `session stop`). If it passes only because the
+data happened to be arranged a certain way, arrange it differently and watch it
+fail.
 
 **Scope / provenance.** Excel documents approximate matching as requiring
 ascending order, and documents nothing about unsorted input. Observed on Excel
@@ -50,8 +53,9 @@ input was not stable enough to state at all.
 `AutoFilter`, given a criteria string — especially against a column that mixes
 numbers with text that spells numbers.
 
-**Risk.** `"<>20"` does not count what `"=20"` leaves out. Both can be right at
-once and the totals will not reconcile, with no error to notice.
+**Risk.** `"<>20"` does not count what `"=20"` leaves out. The two overlap, so
+their counts can exceed the number of cells; both are right at once and the
+totals will not reconcile, with no error to notice.
 
 **Safe rule.** Do not derive one criterion from another by negation. When a
 column may hold text that looks numeric, either normalise the column before
@@ -59,8 +63,10 @@ counting, or state the comparison you actually mean and verify both halves
 against the row count.
 
 **Proof.** Build a range holding the text `"20"`, the number `20`, and the text
-`"20.0"`, then assert `CountIf` for `"=20"`, `"<>20"` and `">=20"` in one test.
-Three cells and five matches is the signal.
+`"20.0"`, then assert `CountIf` for `"=20"`, `"<>20"` and `">=20"` in one test
+run through the session proof loop. The signal is that `"=20"` and `"<>20"`
+together account for five matches over three cells: they overlap rather than
+partition.
 
 **Scope / provenance.** Observed on Excel 16 (Windows 11, ja-JP): `"=20"` counts
 3, `"<>20"` counts 2, `">=20"` counts 1. Equality coerces text that spells a
@@ -168,8 +174,11 @@ named helper. Never change a qualifier during unrelated cleanup. For whitespace,
 `Trim` and `WorksheetFunction.Trim` are not interchangeable at all — pick by
 whether inner runs must collapse.
 
-**Proof.** Assert the boundary case directly: `Round(2.5, 0)` and `Round(3.5, 0)`
-in one test tell you which rule is in force.
+**Proof.** Assert both boundary cases directly. `Round(2.5, 0)` tells you which
+rounding rule is in force — `3.5` agrees under both rules and proves nothing. For
+whitespace, assert `Trim("  a   b  ")` against
+`WorksheetFunction.Trim("  a   b  ")`: one keeps the inner run and the other
+collapses it.
 
 **Scope / provenance.** Both behaviors are documented in their own references;
 they are listed here because the collision is easy to miss and expensive to find.

--- a/internal/agentskill/templates/xlflow/references/object-model-traps.md
+++ b/internal/agentskill/templates/xlflow/references/object-model-traps.md
@@ -26,17 +26,25 @@ dangerous one is a key inside the range: a position comes back with no error and
 no `#N/A`, and it is not the nearest value. The result may also be correct by
 accident on the data you tested with, and wrong on the data your user has.
 
-**Safe rule.** Either sort the range ascending immediately before the lookup, or
-pass exact matching explicitly: `Match(key, rng, 0)`, `VLookup(key, tbl, 2,
-False)`. Prefer exact matching unless a banded or bucketed lookup is genuinely
-intended. Do not rely on any particular wrong answer.
+**Safe rule.** Approximate matching is only defined when the required order is
+established *and* verified. If you cannot show that it holds, pass exact matching
+explicitly: `Match(key, rng, 0)`, `VLookup(key, tbl, 2, False)`. Prefer exact
+matching unless a banded or bucketed lookup is genuinely intended, and do not
+rely on any particular wrong answer.
 
-**Proof.** Write a test that fills a range out of order, performs the lookup, and
-asserts the position you require, then run it through the session proof loop in
-SKILL.md (`session start` → `push --fast --session --no-save` → `test --session
---no-save` → `save --session` → `session stop`). If it passes only because the
-data happened to be arranged a certain way, arrange it differently and watch it
-fail.
+Sorting to satisfy the rule is a structural edit, not a lookup detail. Sort the
+whole associated dataset, never the key column alone — sorting a `VLookup` key
+range by itself breaks its rows away from the columns it returns — and treat
+reordering the user's data as a change that needs its own justification.
+
+**Proof.** Assert the behavior you are relying on, not the one you are avoiding.
+Fill a range out of order and assert that exact matching finds the key wherever
+it sits; or establish the required order in the procedure, assert the order
+itself, and then assert the approximate result. Run it through the session proof
+loop in SKILL.md (`session start` → `push --fast --session --no-save` → `test
+--session --no-save` → `save --session` → `session stop`). Do not assert the
+position an unsorted approximate lookup happens to return: that is the observed
+behavior below, and it is not a contract to hold a test against.
 
 **Scope / provenance.** Excel documents approximate matching as requiring
 ascending order, and documents nothing about unsorted input. Observed on Excel
@@ -89,10 +97,13 @@ stable, it is now reading a different cell.
 addresses after inserting or deleting, or refer to the data through a defined
 name or a table column, which are maintained across the edit.
 
-**Safe rule for ranges.** A range argument resizes rather than shifts. An insert
-inside `SUM(A1:A3)` gives `SUM(A1:A4)`; a deletion across it gives `SUM(A1:A2)`;
-only a range removed in its entirety becomes `#REF!`. Do not treat the absence of
-`#REF!` as evidence that a formula still covers what it used to.
+**Safe rule for ranges.** A range reference may shift or resize, depending on
+where the structural edit meets it. An insert *above* `SUM(A1:A3)` shifts it to
+`SUM(A2:A4)`; an insert *inside* it resizes it to `SUM(A1:A4)`; a deletion across
+it gives `SUM(A1:A2)`; an insert past its end leaves it exactly as it was; only a
+range removed in its entirety becomes `#REF!`. Either way the reference is
+adjusted silently, so do not treat the absence of `#REF!` as evidence that a
+formula still covers what it used to.
 
 **Proof.** Snapshot formulas with `xlflow formulas pull --json` before and after
 the structural edit and compare the regions that matter. The snapshot reads the
@@ -132,25 +143,32 @@ reference adjustment; the merge half is an observation.
 **Trigger.** `Range.Sort` or `AutoFilter` sorting over a column that may hold more
 than one type, or any `Sort` call that omits `Header`.
 
-**Risk.** Two silent failures. Values do not interleave: all numbers come before
-all text, which comes before Booleans, so a "sorted" column can look shuffled to
-a user reading values. And `Header` defaults to `xlNo`, so an omitted argument
-sorts the header row in with the data.
+**Risk.** Two silent failures. Values do not interleave, they group by kind: in
+ascending order all numbers come before all text, which comes before Booleans,
+which come before error values; descending reverses that order of kinds as well
+as the values inside each one. So a "sorted" column can look shuffled to a user
+reading values. And `Header` defaults to `xlNo`, so an omitted argument sorts the
+header row in with the data.
 
 **Safe rule.** Pass `Header:=xlYes` explicitly whenever the range includes a
 header row — do not rely on Excel guessing. Normalise a mixed column to one type
 before sorting if the user expects values to interleave.
 
-**Safe rule for blanks.** Blanks sort to the bottom in both directions. A
-descending sort does not bring them to the top, so "the last row is blank" is not
-a reliable end-of-data test after sorting.
+**Safe rule for blanks.** Blanks sit outside the ordering of kinds: they sort to
+the bottom in both directions. A descending sort does not bring them to the top,
+so "the last row is blank" is not a reliable end-of-data test after sorting.
 
-**Proof.** Sort a column holding a number, a text value, a Boolean and a blank,
-then assert the resulting order cell by cell.
+**Proof.** Sort a column holding a number, a text value, a Boolean, an error and
+a blank — ascending and descending — and assert the resulting order cell by cell.
+Assert both directions: a test that only covers ascending will not notice code
+that assumes the kinds stay in the same order when the direction flips.
 
 **Scope / provenance.** Excel documents the type ordering and the `Header`
-default. Observed to hold on Excel 16 (Windows 11, ja-JP). Locale affects text
-collation, so assert on the type grouping rather than on the order of specific
+default. Observed on Excel 16 (Windows 11, ja-JP), over a column holding `text`,
+`5`, `TRUE`, a blank, `#DIV/0!`, `apple`, `100` and `FALSE`: ascending gives
+`5, 100, apple, text, FALSE, TRUE, #DIV/0!, [blank]` and descending gives
+`#DIV/0!, TRUE, FALSE, text, apple, 100, 5, [blank]`. Locale affects text
+collation, so assert on the grouping by kind rather than on the order of specific
 strings if the workbook may run elsewhere.
 
 ## The Same Name Is Two Different Functions
@@ -186,12 +204,14 @@ Observed on Excel 16 (Windows 11, ja-JP).
 
 ## Safety Rules
 
-- Treat any approximate lookup over data you did not just sort as unverified.
+- Treat any approximate lookup as unverified until the required order is both
+  established and asserted; otherwise pass exact matching.
 - Do not derive a criteria string by negating another one.
 - Re-read addresses after a structural edit; do not trust an address literal
   across `Insert` or `Delete`.
 - Check merges after a partial shift, separately from checking formulas.
-- Pass `Header` explicitly to every `Sort` over a range that has one.
+- Pass `Header` explicitly to every `Sort` over a range that has one, and assert
+  a mixed-type sort in both directions rather than only ascending.
 - Prove the boundary case whenever a rounding or trimming rule matters.
 - When an entry above is marked as an observation, verify it on the target Excel
   version before writing code that depends on the specific value.


### PR DESCRIPTION
Adds `references/object-model-traps.md` and its dispatch entry in `SKILL.md`, as
agreed in #679.

## Summary

Six entries covering Excel runtime behaviour that xlflow structurally cannot
diagnose, because the answer depends on the data rather than on the source:

- approximate lookup over unsorted data
- criteria comparisons not being symmetric (`<>` is not the negation of `=`)
- insert and delete moving absolute references
- a partial shift dividing formulas and merges oppositely
- sorting ordering by kind before value, and the `Header` default
- the same name being two different functions (`Round`, `Trim`)

Each is written as **Trigger / Risk / Safe rule / Proof / Scope-provenance**, per
the shape you set out. The file ends with a short safety list, following
`formulas.md`.

## Following the constraints from the issue

**Observation is kept separate from contract.** For approximate `MATCH` on
unsorted data, the Safe rule is "sort first or pass exact matching; do not rely
on any particular wrong answer". The specific result — position 3, the cell
holding 20 — sits in the Scope section, labelled as one implementation's
behaviour on one environment, with an explicit note not to treat it as a
guaranteed semantic. The same split is applied to the merge half of the partial
shift entry, and to the criteria counts.

**Statically detectable cases are out.** Omitted approximate-match arguments and
unsupported `WorksheetFunction` members are not in this file. They belong in
diagnostics, as you said.

**Nothing binds the VBE oracle.** No fixture is added and nothing here claims
compile-equivalent evidence. Provenance is carried per entry, and the probes
below are supplied for review rather than as corpus.

**Where Excel was genuinely unstable, the case is absent.** A descending
approximate match over shuffled input was not reproducible across runs, so it is
in neither the reference nor the probes, and the reference says so.

## Verification

Every number quoted in the reference was re-run over COM against Excel 16
(Windows 11, ja-JP) while preparing this PR. That caught one error in my own
draft: I had written that a partial `xlShiftDown` grows `SUM(A1:C3)` to
`SUM(A1:C4)`. It does not — the range reaches past the shifted band, so it is
left exactly as it was. The reference and the probes now say that, with a
contrast against the whole-row insert in Probe 3, where the range *does* resize.

Output of the run:

```
p1 unsorted Match(35)=3 cell=20
p1 sorted   Match(35)=3 cell=30
p2 =20 -> 3    <>20 -> 2    >=20 -> 1
p3 C2==$A$3   C3==SUM(A2:A4)
p4 merged before: B5:C5
p4 formula: =SUM(A1:C3)   C3: kept   merged after: B6
p5 order: [5][header][text][True][]
p6 WF.Round(2.5,0)=3  WF.Round(3.5,0)=4  WF.Trim=[a b]
```

`p6`'s VBA-side halves (`Round(2.5, 0)` → 2, `Trim` preserving inner runs) are
documented language behaviour and are asserted by Probe 6 rather than by that
COM run, which can only reach `WorksheetFunction`.

## Probes

Self-contained — each writes its own input, so none needs a prepared workbook.
Happy to move these into the repository in whatever form you prefer, or to leave
them here if the reference's Proof sections are enough.

<details>
<summary>Six probe procedures</summary>

## Probe 1 — approximate lookup over unsorted data

```vba
Public Sub ProbeUnsortedMatch()
    Dim sheet As Worksheet
    Set sheet = ThisWorkbook.Worksheets.Add
    sheet.Range("A1:A5").Value = Application.Transpose(Array(10, 50, 20, 40, 30))

    Debug.Print "Match(35, unsorted, 1): " & _
        WorksheetFunction.Match(35, sheet.Range("A1:A5"), 1) & " | 3"
    Debug.Print "cell at that position:  " & _
        sheet.Range("A1:A5").Cells(WorksheetFunction.Match(35, sheet.Range("A1:A5"), 1)).Value & " | 20"

    ' The same data sorted, where approximate matching is defined.
    sheet.Range("A1:A5").Sort Key1:=sheet.Range("A1"), Order1:=xlAscending, Header:=xlNo
    Debug.Print "Match(35, sorted, 1):   " & _
        WorksheetFunction.Match(35, sheet.Range("A1:A5"), 1) & " | 3"
    Debug.Print "cell at that position:  " & _
        sheet.Range("A1:A5").Cells(WorksheetFunction.Match(35, sheet.Range("A1:A5"), 1)).Value & " | 30"

    Application.DisplayAlerts = False
    sheet.Delete
    Application.DisplayAlerts = True
End Sub
```

Both calls return 3. Only the second one means the nearest value at or below 35.

## Probe 2 — criteria comparisons are not symmetric

```vba
Public Sub ProbeCriteriaAsymmetry()
    Dim sheet As Worksheet
    Set sheet = ThisWorkbook.Worksheets.Add
    sheet.Range("A1").NumberFormat = "@"
    sheet.Range("A1").Value = "20"        ' text
    sheet.Range("A2").Value = 20          ' number
    sheet.Range("A3").NumberFormat = "@"
    sheet.Range("A3").Value = "20.0"      ' text

    Debug.Print "CountIf =20:  " & WorksheetFunction.CountIf(sheet.Range("A1:A3"), "=20") & " | 3"
    Debug.Print "CountIf <>20: " & WorksheetFunction.CountIf(sheet.Range("A1:A3"), "<>20") & " | 2"
    Debug.Print "CountIf >=20: " & WorksheetFunction.CountIf(sheet.Range("A1:A3"), ">=20") & " | 1"
    Debug.Print "cells in range: " & sheet.Range("A1:A3").Count & " | 3"

    Application.DisplayAlerts = False
    sheet.Delete
    Application.DisplayAlerts = True
End Sub
```

Three cells, five matches across `=` and `<>`.

## Probe 3 — insert moves an absolute reference

```vba
Public Sub ProbeAbsoluteShift()
    Dim sheet As Worksheet
    Set sheet = ThisWorkbook.Worksheets.Add
    sheet.Range("A1:A3").Value = Application.Transpose(Array(1, 2, 3))
    sheet.Range("C1").Formula = "=$A$2"
    sheet.Range("C2").Formula = "=SUM(A1:A3)"

    Debug.Print "before, C1: " & sheet.Range("C1").Formula & " | =$A$2"
    Debug.Print "before, C2: " & sheet.Range("C2").Formula & " | =SUM(A1:A3)"

    sheet.Rows(1).Insert
    Debug.Print "after insert, C1: " & sheet.Range("C2").Formula & " | =$A$3"
    Debug.Print "after insert, C2: " & sheet.Range("C3").Formula & " | =SUM(A2:A4)"

    Application.DisplayAlerts = False
    sheet.Delete
    Application.DisplayAlerts = True
End Sub
```

The formulas moved down with the insert, so they are read from `C2`/`C3`
afterwards. `$A$2` became `$A$3`; the SUM range resized rather than shifted.

## Probe 4 — a partial shift divides formulas and merges oppositely

```vba
Public Sub ProbePartialShift()
    Dim sheet As Worksheet
    Set sheet = ThisWorkbook.Worksheets.Add
    sheet.Range("A1:C3").Value = 1
    sheet.Range("E1").Formula = "=SUM(A1:C3)"
    sheet.Range("B3").Value = "kept"
    sheet.Range("C3").Value = "kept"
    sheet.Range("B5:C5").Merge

    Debug.Print "before, merged: " & (sheet.Range("B5").MergeArea.Address(False, False)) & " | B5:C5"

    sheet.Range("B2").Insert Shift:=xlShiftDown

    Debug.Print "formula reaching past the band: " & sheet.Range("E1").Formula & " | =SUM(A1:C3)"
    Debug.Print "C3 untouched by the band:      " & sheet.Range("C3").Value & " | kept"
    Debug.Print "merge half covered:            " & sheet.Range("B6").MergeArea.Address(False, False) & " | B6 (broken)"

    Application.DisplayAlerts = False
    sheet.Delete
    Application.DisplayAlerts = True
End Sub
```

The formula was left exactly as it was, because `A1:C3` reaches past the shifted
band; the merge the same band only half covered was taken apart. Same
containment test, opposite conclusions.

(Contrast with Probe 3, where a whole-row insert did resize `SUM(A1:A3)` to
`SUM(A2:A4)`. Whether the range moves depends on whether the edit spans it.)

## Probe 5 — sorting orders by kind before value

```vba
Public Sub ProbeSortByKind()
    Dim sheet As Worksheet
    Set sheet = ThisWorkbook.Worksheets.Add
    sheet.Range("A1").Value = "header"
    sheet.Range("A2").Value = True
    sheet.Range("A3").Value = "text"
    sheet.Range("A4").Value = 5
    sheet.Range("A5").Value = ""

    ' Header omitted, which defaults to xlNo.
    sheet.Range("A1:A5").Sort Key1:=sheet.Range("A1"), Order1:=xlAscending

    Dim at As Long
    For at = 1 To 5
        Debug.Print "row " & at & ": " & TypeName(sheet.Cells(at, 1).Value) & " " & _
            CStr(sheet.Cells(at, 1).Value)
    Next
    Debug.Print "expected: number 5, then text (header, text), then Boolean True, then blank"

    Application.DisplayAlerts = False
    sheet.Delete
    Application.DisplayAlerts = True
End Sub
```

The header sorted in with the data because `Header` was omitted. Numbers precede
text, which precedes Booleans; the blank stays last.

## Probe 6 — the same name is two different functions

```vba
Public Sub ProbeSameNameTwoFunctions()
    Debug.Print "VBA Round(2.5, 0):              " & Round(2.5, 0) & " | 2"
    Debug.Print "VBA Round(3.5, 0):              " & Round(3.5, 0) & " | 4"
    Debug.Print "WorksheetFunction.Round(2.5,0): " & WorksheetFunction.Round(2.5, 0) & " | 3"
    Debug.Print "WorksheetFunction.Round(3.5,0): " & WorksheetFunction.Round(3.5, 0) & " | 4"

    Debug.Print "VBA Trim:                       [" & Trim("  a   b  ") & "] | [a   b]"
    Debug.Print "WorksheetFunction.Trim:         [" & WorksheetFunction.Trim("  a   b  ") & "] | [a b]"
End Sub
```

VBA rounds half to even, `WorksheetFunction` rounds half away from zero. `3.5`
agrees under both rules, which is why the boundary case must be `2.5`.

## What these do not establish

Probe 1's unsorted result is one implementation's probe path, not a contract.
The reference states it as an observation for that reason. A descending
approximate match over shuffled input was not stable across runs and is
deliberately absent from both the reference and these probes.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for Excel runtime edge cases, including approximate lookups, criteria comparisons, structural edits, partial shifts, merged cells, mixed-type sorting, and rounding or trimming behavior.
  * Added verification steps, boundary-test recommendations, and consolidated safety rules.
  * Updated specialized reference routing to cover these scenarios.
* **Tests**
  * Updated installation checks to verify the new reference documentation and its dispatch link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->