### PR TITLE
fix: avoid VB060 false positives on writable member assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Fixed `VB060` false positives for writable member assignments such as
+  Excel `Range.Hidden`, including member access with an omitted `With`
+  receiver. Incomplete member names are no longer treated as proven constants.
+
 - Reused immutable file and procedure analysis facts across analyzer rule
   families. Shared declaration/constant/procedure indexes, statement and
   expression lookups, member-expression projections, and constant overlays

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -1184,7 +1184,11 @@ Module` directives are also reported as duplicate same-kind declarations.
   error and blocks source preflight; parser recovery alone is not sufficient
   evidence.
 - `VB060`: an assignment targets a `Const` value rejected by the VBE; it is an
-  unsuppressible error and blocks source preflight.
+  unsuppressible error and blocks source preflight. The target must be a
+  provably resolved constant declaration or a complete qualified constant
+  reference. A member access whose receiver is omitted or unresolved is not
+  enough evidence, because the final member name may be a writable property
+  (for example, `Range.Hidden`).
 - `VB061`: a fixed array declaration has a constant lower bound greater than
   its upper bound; it is an unsuppressible error and blocks source preflight.
 - `VB062`: a conditional branch statement uses a form that VBA rejects. The

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -7978,6 +7978,37 @@ End Sub
 	}
 }
 
+func TestAnalyzerIgnoresWritableExcelPropertyChainsForVB060(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Const Hidden As Long = 1
+Public Sub Test(ByVal ws As Worksheet)
+  ws.Rows(1).Hidden = True
+  ws.Rows(1).Hidden = False
+  ws.Columns(1).Hidden = False
+
+  With ws.Rows(1)
+    .Hidden = False
+  End With
+
+  Dim rng As Range
+  Set rng = ws.Rows(1)
+  rng.Hidden = False
+End Sub
+`)
+	result, err := (Analyzer{RootDir: dir, Config: config.Default()}).RunResult()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(result.Findings, "VB060"); len(got) != 0 {
+		t.Fatalf("writable Excel property assignments produced VB060 findings: %#v", got)
+	}
+	if got := findingsByCode(result.PreflightFindings, "VB060"); len(got) != 0 {
+		t.Fatalf("writable Excel property assignments produced VB060 preflight findings: %#v", got)
+	}
+}
+
 func TestVBA208AllowsOneDimensionalAndStableNonFinalDimensions(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/lint/array_shape_diagnostics.go
+++ b/internal/lint/array_shape_diagnostics.go
@@ -174,8 +174,7 @@ func (l Linter) arrayShapeIssues(path, source string, ir *procedureir.DocumentIR
 			if stmt.Recovered || (stmt.Kind != procedureir.StatementAssignment && stmt.Kind != procedureir.StatementSet) || stmt.Target == nil {
 				continue
 			}
-			name := normalizeQualifiedIdentifier(stmt.Target.Text)
-			if isConstAssignmentTarget(name, p, ir.Declarations, consts, qualifiedConsts) && (stmt.Target.Kind == procedureir.ExpressionIdentifier || stmt.Target.Kind == procedureir.ExpressionMember) {
+			if isConstAssignmentTarget(stmt.Target.Text, stmt.Target.Kind, p, ir.Declarations, consts, qualifiedConsts) {
 				issue := l.issueAt(path, stmt.Target.Range, "VB060", "error", "A Const value cannot be assigned.")
 				issue.EndLine, issue.EndColumn = stmt.Target.Range.EndLine, stmt.Target.Range.EndColumn
 				issue.Kind, issue.Symbol = "constant_assignment", stmt.Target.Text
@@ -365,8 +364,26 @@ func enumMemberConstant(line string, previous *int) (string, string) {
 	return name, strconv.Itoa(*previous)
 }
 
-func isConstAssignmentTarget(name string, procedure procedureir.ProcedureIR, moduleDeclarations []procedureir.Declaration, consts, qualifiedConsts map[string]bool) bool {
+func isConstAssignmentTarget(name string, targetKind procedureir.ExpressionKind, procedure procedureir.ProcedureIR, moduleDeclarations []procedureir.Declaration, consts, qualifiedConsts map[string]bool) bool {
+	rawName := strings.TrimSpace(name)
+	if targetKind == procedureir.ExpressionMember && strings.HasPrefix(rawName, ".") {
+		// Preserve the omitted receiver before normalization. This also covers
+		// nested implicit chains such as `.Modes.ModeBad`, whose normalized form
+		// would otherwise look like an explicit qualified constant reference.
+		return false
+	}
 	name = normalizeQualifiedIdentifier(name)
+	if targetKind != procedureir.ExpressionIdentifier && targetKind != procedureir.ExpressionMember {
+		return false
+	}
+	// An implicit member expression (for example, `.Hidden` inside a With
+	// block) is normalized to its final member name. That name alone is not
+	// enough to prove a Const assignment: it may be a writable property on the
+	// With receiver, or any other late-bound member. Only a complete member
+	// chain can be compared with a qualified constant name.
+	if targetKind == procedureir.ExpressionMember && !strings.Contains(name, ".") {
+		return false
+	}
 	if strings.Contains(name, ".") {
 		return qualifiedConsts[name]
 	}
@@ -374,13 +391,13 @@ func isConstAssignmentTarget(name string, procedure procedureir.ProcedureIR, mod
 		if !strings.EqualFold(cleanIdentifier(declaration.Name), name) {
 			continue
 		}
-		return strings.EqualFold(declaration.Kind, "const") || strings.EqualFold(declaration.Kind, "enum_member")
+		return procedureir.IsConstKind(declaration.Kind)
 	}
 	for _, declaration := range moduleDeclarations {
 		if !strings.EqualFold(cleanIdentifier(declaration.Name), name) {
 			continue
 		}
-		return strings.EqualFold(declaration.Kind, "const") || strings.EqualFold(declaration.Kind, "enum_member")
+		return procedureir.IsConstKind(declaration.Kind)
 	}
 	return consts[name]
 }

--- a/internal/lint/array_shape_diagnostics_test.go
+++ b/internal/lint/array_shape_diagnostics_test.go
@@ -246,6 +246,42 @@ End Sub
 	}
 }
 
+func TestLintConstantAssignmentIgnoresWritableExcelPropertyChains(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	source := `Option Explicit
+Public Const Hidden As Long = 1
+Public Enum Modes
+  ModeBad = 1
+End Enum
+Public Sub Test(ByVal ws As Worksheet)
+  ws.Rows(1).Hidden = True
+  ws.Rows(1).Hidden = False
+  ws.Columns(1).Hidden = False
+  With ws.Rows(1)
+    .Hidden = False
+  End With
+
+  Dim receiver As Object
+  With receiver
+    .Modes.ModeBad = 2
+  End With
+
+  Dim rng As Range
+  Set rng = ws.Rows(1)
+  rng.Hidden = False
+End Sub
+`
+	writeLintModule(t, dir, "Main.bas", source)
+	issues, err := (Linter{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := issuesByCode(issues, "VB060"); len(got) != 0 {
+		t.Fatalf("writable Excel property assignments produced VB060: %#v", got)
+	}
+}
+
 func TestLintArrayShapeDoesNotTreatProcedureParametersAsDeclarationBounds(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/lint/array_shape_diagnostics_test.go
+++ b/internal/lint/array_shape_diagnostics_test.go
@@ -280,6 +280,20 @@ End Sub
 	if got := issuesByCode(issues, "VB060"); len(got) != 0 {
 		t.Fatalf("writable Excel property assignments produced VB060: %#v", got)
 	}
+
+	classSource := `Option Explicit
+Private Const Limit As Long = 2
+Public Sub Run()
+  Me.Limit = 3
+End Sub
+`
+	classIssues, err := (Linter{RootDir: dir, Config: config.Default(), ModuleKind: "class"}).LintSource("Widget.cls", []byte(classSource))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := issuesByCode(classIssues, "VB060"); len(got) != 1 || got[0].Symbol != "Me.Limit" {
+		t.Fatalf("Me Const assignment = %#v, want one VB060 for Me.Limit", got)
+	}
 }
 
 func TestLintArrayShapeDoesNotTreatProcedureParametersAsDeclarationBounds(t *testing.T) {

--- a/internal/vba/intel/call_syntax_diagnostics_test.go
+++ b/internal/vba/intel/call_syntax_diagnostics_test.go
@@ -72,6 +72,27 @@ End Sub
 	}
 }
 
+func TestCompileEquivalentDiagnosticsIgnoreWritableMemberAssignments(t *testing.T) {
+	root := t.TempDir()
+	doc := Document{
+		Path: filepath.Join(root, "Main.bas"),
+		Source: `Option Explicit
+Public Const Hidden As Long = 1
+Public Sub Probe(ByVal ws As Worksheet)
+    ws.Rows(1).Hidden = True
+    ws.Columns(1).Hidden = False
+    With ws.Rows(1)
+        .Hidden = False
+    End With
+End Sub
+`,
+	}
+	diagnostics := (Analyzer{RootDir: root, Config: config.Default()}).CompileEquivalentDiagnosticsContext(context.Background(), doc)
+	if got := diagnosticsByCode(diagnostics, "VB060"); len(got) != 0 {
+		t.Fatalf("writable member assignments produced VB060 diagnostics: %#v", got)
+	}
+}
+
 func TestDiagnosticsExposeIssue594SyntaxRules(t *testing.T) {
 	root := t.TempDir()
 	cases := []struct {


### PR DESCRIPTION
## Summary

- Fix `VB060` false positives for writable member assignments such as `Excel.Range.Hidden`.
- Treat implicit member chains such as `.Hidden` and `.Modes.ModeBad` as unresolved unless a constant assignment is provable; explicit qualified constants such as `Me.Limit` remain diagnosed.
- Add lint, analyze, and LSP regression coverage, and update the diagnostic contract and changelog.
- Fixes #685

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/lint ./internal/analyze ./internal/vba/intel -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/lspserver -count=1`
- `rtk task lint`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\test-vbe-oracle.ps1 --case known-compile-accept --case known-compile-reject --case const-assignment-accepted --case const-assignment-rejected --strict`
- `rtk proxy task review:codex`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./... -count=1` (one unrelated flaky `TestJSONRPCPublishesArgumentDiagnostics` failure; the test and the full `internal/lspserver` package passed on rerun)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false `VB060` diagnostics for valid assignments to writable Excel properties, including `Range.Hidden`.
  * Corrected handling of member assignments with omitted receivers inside `With` blocks.
  * Incomplete or unresolved member names are no longer treated as constant references.

* **Documentation**
  * Updated the CLI contract and changelog to clarify `VB060` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->