### PR TITLE
perf(analyze): add bounded procedure-level parallelism for large files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added bounded procedure-level parallelism for large single-file
+  `xlflow analyze` workloads. Procedure batches share the analyzer's bounded
+  execution budget with file workers, merge into source-ordered result slots,
+  and preserve deterministic findings, suppression, JSON output, and
+  cancellation behavior. Ordinary small files retain the existing fast path.
+
 - Reused immutable file and procedure analysis facts across analyzer rule
   families. Shared declaration/constant/procedure indexes, statement and
   expression lookups, member-expression projections, and constant overlays

--- a/docs/adr/ADR-0045-bounded-procedure-analysis-parallelism.md
+++ b/docs/adr/ADR-0045-bounded-procedure-analysis-parallelism.md
@@ -105,6 +105,9 @@ schema field.
   `internal/analyze/analyzer.go`.
 - Existing file-level cancellation and deterministic result-slot regression:
   `internal/analyze/bounded_parallel_test.go`.
+- Procedure-level determinism, shared-budget, cancellation, and small-file
+  fast-path regression coverage:
+  `internal/analyze/bounded_procedure_parallel_test.go`.
 - Synthetic large-module benchmark and profiling dimensions:
   `internal/analyze/benchmark_test.go` and
   `internal/analyze/profiling_test.go`.

--- a/docs/adr/ADR-0045-bounded-procedure-analysis-parallelism.md
+++ b/docs/adr/ADR-0045-bounded-procedure-analysis-parallelism.md
@@ -1,0 +1,140 @@
+# ADR-0045: Bounded Procedure-Level Parallelism for Large Batch Files
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0043 added a bounded worker pool for independent file-level diagnostic
+work. That pool scales projects with many files, but a project whose work is
+concentrated in one module still has only one file job. The procedure-local
+loop in `internal/analyze` can therefore serialize hundreds or thousands of
+independent rule evaluations.
+
+Procedure evaluation is not safe to parallelize by simply starting another
+full-size worker pool inside every file worker. The analyzer also has to keep
+the existing contracts for immutable project/file facts, tree-sitter parser
+lifetime, one-time file diagnostics, cancellation, finding multiplicity, and
+deterministic suppression/JSON output.
+
+## Decision
+
+Add bounded procedure-level parallelism to batch `xlflow analyze` for files
+whose procedure workload is large enough to justify scheduling overhead. The
+threshold is an internal, benchmark-calibrated scheduling gate; it is not a
+public configuration contract. Ordinary small files retain the existing
+direct loop fast path.
+
+Procedure batches run only after project and file analysis state has been
+constructed and frozen. Shared project resolution, effect/object summaries,
+analyzer indexes, module facts, and procedure facts are read-only inputs.
+Flow state, rule overlays, statistics deltas, caches that are not explicitly
+concurrent-safe, and finding buffers are procedure-local. File-global or
+one-time diagnostics remain in the file coordinator where their existing
+deduplication semantics can be preserved.
+
+File jobs and procedure batches use one shared bounded execution budget. A
+large file may be scheduled as procedure batches, but it must not create an
+independent full-size pool while occupying a file-level pool of the same
+size. The scheduler may choose file-level or intra-file work according to the
+workload shape, provided the total active analyzer work stays within the
+shared bound.
+
+Each procedure or batch writes to a stable procedure-indexed result slot.
+The coordinator merges completed slots in source order and then invokes the
+existing deterministic finding sort and suppression/finalization stages.
+Completion order, map iteration order, and worker assignment therefore do
+not affect finding content, multiplicity, source order, suppression, or JSON
+output. Any file-level one-time diagnostic is deduplicated during this stable
+merge rather than through an unsynchronized shared map.
+
+Procedure workers consume owned IR, immutable facts, and owned source values;
+they do not retain tree-sitter nodes or a `ParsedDocument`. Tree and borrowed
+source access remains inside the `ParsedDocument.Read` lifetime boundary. A
+rule that still requires that boundary is executed by the coordinator or
+converted to an owned, read-only projection before procedure work is queued.
+
+The shared analysis context propagates cancellation to queued and active
+procedure work. Queue submission stops promptly, active rule scans continue
+to check the context at their existing cancellation boundaries, and an
+error or cancellation waits for active workers before returning. Partial
+findings are not published after cancellation or worker failure.
+
+This decision changes the execution strategy only. It adds no CLI flag,
+configuration key, diagnostic ID, finding field, LSP capability, or JSON
+schema field.
+
+## Consequences
+
+- Very large single-module projects can use multiple cores while retaining a
+  bounded total analyzer concurrency.
+- Many-small-file projects continue to use the file-level pool without
+  multiplying concurrency, and ordinary small modules avoid procedure-worker
+  overhead.
+- Stable result slots and a source-order merge add bounded result storage and
+  coordination work, but preserve the existing deterministic finalization
+  contract.
+- Stage totals can include concurrent procedure work and therefore remain
+  work-attribution metrics; the existing total elapsed measurement remains
+  the wall-clock measure.
+- Every mutable value reachable from procedure analysis must either be frozen,
+  made explicitly concurrent-safe, or moved into a procedure-local buffer.
+
+## Alternatives Considered
+
+1. **Create one full-size procedure pool inside each file worker** - Rejected
+   because the product of file and procedure worker counts oversubscribes CPU
+   and memory on multi-file projects.
+2. **Start one goroutine per procedure** - Rejected because a large module can
+   create unbounded scheduling, stack, result-buffer, and cancellation pressure.
+3. **Parallelize parser/IR construction at the same time** - Rejected because
+   procedure workers need a frozen owned input, and parser lifetime/read
+   boundaries are a separate concern with less direct evidence of benefit.
+4. **Expose a procedure-worker count or threshold to users** - Rejected
+   because it would create a tuning and compatibility contract before the
+   benchmark data establishes a user need.
+5. **Publish findings as workers finish** - Rejected because completion order
+   would make deduplication, multiplicity, suppression, and JSON output
+   dependent on scheduling.
+
+## Evidence
+
+- Requirements: xlflow issues #675 and #670.
+- Existing bounded file execution and procedure-local loop:
+  `internal/analyze/analyzer.go`.
+- Existing file-level cancellation and deterministic result-slot regression:
+  `internal/analyze/bounded_parallel_test.go`.
+- Synthetic large-module benchmark and profiling dimensions:
+  `internal/analyze/benchmark_test.go` and
+  `internal/analyze/profiling_test.go`.
+- Immutable IR and parser lifetime contract:
+  `docs/specs/vba-analysis-ir.md` and ADR-0021.
+- Existing file-level concurrency decision amended by this ADR:
+  `docs/adr/ADR-0043-bounded-batch-analysis-parallelism.md`.
+
+On the Windows development host used for this change, three `-benchtime=1x`
+trials at `-cpu=4` showed median serial versus bounded times of approximately
+62 versus 64 ms for 100 procedures, 346 versus 253 ms for 500, 840 versus
+574 ms for 1,000, and 1,923 versus 1,331 ms for 2,000. The 100-procedure
+case is within ordinary run-to-run noise while the larger cases show the
+intended wall-clock improvement. These measurements calibrate the internal
+500-procedure gate; they are hardware-local evidence, not CI timing thresholds.
+
+## Supersedes
+
+- The procedure-level-parallelism deferral in ADR-0043's Consequences.
+  ADR-0043 remains authoritative for file-level bounded execution and its
+  shared immutable-state and no-partial-publication requirements.
+
+## Superseded by
+
+- None
+
+## Related
+
+- Issue #675
+- Issue #670
+- ADR-0021, ADR-0022, ADR-0023, ADR-0043
+- `docs/specs/vba-analysis-ir.md`
+- `docs/specs/static-analysis-corpus.md`

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -819,7 +819,7 @@ rtk task bench:corpus
 
 `bench:analyze` retains the existing multi-module and object-worklist baselines.
 `bench:analyze-single-module` keeps fixture generation outside the timed region
-and covers single-module scales around 500, 1,000, and 2,000 procedures,
+and covers single-module scales around 100, 500, 1,000, and 2,000 procedures,
 including large call graphs, declaration sets, and CFGs. `bench:corpus` runs the checked-in
 `std-vba` and `ronecone` analyze-only sub-benchmarks. These tasks use
 `-benchmem -benchtime=1x`; on Windows they run through `scripts/dev/go.ps1` to

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -829,6 +829,17 @@ retain wall time (`ns/op`), allocations, findings, workload dimensions, and the
 these are Go benchmark metrics, not stderr records from
 `analyze --performance-log`.
 
+For issue #675, the benchmark matrix must also include one-file workloads with
+100, 500, 1,000, and 2,000 procedures and a many-file workload. Where the
+host permits, compare `-cpu=1,2,4,8` (equivalent `GOMAXPROCS` settings) and
+record wall time, allocations, finding counts, and stable JSON equality across
+repeated runs. The 100-
+procedure and many-file cases guard the ordinary file-level fast path; the
+1,000- and 2,000-procedure cases measure the intended intra-file speedup. These
+measurements are hardware-local evidence, not CI timing thresholds, and the
+benchmark must not run from ordinary `analyze`, corpus snapshot, or VBE-oracle
+workflows.
+
 For issue #677, the same Windows amd64 machine (12th Gen Intel(R) Core(TM)
 i7-12700, Go 1.26.6 toolchain) was used with baseline HEAD
 `245d4ad0792bbc49c2769e3cbd7f0156dc9a7c33` and the implementation worktree,

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -287,6 +287,30 @@ run. The performance recorder reports `module_fact_builds` and
 and one procedure build per procedure, independent of the number of rule
 families that consume them.
 
+### Batch procedure-worker boundary
+
+Batch `analyze` may evaluate procedures concurrently for a large file after
+the project and file facts have been constructed. Procedure workers share the
+same immutable `moduleAnalysisFacts`, `procedureAnalysisFacts`, resolution
+snapshot, effect/object summaries, and analyzer indexes; flow state, rule
+overlays, statistics deltas, and finding buffers remain procedure-local. The
+file coordinator owns file-global one-time diagnostics and performs any
+deduplication that depends on source order.
+
+The batch scheduler uses one bounded execution budget for file jobs and
+procedure batches. It does not create an independent full-size pool inside
+each file worker, and ordinary small files use the direct loop path. Procedure
+results are written to stable procedure-indexed slots, merged in source order,
+and passed through the existing final sort and suppression stages. Cancellation
+stops queued work, is checked by active context-aware scans, and does not
+publish partial findings.
+
+Workers consume owned IR, facts, and source values only. They must not retain
+tree-sitter nodes, a `ParsedDocument`, or borrowed `ParsedView.Source` data;
+all tree/source access remains within `ParsedDocument.Read`. This is an
+execution boundary for batch analysis and does not add a public CLI, JSON, or
+LSP contract.
+
 ## Compatibility and Layer Boundaries
 
 Existing adapters may project IR facts into `calls.CallSite`, analyzer findings,

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -2,6 +2,7 @@ package analyze
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -122,6 +123,110 @@ type Analyzer struct {
 	// analysisWorkerLimit is test-only tuning for the bounded file analysis
 	// pool. A zero value derives the limit from GOMAXPROCS and project size.
 	analysisWorkerLimit int
+}
+
+// procedureParallelThreshold is deliberately high enough that the ordinary
+// file path does not pay for a second scheduler.  The threshold is kept
+// internal: callers should tune the existing analysis worker limit rather than
+// depending on a new public setting.
+const procedureParallelThreshold = 500
+
+// analysisExecutionBudget is shared by file jobs and procedure jobs.  A file
+// worker gives its slot back while waiting for its procedure jobs, so nested
+// scheduling never multiplies the configured worker count.
+type analysisExecutionBudget struct {
+	limit         int
+	sem           chan struct{}
+	procedureJobs chan procedureBatchJob
+	procedureWg   sync.WaitGroup
+}
+
+type procedureBatchJob struct {
+	ctx      context.Context
+	run      func(context.Context) ([]Finding, error)
+	complete func([]Finding, error)
+}
+
+type analysisExecutionBudgetKey struct{}
+
+func newAnalysisExecutionBudget(limit int) *analysisExecutionBudget {
+	if limit < 1 {
+		limit = 1
+	}
+	return &analysisExecutionBudget{limit: limit, sem: make(chan struct{}, limit)}
+}
+
+func (budget *analysisExecutionBudget) acquire(ctx context.Context) error {
+	if budget == nil {
+		return ctx.Err()
+	}
+	select {
+	case budget.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (budget *analysisExecutionBudget) release() {
+	if budget == nil {
+		return
+	}
+	<-budget.sem
+}
+
+func (budget *analysisExecutionBudget) startProcedurePool() {
+	if budget == nil {
+		return
+	}
+	budget.procedureJobs = make(chan procedureBatchJob)
+	budget.procedureWg.Add(budget.limit)
+	for worker := 0; worker < budget.limit; worker++ {
+		go func() {
+			defer budget.procedureWg.Done()
+			for job := range budget.procedureJobs {
+				if err := budget.acquire(job.ctx); err != nil {
+					job.complete(nil, err)
+					continue
+				}
+				findings, err := job.run(job.ctx)
+				budget.release()
+				job.complete(findings, err)
+			}
+		}()
+	}
+}
+
+func (budget *analysisExecutionBudget) submitProcedureBatch(ctx context.Context, job procedureBatchJob) bool {
+	if budget == nil || budget.procedureJobs == nil {
+		return false
+	}
+	select {
+	case budget.procedureJobs <- job:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (budget *analysisExecutionBudget) stopProcedurePool() {
+	if budget == nil || budget.procedureJobs == nil {
+		return
+	}
+	close(budget.procedureJobs)
+	budget.procedureWg.Wait()
+}
+
+func withAnalysisExecutionBudget(ctx context.Context, budget *analysisExecutionBudget) context.Context {
+	return context.WithValue(ctx, analysisExecutionBudgetKey{}, budget)
+}
+
+func analysisExecutionBudgetFromContext(ctx context.Context) *analysisExecutionBudget {
+	if ctx == nil {
+		return nil
+	}
+	budget, _ := ctx.Value(analysisExecutionBudgetKey{}).(*analysisExecutionBudget)
+	return budget
 }
 
 var (
@@ -697,19 +802,31 @@ func (a Analyzer) analyzeFilesBoundedWith(ctx context.Context, files []parsedFil
 	if len(files) == 0 {
 		return nil, nil
 	}
-	workerLimit := a.analysisWorkerLimit
-	if workerLimit <= 0 {
-		workerLimit = runtime.GOMAXPROCS(0)
+	executionLimit := a.analysisWorkerLimit
+	if executionLimit <= 0 {
+		executionLimit = runtime.GOMAXPROCS(0)
 	}
-	if workerLimit < 1 {
-		workerLimit = 1
+	if executionLimit < 1 {
+		executionLimit = 1
 	}
+	workerLimit := executionLimit
 	if workerLimit > len(files) {
 		workerLimit = len(files)
 	}
 
 	workCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	budget := newAnalysisExecutionBudget(executionLimit)
+	for _, file := range files {
+		if len(file.Procedures) >= procedureParallelThreshold || len(file.IR.Procedures) >= procedureParallelThreshold {
+			if executionLimit > 1 {
+				budget.startProcedurePool()
+			}
+			break
+		}
+	}
+	defer budget.stopProcedurePool()
+	workCtx = withAnalysisExecutionBudget(workCtx, budget)
 	jobs := make(chan int)
 	results := make([]parsedFileAnalysisResult, len(files))
 	var (
@@ -729,7 +846,11 @@ func (a Analyzer) analyzeFilesBoundedWith(ctx context.Context, files []parsedFil
 					if !ok {
 						return
 					}
+					if err := budget.acquire(workCtx); err != nil {
+						return
+					}
 					fileFindings, filePreflight, err := analyzeFile(workCtx, files[index], analysisCtx, projectEffects, publicAPITypeIndex)
+					budget.release()
 					results[index] = parsedFileAnalysisResult{findings: fileFindings, preflight: filePreflight, err: err}
 					if err != nil {
 						workerErrOnce.Do(func() {
@@ -767,22 +888,39 @@ sendJobs:
 func (a Analyzer) analyzeParsedFileBounded(ctx context.Context, file parsedFile, analysisCtx analysisContext, projectEffects effects.ProjectSummary, publicAPITypeIndex *apiTypeIndex) ([]Finding, []Finding, error) {
 	finishStage := analysisstats.Measure(ctx, "procedure_local_diagnostics")
 	var findings []Finding
+	// Procedure-local analysis only consumes immutable source/IR/CFG facts. Run
+	// it outside ParsedDocument.Read so workers never retain or receive a
+	// tree-sitter node. The tree is leased below only for the one file-global
+	// scan that still needs it.
+	file.Root = nil
+	procedureFindings, procedureErr := a.analyzeParsedFileContext(ctx, analysisCtx, file, projectEffects)
+	if procedureErr != nil {
+		finishStage(0, procedureErr)
+		return nil, nil, procedureErr
+	}
+	findings = append(findings, procedureFindings...)
 	readErr := file.Parsed.Read(func(view vbaast.ParsedView) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		file.Root = view.Root
-		fileFindings, err := a.analyzeParsedFileContext(ctx, analysisCtx, file, projectEffects)
-		if err != nil {
-			return err
+		if a.Config.Analyze.DetectNonShortCircuitObjectGuard {
+			procedures := sourceProceduresWithEffects(file, projectEffects)
+			guardFindings, err := a.vba212ScanWithContext(ctx, file, procedures, nil, vba212Context{projectEffects: projectEffects})
+			if err != nil {
+				return err
+			}
+			findings = append(findings, guardFindings...)
 		}
-		findings = append(findings, fileFindings...)
 		if publicAPITypeIndex != nil {
 			findings = append(findings, a.publicAPITypeFindings(file, publicAPITypeIndex)...)
 		}
 		findings = append(findings, a.errorValueWrapperFindings(file)...)
 		return nil
 	})
+	// ParsedView.Root is borrowed for the Read callback only. Do not leave the
+	// tree-sitter node reachable from the file projection after the lease ends.
+	file.Root = nil
 	finishStage(len(findings), readErr)
 	if readErr != nil {
 		return nil, nil, readErr
@@ -1912,37 +2050,132 @@ func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analys
 	if err := cancelCtx.Err(); err != nil {
 		return nil, err
 	}
-	reportedMissingHelpers := map[string]bool{}
 	var findings []Finding
 	procedures := sourceProceduresWithEffects(file, projectEffects)
 	moduleDecls := file.moduleDecls()
 	findings = append(findings, a.hardcodedSecretFindings(file, procedures)...)
-	for _, proc := range procedures {
-		if err := cancelCtx.Err(); err != nil {
-			return nil, err
-		}
-		procedureFindings, err := a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers)
-		if err != nil {
-			return nil, err
-		}
-		findings = append(findings, procedureFindings...)
+	procedureFindings, err := a.analyzeProcedureContextsBounded(cancelCtx, file, procedures, moduleDecls, ctx, projectEffects)
+	if err != nil {
+		return nil, err
 	}
+	findings = append(findings, procedureFindings...)
+	return findings, cancelCtx.Err()
+}
+
+// analyzeProcedureContextsBounded evaluates procedure-local rules using the
+// shared analysis execution budget. Each result is stored by source index and
+// merged in that order, so worker completion order cannot affect findings.
+func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, file parsedFile, procedures []sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary) ([]Finding, error) {
 	if len(procedures) == 0 {
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		procedureFindings, err := a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers)
-		if err != nil {
-			return nil, err
-		}
-		findings = append(findings, procedureFindings...)
+		return a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, map[string]bool{})
 	}
-	if a.Config.Analyze.DetectNonShortCircuitObjectGuard {
-		guardFindings, err := a.vba212ScanWithContext(cancelCtx, file, procedures, nil, vba212Context{projectEffects: projectEffects})
-		if err != nil {
-			return nil, err
+	budget := analysisExecutionBudgetFromContext(cancelCtx)
+	if budget == nil || budget.procedureJobs == nil || budget.limit < 2 || len(procedures) < procedureParallelThreshold {
+		reportedMissingHelpers := map[string]bool{}
+		var findings []Finding
+		for _, proc := range procedures {
+			if err := cancelCtx.Err(); err != nil {
+				return nil, err
+			}
+			procedureFindings, err := a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers)
+			if err != nil {
+				return nil, err
+			}
+			findings = append(findings, procedureFindings...)
 		}
-		findings = append(findings, guardFindings...)
+		return findings, nil
 	}
-	return findings, cancelCtx.Err()
+
+	// The enclosing file job owns one permit. Yield it before waiting for
+	// procedure jobs; otherwise a full set of file workers could deadlock while
+	// trying to acquire the same budget for their children.
+	budget.release()
+	defer func() {
+		// The caller owns a permit for the duration of analyzeParsedFileBounded.
+		// Cancellation is handled by the caller's existing error path. Reacquire
+		// without that cancellation so the ownership invariant remains balanced
+		// before the file worker releases its original permit.
+		_ = budget.acquire(context.Background())
+	}()
+
+	workCtx, cancel := context.WithCancel(cancelCtx)
+	defer cancel()
+	results := make([][]Finding, len(procedures))
+	var (
+		batches  sync.WaitGroup
+		firstErr error
+		errOnce  sync.Once
+	)
+	batchSize := (len(procedures) + budget.limit*4 - 1) / (budget.limit * 4)
+	if batchSize < 1 {
+		batchSize = 1
+	}
+	for start := 0; start < len(procedures); start += batchSize {
+		end := start + batchSize
+		if end > len(procedures) {
+			end = len(procedures)
+		}
+		batchStart, batchEnd := start, end
+		batches.Add(1)
+		job := procedureBatchJob{
+			ctx: workCtx,
+			run: func(jobCtx context.Context) ([]Finding, error) {
+				procedureFile := file
+				procedureFile.Root = nil
+				var batchFindings []Finding
+				for index := batchStart; index < batchEnd; index++ {
+					if err := jobCtx.Err(); err != nil {
+						return nil, err
+					}
+					findings, err := a.analyzeProcedureContext(jobCtx, procedureFile, procedures[index], moduleDecls, ctx, projectEffects, map[string]bool{})
+					if err != nil {
+						return nil, err
+					}
+					results[index] = findings
+				}
+				return batchFindings, nil
+			},
+			complete: func(_ []Finding, err error) {
+				defer batches.Done()
+				if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+					errOnce.Do(func() {
+						firstErr = err
+						cancel()
+					})
+				}
+			},
+		}
+		if !budget.submitProcedureBatch(workCtx, job) {
+			batches.Done()
+			break
+		}
+	}
+	batches.Wait()
+	if err := cancelCtx.Err(); err != nil {
+		return nil, err
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	// Helper dependency findings are file-global one-time diagnostics. Workers
+	// collect them locally, then this source-order merge keeps the first
+	// occurrence and drops later duplicates exactly like the serial map did.
+	seenHelpers := map[string]bool{}
+	var findings []Finding
+	for index := range results {
+		for _, finding := range results[index] {
+			if finding.Code == "VBA105" || finding.Code == "VBA106" {
+				if seenHelpers[finding.Code] {
+					continue
+				}
+				seenHelpers[finding.Code] = true
+			}
+			findings = append(findings, finding)
+		}
+	}
+	return findings, nil
 }
 
 func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary, reportedMissingHelpers map[string]bool) ([]Finding, error) {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -893,7 +893,7 @@ func (a Analyzer) analyzeParsedFileBounded(ctx context.Context, file parsedFile,
 	// tree-sitter node. The tree is leased below only for the one file-global
 	// scan that still needs it.
 	file.Root = nil
-	procedureFindings, procedureErr := a.analyzeParsedFileContext(ctx, analysisCtx, file, projectEffects)
+	procedureFindings, procedureErr := a.analyzeParsedFileContext(ctx, analysisCtx, file, projectEffects, true)
 	if procedureErr != nil {
 		finishStage(0, procedureErr)
 		return nil, nil, procedureErr
@@ -2046,7 +2046,7 @@ func recordBatchWorkload(ctx context.Context, files []parsedFile) {
 	}
 }
 
-func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analysisContext, file parsedFile, projectEffects effects.ProjectSummary) ([]Finding, error) {
+func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analysisContext, file parsedFile, projectEffects effects.ProjectSummary, filePermitHeld bool) ([]Finding, error) {
 	if err := cancelCtx.Err(); err != nil {
 		return nil, err
 	}
@@ -2054,7 +2054,7 @@ func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analys
 	procedures := sourceProceduresWithEffects(file, projectEffects)
 	moduleDecls := file.moduleDecls()
 	findings = append(findings, a.hardcodedSecretFindings(file, procedures)...)
-	procedureFindings, err := a.analyzeProcedureContextsBounded(cancelCtx, file, procedures, moduleDecls, ctx, projectEffects)
+	procedureFindings, err := a.analyzeProcedureContextsBounded(cancelCtx, file, procedures, moduleDecls, ctx, projectEffects, filePermitHeld)
 	if err != nil {
 		return nil, err
 	}
@@ -2065,13 +2065,13 @@ func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analys
 // analyzeProcedureContextsBounded evaluates procedure-local rules using the
 // shared analysis execution budget. Each result is stored by source index and
 // merged in that order, so worker completion order cannot affect findings.
-func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, file parsedFile, procedures []sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary) ([]Finding, error) {
+func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, file parsedFile, procedures []sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary, filePermitHeld bool) ([]Finding, error) {
 	if len(procedures) == 0 {
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
 		return a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, map[string]bool{})
 	}
 	budget := analysisExecutionBudgetFromContext(cancelCtx)
-	if budget == nil || budget.procedureJobs == nil || budget.limit < 2 || len(procedures) < procedureParallelThreshold {
+	if !filePermitHeld || budget == nil || budget.procedureJobs == nil || budget.limit < 2 || len(procedures) < procedureParallelThreshold {
 		reportedMissingHelpers := map[string]bool{}
 		var findings []Finding
 		for _, proc := range procedures {
@@ -2090,13 +2090,19 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 	// The enclosing file job owns one permit. Yield it before waiting for
 	// procedure jobs; otherwise a full set of file workers could deadlock while
 	// trying to acquire the same budget for their children.
+	// The caller explicitly confirms that it owns the file-level permit. A
+	// future caller without that permit must take the serial path above rather
+	// than releasing an unrelated semaphore slot.
 	budget.release()
+	filePermitHeld = false
 	defer func() {
 		// The caller owns a permit for the duration of analyzeParsedFileBounded.
 		// Cancellation is handled by the caller's existing error path. Reacquire
 		// without that cancellation so the ownership invariant remains balanced
 		// before the file worker releases its original permit.
-		_ = budget.acquire(context.Background())
+		if !filePermitHeld {
+			_ = budget.acquire(context.Background())
+		}
 	}()
 
 	workCtx, cancel := context.WithCancel(cancelCtx)
@@ -2123,7 +2129,6 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 			run: func(jobCtx context.Context) ([]Finding, error) {
 				procedureFile := file
 				procedureFile.Root = nil
-				var batchFindings []Finding
 				for index := batchStart; index < batchEnd; index++ {
 					if err := jobCtx.Err(); err != nil {
 						return nil, err
@@ -2134,7 +2139,7 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 					}
 					results[index] = findings
 				}
-				return batchFindings, nil
+				return nil, nil
 			},
 			complete: func(_ []Finding, err error) {
 				defer batches.Done()

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -123,6 +123,9 @@ type Analyzer struct {
 	// analysisWorkerLimit is test-only tuning for the bounded file analysis
 	// pool. A zero value derives the limit from GOMAXPROCS and project size.
 	analysisWorkerLimit int
+	// procedureAnalysisStartHook is test-only synchronization for cancellation
+	// coverage. Production callers leave it nil.
+	procedureAnalysisStartHook func()
 }
 
 // procedureParallelThreshold is deliberately high enough that the ordinary
@@ -2109,9 +2112,10 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 	defer cancel()
 	results := make([][]Finding, len(procedures))
 	var (
-		batches  sync.WaitGroup
-		firstErr error
-		errOnce  sync.Once
+		batches   sync.WaitGroup
+		firstErr  error
+		errOnce   sync.Once
+		startOnce sync.Once
 	)
 	batchSize := (len(procedures) + budget.limit*4 - 1) / (budget.limit * 4)
 	if batchSize < 1 {
@@ -2129,6 +2133,11 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 			run: func(jobCtx context.Context) ([]Finding, error) {
 				procedureFile := file
 				procedureFile.Root = nil
+				startOnce.Do(func() {
+					if a.procedureAnalysisStartHook != nil {
+						a.procedureAnalysisStartHook()
+					}
+				})
 				for index := batchStart; index < batchEnd; index++ {
 					if err := jobCtx.Err(); err != nil {
 						return nil, err

--- a/internal/analyze/benchmark_test.go
+++ b/internal/analyze/benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -97,6 +98,49 @@ func BenchmarkSingleModuleSynthetic(b *testing.B) {
 			b.ReportMetric(float64(findings)/float64(b.N), "findings/op")
 			b.ReportMetric(float64(warnings)/float64(b.N), "warnings/op")
 			reportAnalysisRecorderMetrics(b, recorder, b.N)
+		})
+	}
+}
+
+// BenchmarkSingleModuleProcedureScheduling compares the serial procedure
+// path with the bounded procedure-aware path. The workload is intentionally a
+// single source file so file-level parallelism cannot hide a missing
+// procedure-level scheduler. Run with -cpu=1,2,4,8 to compare the effect of
+// the process-wide execution budget under different runtime settings.
+func BenchmarkSingleModuleProcedureScheduling(b *testing.B) {
+	for _, procedureCount := range []int{100, 500, 1000, 2000} {
+		procedureCount := procedureCount
+		b.Run(fmt.Sprintf("%d-procedures", procedureCount), func(b *testing.B) {
+			for _, mode := range []struct {
+				name  string
+				limit int
+			}{
+				{name: "serial", limit: 1},
+				{name: "bounded", limit: runtime.GOMAXPROCS(0)},
+			} {
+				mode := mode
+				b.Run(mode.name, func(b *testing.B) {
+					root := b.TempDir()
+					fixture := writeSingleModuleBenchmarkProject(b, root, singleModuleBenchmarkWorkload{shape: "independent", size: procedureCount})
+					b.Setenv(typedb.EnvDir, filepath.Join(b.TempDir(), "typelib"))
+					cfg := config.Default()
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					findings := 0
+					for i := 0; i < b.N; i++ {
+						result, err := (Analyzer{RootDir: root, Config: cfg, analysisWorkerLimit: mode.limit}).RunResult()
+						if err != nil {
+							b.Fatalf("analyze single-module %d-procedure fixture (%s): %v", procedureCount, mode.name, err)
+						}
+						findings += len(result.Findings)
+					}
+					b.StopTimer()
+
+					b.ReportMetric(float64(fixture.procedures), "procedures/op")
+					b.ReportMetric(float64(findings)/float64(b.N), "findings/op")
+				})
+			}
 		})
 	}
 }
@@ -274,7 +318,7 @@ type singleModuleBenchmarkWorkload struct {
 func singleModuleBenchmarkWorkloads() []singleModuleBenchmarkWorkload {
 	workloads := make([]singleModuleBenchmarkWorkload, 0, 17)
 	for _, shape := range []string{"independent", "chain", "declarations"} {
-		for _, size := range []int{500, 1000, 2000} {
+		for _, size := range []int{100, 500, 1000, 2000} {
 			workloads = append(workloads, singleModuleBenchmarkWorkload{shape: shape, size: size})
 		}
 	}

--- a/internal/analyze/benchmark_test.go
+++ b/internal/analyze/benchmark_test.go
@@ -316,7 +316,7 @@ type singleModuleBenchmarkWorkload struct {
 }
 
 func singleModuleBenchmarkWorkloads() []singleModuleBenchmarkWorkload {
-	workloads := make([]singleModuleBenchmarkWorkload, 0, 17)
+	workloads := make([]singleModuleBenchmarkWorkload, 0, 20)
 	for _, shape := range []string{"independent", "chain", "declarations"} {
 		for _, size := range []int{100, 500, 1000, 2000} {
 			workloads = append(workloads, singleModuleBenchmarkWorkload{shape: shape, size: size})

--- a/internal/analyze/bounded_procedure_parallel_test.go
+++ b/internal/analyze/bounded_procedure_parallel_test.go
@@ -177,25 +177,34 @@ func TestAnalyzerSingleModuleProcedureCancellationReturnsNoResult(t *testing.T) 
 	}
 	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
 	ctx, cancel := context.WithCancel(context.Background())
+	procedureStarted := make(chan struct{})
 	resultCh := make(chan struct {
 		result Result
 		err    error
 	}, 1)
 	go func() {
-		result, err := (Analyzer{RootDir: root, Config: config.Default(), analysisWorkerLimit: 4}).RunResultContext(ctx)
+		result, err := (Analyzer{
+			RootDir:                    root,
+			Config:                     config.Default(),
+			analysisWorkerLimit:        4,
+			procedureAnalysisStartHook: func() { close(procedureStarted) },
+		}).RunResultContext(ctx)
 		resultCh <- struct {
 			result Result
 			err    error
 		}{result: result, err: err}
 	}()
-	timer := time.NewTimer(100 * time.Millisecond)
+	timer := time.NewTimer(10 * time.Second)
 	defer timer.Stop()
 	select {
 	case outcome := <-resultCh:
 		cancel()
-		t.Fatalf("large-module analysis completed before the cancellation window: %v", outcome.err)
+		t.Fatalf("large-module analysis completed before procedure work started: %v", outcome.err)
+	case <-procedureStarted:
+		cancel()
 	case <-timer.C:
 		cancel()
+		t.Fatal("timed out waiting for procedure analysis to start")
 	}
 	select {
 	case outcome := <-resultCh:

--- a/internal/analyze/bounded_procedure_parallel_test.go
+++ b/internal/analyze/bounded_procedure_parallel_test.go
@@ -1,0 +1,165 @@
+package analyze
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/typedb"
+	"github.com/harumiWeb/xlflow/internal/vba/effects"
+)
+
+// TestAnalyzerSingleModuleProcedureAnalysisIsDeterministic exercises the
+// workload shape that file-level workers cannot parallelize: one source file
+// with hundreds of independent procedures. The serial and bounded paths must
+// produce identical findings, including their serialized representation.
+func TestAnalyzerSingleModuleProcedureAnalysisIsDeterministic(t *testing.T) {
+	root := t.TempDir()
+	fixture := writeSingleModuleBenchmarkProject(t, root, singleModuleBenchmarkWorkload{shape: "independent", size: 500})
+	if fixture.procedures != 500 {
+		t.Fatalf("single-module fixture has %d procedures, want 500", fixture.procedures)
+	}
+	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
+	cfg := config.Default()
+
+	serial, err := (Analyzer{RootDir: root, Config: cfg, analysisWorkerLimit: 1}).RunResult()
+	if err != nil {
+		t.Fatalf("serial analysis: %v", err)
+	}
+	parallelAnalyzer := Analyzer{RootDir: root, Config: cfg, analysisWorkerLimit: 4}
+	parallel, err := parallelAnalyzer.RunResult()
+	if err != nil {
+		t.Fatalf("bounded analysis: %v", err)
+	}
+	repeated, err := parallelAnalyzer.RunResult()
+	if err != nil {
+		t.Fatalf("repeated bounded analysis: %v", err)
+	}
+
+	if !reflect.DeepEqual(serial, parallel) {
+		t.Fatalf("serial and bounded results differ:\nserial:   %+v\nbounded: %+v", serial, parallel)
+	}
+	if !reflect.DeepEqual(parallel, repeated) {
+		t.Fatalf("repeated bounded results differ:\nfirst:  %+v\nsecond: %+v", parallel, repeated)
+	}
+	serialJSON, err := json.Marshal(serial)
+	if err != nil {
+		t.Fatalf("marshal serial result: %v", err)
+	}
+	parallelJSON, err := json.Marshal(parallel)
+	if err != nil {
+		t.Fatalf("marshal bounded result: %v", err)
+	}
+	if !bytes.Equal(serialJSON, parallelJSON) {
+		t.Fatalf("serial and bounded JSON differ:\nserial:   %s\nbounded: %s", serialJSON, parallelJSON)
+	}
+}
+
+// TestAnalyzeFilesBoundedCapsConcurrentAnalyses protects the existing
+// process-wide file budget. Procedure-level scheduling is allowed to add work
+// inside a file, but it must not multiply the outer worker limit.
+func TestAnalyzeFilesBoundedCapsConcurrentAnalyses(t *testing.T) {
+	for _, workerLimit := range []int{1, 2, 4} {
+		workerLimit := workerLimit
+		t.Run(fmt.Sprintf("limit-%d", workerLimit), func(t *testing.T) {
+			files := make([]parsedFile, 8)
+			for index := range files {
+				files[index].Path = fmt.Sprintf("Module%d.bas", index)
+			}
+
+			var active atomic.Int32
+			var maxActive atomic.Int32
+			updateMax := func(value int32) {
+				for {
+					old := maxActive.Load()
+					if value <= old || maxActive.CompareAndSwap(old, value) {
+						return
+					}
+				}
+			}
+			firstBatchStarted := make(chan struct{})
+			release := make(chan struct{})
+			var firstBatchOnce sync.Once
+			resultCh := make(chan error, 1)
+			go func() {
+				_, err := (Analyzer{analysisWorkerLimit: workerLimit}).analyzeFilesBoundedWith(
+					context.Background(), files, analysisContext{}, effects.ProjectSummary{}, nil,
+					func(ctx context.Context, file parsedFile, _ analysisContext, _ effects.ProjectSummary, _ *apiTypeIndex) ([]Finding, []Finding, error) {
+						current := active.Add(1)
+						defer active.Add(-1)
+						updateMax(current)
+						if current == int32(workerLimit) {
+							firstBatchOnce.Do(func() { close(firstBatchStarted) })
+						}
+						select {
+						case <-release:
+						case <-ctx.Done():
+							return nil, nil, ctx.Err()
+						}
+						return nil, nil, nil
+					},
+				)
+				resultCh <- err
+			}()
+
+			select {
+			case <-firstBatchStarted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for the bounded worker batch")
+			}
+			close(release)
+			select {
+			case err := <-resultCh:
+				if err != nil {
+					t.Fatalf("bounded analysis: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for bounded analysis completion")
+			}
+			if got := maxActive.Load(); got > int32(workerLimit) {
+				t.Fatalf("maximum concurrent analyses = %d, want <= %d", got, workerLimit)
+			}
+		})
+	}
+}
+
+func TestAnalyzerSingleModuleProcedureCancellationReturnsNoResult(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := (Analyzer{RootDir: t.TempDir(), Config: config.Default(), analysisWorkerLimit: 4}).RunResultContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunResultContext error = %v, want context.Canceled", err)
+	}
+	if !reflect.DeepEqual(result, Result{}) {
+		t.Fatalf("canceled analysis returned partial result: %+v", result)
+	}
+}
+
+func TestAnalyzeFilesBoundedSkipsProcedurePoolForSmallFiles(t *testing.T) {
+	files := []parsedFile{{Procedures: make([]sourceProcedure, procedureParallelThreshold-1)}}
+	seen := make(chan bool, 1)
+	_, err := (Analyzer{analysisWorkerLimit: 4}).analyzeFilesBoundedWith(
+		context.Background(), files, analysisContext{}, effects.ProjectSummary{}, nil,
+		func(ctx context.Context, _ parsedFile, _ analysisContext, _ effects.ProjectSummary, _ *apiTypeIndex) ([]Finding, []Finding, error) {
+			budget := analysisExecutionBudgetFromContext(ctx)
+			seen <- budget != nil && budget.procedureJobs != nil
+			return nil, nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("bounded analysis: %v", err)
+	}
+	if got := <-seen; got {
+		t.Fatal("small-file analysis started a procedure pool")
+	}
+}

--- a/internal/analyze/bounded_procedure_parallel_test.go
+++ b/internal/analyze/bounded_procedure_parallel_test.go
@@ -64,6 +64,43 @@ func TestAnalyzerSingleModuleProcedureAnalysisIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestAnalyzeFilesBoundedStartsProcedurePoolForLargeFiles(t *testing.T) {
+	files := []parsedFile{{Procedures: make([]sourceProcedure, procedureParallelThreshold)}}
+	seen := make(chan bool, 1)
+	_, err := (Analyzer{analysisWorkerLimit: 4}).analyzeFilesBoundedWith(
+		context.Background(), files, analysisContext{}, effects.ProjectSummary{}, nil,
+		func(ctx context.Context, _ parsedFile, _ analysisContext, _ effects.ProjectSummary, _ *apiTypeIndex) ([]Finding, []Finding, error) {
+			budget := analysisExecutionBudgetFromContext(ctx)
+			seen <- budget != nil && budget.procedureJobs != nil
+			return nil, nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("bounded analysis: %v", err)
+	}
+	if got := <-seen; !got {
+		t.Fatal("large-file analysis did not start the shared procedure pool")
+	}
+}
+
+func TestAnalyzerMultipleLargeFilesCompleteWithSharedProcedurePool(t *testing.T) {
+	root := t.TempDir()
+	source := singleModuleBenchmarkSource(singleModuleBenchmarkWorkload{shape: "independent", size: procedureParallelThreshold})
+	writeModule(t, root, "LargeA.bas", source)
+	writeModule(t, root, "LargeB.bas", source)
+	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	result, err := (Analyzer{RootDir: root, Config: config.Default(), analysisWorkerLimit: 2}).RunResultContext(ctx)
+	if err != nil {
+		t.Fatalf("multi-file bounded analysis: %v", err)
+	}
+	if result.AnalyzedFiles != 2 {
+		t.Fatalf("analyzed files = %d, want 2", result.AnalyzedFiles)
+	}
+}
+
 // TestAnalyzeFilesBoundedCapsConcurrentAnalyses protects the existing
 // process-wide file budget. Procedure-level scheduling is allowed to add work
 // inside a file, but it must not multiply the outer worker limit.
@@ -133,15 +170,44 @@ func TestAnalyzeFilesBoundedCapsConcurrentAnalyses(t *testing.T) {
 }
 
 func TestAnalyzerSingleModuleProcedureCancellationReturnsNoResult(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	result, err := (Analyzer{RootDir: t.TempDir(), Config: config.Default(), analysisWorkerLimit: 4}).RunResultContext(ctx)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("RunResultContext error = %v, want context.Canceled", err)
+	root := t.TempDir()
+	fixture := writeSingleModuleBenchmarkProject(t, root, singleModuleBenchmarkWorkload{shape: "independent", size: 2000})
+	if fixture.procedures < procedureParallelThreshold {
+		t.Fatalf("cancellation fixture has %d procedures, want at least %d", fixture.procedures, procedureParallelThreshold)
 	}
-	if !reflect.DeepEqual(result, Result{}) {
-		t.Fatalf("canceled analysis returned partial result: %+v", result)
+	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan struct {
+		result Result
+		err    error
+	}, 1)
+	go func() {
+		result, err := (Analyzer{RootDir: root, Config: config.Default(), analysisWorkerLimit: 4}).RunResultContext(ctx)
+		resultCh <- struct {
+			result Result
+			err    error
+		}{result: result, err: err}
+	}()
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case outcome := <-resultCh:
+		cancel()
+		t.Fatalf("large-module analysis completed before the cancellation window: %v", outcome.err)
+	case <-timer.C:
+		cancel()
+	}
+	select {
+	case outcome := <-resultCh:
+		result, err := outcome.result, outcome.err
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunResultContext error = %v, want context.Canceled", err)
+		}
+		if !reflect.DeepEqual(result, Result{}) {
+			t.Fatalf("canceled analysis returned partial result: %+v", result)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for canceled large-module analysis")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add bounded procedure-level parallelism for files with at least 500 procedures.
- Share the analyzer execution budget between file jobs and procedure batches, while keeping the small-file fast path and deterministic source-order merge.
- Preserve tree-sitter lifetime boundaries, helper deduplication, cancellation, suppression, and JSON compatibility.
- Add ADR-0045, benchmark coverage, regression tests, specification updates, and an Unreleased changelog entry.

Closes #675

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/analyze -count=1`
- `rtk task test`
- `rtk task corpus:test`
- `rtk golangci-lint run`
- `rtk pnpm lint`
- `rtk pnpm docs:check`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^BenchmarkSingleModuleProcedureScheduling/(100|500|1000|2000)-procedures/(serial|bounded)$' '-cpu=1,4' -benchtime=1x -count=3`

## Performance

- On the Windows development host at `-cpu=4`, median serial-to-bounded time was approximately 346-to-253 ms for 500 procedures, 840-to-574 ms for 1,000, and 1,923-to-1,331 ms for 2,000.
- The 100-procedure case remained within ordinary run-to-run noise; no public tuning option was added.

## Documentation

- Added ADR-0045 and updated the VBA analysis and static-analysis performance specifications and the Unreleased changelog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved analysis speed for large single-file workloads with bounded procedure-level parallelism.
  * Preserved fast processing for smaller files.

* **Reliability**
  * Maintained deterministic findings, source ordering, suppression, JSON output, and cancellation behavior.
  * Ensured cancellation does not publish partial results.

* **Documentation**
  * Added architecture and analysis specifications describing the execution behavior.
  * Added benchmark requirements and performance coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->