### PR TITLE
perf(analyze): add rule-domain profiling for giant modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added opt-in semantic-domain profiling beneath
+  `procedure_local_diagnostics` for giant-module `xlflow analyze` workloads.
+  `--performance-log` now attributes aggregate source-scan, runtime, array,
+  object, dictionary, error, dataflow, resource, Excel, application-state,
+  and other procedure-local work, and reports candidate/traversal/kernel work
+  counters. Parallel domain timings are cumulative worker time, not an additive
+  wall-time partition. Output remains stderr-only and findings, exit codes, and
+  JSON output are unchanged when profiling is enabled.
+
 - Added bounded procedure-level parallelism for large single-file
   `xlflow analyze` workloads. Procedure batches share the analyzer's bounded
   execution budget with file workers, merge into source-ordered result slots,

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -280,15 +280,45 @@ stages are `source_discovery`, `file_read`, `parse`, `procedure_ir`, `cfg`,
 `suppression_and_finalize`; the complete operation is reported as
 `analyze_total`. These are the canonical CLI labels.
 
+The `procedure_local_diagnostics` stage remains the parent for procedure-local
+work. When profiling is enabled, its aggregate is additionally attributed to
+the following semantic-domain stages:
+`procedure_local/source_scan`, `procedure_local/runtime`,
+`procedure_local/array`, `procedure_local/object`,
+`procedure_local/dictionary`, `procedure_local/error`,
+`procedure_local/dataflow`, `procedure_local/resource`,
+`procedure_local/excel`, `procedure_local/application_state`, and
+`procedure_local/other`. Domain records are aggregate records; they do not
+create one timer or record per procedure. Typed Excel, object summary/entry
+state, and project-context index work keep their existing top-level stages.
+When procedures run in parallel, a domain's elapsed value is the cumulative
+worker time and is not an additive partition of the parent's wall time; domain
+values may therefore exceed the parent stage's elapsed value.
+
 The performance output also reports workload counters in stable order. Aggregate
 workload counters are `file_count`, `procedure_count`, `statement_count`,
 `expression_count`, `call_site_count`, `cfg_block_count`, `cfg_edge_count`, and
 `project_symbol_count`, `line_count`, and `module_declaration_count`.
+Counter records use the existing `operation="analyze/counter"` stderr record
+shape; stage records continue to use `operation="analyze/stage"`.
 `line_count` uses physical source lines and does not count a terminal newline as
 an additional empty line.
 Analyzer worklist counters such as `object_summary_evaluations`,
 `object_entry_flow_evaluations`, and `byref_diagnostic_passes` may also be
 reported when those subsystems run.
+Procedure-local profiling also exposes work counters when the corresponding
+domain runs. Candidate counters are
+`runtime_candidate_procedures`, `array_candidate_procedures`,
+`object_candidate_procedures`, `dictionary_candidate_procedures`,
+`error_candidate_procedures`, `dataflow_candidate_procedures`,
+`resource_candidate_procedures`, `excel_candidate_procedures`, and
+`application_state_candidate_procedures`. Traversal counters are
+`source_line_scans`, `runtime_cfg_walks`, `array_cfg_walks`,
+`dictionary_cfg_walks`, `error_cfg_walks`, `dataflow_cfg_walks`,
+`resource_cfg_walks`, and `excel_cfg_walks`; `semantic_kernel_runs` counts
+valid semantic-domain kernel invocations. Candidate counters count procedures
+that pass the rule gate and are actually analyzed, traversal counters count
+started source/CFG traversals, and none of these counters count findings.
 The effect-summary stage may additionally report
 `effect_summary_worklist_evaluations`,
 `effect_summary_max_propagated_facts_per_procedure`, and

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -294,6 +294,10 @@ state, and project-context index work keep their existing top-level stages.
 When procedures run in parallel, a domain's elapsed value is the cumulative
 worker time and is not an additive partition of the parent's wall time; domain
 values may therefore exceed the parent stage's elapsed value.
+The `procedure_local/source_scan` measurement is also a containment measure for
+the source-line loop: its elapsed time and result count include nested Excel,
+object, and array measurements performed while scanning those lines. Consumers
+must not add nested domain values to source-scan values as if they were disjoint.
 
 The performance output also reports workload counters in stable order. Aggregate
 workload counters are `file_count`, `procedure_count`, `statement_count`,

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -997,12 +997,31 @@ allocation-space and allocation-object consumers, and the final view reports
 heap in use when that profile sample is available. Keep the complete command
 output with the benchmark record.
 
-On Linux or macOS, use the same command with `rtk go test` instead of the
-Windows wrapper. Keep the Go version, machine, power state, benchmark filter,
-and sample count constant for before/after comparisons, and report unusually
-slow runs with the complete command and environment. Benchmark generation is
-test-only infrastructure and must not run from ordinary `analyze`, `check`,
-corpus snapshot, or Excel/VBE oracle workflows.
+On Linux or macOS, use this directly executable POSIX equivalent. It writes a
+native test binary (without the Windows `.exe` suffix) and keeps profiles in a
+temporary directory:
+
+```sh
+profile_dir="${TMPDIR:-/tmp}/xlflow-ronecone-694"
+rtk mkdir -p "$profile_dir"
+rtk go test ./internal/staticanalysis/corpus \
+  -run '^$' \
+  -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' \
+  -benchtime=1x -count=1 \
+  -cpuprofile="$profile_dir/ronecone.cpu.pprof" \
+  -memprofile="$profile_dir/ronecone.mem.pprof" \
+  -o="$profile_dir/ronecone-corpus.test"
+rtk go tool pprof -top "$profile_dir/ronecone-corpus.test" "$profile_dir/ronecone.cpu.pprof"
+rtk go tool pprof -sample_index=alloc_space -top "$profile_dir/ronecone-corpus.test" "$profile_dir/ronecone.mem.pprof"
+rtk go tool pprof -sample_index=alloc_objects -top "$profile_dir/ronecone-corpus.test" "$profile_dir/ronecone.mem.pprof"
+rtk go tool pprof -sample_index=inuse_space -top "$profile_dir/ronecone-corpus.test" "$profile_dir/ronecone.mem.pprof"
+```
+
+Keep the Go version, machine, power state, benchmark filter, and sample count
+constant for before/after comparisons, and report unusually slow runs with the
+complete command and environment. Benchmark generation is test-only
+infrastructure and must not run from ordinary `analyze`, `check`, corpus
+snapshot, or Excel/VBE oracle workflows.
 
 ### Issue #694 baseline record
 
@@ -1036,7 +1055,10 @@ baseline. This is a workload result, not a disabled-profiling regression.
 For ROneCOne, the median parent `procedure_local_diagnostics` wall time was
 3.456 s. Domain values below are median accumulated worker execution times;
 they overlap under procedure parallelism and therefore must not be added or
-compared as a partition of the parent wall time.
+compared as a partition of the parent wall time. In addition,
+`procedure_local/source_scan` contains the source-line loop and therefore
+includes elapsed time and result counts from nested Excel, object, and array
+measurements; those nested values must not be added to source-scan values.
 
 | semantic domain         | median accumulated time |
 | ----------------------- | ----------------------: |

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -808,6 +808,36 @@ diagnostics. The canonical stage labels include `parse`, `procedure_ir`, `cfg`,
 `effect_summaries`, `project_context`, `project_wide_diagnostics`,
 `procedure_local_diagnostics`, and `suppression_and_finalize`.
 
+For issue #694, `procedure_local_diagnostics` remains the parent stage and is
+also attributed to these aggregate semantic-domain stages:
+`procedure_local/source_scan`, `procedure_local/runtime`,
+`procedure_local/array`, `procedure_local/object`,
+`procedure_local/dictionary`, `procedure_local/error`,
+`procedure_local/dataflow`, `procedure_local/resource`,
+`procedure_local/excel`, `procedure_local/application_state`, and
+`procedure_local/other`. The records are aggregate observations rather than
+one timer per procedure. Procedure work may run in parallel, so a domain's
+elapsed time is cumulative worker time, not an additive wall-time partition;
+domain values can exceed the parent stage's elapsed time. Typed Excel, object
+summary/entry state, and project-context index work remain in their existing
+top-level stages.
+
+Domain profiling also reports work counters when the corresponding work runs.
+Candidate counters are `runtime_candidate_procedures`,
+`array_candidate_procedures`, `object_candidate_procedures`,
+`dictionary_candidate_procedures`, `error_candidate_procedures`,
+`dataflow_candidate_procedures`, `resource_candidate_procedures`,
+`excel_candidate_procedures`, and `application_state_candidate_procedures`.
+Traversal counters are `source_line_scans`, `runtime_cfg_walks`,
+`array_cfg_walks`, `dictionary_cfg_walks`, `error_cfg_walks`,
+`dataflow_cfg_walks`, `resource_cfg_walks`, and `excel_cfg_walks`.
+`semantic_kernel_runs` counts valid semantic-domain kernel invocations.
+Candidates are procedures that pass the relevant rule gate and are actually
+analyzed; traversal counters count started source/CFG traversals. These are
+workload counters and never counts of emitted findings.
+The CLI emits stage records with `operation="analyze/stage"` and counter
+records with `operation="analyze/counter"`; both remain stderr-only.
+
 Run the deterministic synthetic benchmark and the real-world corpus hotspot
 benchmark with the repository tasks:
 
@@ -820,7 +850,17 @@ rtk task bench:corpus
 `bench:analyze` retains the existing multi-module and object-worklist baselines.
 `bench:analyze-single-module` keeps fixture generation outside the timed region
 and covers single-module scales around 100, 500, 1,000, and 2,000 procedures,
-including large call graphs, declaration sets, and CFGs. `bench:corpus` runs the checked-in
+including large call graphs, declaration sets, and CFGs. The 2,000-procedure
+domain-profiling matrix retains these four workload shapes:
+
+| benchmark                        | workload shape         |
+| -------------------------------- | ---------------------- |
+| `independent/2000-procedures`    | independent procedures |
+| `declarations/2000-declarations` | declaration-heavy      |
+| `chain/2000-procedures`          | call-heavy             |
+| `cfg-independent/2000-branches`  | CFG-heavy              |
+
+`bench:corpus` runs the checked-in
 `std-vba` and `ronecone` analyze-only sub-benchmarks. These tasks use
 `-benchmem -benchtime=1x`; on Windows they run through `scripts/dev/go.ps1` to
 keep CGO and tree-sitter toolchain selection consistent. Benchmark output should
@@ -933,8 +973,29 @@ ROneCOne profiling is developer-only and must be selected explicitly as a leaf
 benchmark; it is Excel/COM-free and is not part of ordinary `go test ./...`:
 
 ```powershell
-rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count 2
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count 5
 ```
+
+For a reproducible CPU and allocation profile, use `-count=1` and keep the
+benchmark binary and profiles outside the repository. The benchmark
+materializes and loads the fixture before the timed `analyze-only` region.
+Go's process-wide profile may still observe the small amount of benchmark
+setup, but the leaf filter keeps the captured workload focused on analyzer
+work:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -Command '$cpu = Join-Path $env:TEMP "xlflow-ronecone.cpu.pprof"; $mem = Join-Path $env:TEMP "xlflow-ronecone.mem.pprof"; $bin = Join-Path $env:TEMP "xlflow-ronecone-corpus.test.exe"; $args = @("test", "./internal/staticanalysis/corpus", "-run", "^$", "-bench", "^BenchmarkRealWorldCorpus/ronecone/analyze-only$", "-benchtime=1x", "-count=1", "-cpuprofile=$cpu", "-memprofile=$mem", "-o=$bin"); & ".\scripts\dev\go.ps1" @args'
+rtk go tool pprof -top "$env:TEMP\xlflow-ronecone-corpus.test.exe" "$env:TEMP\xlflow-ronecone.cpu.pprof"
+rtk go tool pprof -sample_index=alloc_space -top "$env:TEMP\xlflow-ronecone-corpus.test.exe" "$env:TEMP\xlflow-ronecone.mem.pprof"
+rtk go tool pprof -sample_index=alloc_objects -top "$env:TEMP\xlflow-ronecone-corpus.test.exe" "$env:TEMP\xlflow-ronecone.mem.pprof"
+rtk go tool pprof -sample_index=inuse_space -top "$env:TEMP\xlflow-ronecone-corpus.test.exe" "$env:TEMP\xlflow-ronecone.mem.pprof"
+```
+
+Add `-cum` to the first `pprof` view when cumulative CPU consumers are needed;
+without it the view is ordered by flat CPU. The next two report top
+allocation-space and allocation-object consumers, and the final view reports
+heap in use when that profile sample is available. Keep the complete command
+output with the benchmark record.
 
 On Linux or macOS, use the same command with `rtk go test` instead of the
 Windows wrapper. Keep the Go version, machine, power state, benchmark filter,
@@ -942,6 +1003,92 @@ and sample count constant for before/after comparisons, and report unusually
 slow runs with the complete command and environment. Benchmark generation is
 test-only infrastructure and must not run from ordinary `analyze`, `check`,
 corpus snapshot, or Excel/VBE oracle workflows.
+
+### Issue #694 baseline record
+
+The post-wave-2 observations above remain historical reference values and must
+not be overwritten. After capturing the first rule-domain profiles, append one
+completed row per ROneCOne or synthetic workload to the following record shape.
+Record the repository SHA, machine/toolchain and power-state notes, complete
+command, wall time, `B/op`, `allocs/op`, top CPU consumers, top alloc-space
+consumers, and the semantic-domain timings and work counters from the same run.
+
+The initial #694 capture was made on 2026-08-22 from base SHA
+`6858757ea938d60e123cbadd2e9facf1f34e4217` plus the #694 working-tree change,
+using Go 1.26.6 on Windows 11 Home 10.0.22631, a Thirdwave XA7C-R38 with an
+Intel Core i7-12700 (12 cores / 20 logical processors), and the normal
+plugged-in developer power state. Five `-benchtime=1x` samples were taken
+serially.
+
+| workload                          | `ns/op` samples                                                                |   median | min--max spread |  median `B/op` | median `allocs/op` |
+| --------------------------------- | ------------------------------------------------------------------------------ | -------: | --------------: | -------------: | -----------------: |
+| ROneCOne analyze-only             | 23,815,264,100; 24,193,761,600; 28,179,640,900; 26,682,322,000; 24,197,555,700 | 24.198 s |         4.365 s | 27,319,440,464 |        178,295,249 |
+| independent / 2,000 procedures    | 1,237,728,400; 1,234,423,800; 1,236,714,300; 1,231,832,700; 2,670,839,000      |  1.237 s |         1.439 s |  1,469,165,568 |         11,450,545 |
+| declarations / 2,000 declarations | 1,673,953,300; 1,540,513,700; 1,431,431,000; 1,462,106,900; 1,617,206,000      |  1.541 s |         0.243 s |  3,578,884,504 |          1,044,303 |
+| chain / 2,000 procedures          | 963,067,500; 864,272,300; 849,723,600; 876,187,500; 856,400,900                |  0.864 s |         0.113 s |  1,501,293,120 |         11,974,108 |
+
+The `cfg-independent/2000-branches` fixture remains contract-tested and
+benchmark-selectable, but its five-sample capture did not complete on this
+machine: the pre-instrumentation five-run command failed after about 368 s and
+a single run exceeded ten minutes. No partial timing is presented as a
+baseline. This is a workload result, not a disabled-profiling regression.
+
+For ROneCOne, the median parent `procedure_local_diagnostics` wall time was
+3.456 s. Domain values below are median accumulated worker execution times;
+they overlap under procedure parallelism and therefore must not be added or
+compared as a partition of the parent wall time.
+
+| semantic domain         | median accumulated time |
+| ----------------------- | ----------------------: |
+| source scan             |                 1.754 s |
+| runtime                 |                 4.964 s |
+| array                   |                10.001 s |
+| object                  |                 1.585 s |
+| dictionary / collection |                 3.011 s |
+| error                   |                 0.109 s |
+| dataflow                |                28.564 s |
+| resource                |                 0.014 s |
+| Excel-specific          |                 4.604 s |
+| application state       |                 0.284 s |
+| other                   |                 0.002 s |
+
+The work counters were stable across the five samples: 1,565 procedures for
+each candidate domain; 24,303 source lines scanned; 134,289 semantic kernel
+runs; 1,565 runtime, dictionary, dataflow, and resource CFG walks; 6,260 array
+CFG walks; 4,695 error CFG walks; and 3,130 Excel CFG walks. The object
+candidate counter was 1,565 and has no CFG-walk counter by design.
+
+The `-count=1` CPU/allocation profile completed in 23.83 s with 84.88 s of CPU
+samples. Its flat CPU top ten were `runtime.semasleep` (13.57%),
+`runtime.scanObject` (4.92%), `runtime.tryDeferToSpanScan` (4.50%),
+`regexp.(*Regexp).tryBacktrack` (3.19%), `aeshashbody` (2.95%),
+`runtime.spanClass.sizeclass` (2.58%), `runtime.findObject` (2.21%),
+`internal/runtime/maps.(*Iter).Next` (2.14%), `strings.ToLower` (1.89%), and
+`runtime.scanObjectsSmall` (1.87%).
+
+The alloc-space top ten were `cloneHTTPState` (5,755.43 MB),
+`cloneArrayState` (5,420.14 MB), `internal/bytealg.MakeNoZero` (2,049.05 MB),
+`meetArrayState` (1,694.06 MB), `arrayVariables.func1` (1,106.16 MB),
+`strings.Fields` (1,098.09 MB), `cfg.buildQueryIndex` (824.41 MB),
+`constexpr.NewValues` (520.52 MB), `cfg.Graph.Dominators` (426.53 MB), and
+`dcFlowState.clone` (425.54 MB). The alloc-object top ten were
+`internal/bytealg.MakeNoZero` (58,031,404), `strings.Fields` (18,443,983),
+`reflect.unsafe_New` (17,694,988), `cloneArrayState` (4,887,930),
+`strings.genSplit` (4,482,038), tree-sitter `GoString` (3,883,006),
+`cloneApplicationStateSnapshot` (3,746,639), `cfg.buildQueryIndex` (3,598,583),
+`cloneHTTPState` (3,361,323), and `meetArrayState` (2,406,706).
+
+The unprofiled, bounded `independent/2000` scheduling benchmark changed from a
+pre-instrumentation median of 1.391 s to 1.382 s after instrumentation
+(-0.6%). Median allocation changed from 1,469,546,792 B/op and 11,452,572
+allocs/op to 1,470,062,104 B/op and 11,450,001 allocs/op. This is within the
+local 2% disabled-path threshold; timing remains observational rather than a
+CI assertion.
+
+Use the same five-sample benchmark convention for comparisons where practical;
+the profile-producing command itself remains a single `-count=1` run so profile
+files are not overwritten. These are developer observations for same-machine
+comparison, not fixed CI thresholds.
 
 ## Verification requirements
 

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -2071,22 +2071,29 @@ func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analys
 func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, file parsedFile, procedures []sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary, filePermitHeld bool) ([]Finding, error) {
 	if len(procedures) == 0 {
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		return a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, map[string]bool{})
+		profile := newProcedureDomainProfile(cancelCtx)
+		findings, err := a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, map[string]bool{}, profile)
+		profile.flush()
+		return findings, err
 	}
 	budget := analysisExecutionBudgetFromContext(cancelCtx)
 	if !filePermitHeld || budget == nil || budget.procedureJobs == nil || budget.limit < 2 || len(procedures) < procedureParallelThreshold {
+		profile := newProcedureDomainProfile(cancelCtx)
 		reportedMissingHelpers := map[string]bool{}
 		var findings []Finding
 		for _, proc := range procedures {
 			if err := cancelCtx.Err(); err != nil {
+				profile.flush()
 				return nil, err
 			}
-			procedureFindings, err := a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers)
+			procedureFindings, err := a.analyzeProcedureContext(cancelCtx, file, proc, moduleDecls, ctx, projectEffects, reportedMissingHelpers, profile)
 			if err != nil {
+				profile.flush()
 				return nil, err
 			}
 			findings = append(findings, procedureFindings...)
 		}
+		profile.flush()
 		return findings, nil
 	}
 
@@ -2133,6 +2140,7 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 			run: func(jobCtx context.Context) ([]Finding, error) {
 				procedureFile := file
 				procedureFile.Root = nil
+				profile := newProcedureDomainProfile(jobCtx)
 				startOnce.Do(func() {
 					if a.procedureAnalysisStartHook != nil {
 						a.procedureAnalysisStartHook()
@@ -2142,12 +2150,14 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 					if err := jobCtx.Err(); err != nil {
 						return nil, err
 					}
-					findings, err := a.analyzeProcedureContext(jobCtx, procedureFile, procedures[index], moduleDecls, ctx, projectEffects, map[string]bool{})
+					findings, err := a.analyzeProcedureContext(jobCtx, procedureFile, procedures[index], moduleDecls, ctx, projectEffects, map[string]bool{}, profile)
 					if err != nil {
+						profile.flush()
 						return nil, err
 					}
 					results[index] = findings
 				}
+				profile.flush()
 				return nil, nil
 			},
 			complete: func(_ []Finding, err error) {
@@ -2192,7 +2202,7 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 	return findings, nil
 }
 
-func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary, reportedMissingHelpers map[string]bool) ([]Finding, error) {
+func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary, reportedMissingHelpers map[string]bool, profile *procedureDomainProfile) ([]Finding, error) {
 	if err := cancelCtx.Err(); err != nil {
 		return nil, err
 	}
@@ -2204,18 +2214,65 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	guardedFinds := map[string]bool{}
 	worksheetRoots := newWorksheetRootTracker(ctx.worksheetCodenames)
 	var findings []Finding
-	findings = append(findings, a.opaqueBooleanArgumentFindings(file, proc, ctx.procedures)...)
-	findings = append(findings, a.deterministicRuntimeErrorFindings(file, proc, ctx, moduleDecls)...)
+	var candidateCounters uint32
+	otherMeasurement := profile.begin(procedureDomainOther)
+	opaqueFindings := a.opaqueBooleanArgumentFindings(file, proc, ctx.procedures)
+	if a.Config.Analyze.DetectOpaqueBooleanArguments {
+		profile.kernel()
+	}
+	otherMeasurement.finish(len(opaqueFindings))
+	findings = append(findings, opaqueFindings...)
+	runtimeMeasurement := profile.begin(procedureDomainRuntime)
+	runtimeFindings := a.deterministicRuntimeErrorFindings(file, proc, ctx, moduleDecls)
+	if enabled, known := config.AnalyzeRuleEnabled(a.Config.Analyze, "VBA249"); known && enabled {
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterRuntimeCandidateProcedures)
+		if proc.Graph != nil {
+			profile.add(analysisstats.CounterRuntimeCFGWalks, 1)
+		}
+	}
+	runtimeMeasurement.finish(len(runtimeFindings))
+	findings = append(findings, runtimeFindings...)
 	if dictionaryCollectionAnalysisEnabled(a.Config.Analyze) {
-		findings = append(findings, a.dictionaryCollectionSafetyFindings(file, proc, moduleDecls)...)
+		dictionaryMeasurement := profile.begin(procedureDomainDictionary)
+		dictionaryFindings := a.dictionaryCollectionSafetyFindings(file, proc, moduleDecls)
+		if proc.Graph != nil {
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterDictionaryCandidateProcedures)
+			profile.add(analysisstats.CounterDictionaryCFGWalks, 1)
+		}
+		dictionaryMeasurement.finish(len(dictionaryFindings))
+		findings = append(findings, dictionaryFindings...)
 	}
 	if a.Config.Analyze.DetectDictionaryIterationValueUsage {
-		findings = append(findings, a.dictionaryIterationValueUsageFindings(file, proc, moduleDecls)...)
+		dictionaryMeasurement := profile.begin(procedureDomainDictionary)
+		dictionaryFindings := a.dictionaryIterationValueUsageFindings(file, proc, moduleDecls)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterDictionaryCandidateProcedures)
+		dictionaryMeasurement.finish(len(dictionaryFindings))
+		findings = append(findings, dictionaryFindings...)
 	}
 
+	sourceMeasurement := profile.begin(procedureDomainSourceScan)
+	sourceFindingStart := len(findings)
+	if profile != nil {
+		start := proc.StartLine - 1
+		if start < 0 {
+			start = 0
+		}
+		end := proc.EndLine
+		if end > len(file.Lines) {
+			end = len(file.Lines)
+		}
+		if end > start {
+			profile.add(analysisstats.CounterSourceLineScans, uint64(end-start))
+			profile.kernel()
+		}
+	}
 	for i := proc.StartLine - 1; i < proc.EndLine && i < len(file.Lines); i++ {
 		if i&0xff == 0 {
 			if err := cancelCtx.Err(); err != nil {
+				sourceMeasurement.finishOutcome(len(findings)-sourceFindingStart, cancelCtx, err)
 				return nil, err
 			}
 		}
@@ -2235,13 +2292,23 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 			continue
 		}
 		if worksheetStatementStart && a.Config.Analyze.ForbidUnqualifiedExcelObjects {
-			findings = append(findings, a.unqualifiedExcelFindings(file, proc, lineNo, normalizedCodeLine(worksheetStmt), shadowedVBA205)...)
+			excelMeasurement := profile.begin(procedureDomainExcel)
+			excelFindings := a.unqualifiedExcelFindings(file, proc, lineNo, normalizedCodeLine(worksheetStmt), shadowedVBA205)
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+			excelMeasurement.finish(len(excelFindings))
+			findings = append(findings, excelFindings...)
 		}
 		if m := withRe.FindStringSubmatch(stmt); len(m) > 0 {
 			withStack = append(withStack, resolveWithInfo(m[1], decls))
 			if worksheetStatementStart {
 				if a.Config.Analyze.DetectWorksheetRootMismatch || a.Config.Analyze.DetectUnstableLastRowPatterns {
-					findings = append(findings, a.worksheetRootFindings(file, proc, lineNo, worksheetStmt, worksheetRoots)...)
+					excelMeasurement := profile.begin(procedureDomainExcel)
+					excelFindings := a.worksheetRootFindings(file, proc, lineNo, worksheetStmt, worksheetRoots)
+					profile.kernel()
+					profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+					excelMeasurement.finish(len(excelFindings))
+					findings = append(findings, excelFindings...)
 				}
 				if rootWith := withRe.FindStringSubmatch(worksheetStmt); len(rootWith) > 0 {
 					worksheetRoots.pushWith(rootWith[1])
@@ -2253,7 +2320,12 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 		}
 		if worksheetStatementStart {
 			if a.Config.Analyze.DetectWorksheetRootMismatch || a.Config.Analyze.DetectUnstableLastRowPatterns {
-				findings = append(findings, a.worksheetRootFindings(file, proc, lineNo, worksheetStmt, worksheetRoots)...)
+				excelMeasurement := profile.begin(procedureDomainExcel)
+				excelFindings := a.worksheetRootFindings(file, proc, lineNo, worksheetStmt, worksheetRoots)
+				profile.kernel()
+				profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+				excelMeasurement.finish(len(excelFindings))
+				findings = append(findings, excelFindings...)
 			}
 			worksheetRoots.observeSetAssignment(worksheetStmt)
 		}
@@ -2268,9 +2340,19 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 			}
 		}
 		if a.Config.Analyze.DetectExcelObjectMemberMismatch {
-			findings = append(findings, a.memberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)...)
+			excelMeasurement := profile.begin(procedureDomainExcel)
+			excelFindings := a.memberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+			excelMeasurement.finish(len(excelFindings))
+			findings = append(findings, excelFindings...)
 		} else {
-			findings = append(findings, a.legacyMemberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)...)
+			excelMeasurement := profile.begin(procedureDomainExcel)
+			excelFindings := a.legacyMemberMismatchFindings(file, proc, lineNo, stmt, decls, withStack)
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+			excelMeasurement.finish(len(excelFindings))
+			findings = append(findings, excelFindings...)
 		}
 		if setAssignRe.MatchString(stmt) {
 			if name, receiver, ok := rangeFindAssignment(stmt, currentWithExpression(withStack)); ok {
@@ -2281,83 +2363,236 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 		if m := assignRe.FindStringSubmatch(stmt); len(m) > 0 {
 			target := strings.ToLower(m[1])
 			if proc.Name != "" && strings.EqualFold(target, proc.Name) && isObjectType(proc.ReturnType) {
-				findings = append(findings, a.objectSetFinding(file, proc, lineNo, "VBA103", m[1], proc.ReturnType))
+				objectMeasurement := profile.begin(procedureDomainObject)
+				objectFinding := a.objectSetFinding(file, proc, lineNo, "VBA103", m[1], proc.ReturnType)
+				profile.kernel()
+				profile.candidate(&candidateCounters, analysisstats.CounterObjectCandidateProcedures)
+				objectMeasurement.finish(1)
+				findings = append(findings, objectFinding)
 				continue
 			}
 			if cm := callAssignRe.FindStringSubmatch(stmt); len(cm) > 0 {
 				callee := strings.ToLower(lastName(cm[2]))
 				if typ, ok := decls.lookup(target); ok && typ.Object && isObjectType(ctx.functionReturns[callee]) {
-					findings = append(findings, a.objectSetFinding(file, proc, lineNo, "VBA102", m[1], ctx.functionReturns[callee]))
+					objectMeasurement := profile.begin(procedureDomainObject)
+					objectFinding := a.objectSetFinding(file, proc, lineNo, "VBA102", m[1], ctx.functionReturns[callee])
+					profile.kernel()
+					profile.candidate(&candidateCounters, analysisstats.CounterObjectCandidateProcedures)
+					objectMeasurement.finish(1)
+					findings = append(findings, objectFinding)
 					continue
 				}
 			}
 			if decl, ok := decls.lookup(target); ok && decl.Object {
-				findings = append(findings, a.objectSetFinding(file, proc, lineNo, "VBA101", m[1], decl.Type))
+				objectMeasurement := profile.begin(procedureDomainObject)
+				objectFinding := a.objectSetFinding(file, proc, lineNo, "VBA101", m[1], decl.Type)
+				profile.kernel()
+				profile.candidate(&candidateCounters, analysisstats.CounterObjectCandidateProcedures)
+				objectMeasurement.finish(1)
+				findings = append(findings, objectFinding)
 			}
 		}
 		if a.Config.Analyze.DetectRangeFindNothingCheck {
-			findings = append(findings, a.rangeFindFindings(file, proc, lineNo, stmt, findAssignments, guardedFinds)...)
+			excelMeasurement := profile.begin(procedureDomainExcel)
+			excelFindings := a.rangeFindFindings(file, proc, lineNo, stmt, findAssignments, guardedFinds)
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+			excelMeasurement.finish(len(excelFindings))
+			findings = append(findings, excelFindings...)
 		}
 		if a.Config.Analyze.DetectObjectArrayComparison && objectNothingEqualityLineIsExecutable(proc, lineNo, stmt) {
-			findings = append(findings, a.objectArrayComparisonFindings(file, proc, lineNo, stmt, decls)...)
+			arrayMeasurement := profile.begin(procedureDomainArray)
+			arrayFindings := a.objectArrayComparisonFindings(file, proc, lineNo, stmt, decls)
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
+			arrayMeasurement.finish(len(arrayFindings))
+			findings = append(findings, arrayFindings...)
 		}
 		_ = lower
 	}
+	sourceMeasurement.finish(len(findings) - sourceFindingStart)
 	if a.Config.Analyze.DetectObjectUseBeforeSet && ctx.objectAnalysis != nil {
 		key := objectSummaryKey(file.IR.Path, objectProcedureQualifiedName(proc), string(proc.ProcedureKind), proc.StartLine)
 		if plan := ctx.objectAnalysis.plans[key]; plan != nil {
-			findings = append(findings, a.objectUseBeforeSetIRFindingsPlan(plan, ctx.objectAnalysis.summaries, ctx.objectAnalysis.entries[key])...)
+			objectMeasurement := profile.begin(procedureDomainObject)
+			objectFindings := a.objectUseBeforeSetIRFindingsPlan(plan, ctx.objectAnalysis.summaries, ctx.objectAnalysis.entries[key])
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterObjectCandidateProcedures)
+			objectMeasurement.finish(len(objectFindings))
+			findings = append(findings, objectFindings...)
 		}
 	}
-	findings = append(findings, a.arrayLifecycleFindings(file, proc, ctx, moduleDecls)...)
+	arrayMeasurement := profile.begin(procedureDomainArray)
+	arrayFindings := a.arrayLifecycleFindings(file, proc, ctx, moduleDecls)
+	if a.Config.Analyze.DetectArrayLifecycleSafety || a.Config.Analyze.DetectRedimPreserveDimension || a.Config.Analyze.DetectObjectArrayComparison {
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
+		if proc.Graph != nil {
+			profile.add(analysisstats.CounterArrayCFGWalks, 1)
+			if a.Config.Analyze.DetectArrayLifecycleSafety {
+				profile.add(analysisstats.CounterArrayCFGWalks, 1)
+			}
+		}
+	}
+	arrayMeasurement.finish(len(arrayFindings))
+	findings = append(findings, arrayFindings...)
 	findings = suppressDeterministicArrayWarningDuplicates(findings)
 	if a.Config.Analyze.DetectRedimPreserveInLoops {
-		findings = append(findings, a.redimPreserveLoopFindings(file, proc, moduleDecls)...)
+		arrayMeasurement := profile.begin(procedureDomainArray)
+		redimFindings := a.redimPreserveLoopFindings(file, proc, moduleDecls)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
+		if proc.Graph != nil {
+			profile.add(analysisstats.CounterArrayCFGWalks, 1)
+		}
+		arrayMeasurement.finish(len(redimFindings))
+		findings = append(findings, redimFindings...)
 	}
 	if a.Config.Analyze.DetectApplicationStateRestore {
-		findings = append(findings, a.applicationStateFindings(file, proc, projectEffects)...)
+		applicationMeasurement := profile.begin(procedureDomainApplicationState)
+		applicationFindings := a.applicationStateFindings(file, proc, projectEffects)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterApplicationStateCandidateProcedures)
+		applicationMeasurement.finish(len(applicationFindings))
+		findings = append(findings, applicationFindings...)
 	}
 	if a.Config.Analyze.DetectApplicationStateCallEffects {
-		findings = append(findings, a.applicationStateCallEffectFindings(file, proc, projectEffects)...)
+		applicationMeasurement := profile.begin(procedureDomainApplicationState)
+		applicationFindings := a.applicationStateCallEffectFindings(file, proc, projectEffects)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterApplicationStateCandidateProcedures)
+		applicationMeasurement.finish(len(applicationFindings))
+		findings = append(findings, applicationFindings...)
 	}
 	if a.Config.Analyze.DetectEventHandlerReentry {
-		findings = append(findings, a.eventHandlerReentryFindings(file, proc, projectEffects)...)
+		applicationMeasurement := profile.begin(procedureDomainApplicationState)
+		eventFindings := a.eventHandlerReentryFindings(file, proc, projectEffects)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterApplicationStateCandidateProcedures)
+		applicationMeasurement.finish(len(eventFindings))
+		findings = append(findings, eventFindings...)
 	}
+	dataflowMeasurement := profile.begin(procedureDomainDataflow)
 	dataFlowFindings, httpFindings, err := a.httpDataFlowFindingsContext(cancelCtx, file, proc)
+	if (a.Config.Analyze.DetectUntrustedDataFlow || a.Config.Analyze.DetectUnsafeCommandConstruction || a.Config.Analyze.DetectUnsafeSQLConstruction) && proc.Graph != nil {
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterDataflowCandidateProcedures)
+		profile.add(analysisstats.CounterDataflowCFGWalks, 1)
+	}
+	dataflowMeasurement.finishOutcome(len(dataFlowFindings)+len(httpFindings), cancelCtx, err)
 	if err != nil {
 		return nil, err
 	}
 	findings = append(findings, suppressHTTPDataFlowDuplicates(dataFlowFindings, httpFindings)...)
-	findings = append(findings, a.filePathSafetyFindings(file, proc)...)
+	if a.Config.Analyze.DetectUnsafeFilePath {
+		dataflowMeasurement := profile.begin(procedureDomainDataflow)
+		filePathFindings := a.filePathSafetyFindings(file, proc)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterDataflowCandidateProcedures)
+		dataflowMeasurement.finish(len(filePathFindings))
+		findings = append(findings, filePathFindings...)
+	}
 	findings = append(findings, httpFindings...)
 	if a.Config.Analyze.DetectResourceLeaks {
-		findings = append(findings, a.resourceLeakFindings(file, proc)...)
+		resourceMeasurement := profile.begin(procedureDomainResource)
+		resourceFindings := a.resourceLeakFindings(file, proc)
+		if proc.Graph != nil {
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterResourceCandidateProcedures)
+			profile.add(analysisstats.CounterResourceCFGWalks, 1)
+		}
+		resourceMeasurement.finish(len(resourceFindings))
+		findings = append(findings, resourceFindings...)
 	}
 	if a.Config.Analyze.DetectExcelCellAccessInLoops {
-		findings = append(findings, a.excelLoopAccessFindings(file, proc)...)
+		excelMeasurement := profile.begin(procedureDomainExcel)
+		excelFindings := a.excelLoopAccessFindings(file, proc)
+		if a.typeDB != nil && proc.Graph != nil {
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+			profile.add(analysisstats.CounterExcelCFGWalks, 1)
+		}
+		excelMeasurement.finish(len(excelFindings))
+		findings = append(findings, excelFindings...)
 	}
 	if a.Config.Analyze.DetectLoopInvariantExcelObjectResolution {
-		findings = append(findings, a.excelLoopInvariantFindings(file, proc)...)
+		excelMeasurement := profile.begin(procedureDomainExcel)
+		excelFindings := a.excelLoopInvariantFindings(file, proc)
+		if a.typeDB != nil && proc.Graph != nil {
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+			profile.add(analysisstats.CounterExcelCFGWalks, 1)
+		}
+		excelMeasurement.finish(len(excelFindings))
+		findings = append(findings, excelFindings...)
 	}
 	if a.Config.Analyze.DetectExpensiveFullRangeOperations {
-		findings = append(findings, a.expensiveFullRangeOperationFindings(file, proc)...)
+		excelMeasurement := profile.begin(procedureDomainExcel)
+		excelFindings := a.expensiveFullRangeOperationFindings(file, proc)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+		excelMeasurement.finish(len(excelFindings))
+		findings = append(findings, excelFindings...)
 	}
 	if a.Config.Analyze.DetectValue2PerformanceOpportunities {
-		findings = append(findings, a.value2PerformanceFindings(file, proc)...)
+		excelMeasurement := profile.begin(procedureDomainExcel)
+		excelFindings := a.value2PerformanceFindings(file, proc)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterExcelCandidateProcedures)
+		excelMeasurement.finish(len(excelFindings))
+		findings = append(findings, excelFindings...)
 	}
 	if a.Config.Analyze.DetectErrorHandlerFallthrough {
-		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc)...)
+		errorMeasurement := profile.begin(procedureDomainError)
+		errorFindings := a.errorHandlerFallthroughFindings(file, proc)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterErrorCandidateProcedures)
+		if proc.Graph != nil {
+			profile.add(analysisstats.CounterErrorCFGWalks, 1)
+		}
+		errorMeasurement.finish(len(errorFindings))
+		findings = append(findings, errorFindings...)
 	}
 	if a.Config.Analyze.DetectLeakedOnErrorResumeNextScopes {
-		findings = append(findings, a.leakedOnErrorResumeNextFindings(file, proc)...)
+		errorMeasurement := profile.begin(procedureDomainError)
+		errorFindings := a.leakedOnErrorResumeNextFindings(file, proc)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterErrorCandidateProcedures)
+		if proc.Graph != nil {
+			profile.add(analysisstats.CounterErrorCFGWalks, 1)
+		}
+		errorMeasurement.finish(len(errorFindings))
+		findings = append(findings, errorFindings...)
 	}
 	if a.Config.Analyze.DetectErrorSuppressionPropagation {
-		findings = append(findings, a.errorSuppressionFindings(file, proc, projectEffects)...)
+		errorMeasurement := profile.begin(procedureDomainError)
+		errorFindings := a.errorSuppressionFindings(file, proc, projectEffects)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterErrorCandidateProcedures)
+		if proc.Graph != nil {
+			profile.add(analysisstats.CounterErrorCFGWalks, 1)
+		}
+		errorMeasurement.finish(len(errorFindings))
+		findings = append(findings, errorFindings...)
 	}
 	if a.Config.Analyze.DetectRangeValueArrayShape {
-		findings = append(findings, a.rangeValueShapeFindings(file, proc)...)
+		arrayMeasurement := profile.begin(procedureDomainArray)
+		arrayFindings := a.rangeValueShapeFindings(file, proc)
+		profile.kernel()
+		profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
+		if proc.Graph != nil {
+			profile.add(analysisstats.CounterArrayCFGWalks, 1)
+		}
+		arrayMeasurement.finish(len(arrayFindings))
+		findings = append(findings, arrayFindings...)
 	}
-	findings = append(findings, a.functionReturnPathFindings(file, proc)...)
+	otherMeasurement = profile.begin(procedureDomainOther)
+	functionFindings := a.functionReturnPathFindings(file, proc)
+	if a.Config.Analyze.DetectFunctionReturnPath {
+		profile.kernel()
+	}
+	otherMeasurement.finish(len(functionFindings))
+	findings = append(findings, functionFindings...)
 	findings = suppressDictionaryGuardsForUninitializedObjects(findings)
 	return findings, cancelCtx.Err()
 }

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -2148,6 +2148,7 @@ func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, fil
 				})
 				for index := batchStart; index < batchEnd; index++ {
 					if err := jobCtx.Err(); err != nil {
+						profile.flush()
 						return nil, err
 					}
 					findings, err := a.analyzeProcedureContext(jobCtx, procedureFile, procedures[index], moduleDecls, ctx, projectEffects, map[string]bool{}, profile)
@@ -2272,7 +2273,7 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	for i := proc.StartLine - 1; i < proc.EndLine && i < len(file.Lines); i++ {
 		if i&0xff == 0 {
 			if err := cancelCtx.Err(); err != nil {
-				sourceMeasurement.finishOutcome(len(findings)-sourceFindingStart, cancelCtx, err)
+				sourceMeasurement.finishOutcome(cancelCtx, len(findings)-sourceFindingStart, err)
 				return nil, err
 			}
 		}
@@ -2282,8 +2283,6 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 		if stmt == "" {
 			continue
 		}
-		lower := strings.ToLower(stmt)
-
 		if endWithRe.MatchString(stmt) {
 			if len(withStack) > 0 {
 				withStack = withStack[:len(withStack)-1]
@@ -2408,7 +2407,6 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 			arrayMeasurement.finish(len(arrayFindings))
 			findings = append(findings, arrayFindings...)
 		}
-		_ = lower
 	}
 	sourceMeasurement.finish(len(findings) - sourceFindingStart)
 	if a.Config.Analyze.DetectObjectUseBeforeSet && ctx.objectAnalysis != nil {
@@ -2479,7 +2477,7 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 		profile.candidate(&candidateCounters, analysisstats.CounterDataflowCandidateProcedures)
 		profile.add(analysisstats.CounterDataflowCFGWalks, 1)
 	}
-	dataflowMeasurement.finishOutcome(len(dataFlowFindings)+len(httpFindings), cancelCtx, err)
+	dataflowMeasurement.finishOutcome(cancelCtx, len(dataFlowFindings)+len(httpFindings), err)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -2472,7 +2472,7 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	}
 	dataflowMeasurement := profile.begin(procedureDomainDataflow)
 	dataFlowFindings, httpFindings, err := a.httpDataFlowFindingsContext(cancelCtx, file, proc)
-	if (a.Config.Analyze.DetectUntrustedDataFlow || a.Config.Analyze.DetectUnsafeCommandConstruction || a.Config.Analyze.DetectUnsafeSQLConstruction) && proc.Graph != nil {
+	if (a.Config.Analyze.DetectUntrustedDataFlow || a.Config.Analyze.DetectUnsafeCommandConstruction || a.Config.Analyze.DetectUnsafeSQLConstruction || a.Config.Analyze.DetectUnsafeHTTPConfiguration || a.Config.Analyze.DetectMissingHTTPTimeout) && proc.Graph != nil {
 		profile.kernel()
 		profile.candidate(&candidateCounters, analysisstats.CounterDataflowCandidateProcedures)
 		profile.add(analysisstats.CounterDataflowCFGWalks, 1)

--- a/internal/analyze/benchmark_test.go
+++ b/internal/analyze/benchmark_test.go
@@ -21,7 +21,7 @@ import (
 // procedures grows. The source is generated before the timer starts so these
 // measurements describe analysis work rather than fixture construction.
 func BenchmarkSyntheticProject(b *testing.B) {
-	for _, procedureCount := range []int{100, 500, 1000} {
+	for _, procedureCount := range []int{100, 500, 1000, 2000} {
 		procedureCount := procedureCount
 		b.Run(fmt.Sprintf("%d-procedures", procedureCount), func(b *testing.B) {
 			root := b.TempDir()
@@ -285,6 +285,32 @@ func TestSingleModuleBenchmarkFixtureScale(t *testing.T) {
 			}
 			if fixture.calls != workload.expectedCalls() {
 				t.Fatalf("single-module %s calls = %d, want %d", workload.benchmarkName(), fixture.calls, workload.expectedCalls())
+			}
+		})
+	}
+}
+
+// TestCanonicalLargeModuleBenchmarkFixtures keeps the four workload shapes
+// used for rule-domain comparisons explicit. These fixtures are materialized
+// and parsed here, but analyzer execution remains benchmark-only so ordinary
+// test runs do not spend minutes on 2,000-procedure analysis.
+func TestCanonicalLargeModuleBenchmarkFixtures(t *testing.T) {
+	for _, shape := range []string{"independent", "declarations", "chain", "cfg-independent"} {
+		shape := shape
+		t.Run(shape, func(t *testing.T) {
+			workload := singleModuleBenchmarkWorkload{shape: shape, size: 2000}
+			fixture := writeSingleModuleBenchmarkProject(t, t.TempDir(), workload)
+			if fixture.moduleCount != 1 || fixture.sourcePath == "" || fixture.lines == 0 {
+				t.Fatalf("large-module %s fixture metadata = %+v", shape, fixture)
+			}
+			if fixture.procedures != workload.expectedProcedures() {
+				t.Fatalf("large-module %s procedures = %d, want %d", shape, fixture.procedures, workload.expectedProcedures())
+			}
+			if fixture.moduleDeclarations != workload.expectedModuleDeclarations() {
+				t.Fatalf("large-module %s declarations = %d, want %d", shape, fixture.moduleDeclarations, workload.expectedModuleDeclarations())
+			}
+			if fixture.calls != workload.expectedCalls() {
+				t.Fatalf("large-module %s calls = %d, want %d", shape, fixture.calls, workload.expectedCalls())
 			}
 		})
 	}
@@ -619,18 +645,35 @@ func reportAnalysisRecorderMetrics(b *testing.B, recorder *analysisstats.Recorde
 	}
 	stages, counters := recorder.Totals()
 	for _, stage := range stages {
-		metricName := "stage_" + strings.ReplaceAll(stage.Name, "-", "_")
+		// Domain stages contain a slash (for example,
+		// procedure_local/source_scan). Normalize it before passing the name to
+		// testing.B so each domain remains one stable benchmark metric rather
+		// than being interpreted as a benchmark sub-name.
+		metricName := "stage_" + normalizeAnalysisBenchmarkMetricName(stage.Name)
 		b.ReportMetric(float64(stage.Elapsed.Nanoseconds())/float64(iterations), metricName+"-ns/op")
 		b.ReportMetric(float64(stage.Calls)/float64(iterations), metricName+"-calls/op")
 		b.ReportMetric(float64(stage.ResultCount)/float64(iterations), metricName+"-results/op")
 	}
 	for _, counter := range counters {
-		metricName := "counter_" + strings.ReplaceAll(counter.Name, "-", "_")
+		metricName := "counter_" + normalizeAnalysisBenchmarkMetricName(counter.Name)
 		if strings.HasPrefix(counter.Name, "max_") {
 			b.ReportMetric(float64(counter.Value), metricName)
 			continue
 		}
 		metricValue := float64(counter.Value) / float64(iterations)
 		b.ReportMetric(metricValue, metricName+"/op")
+	}
+}
+
+func normalizeAnalysisBenchmarkMetricName(name string) string {
+	return strings.NewReplacer("-", "_", "/", "_").Replace(name)
+}
+
+func TestBenchmarkMetricNameNormalizesDomainSlash(t *testing.T) {
+	if got := normalizeAnalysisBenchmarkMetricName("procedure_local/source_scan"); got != "procedure_local_source_scan" {
+		t.Fatalf("normalized domain metric = %q, want %q", got, "procedure_local_source_scan")
+	}
+	if got := normalizeAnalysisBenchmarkMetricName("runtime-cfg/walks"); got != "runtime_cfg_walks" {
+		t.Fatalf("normalized compound metric = %q, want %q", got, "runtime_cfg_walks")
 	}
 }

--- a/internal/analyze/procedure_profile.go
+++ b/internal/analyze/procedure_profile.go
@@ -51,10 +51,13 @@ func (p *procedureDomainProfile) begin(domain procedureDomain) procedureDomainMe
 }
 
 func (m procedureDomainMeasurement) finish(resultCount int) {
-	m.finishOutcome(resultCount, nil, nil)
+	if m.owner == nil {
+		return
+	}
+	m.measurement.FinishOutcome(resultCount, "ok")
 }
 
-func (m procedureDomainMeasurement) finishOutcome(resultCount int, ctx context.Context, err error) {
+func (m procedureDomainMeasurement) finishOutcome(ctx context.Context, resultCount int, err error) {
 	if m.owner == nil {
 		return
 	}
@@ -86,6 +89,13 @@ func (p *procedureDomainProfile) candidate(seen *uint32, counter analysisstats.W
 	*seen |= uint32(1) << bit
 	p.aggregate.AddCounter(counter, 1)
 }
+
+// Keep the per-procedure candidate bitset wide enough for every current
+// workload counter. If a future counter grows past the bitset limit, this
+// package must widen the mask before candidate attribution can silently drop.
+const procedureCandidateBitLimit = 32
+
+var _ [procedureCandidateBitLimit - analysisstats.WorkCounterCount]struct{}
 
 func (p *procedureDomainProfile) kernel() {
 	p.add(analysisstats.CounterSemanticKernelRuns, 1)

--- a/internal/analyze/procedure_profile.go
+++ b/internal/analyze/procedure_profile.go
@@ -1,0 +1,99 @@
+package analyze
+
+import (
+	"context"
+
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+)
+
+type procedureDomain = analysisstats.Domain
+
+const (
+	procedureDomainSourceScan       = analysisstats.DomainSourceScan
+	procedureDomainRuntime          = analysisstats.DomainRuntime
+	procedureDomainArray            = analysisstats.DomainArray
+	procedureDomainObject           = analysisstats.DomainObject
+	procedureDomainDictionary       = analysisstats.DomainDictionary
+	procedureDomainError            = analysisstats.DomainError
+	procedureDomainDataflow         = analysisstats.DomainDataflow
+	procedureDomainResource         = analysisstats.DomainResource
+	procedureDomainExcel            = analysisstats.DomainExcel
+	procedureDomainApplicationState = analysisstats.DomainApplicationState
+	procedureDomainOther            = analysisstats.DomainOther
+)
+
+// procedureDomainProfile is owned by one serial file analysis or one
+// procedure batch. It never crosses worker boundaries. This keeps the hot
+// procedure loop free from Recorder locks and makes the default (no recorder)
+// path a nil fast path.
+type procedureDomainProfile struct {
+	aggregate *analysisstats.DomainAggregate
+}
+
+func newProcedureDomainProfile(ctx context.Context) *procedureDomainProfile {
+	recorder := analysisstats.FromContext(ctx)
+	if recorder == nil {
+		return nil
+	}
+	return &procedureDomainProfile{aggregate: analysisstats.NewAggregate(recorder)}
+}
+
+type procedureDomainMeasurement struct {
+	owner       *procedureDomainProfile
+	measurement analysisstats.Measurement
+}
+
+func (p *procedureDomainProfile) begin(domain procedureDomain) procedureDomainMeasurement {
+	if p == nil {
+		return procedureDomainMeasurement{}
+	}
+	return procedureDomainMeasurement{owner: p, measurement: p.aggregate.Start(domain)}
+}
+
+func (m procedureDomainMeasurement) finish(resultCount int) {
+	m.finishOutcome(resultCount, nil, nil)
+}
+
+func (m procedureDomainMeasurement) finishOutcome(resultCount int, ctx context.Context, err error) {
+	if m.owner == nil {
+		return
+	}
+	outcome := "ok"
+	if err != nil {
+		outcome = "error"
+	}
+	if ctx != nil && ctx.Err() != nil {
+		outcome = "canceled"
+	}
+	m.measurement.FinishOutcome(resultCount, outcome)
+}
+
+func (p *procedureDomainProfile) add(counter analysisstats.WorkCounter, value uint64) {
+	if p == nil {
+		return
+	}
+	p.aggregate.AddCounter(counter, value)
+}
+
+func (p *procedureDomainProfile) candidate(seen *uint32, counter analysisstats.WorkCounter) {
+	if p == nil || seen == nil {
+		return
+	}
+	bit := uint(counter)
+	if bit >= 32 || *seen&(uint32(1)<<bit) != 0 {
+		return
+	}
+	*seen |= uint32(1) << bit
+	p.aggregate.AddCounter(counter, 1)
+}
+
+func (p *procedureDomainProfile) kernel() {
+	p.add(analysisstats.CounterSemanticKernelRuns, 1)
+}
+
+func (p *procedureDomainProfile) flush() {
+	if p == nil || p.aggregate == nil {
+		return
+	}
+	p.aggregate.Merge()
+}

--- a/internal/analyze/profiling_test.go
+++ b/internal/analyze/profiling_test.go
@@ -5,12 +5,51 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/typedb"
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 )
+
+// procedureLocalProfileDomains is the stable, aggregate-only profiling
+// surface for the procedure-local analyzer. Keep this list in the test so a
+// newly added domain cannot silently disappear from the developer profile.
+var procedureLocalProfileDomains = []string{
+	analysisstats.ProcedureLocalSourceScan,
+	analysisstats.ProcedureLocalRuntime,
+	analysisstats.ProcedureLocalArray,
+	analysisstats.ProcedureLocalObject,
+	analysisstats.ProcedureLocalDictionary,
+	analysisstats.ProcedureLocalError,
+	analysisstats.ProcedureLocalDataflow,
+	analysisstats.ProcedureLocalResource,
+	analysisstats.ProcedureLocalExcel,
+	analysisstats.ProcedureLocalApplicationState,
+	analysisstats.ProcedureLocalOther,
+}
+
+var procedureLocalProfileCounters = []string{
+	analysisstats.RuntimeCandidateProceduresCounter,
+	analysisstats.ArrayCandidateProceduresCounter,
+	analysisstats.ObjectCandidateProceduresCounter,
+	analysisstats.DictionaryCandidateProceduresCounter,
+	analysisstats.ErrorCandidateProceduresCounter,
+	analysisstats.DataflowCandidateProceduresCounter,
+	analysisstats.ResourceCandidateProceduresCounter,
+	analysisstats.ExcelCandidateProceduresCounter,
+	analysisstats.ApplicationStateCandidateProceduresCounter,
+	analysisstats.ArrayCFGWalksCounter,
+	analysisstats.DataflowCFGWalksCounter,
+	analysisstats.DictionaryCFGWalksCounter,
+	analysisstats.ErrorCFGWalksCounter,
+	analysisstats.ResourceCFGWalksCounter,
+	analysisstats.ExcelCFGWalksCounter,
+	analysisstats.RuntimeCFGWalksCounter,
+	analysisstats.SourceLineScansCounter,
+	analysisstats.SemanticKernelRunsCounter,
+}
 
 func TestPhysicalSourceLineCount(t *testing.T) {
 	for _, test := range []struct {
@@ -78,6 +117,31 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 			t.Fatalf("stage %q = %+v", name, stage)
 		}
 	}
+	validDomains := make(map[string]bool, len(procedureLocalProfileDomains))
+	for _, name := range procedureLocalProfileDomains {
+		validDomains[name] = true
+	}
+	for _, stage := range stages {
+		if !strings.HasPrefix(stage.Name, "procedure_local/") {
+			continue
+		}
+		if !validDomains[stage.Name] {
+			t.Fatalf("unknown procedure-local domain stage %q", stage.Name)
+		}
+		if stage.Calls < 1 || stage.Outcome != "ok" {
+			t.Fatalf("procedure-local domain stage %q = %+v", stage.Name, stage)
+		}
+	}
+	for _, name := range []string{
+		analysisstats.ProcedureLocalSourceScan,
+		analysisstats.ProcedureLocalRuntime,
+		analysisstats.ProcedureLocalDictionary,
+		analysisstats.ProcedureLocalOther,
+	} {
+		if _, ok := stageByName[name]; !ok {
+			t.Fatalf("missing representative procedure-local domain stage %q: %+v", name, stages)
+		}
+	}
 	counterByName := make(map[string]uint64, len(counters))
 	for _, counter := range counters {
 		counterByName[counter.Name] = counter.Value
@@ -93,6 +157,25 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 		if _, ok := counterByName[name]; !ok {
 			t.Fatalf("missing counter %q: %+v", name, counters)
 		}
+	}
+	validCounters := make(map[string]bool, len(procedureLocalProfileCounters))
+	for _, name := range procedureLocalProfileCounters {
+		validCounters[name] = true
+	}
+	for name := range counterByName {
+		if validCounters[name] {
+			continue
+		}
+		looksLikeProcedureLocalCounter := strings.HasSuffix(name, "_candidate_procedures") ||
+			strings.HasSuffix(name, "_cfg_walks") ||
+			name == analysisstats.SourceLineScansCounter ||
+			name == analysisstats.SemanticKernelRunsCounter
+		if looksLikeProcedureLocalCounter {
+			t.Fatalf("unknown procedure-local work counter %q", name)
+		}
+	}
+	if counterByName[analysisstats.SourceLineScansCounter] == 0 || counterByName[analysisstats.SemanticKernelRunsCounter] == 0 {
+		t.Fatalf("procedure-local traversal counters = %+v", counters)
 	}
 	if counterByName["file_count"] != 1 || counterByName["procedure_count"] != 1 {
 		t.Fatalf("workload counters = %+v", counters)
@@ -156,10 +239,36 @@ func TestBatchAnalysisSkipsVBA202ContextWhenDisabled(t *testing.T) {
 	for _, counter := range counters {
 		counterByName[counter.Name] = counter.Value
 	}
-	for _, name := range []string{"object_summary_evaluations", "object_entry_flow_evaluations"} {
+	for _, name := range []string{
+		"object_summary_evaluations", "object_entry_flow_evaluations",
+	} {
 		value, ok := counterByName[name]
-		if !ok || value != 0 {
+		if ok && value != 0 {
 			t.Fatalf("disabled VBA202 counter %q = %d (present=%t), want zero", name, value, ok)
+		}
+	}
+}
+
+func TestBatchAnalysisDoesNotCountDisabledRuntimeCandidates(t *testing.T) {
+	root := t.TempDir()
+	modules := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(modules, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modules, "Main.bas"), []byte("Option Explicit\nPublic Sub Run()\n  Debug.Print 1 / 0\nEnd Sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
+	cfg := config.Default()
+	cfg.Analyze.DetectDeterministicRuntimeErrors = false
+	recorder := analysisstats.NewRecorder()
+	if _, err := (Analyzer{RootDir: root, Config: cfg}).RunResultContext(analysisstats.WithRecorder(context.Background(), recorder)); err != nil {
+		t.Fatal(err)
+	}
+	_, counters := recorder.Totals()
+	for _, counter := range counters {
+		if counter.Name == analysisstats.RuntimeCandidateProceduresCounter || counter.Name == analysisstats.RuntimeCFGWalksCounter {
+			t.Fatalf("disabled runtime counter %q = %d, want absent", counter.Name, counter.Value)
 		}
 	}
 }

--- a/internal/analyze/profiling_test.go
+++ b/internal/analyze/profiling_test.go
@@ -273,6 +273,50 @@ func TestBatchAnalysisDoesNotCountDisabledRuntimeCandidates(t *testing.T) {
 	}
 }
 
+func TestBatchAnalysisProfilesHTTPOnlyDataflowWork(t *testing.T) {
+	root := t.TempDir()
+	modules := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(modules, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := "Option Explicit\nPublic Sub Run()\n  Dim request As Object\n  Set request = CreateObject(\"MSXML2.XMLHTTP\")\n  request.Open \"GET\", \"http://example.test\", False\n  request.Send\nEnd Sub\n"
+	if err := os.WriteFile(filepath.Join(modules, "Main.bas"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
+	cfg := config.Default()
+	cfg.Analyze.DetectUntrustedDataFlow = false
+	cfg.Analyze.DetectUnsafeCommandConstruction = false
+	cfg.Analyze.DetectUnsafeSQLConstruction = false
+	cfg.Analyze.DetectUnsafeHTTPConfiguration = true
+	cfg.Analyze.DetectMissingHTTPTimeout = true
+	recorder := analysisstats.NewRecorder()
+	if _, err := (Analyzer{RootDir: root, Config: cfg}).RunResultContext(analysisstats.WithRecorder(context.Background(), recorder)); err != nil {
+		t.Fatal(err)
+	}
+	stages, counters := recorder.Totals()
+	stageByName := make(map[string]analysisstats.Stage, len(stages))
+	for _, stage := range stages {
+		stageByName[stage.Name] = stage
+	}
+	if stageByName[analysisstats.ProcedureLocalDataflow].Calls == 0 {
+		t.Fatalf("HTTP-only dataflow stage missing: %+v", stages)
+	}
+	counterByName := make(map[string]uint64, len(counters))
+	for _, counter := range counters {
+		counterByName[counter.Name] = counter.Value
+	}
+	for _, name := range []string{
+		analysisstats.DataflowCandidateProceduresCounter,
+		analysisstats.DataflowCFGWalksCounter,
+		analysisstats.SemanticKernelRunsCounter,
+	} {
+		if counterByName[name] == 0 {
+			t.Fatalf("HTTP-only dataflow counter %q = %d; counters = %+v", name, counterByName[name], counters)
+		}
+	}
+}
+
 func TestVBA202WorklistEvaluationCountScalesWithDependencyChain(t *testing.T) {
 	const procedureCount = 40
 	root := t.TempDir()

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -760,11 +760,18 @@ func TestAnalyzePerformanceLogFlagIsOptInAndPreservesJSON(t *testing.T) {
 		`stage="typed_excel_diagnostics"`, `stage="byref_diagnostics"`,
 		`stage="compile_equivalent_diagnostics"`,
 		`stage="suppression_and_finalize"`, `stage="analyze_total"`,
+		`stage="procedure_local/source_scan"`, `stage="procedure_local/runtime"`,
+		`stage="procedure_local/dictionary"`, `stage="procedure_local/excel"`,
+		`stage="procedure_local/other"`,
 		`operation="analyze/counter"`, `counter="file_count"`, `counter="line_count"`,
 		`counter="module_declaration_count"`, `counter="procedure_count"`,
 		`counter="max_lines_per_file"`, `counter="max_procedures_per_file"`,
 		`counter="max_calls_per_file"`, `counter="max_statements_per_procedure"`,
 		`counter="max_cfg_blocks_per_procedure"`, `counter="max_cfg_edges_per_procedure"`,
+		`counter="runtime_candidate_procedures"`,
+		`counter="dictionary_candidate_procedures"`,
+		`counter="dictionary_cfg_walks"`, `counter="runtime_cfg_walks"`,
+		`counter="source_line_scans"`, `counter="semantic_kernel_runs"`,
 	} {
 		if !strings.Contains(profiledStderr, expected) {
 			t.Fatalf("performance output missing %q:\n%s", expected, profiledStderr)
@@ -776,6 +783,8 @@ func TestWriteAnalyzePerformanceReportsWorkloadCounters(t *testing.T) {
 	recorder := analysisstats.NewRecorder()
 	recorder.Record(analysisstats.Stage{Name: "procedure_local_diagnostics", Elapsed: time.Millisecond, Outcome: "ok", ResultCount: 2})
 	recorder.Record(analysisstats.Stage{Name: "procedure_local_diagnostics", Elapsed: 2 * time.Millisecond, Outcome: "error", ResultCount: 3})
+	recorder.Record(analysisstats.Stage{Name: "procedure_local/source_scan", Elapsed: time.Millisecond, Outcome: "ok", ResultCount: 0})
+	recorder.Record(analysisstats.Stage{Name: "procedure_local/runtime", Elapsed: 2 * time.Millisecond, Outcome: "ok", ResultCount: 1})
 	recorder.Record(analysisstats.Stage{Name: "suppression_and_finalize", Elapsed: time.Millisecond, Outcome: "ok", ResultCount: 1})
 	for _, name := range []string{
 		"file_count", "procedure_count", "statement_count", "expression_count",
@@ -789,18 +798,42 @@ func TestWriteAnalyzePerformanceReportsWorkloadCounters(t *testing.T) {
 	} {
 		recorder.AddMax(name, 1)
 	}
+	for _, name := range []string{
+		"runtime_candidate_procedures", "array_candidate_procedures",
+		"object_candidate_procedures", "dictionary_candidate_procedures",
+		"error_candidate_procedures", "dataflow_candidate_procedures",
+		"resource_candidate_procedures", "excel_candidate_procedures",
+		"application_state_candidate_procedures", "array_cfg_walks",
+		"dataflow_cfg_walks", "dictionary_cfg_walks", "error_cfg_walks",
+		"resource_cfg_walks", "excel_cfg_walks", "runtime_cfg_walks",
+		"source_line_scans", "semantic_kernel_runs",
+	} {
+		recorder.AddSum(name, 1)
+	}
 
 	var stderr bytes.Buffer
 	writeAnalyzePerformance(&stderr, recorder)
 	output := stderr.String()
 	for _, expected := range []string{
 		`stage="procedure_local_diagnostics" elapsed_ms=3.000`,
+		`stage="procedure_local/source_scan"`,
+		`stage="procedure_local/runtime"`,
 		`calls=2 result_count=5 outcome="error"`,
 		`stage="suppression_and_finalize"`,
 		`counter="file_count"`, `counter="procedure_count"`,
 		`counter="max_lines_per_file"`, `counter="max_procedures_per_file"`,
 		`counter="max_calls_per_file"`, `counter="max_statements_per_procedure"`,
 		`counter="max_cfg_blocks_per_procedure"`, `counter="max_cfg_edges_per_procedure"`,
+		`counter="runtime_candidate_procedures"`, `counter="array_candidate_procedures"`,
+		`counter="object_candidate_procedures"`, `counter="dictionary_candidate_procedures"`,
+		`counter="error_candidate_procedures"`, `counter="dataflow_candidate_procedures"`,
+		`counter="resource_candidate_procedures"`, `counter="excel_candidate_procedures"`,
+		`counter="application_state_candidate_procedures"`,
+		`counter="array_cfg_walks"`, `counter="dataflow_cfg_walks"`,
+		`counter="dictionary_cfg_walks"`, `counter="error_cfg_walks"`,
+		`counter="resource_cfg_walks"`, `counter="excel_cfg_walks"`,
+		`counter="runtime_cfg_walks"`, `counter="source_line_scans"`,
+		`counter="semantic_kernel_runs"`,
 	} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("performance output missing %q:\n%s", expected, output)

--- a/internal/staticanalysis/corpus/benchmark_test.go
+++ b/internal/staticanalysis/corpus/benchmark_test.go
@@ -120,17 +120,30 @@ func reportCorpusAnalysisRecorderMetrics(b *testing.B, recorder *analysisstats.R
 	}
 	stages, counters := recorder.Totals()
 	for _, stage := range stages {
-		metricName := "stage_" + strings.ReplaceAll(stage.Name, "-", "_")
+		// Domain stages use slash-qualified names. Normalize the slash before
+		// emitting benchmark metrics so each stage is reported as one stable
+		// metric name (the /op suffix below remains the standard unit suffix).
+		metricName := "stage_" + normalizeCorpusBenchmarkMetricName(stage.Name)
 		b.ReportMetric(float64(stage.Elapsed.Nanoseconds())/float64(iterations), metricName+"-ns/op")
 		b.ReportMetric(float64(stage.Calls)/float64(iterations), metricName+"-calls/op")
 		b.ReportMetric(float64(stage.ResultCount)/float64(iterations), metricName+"-results/op")
 	}
 	for _, counter := range counters {
-		metricName := "counter_" + strings.ReplaceAll(counter.Name, "-", "_")
+		metricName := "counter_" + normalizeCorpusBenchmarkMetricName(counter.Name)
 		if strings.HasPrefix(counter.Name, "max_") {
 			b.ReportMetric(float64(counter.Value), metricName)
 			continue
 		}
 		b.ReportMetric(float64(counter.Value)/float64(iterations), metricName+"/op")
+	}
+}
+
+func normalizeCorpusBenchmarkMetricName(name string) string {
+	return strings.NewReplacer("-", "_", "/", "_").Replace(name)
+}
+
+func TestCorpusBenchmarkMetricNameNormalizesDomainSlash(t *testing.T) {
+	if got := normalizeCorpusBenchmarkMetricName("procedure_local/source_scan"); got != "procedure_local_source_scan" {
+		t.Fatalf("normalized domain metric = %q, want %q", got, "procedure_local_source_scan")
 	}
 }

--- a/internal/vba/analysisstats/recorder.go
+++ b/internal/vba/analysisstats/recorder.go
@@ -68,6 +68,13 @@ var domainNames = [...]string{
 	ProcedureLocalOther,
 }
 
+// These paired array declarations fail compilation if a domain is added
+// without adding its canonical output name (or vice versa).
+var (
+	_ [len(domainNames) - domainCount]struct{}
+	_ [domainCount - len(domainNames)]struct{}
+)
+
 // String returns the stable stage name used by performance-log output.
 func (d Domain) String() string {
 	if int(d) >= 0 && int(d) < len(domainNames) {
@@ -103,6 +110,11 @@ const (
 )
 
 const counterCount = int(CounterSemanticKernelRuns) + 1
+
+// WorkCounterCount is the fixed number of counter slots used by
+// DomainAggregate. It is exposed for compile-time guards in lightweight
+// callers that use a bitset for per-procedure de-duplication.
+const WorkCounterCount = counterCount
 
 const (
 	RuntimeCandidateProceduresCounter          = "runtime_candidate_procedures"
@@ -145,6 +157,13 @@ var counterNames = [...]string{
 	ExcelCFGWalksCounter,
 	SemanticKernelRunsCounter,
 }
+
+// These paired array declarations fail compilation if a counter is added
+// without adding its canonical output name (or vice versa).
+var (
+	_ [len(counterNames) - counterCount]struct{}
+	_ [counterCount - len(counterNames)]struct{}
+)
 
 // String returns the stable counter name used by performance-log output.
 func (c WorkCounter) String() string {

--- a/internal/vba/analysisstats/recorder.go
+++ b/internal/vba/analysisstats/recorder.go
@@ -16,6 +16,144 @@ type Stage struct {
 	Calls       int
 }
 
+// Domain identifies one of the semantic areas of procedure-local analysis.
+//
+// Domain values are deliberately a small integer enum. A DomainAggregate uses
+// the value as an index into a fixed-size array, so recording a domain does not
+// require a map lookup or an allocation. Unknown values are attributed to
+// DomainOther.
+type Domain uint8
+
+const (
+	DomainSourceScan Domain = iota
+	DomainRuntime
+	DomainArray
+	DomainObject
+	DomainDictionary
+	DomainError
+	DomainDataflow
+	DomainResource
+	DomainExcel
+	DomainApplicationState
+	DomainOther
+)
+
+const domainCount = int(DomainOther) + 1
+
+const (
+	ProcedureLocalSourceScan       = "procedure_local/source_scan"
+	ProcedureLocalRuntime          = "procedure_local/runtime"
+	ProcedureLocalArray            = "procedure_local/array"
+	ProcedureLocalObject           = "procedure_local/object"
+	ProcedureLocalDictionary       = "procedure_local/dictionary"
+	ProcedureLocalError            = "procedure_local/error"
+	ProcedureLocalDataflow         = "procedure_local/dataflow"
+	ProcedureLocalResource         = "procedure_local/resource"
+	ProcedureLocalExcel            = "procedure_local/excel"
+	ProcedureLocalApplicationState = "procedure_local/application_state"
+	ProcedureLocalOther            = "procedure_local/other"
+)
+
+var domainNames = [...]string{
+	ProcedureLocalSourceScan,
+	ProcedureLocalRuntime,
+	ProcedureLocalArray,
+	ProcedureLocalObject,
+	ProcedureLocalDictionary,
+	ProcedureLocalError,
+	ProcedureLocalDataflow,
+	ProcedureLocalResource,
+	ProcedureLocalExcel,
+	ProcedureLocalApplicationState,
+	ProcedureLocalOther,
+}
+
+// String returns the stable stage name used by performance-log output.
+func (d Domain) String() string {
+	if int(d) >= 0 && int(d) < len(domainNames) {
+		return domainNames[d]
+	}
+	return ProcedureLocalOther
+}
+
+// WorkCounter identifies a fixed workload counter. Counter values are kept in
+// a fixed-size array by DomainAggregate; the string names are emitted only
+// when an aggregate is merged into a Recorder.
+type WorkCounter uint8
+
+const (
+	CounterRuntimeCandidateProcedures WorkCounter = iota
+	CounterArrayCandidateProcedures
+	CounterObjectCandidateProcedures
+	CounterDictionaryCandidateProcedures
+	CounterErrorCandidateProcedures
+	CounterDataflowCandidateProcedures
+	CounterResourceCandidateProcedures
+	CounterExcelCandidateProcedures
+	CounterApplicationStateCandidateProcedures
+	CounterSourceLineScans
+	CounterRuntimeCFGWalks
+	CounterArrayCFGWalks
+	CounterDictionaryCFGWalks
+	CounterErrorCFGWalks
+	CounterDataflowCFGWalks
+	CounterResourceCFGWalks
+	CounterExcelCFGWalks
+	CounterSemanticKernelRuns
+)
+
+const counterCount = int(CounterSemanticKernelRuns) + 1
+
+const (
+	RuntimeCandidateProceduresCounter          = "runtime_candidate_procedures"
+	ArrayCandidateProceduresCounter            = "array_candidate_procedures"
+	ObjectCandidateProceduresCounter           = "object_candidate_procedures"
+	DictionaryCandidateProceduresCounter       = "dictionary_candidate_procedures"
+	ErrorCandidateProceduresCounter            = "error_candidate_procedures"
+	DataflowCandidateProceduresCounter         = "dataflow_candidate_procedures"
+	ResourceCandidateProceduresCounter         = "resource_candidate_procedures"
+	ExcelCandidateProceduresCounter            = "excel_candidate_procedures"
+	ApplicationStateCandidateProceduresCounter = "application_state_candidate_procedures"
+	SourceLineScansCounter                     = "source_line_scans"
+	RuntimeCFGWalksCounter                     = "runtime_cfg_walks"
+	ArrayCFGWalksCounter                       = "array_cfg_walks"
+	DictionaryCFGWalksCounter                  = "dictionary_cfg_walks"
+	ErrorCFGWalksCounter                       = "error_cfg_walks"
+	DataflowCFGWalksCounter                    = "dataflow_cfg_walks"
+	ResourceCFGWalksCounter                    = "resource_cfg_walks"
+	ExcelCFGWalksCounter                       = "excel_cfg_walks"
+	SemanticKernelRunsCounter                  = "semantic_kernel_runs"
+)
+
+var counterNames = [...]string{
+	RuntimeCandidateProceduresCounter,
+	ArrayCandidateProceduresCounter,
+	ObjectCandidateProceduresCounter,
+	DictionaryCandidateProceduresCounter,
+	ErrorCandidateProceduresCounter,
+	DataflowCandidateProceduresCounter,
+	ResourceCandidateProceduresCounter,
+	ExcelCandidateProceduresCounter,
+	ApplicationStateCandidateProceduresCounter,
+	SourceLineScansCounter,
+	RuntimeCFGWalksCounter,
+	ArrayCFGWalksCounter,
+	DictionaryCFGWalksCounter,
+	ErrorCFGWalksCounter,
+	DataflowCFGWalksCounter,
+	ResourceCFGWalksCounter,
+	ExcelCFGWalksCounter,
+	SemanticKernelRunsCounter,
+}
+
+// String returns the stable counter name used by performance-log output.
+func (c WorkCounter) String() string {
+	if int(c) >= 0 && int(c) < len(counterNames) {
+		return counterNames[c]
+	}
+	return ""
+}
+
 // Fact-build counters are additive observations. They deliberately live in
 // analysisstats rather than in an analyzer rule package so batch, realtime,
 // and benchmark callers use the same stable names when reporting the amount
@@ -32,6 +170,144 @@ type Recorder struct {
 }
 
 func NewRecorder() *Recorder { return &Recorder{counters: make(map[string]uint64)} }
+
+type aggregateStage struct {
+	elapsed     time.Duration
+	resultCount int
+	calls       int
+	outcome     string
+}
+
+// DomainAggregate collects procedure-local measurements before publishing
+// them to a Recorder. It is intended to be owned by one analyzer worker (or
+// one file analysis) and merged once when that work completes. Its fixed-size
+// arrays avoid per-procedure maps, slices, recorder calls, and lock
+// contention. Multiple aggregates may be merged concurrently into a Recorder.
+type DomainAggregate struct {
+	recorder *Recorder
+	stages   [domainCount]aggregateStage
+	counters [counterCount]uint64
+}
+
+// NewAggregate returns a local aggregate connected to recorder. When recorder
+// is nil it returns nil, allowing callers to keep the disabled profiling path
+// allocation-free. A nil *Recorder is also safe when called as a method.
+func NewAggregate(recorder *Recorder) *DomainAggregate {
+	if recorder == nil {
+		return nil
+	}
+	return &DomainAggregate{recorder: recorder}
+}
+
+// Start begins timing one aggregate domain. The zero Measurement returned for
+// a nil aggregate is a no-op, so the normal non-profiled path does not call
+// time.Now.
+func (a *DomainAggregate) Start(domain Domain) Measurement {
+	if a == nil {
+		return Measurement{}
+	}
+	return Measurement{aggregate: a, domain: normalizeDomain(domain), started: time.Now()}
+}
+
+// Record adds an already measured domain observation to this local aggregate.
+// No operation is performed for a nil aggregate.
+func (a *DomainAggregate) Record(domain Domain, elapsed time.Duration, resultCount int, outcome string) {
+	if a == nil {
+		return
+	}
+	stage := &a.stages[normalizeDomain(domain)]
+	stage.elapsed += elapsed
+	stage.resultCount += resultCount
+	stage.calls++
+	stage.outcome = combinedOutcome(stage.outcome, outcome)
+}
+
+// AddCounter adds an observation to one of the fixed workload counters. An
+// invalid counter is ignored, which keeps callers safe if they pass a value
+// from a future or external enum without introducing a dynamic map.
+func (a *DomainAggregate) AddCounter(counter WorkCounter, value uint64) {
+	if a == nil || int(counter) < 0 || int(counter) >= len(a.counters) {
+		return
+	}
+	a.counters[counter] += value
+}
+
+// Merge publishes this local aggregate to its Recorder with one recorder lock
+// acquisition. The local values are retained, so callers may inspect or merge
+// the same aggregate again when that is useful for a test or a staged caller.
+func (a *DomainAggregate) Merge() {
+	if a == nil || a.recorder == nil {
+		return
+	}
+	a.recorder.MergeAggregate(a)
+}
+
+// Measurement is a stack-friendly timer returned by DomainAggregate.Start.
+// It intentionally does not use a closure, which avoids one allocation for
+// every measured procedure/domain.
+type Measurement struct {
+	aggregate *DomainAggregate
+	domain    Domain
+	started   time.Time
+}
+
+// Finish records a measured domain and derives the outcome from err. A nil
+// error is "ok"; a non-nil error is "error". Context cancellation can be
+// represented explicitly with FinishOutcome when the caller has that state.
+func (m Measurement) Finish(resultCount int, err error) {
+	outcome := "ok"
+	if err != nil {
+		outcome = "error"
+	}
+	m.FinishOutcome(resultCount, outcome)
+}
+
+// FinishOutcome records a measured domain with an explicit outcome.
+func (m Measurement) FinishOutcome(resultCount int, outcome string) {
+	if m.aggregate == nil {
+		return
+	}
+	m.aggregate.Record(m.domain, time.Since(m.started), resultCount, outcome)
+}
+
+// MergeAggregate publishes all non-empty domain stages and counters in their
+// canonical order. The single lock acquisition is the important property for
+// large modules: a worker can record many procedures locally without touching
+// the shared recorder until this method is called.
+func (r *Recorder) MergeAggregate(a *DomainAggregate) {
+	if r == nil || a == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.counters == nil {
+		r.counters = make(map[string]uint64)
+	}
+	for index, stage := range a.stages {
+		if stage.calls == 0 {
+			continue
+		}
+		r.stages = append(r.stages, Stage{
+			Name:        domainNames[index],
+			Elapsed:     stage.elapsed,
+			Outcome:     stage.outcome,
+			ResultCount: stage.resultCount,
+			Calls:       stage.calls,
+		})
+	}
+	for index, value := range a.counters {
+		if value != 0 {
+			r.counters[counterNames[index]] += value
+		}
+	}
+	r.mu.Unlock()
+}
+
+func normalizeDomain(domain Domain) Domain {
+	if int(domain) >= 0 && int(domain) < domainCount {
+		return domain
+	}
+	return DomainOther
+}
 
 func (r *Recorder) Record(stage Stage) {
 	if r == nil {

--- a/internal/vba/analysisstats/recorder_test.go
+++ b/internal/vba/analysisstats/recorder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -94,5 +95,107 @@ func TestMeasureRecordsCanceledOutcome(t *testing.T) {
 	stages, _ := recorder.Totals()
 	if len(stages) != 1 || stages[0].Outcome != "canceled" {
 		t.Fatalf("stages = %+v", stages)
+	}
+}
+
+func TestDomainAggregateMergesFixedStagesAndCounters(t *testing.T) {
+	recorder := NewRecorder()
+	aggregate := NewAggregate(recorder)
+	aggregate.Record(DomainDataflow, 3*time.Millisecond, 2, "ok")
+	aggregate.Record(DomainSourceScan, time.Millisecond, 0, "ok")
+	aggregate.Record(DomainDataflow, 5*time.Millisecond, 1, "error")
+	aggregate.AddCounter(CounterDataflowCandidateProcedures, 3)
+	aggregate.AddCounter(CounterDataflowCFGWalks, 7)
+	aggregate.AddCounter(CounterSourceLineScans, 11)
+	aggregate.Merge()
+
+	stages, counters := recorder.Totals()
+	wantStages := []Stage{
+		{Name: ProcedureLocalSourceScan, Elapsed: time.Millisecond, Outcome: "ok", Calls: 1},
+		{Name: ProcedureLocalDataflow, Elapsed: 8 * time.Millisecond, Outcome: "error", ResultCount: 3, Calls: 2},
+	}
+	if !reflect.DeepEqual(stages, wantStages) {
+		t.Fatalf("stages = %+v, want %+v", stages, wantStages)
+	}
+	wantCounters := []Counter{
+		{Name: DataflowCandidateProceduresCounter, Value: 3},
+		{Name: DataflowCFGWalksCounter, Value: 7},
+		{Name: SourceLineScansCounter, Value: 11},
+	}
+	if !reflect.DeepEqual(counters, wantCounters) {
+		t.Fatalf("counters = %+v, want %+v", counters, wantCounters)
+	}
+}
+
+func TestDomainAggregateMergesInParallel(t *testing.T) {
+	const workers = 16
+	recorder := NewRecorder()
+	var wait sync.WaitGroup
+	wait.Add(workers)
+	for index := 0; index < workers; index++ {
+		go func() {
+			defer wait.Done()
+			aggregate := NewAggregate(recorder)
+			aggregate.Record(DomainArray, time.Nanosecond, 1, "ok")
+			aggregate.Record(DomainDataflow, 2*time.Nanosecond, 2, "ok")
+			aggregate.AddCounter(CounterArrayCandidateProcedures, 1)
+			aggregate.AddCounter(CounterDataflowCFGWalks, 2)
+			aggregate.Merge()
+		}()
+	}
+	wait.Wait()
+
+	stages, counters := recorder.Totals()
+	if len(stages) != 2 || stages[0].Name != ProcedureLocalArray || stages[1].Name != ProcedureLocalDataflow {
+		t.Fatalf("stage order = %+v", stages)
+	}
+	if stages[0].Calls != workers || stages[0].ResultCount != workers || stages[1].Calls != workers || stages[1].ResultCount != 2*workers {
+		t.Fatalf("stage totals = %+v", stages)
+	}
+	wantCounters := []Counter{
+		{Name: ArrayCandidateProceduresCounter, Value: workers},
+		{Name: DataflowCFGWalksCounter, Value: 2 * workers},
+	}
+	if !reflect.DeepEqual(counters, wantCounters) {
+		t.Fatalf("counters = %+v, want %+v", counters, wantCounters)
+	}
+}
+
+func TestDomainAggregateMeasurement(t *testing.T) {
+	recorder := NewRecorder()
+	aggregate := NewAggregate(recorder)
+	measurement := aggregate.Start(DomainRuntime)
+	measurement.FinishOutcome(4, "canceled")
+	aggregate.Merge()
+
+	stages, _ := recorder.Totals()
+	if len(stages) != 1 || stages[0].Name != ProcedureLocalRuntime || stages[0].Calls != 1 || stages[0].ResultCount != 4 || stages[0].Outcome != "canceled" {
+		t.Fatalf("measurement stage = %+v", stages)
+	}
+}
+
+func TestDomainAggregateNilFastPathHasNoAllocations(t *testing.T) {
+	var aggregate *DomainAggregate
+	allocs := testing.AllocsPerRun(1000, func() {
+		measurement := aggregate.Start(DomainArray)
+		measurement.Finish(0, nil)
+		aggregate.Record(DomainArray, time.Second, 0, "ok")
+		aggregate.AddCounter(CounterArrayCFGWalks, 1)
+		aggregate.Merge()
+	})
+	if allocs != 0 {
+		t.Fatalf("nil aggregate allocations = %v, want zero", allocs)
+	}
+}
+
+func TestDomainAndCounterNamesAreStable(t *testing.T) {
+	if DomainSourceScan.String() != ProcedureLocalSourceScan || DomainOther.String() != ProcedureLocalOther {
+		t.Fatalf("domain names = %q, %q", DomainSourceScan, DomainOther)
+	}
+	if CounterRuntimeCandidateProcedures.String() != RuntimeCandidateProceduresCounter || CounterSemanticKernelRuns.String() != SemanticKernelRunsCounter {
+		t.Fatalf("counter names = %q, %q", CounterRuntimeCandidateProcedures, CounterSemanticKernelRuns)
+	}
+	if Domain(255).String() != ProcedureLocalOther || WorkCounter(255).String() != "" {
+		t.Fatalf("invalid enum names = %q, %q", Domain(255), WorkCounter(255))
 	}
 }

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -69,14 +69,40 @@ complete `analyze_total` operation. The canonical stage labels include
 `project_context_indexes`, `procedure_local_diagnostics`,
 `typed_excel_diagnostics`, and `suppression_and_finalize`.
 
+`procedure_local_diagnostics` remains the parent stage for procedure-local
+work. With profiling enabled, aggregate child stages attribute that work to
+`procedure_local/source_scan`, `procedure_local/runtime`,
+`procedure_local/array`, `procedure_local/object`,
+`procedure_local/dictionary`, `procedure_local/error`,
+`procedure_local/dataflow`, `procedure_local/resource`,
+`procedure_local/excel`, `procedure_local/application_state`, and
+`procedure_local/other`. These are aggregate domain records, not per-procedure
+timers. Parallel procedure analysis reports cumulative worker time for a
+domain, so child timings are not a wall-time partition and may exceed the
+parent stage.
+
 The performance output includes stable aggregate workload counters:
 `file_count`, `procedure_count`, `statement_count`, `expression_count`,
 `call_site_count`, `cfg_block_count`, `cfg_edge_count`, and
 `project_symbol_count`, `line_count`, and `module_declaration_count`.
+Counter records use the existing `operation="analyze/counter"` stderr shape;
+stage records use `operation="analyze/stage"`.
 `line_count` uses physical source lines and excludes a terminal newline from the
 count.
 Subsystem worklist counters such as `object_summary_evaluations`,
 `object_entry_flow_evaluations`, and `byref_diagnostic_passes` may also appear.
+Procedure-local work counters include candidate counts
+(`runtime_candidate_procedures`, `array_candidate_procedures`,
+`object_candidate_procedures`, `dictionary_candidate_procedures`,
+`error_candidate_procedures`, `dataflow_candidate_procedures`,
+`resource_candidate_procedures`, `excel_candidate_procedures`, and
+`application_state_candidate_procedures`), traversal counts
+(`source_line_scans`, `runtime_cfg_walks`, `array_cfg_walks`,
+`dictionary_cfg_walks`, `error_cfg_walks`, `dataflow_cfg_walks`,
+`resource_cfg_walks`, and `excel_cfg_walks`), and
+`semantic_kernel_runs`. They describe work performed: candidates pass the
+relevant rule gate, traversals start a source/CFG walk, and kernel runs invoke
+a valid semantic-domain kernel. Findings are not counted by these counters.
 Large-module profiles also expose maximum dimensions:
 `max_lines_per_file`, `max_procedures_per_file`, `max_calls_per_file`,
 `max_statements_per_procedure`, `max_cfg_blocks_per_procedure`, and
@@ -85,6 +111,14 @@ findings. Timings vary by machine and Go toolchain; use them for same-
 environment comparisons rather than fixed pass/fail limits.
 The flag does not change findings, their order, exit status, or the JSON schema.
 `check` has no performance-log option.
+
+For the reproducible ROneCOne CPU and heap workflow, keep fixture materialization
+outside the timed `analyze-only` benchmark and run the explicit leaf benchmark
+with `-benchtime=1x -count=1` as documented in the
+[static-analysis corpus specification](https://github.com/harumiWeb/xlflow/blob/main/docs/specs/static-analysis-corpus.md).
+Use `go tool pprof` on the resulting files to inspect CPU, allocation-space,
+allocation-object, and heap-in-use views. These developer profiles are written
+to temporary paths and are never part of analyzer JSON output.
 
 For reproducible developer measurements, use `rtk task bench:analyze-single-module`
 for the synthetic large-module workloads, `rtk task bench:analyze` for the

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -16,12 +16,15 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `analyze_disabled_rules_precedence`
 - `analyze_failed`
 - `analyze_total`
+- `application_state_candidate_procedures`
 - `args_invalid`
 - `argument_count`
 - `argument_diagnostics`
 - `argument_list`
 - `array_bound`
 - `array_bounds`
+- `array_candidate_procedures`
+- `array_cfg_walks`
 - `array_subscript_out_of_bounds`
 - `array_unallocated`
 - `as_type_clause`
@@ -198,6 +201,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `cyclomatic_complexity`
 - `data_flow`
 - `database_result`
+- `dataflow_candidate_procedures`
+- `dataflow_cfg_walks`
 - `debug_log`
 - `debug_stream_init_failed`
 - `declaration_range`
@@ -279,6 +284,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `diagnostic_meaning`
 - `diagnostic_runs`
 - `dialog_id`
+- `dictionary_candidate_procedures`
+- `dictionary_cfg_walks`
 - `diff_args_invalid`
 - `diff_failed`
 - `direct_callees`
@@ -348,6 +355,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `enum_group`
 - `enum_member`
 - `environment_variable`
+- `error_candidate_procedures`
+- `error_cfg_walks`
 - `error_handling_count`
 - `event_declaration`
 - `event_reader_count`
@@ -362,6 +371,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `exceeds_max_count`
 - `exceeds_max_total_size`
 - `excel_available`
+- `excel_candidate_procedures`
+- `excel_cfg_walks`
 - `excel_cleanup`
 - `excel_com`
 - `excel_com_failure`
@@ -693,6 +704,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `nothing_literal`
 - `number_format`
 - `numeric_type_mismatch`
+- `object_candidate_procedures`
 - `object_entry_flow_evaluations`
 - `object_entry_states`
 - `object_procedure_summaries`
@@ -793,6 +805,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `procedure_ir_singleflight`
 - `procedure_kind`
 - `procedure_local_diagnostics`
+- `procedure_local_source_scan`
 - `procedure_modifier`
 - `procedure_name`
 - `procedure_name_constant`
@@ -880,6 +893,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `residual_path`
 - `resolved_result`
 - `resolved_value`
+- `resource_candidate_procedures`
+- `resource_cfg_walks`
 - `resource_ownership_count`
 - `resource_scope`
 - `response_source`
@@ -914,6 +929,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `run_command`
 - `run_diagnostic`
 - `runner_args_invalid`
+- `runtime_candidate_procedures`
+- `runtime_cfg_walks`
 - `runtime_error`
 - `runtime_form_load_failed`
 - `runtime_form_loads_initialize`
@@ -939,6 +956,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `selected_bridge`
 - `selected_by`
 - `selected_index`
+- `semantic_kernel_runs`
 - `sensitive_module_constant`
 - `session_args_invalid`
 - `session_dirty`
@@ -983,6 +1001,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `source_file`
 - `source_files`
 - `source_line_count`
+- `source_line_scans`
 - `source_lines`
 - `source_newer_than_workbook`
 - `source_of_truth`


### PR DESCRIPTION
## Summary

- Add opt-in aggregate profiling for `procedure_local_diagnostics`, split across source scan, runtime, array, object, dictionary, error, dataflow, resource, Excel, application-state, and other domains.
- Add canonical candidate, traversal, and semantic-kernel workload counters while preserving analyzer findings, ordering, exit codes, and JSON output.
- Use fixed-size worker-local aggregates and one recorder merge per batch/file so the disabled path avoids timers, recorder locks, and recording allocations.
- Document the CPU/allocation profiling workflow and record the post-wave-2 ROneCOne and synthetic workload observations.

## Compatibility and scope

- Profiling remains opt-in through the existing `analyze --performance-log` path.
- Performance records remain on stderr using the existing `analyze/stage` and `analyze/counter` formats; analyzer JSON is unchanged.
- Parallel domain elapsed values are cumulative worker time and are not an additive wall-time partition of `procedure_local_diagnostics`.
- Batch analyzer only; LSP/realtime analyzer behavior is unchanged.

## Verification

- `task test`
- `task lint`
- `go test ./internal/analyze ./internal/vba/analysisstats ./internal/cli ./internal/staticanalysis/corpus`
- `git diff --check`
- Repository `final-review` completed with no actionable findings.

## Measurements

- ROneCOne five-run median: 24.198s, 27,319,440,464 B/op, 178,295,249 allocs/op, 510 findings.
- Disabled bounded independent/2000 median: 1.391s before instrumentation vs 1.382s after (-0.6%).
- CPU, alloc-space, and alloc-object profiles were reproduced with `-count=1`; artifacts are documented in `docs/specs/static-analysis-corpus.md`.
- `cfg-independent/2000-branches` remains contract-tested, but did not complete within the available local benchmark window and is documented as having no numeric baseline.

Closes #694


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in procedure-level performance diagnostics for `xlflow analyze --performance-log`.
  * Reports timing by analysis area, candidate procedures, traversal counts, source-line scans, and semantic-kernel runs.
  * Parallel timings now clarify cumulative worker-time semantics.

* **Documentation**
  * Updated CLI, benchmarking, and performance-profiling documentation with diagnostic details and reproducible profiling guidance.

* **Bug Fixes**
  * Preserved existing findings, exit codes, and JSON output when performance logging is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->