### PR TITLE
perf(analyze): consolidate array diagnostics onto shared semantic kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ All notable changes to xlflow will be documented in this file.
   `--performance-log` output adds planned/skipped domain counters; findings,
   exit codes, and normal JSON/LSP contracts remain unchanged.
 
+- Consolidated compatible array diagnostics onto one immutable,
+  procedure-local array semantic result per analysis revision. `VBA227`,
+  deterministic array `VBA249`, `VBA208`, object-array `VBA101`/`VBA102`,
+  `VBA241`, and applicable `VBA226` projections reuse shared preparation and
+  fixed-point facts while retaining their existing diagnostic ownership and
+  conservatism. Performance logs expose `array_kernel_runs`,
+  `array_cfg_walks`, and `array_projection_runs`; findings, snapshots, exit
+  codes, and normal JSON/LSP contracts remain unchanged.
+
 - Added opt-in semantic-domain profiling beneath
   `procedure_local_diagnostics` for giant-module `xlflow analyze` workloads.
   `--performance-log` now attributes aggregate source-scan, runtime, array,

--- a/docs/adr/ADR-0040-array-operation-shape-validation.md
+++ b/docs/adr/ADR-0040-array-operation-shape-validation.md
@@ -65,13 +65,14 @@ their reset-but-allocated state and dynamic arrays to unallocated state.
 The canonical procedure result is an internal, immutable
 `ArrayAnalysisResult`. It is materialized at most once for one procedure
 analysis revision after the reusable procedure/module facts have been
-prepared. The result may contain variable metadata, entry-state facts,
-allocation and shape states, bounds, operation facts, `ReDim` transitions,
-branch refinements, and proven runtime failures. It contains semantic facts,
-not `Finding` values, rule enablement, suppression state, or diagnostic
-severity. It lives only for the current procedure analysis and is safe for
-concurrent read-only projection; it is not a project-wide or cross-revision
-cache.
+prepared. The compact implementation keeps the shared variable/entry-state
+preparation and policy-lane outputs in categorized slices
+(`lifecycleFindings`, `runtimeFindings`, `redimFindings`, and
+`rangeFindings`). Projectors expose copies of those slices, so the result is
+still read-only after materialization; the stored `Finding` values do not
+carry rule enablement, suppression mutation, or a new severity contract. It
+lives only for the current procedure analysis and is safe for concurrent
+read-only projection; it is not a project-wide or cross-revision cache.
 
 The array kernel projects the result into the applicable diagnostics for both
 batch and realtime/LSP analysis. The block-level projection preserves the

--- a/docs/adr/ADR-0040-array-operation-shape-validation.md
+++ b/docs/adr/ADR-0040-array-operation-shape-validation.md
@@ -21,6 +21,12 @@ observation into a preflight-blocking compiler claim. Local VBE oracle fixtures
 provide evidence for that boundary, while ordinary analysis remains
 Excel-free.
 
+Issue #696 identifies the cost of having each array-sensitive diagnostic
+reconstruct overlapping allocation, shape, bounds, entry-state, and operation
+facts. The reuse boundary must be large enough to amortize that work without
+making a diagnostic with intentionally different control-flow conservatism
+adopt another rule's state contract.
+
 ## Decision
 
 Extend the shared array metadata and transfer model with a reusable shape
@@ -56,10 +62,39 @@ quiet. Fixed arrays are never treated as resizable, and a scalar is never
 treated as an array or iterable source. `Erase` transitions fixed arrays to
 their reset-but-allocated state and dynamic arrays to unallocated state.
 
+The canonical procedure result is an internal, immutable
+`ArrayAnalysisResult`. It is materialized at most once for one procedure
+analysis revision after the reusable procedure/module facts have been
+prepared. The result may contain variable metadata, entry-state facts,
+allocation and shape states, bounds, operation facts, `ReDim` transitions,
+branch refinements, and proven runtime failures. It contains semantic facts,
+not `Finding` values, rule enablement, suppression state, or diagnostic
+severity. It lives only for the current procedure analysis and is safe for
+concurrent read-only projection; it is not a project-wide or cross-revision
+cache.
+
+The array kernel projects the result into the applicable diagnostics for both
+batch and realtime/LSP analysis. The block-level projection preserves the
+existing `VBA208`, deterministic array `VBA249`, object-array `VBA101` /
+`VBA102`, and related operation semantics. The `VBA227` lifecycle projection
+retains its physical source-line ordering, normal-edge pruning,
+`On Error Resume Next`, and reliable-allocation policy. `VBA241` consumes
+shared `ReDim` and loop-region facts without another fixed-point walk. `VBA226`
+retains its scalar/2D `Range.Value` shape lattice and may use an explicitly
+separate secondary pass when that policy requires it. These policy lanes are
+projection choices, not alternative public state models; duplicate findings
+continue to be resolved by the existing operation identity and ownership
+rules.
+
 ## Consequences
 
 - Array-sensitive diagnostics agree across declarations, assignments, calls,
   bounds, `Erase`, `ReDim`, and `For Each`.
+- Shared preparation and the main array fixed point run once per procedure
+  revision, after which multiple diagnostic projectors read the same result.
+- The performance recorder exposes `array_kernel_runs`, `array_cfg_walks`,
+  and `array_projection_runs`. Core array projections keep one kernel result
+  and one main CFG walk; an applicable `VBA226` secondary pass is explicit.
 - Existing `VBA208`, `VBA227`, `VBA228`, and `VB023` ownership boundaries remain
   stable; new compile-equivalent contracts are registered separately from
   runtime-safety warnings.
@@ -100,6 +135,7 @@ their reset-but-allocated state and dynamic arrays to unallocated state.
   runtime safety rather than compile-equivalent diagnostics.
 - `docs/specs/array-lifecycle-safety.md` and ADR-0028 for the existing
   allocation/dimension model and `VBA208` ownership.
+- Issue #696 acceptance criteria and its shared-kernel performance matrix.
 - `docs/specs/vba-analysis-ir.md` and `internal/vba/procedureir` for array
   declaration, bounds, `ParamArray`, and procedure-return facts.
 - `docs/specs/vbe-oracle.md` and ADR-0026 for compile-equivalent evidence,
@@ -119,6 +155,7 @@ None
 ## Related
 
 - Issue #593
+- Issue #696
 - ADR-0026, ADR-0028
 - `docs/specs/array-lifecycle-safety.md`
 - `docs/specs/range-value-array-shape-safety.md`

--- a/docs/adr/ADR-0046-procedure-applicability-planning.md
+++ b/docs/adr/ADR-0046-procedure-applicability-planning.md
@@ -18,6 +18,12 @@ optimization must also work for realtime/LSP analysis, preserve the existing
 batch and project-wide effect contracts, and retain the conservative behavior
 of recovered or unresolved VBA.
 
+Issue #696 applies the same planning boundary to overlapping array diagnostics.
+Array applicability must decide whether the array domain is needed, while the
+domain itself must materialize one canonical procedure result that can feed
+several rule projections. Applicability planning must not become a second
+array parser or a rule-specific cache.
+
 ## Decision
 
 Derive one immutable, procedure-local applicability summary from the owned IR
@@ -57,6 +63,21 @@ changes them. Planning is an execution optimization only: finding content,
 range, multiplicity, ordering, severity, suppression, exit status, and normal
 JSON/LSP schemas remain unchanged.
 
+When the array domain is planned, its procedure worker materializes one
+immutable `ArrayAnalysisResult` for the current analysis revision and passes
+that result to the applicable array projectors. The result reuses the owned
+procedure/module facts and is discarded with the procedure analysis; it is not
+promoted to a project-wide cache. `array_kernel_runs` and the main
+`array_cfg_walks` therefore remain one per applicable procedure even when
+`VBA227`, deterministic `VBA249`, `VBA208`, `VBA209`, object-array
+`VBA101`/`VBA102`, `VBA241`, and `VBA226` are enabled together. The
+`array_projection_runs` counter records applicable projectors, while an
+explicit `VBA226` secondary shape pass is the only additional array walk
+allowed by this plan. `VBA241` reads shared facts and does not start a new
+fixed-point traversal. Rule-specific conservatism remains in the projection
+policy, including the source-line lifecycle policy of `VBA227` and the
+independent `Range.Value` shape policy of `VBA226`.
+
 The analyzer's opt-in performance recorder emits additive planned/skipped
 counters for each gated semantic domain. A counter is recorded once per
 procedure/domain decision; unknown applicability is counted as planned. These
@@ -89,6 +110,9 @@ produce a finding.
 - Requirement metadata becomes an internal completeness contract: a new
   gated rule must declare its domain requirements and add planner/correctness
   coverage before it can rely on skipping.
+- Array applicability is a domain-level decision rather than one decision per
+  array diagnostic. Adding an array projector changes projection work and
+  telemetry, not the canonical kernel or main CFG walk count.
 
 ## Alternatives Considered
 
@@ -126,11 +150,15 @@ produce a finding.
 - Existing analyzer performance and corpus measurement procedure:
   `docs/specs/cli-contract.md` and
   `docs/specs/static-analysis-corpus.md`.
+- ADR-0040 for the canonical array semantic result and its diagnostic
+  ownership boundaries.
 
 ## Related
 
 - Issue #693 (parent)
 - Issue #695
+- Issue #696
 - ADR-0021, ADR-0022, ADR-0023, ADR-0024, ADR-0043, ADR-0045
+- ADR-0040
 - `docs/specs/vba-analysis-ir.md`
 - `docs/specs/static-analysis-corpus.md`

--- a/docs/specs/array-lifecycle-safety.md
+++ b/docs/specs/array-lifecycle-safety.md
@@ -29,6 +29,29 @@ comparison safety.
 The rule uses the existing `Finding` fields and adds no JSON fields, CLI flags,
 or LSP capabilities.
 
+## Shared procedure result
+
+For one procedure analysis revision, the array domain materializes one internal
+`ArrayAnalysisResult` after the immutable procedure/module preparation has been
+resolved. The result is worker-local, discarded with that revision, and
+read-only after construction; it is never promoted to a project cache. Its
+semantic payload covers the variable catalog, entry state, allocation and
+shape/bound transitions, operation identity, branch refinements, ReDim facts,
+and proven array runtime failures. Diagnostic projectors consume that payload
+for `VBA227`, deterministic array `VBA249`, `VBA208`, `VBA209`, object-array
+`VBA101`/`VBA102`, `VBA241`, and applicable `VBA226` without rebuilding the
+catalog, constants, capacity guards, or operation lookup.
+
+The procedure worker uses independent policy lanes over shared CFG scheduling.
+The block-level lane preserves `VBA208`, `VBA249`, and object-array semantics;
+the lifecycle lane retains `VBA227` physical source-line ordering, normal-edge
+pruning, and reliable `On Error Resume Next` allocation behavior. `VBA226`
+keeps its scalar/two-dimensional `Range.Value` lattice and may use one explicit
+secondary walk. `VBA241` is a source/loop-region projection and is not counted
+as another fixed-point walk. These policy choices are deliberate and do not
+change diagnostic code, severity, message, range, ordering, suppression, or
+Batch/realtime parity.
+
 ## State model
 
 The analyzer carries a case-insensitive variable state through the procedure

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -324,6 +324,20 @@ valid semantic-domain kernel invocations. Candidate counters count procedures
 that pass the rule gate and are actually analyzed, traversal counters count
 started source/CFG traversals, and none of these counters count findings.
 
+Array-domain profiling adds three counters with the following meanings:
+`array_kernel_runs` counts canonical `ArrayAnalysisResult` materializations,
+`array_cfg_walks` counts started array fixed-point walks, and
+`array_projection_runs` counts enabled, applicable array diagnostic projectors.
+The array candidate and kernel counters are per procedure analysis revision,
+not per rule. With the core array projectors enabled together, the kernel and
+main CFG walk remain `1` for an applicable procedure while projection runs
+increase for the projectors that are applicable. `VBA241` reads shared facts
+without starting another fixed-point walk. An applicable `VBA226` policy may
+start its explicitly separate secondary shape pass, which is reflected in
+`array_cfg_walks`; this exception does not change the shared result lifetime.
+These counters are emitted only in stderr performance records and never count
+findings.
+
 Applicability planning adds additive decision counters for each gated semantic
 domain: `planned_runtime_runs` / `skipped_runtime_runs`,
 `planned_array_runs` / `skipped_array_runs`,
@@ -1423,6 +1437,10 @@ execution failure from both compile-equivalent errors and warning-level
 runtime-safety inference. It reports only deterministic division, conversion,
 numeric-operand, and array allocation/bound failures described in
 [Deterministic VBA Runtime-Error Diagnostics](vba-runtime-error-diagnostics.md).
+Array allocation and bound failures are projected from the same procedure-local
+array semantic result used by the compatible array diagnostics; this sharing
+does not broaden the deterministic proof threshold or change duplicate
+ownership with `VBA227`.
 Unknown `Variant`, late-bound, external, locale-dependent, and branch-merged
 values remain silent. Disable it with
 `[analyze].disabled_rules = ["VBA249"]` or suppress an intentional local case
@@ -1502,6 +1520,13 @@ and standalone getter predicates, remain allowed.
 
 For `VBA226`, the configurable analyzer mapping is `VBA226 = detect_range_value_array_shape`.
 `VBA227` is default-enabled, non-blocking, warning-level, inline-suppressible, and supported in batch and real-time analysis. It uses a conservative CFG allocation lattice (`allocated`, `unallocated`, and `unknown`) for fixed, dynamic, multidimensional, object, and Variant arrays. It reports unallocated bound/access operations, invalid dimensions or known bounds, fixed-array `ReDim`, incompatible `Erase`, known scalar bound/iterable sources, and impossible constant `ReDim` bounds. Unknown Variant operations remain fail-open. The shared state supplies `VBA208` `ReDim Preserve` findings and object-array missing-`Set` findings under `VBA101` / `VBA102`, which retain their existing ownership and configuration contracts. Unique project-local Function and Property Get return assignments may establish an array value; mixed, recursive, ambiguous, and external returns remain unknown. Batch summaries may use project-local files, while real-time summaries are limited to the active document. `Range.Value` / `Value2` shape findings remain owned by `VBA226` and are not duplicated. Disable it with `[analyze].disabled_rules = ["VBA227"]` or use `detect_array_lifecycle_safety`.
+The analyzer materializes one immutable procedure-local array semantic result
+for these compatible projections. The result is discarded with the current
+analysis revision, is read-only during projection, and does not contain
+diagnostic policy. `VBA227` retains its source-line lifecycle ordering and
+exceptional-edge policy; `VBA226` retains its independent `Range.Value` shape
+lattice and may use a secondary pass. These compatibility policies are not
+weakened to make the shared preparation possible.
 Conditional `ByRef` output helpers that exit on a zero collection/count and
 `ReDim` from that count are carried only into matching positive-count branches,
 including numeric `Select Case` clauses; the helper does not establish an

--- a/docs/specs/runtime-debugging.md
+++ b/docs/specs/runtime-debugging.md
@@ -145,6 +145,14 @@ document in realtime); unresolved, external, ambiguous, and effect-free
 getters are not inferred as hazards, and standalone getter predicates are
 allowed. General array allocation/dimension safety remains owned by VBA227.
 
+Array runtime projections share the same procedure-local `ArrayAnalysisResult`
+as lifecycle diagnostics. Deterministic array `VBA249` consumes proven
+allocation, shape, bound, and operation facts from that result; it does not
+start a second array CFG fixed point. The result is immutable for the current
+analysis revision and is shared by batch and realtime workers. Performance-log
+records expose `array_kernel_runs`, `array_cfg_walks`, and
+`array_projection_runs`; these counters describe analysis work, not findings.
+
 `xlflow check` aggregates `lint`, `analyze`, and `doctor`. It continues after lint/analyze findings and returns all cheap source feedback before reporting Excel COM doctor status.
 
 ## Macro Entrypoint Discovery

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -835,6 +835,17 @@ Traversal counters are `source_line_scans`, `runtime_cfg_walks`,
 Candidates are procedures that pass the relevant rule gate and are actually
 analyzed; traversal counters count started source/CFG traversals. These are
 workload counters and never counts of emitted findings.
+
+Array-domain profiles additionally report `array_kernel_runs`,
+`array_cfg_walks`, and `array_projection_runs`. The first counts one canonical
+array semantic-result materialization per applicable procedure revision, the
+second counts started array fixed-point walks, and the third counts enabled
+and applicable array projectors. Enabling multiple core array diagnostics must
+leave the kernel and main CFG-walk counts at one per applicable procedure;
+`VBA241` is a shared-fact projection, while an applicable `VBA226` secondary
+shape pass is recorded as an explicit additional walk. These counters measure
+work, not findings, and are compared alongside `ns/op`, `B/op`, and
+`allocs/op`.
 The CLI emits stage records with `operation="analyze/stage"` and counter
 records with `operation="analyze/counter"`; both remain stderr-only.
 
@@ -868,6 +879,16 @@ retain wall time (`ns/op`), allocations, findings, workload dimensions, and the
 `stage_*` / `counter_*` metrics derived from the attached analysis recorder;
 these are Go benchmark metrics, not stderr records from
 `analyze --performance-log`.
+
+For issue #696, the benchmark matrix also covers no-array procedures, simple
+dynamic arrays, ReDim-heavy procedures, branch-heavy array lifecycles,
+multidimensional arrays, ByRef array flows, large CFGs, and a workload with
+all compatible array projectors enabled. Record the array kernel, walk, and
+projection counters with the standard wall-time and allocation metrics. A
+repeated run must retain deterministic findings and snapshots; a performance
+comparison must show reduced array walks or allocations on array-heavy and
+ROneCOne workloads without multiplying the main fixed-point work when another
+projector is enabled.
 
 For issue #675, the benchmark matrix must also include one-file workloads with
 100, 500, 1,000, and 2,000 procedures and a many-file workload. Where the

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -1731,9 +1731,22 @@ func (a Analyzer) sourceRealtimeProcedureFindingsContext(ctx context.Context, fi
 	profile := newProcedureDomainProfile(ctx)
 	profile.plannerDecisions(plan)
 	defer profile.flush()
+	var arrayResult *ArrayAnalysisResult
+	if plan.runs(procedureDomainArray) {
+		arrayResult = a.buildArrayAnalysisResult(file, proc, analysisCtx, moduleDecls)
+		if arrayResult != nil {
+			profile.kernel()
+			profile.add(analysisstats.CounterArrayKernelRuns, 1)
+			profile.add(analysisstats.CounterArrayCFGWalks, arrayResult.cfgWalks)
+			profile.add(analysisstats.CounterArrayProjectionRuns, arrayResult.projectionRuns)
+			if arrayResult.projectionRuns > 0 {
+				profile.add(analysisstats.CounterArrayCandidateProcedures, 1)
+			}
+		}
+	}
 	findings = append(findings, a.opaqueBooleanArgumentFindings(file, proc, analysisCtx.procedures)...)
 	if plan.runs(procedureDomainRuntime) {
-		findings = append(findings, a.deterministicRuntimeErrorFindings(file, proc, analysisCtx, moduleDecls)...)
+		findings = append(findings, a.deterministicRuntimeErrorFindingsWithArrayResult(file, proc, analysisCtx, moduleDecls, arrayResult)...)
 	}
 	if plan.runs(procedureDomainDictionary) && dictionaryCollectionAnalysisEnabled(a.Config.Analyze) {
 		findings = append(findings, a.dictionaryCollectionSafetyFindings(file, proc, moduleDecls)...)
@@ -1791,14 +1804,26 @@ func (a Analyzer) sourceRealtimeProcedureFindingsContext(ctx context.Context, fi
 		}
 	}
 	if plan.runs(procedureDomainArray) && a.Config.Analyze.DetectRangeValueArrayShape {
-		findings = append(findings, a.rangeValueShapeFindings(file, proc)...)
+		if arrayResult != nil {
+			findings = append(findings, arrayResult.rangeShape()...)
+		} else {
+			findings = append(findings, a.rangeValueShapeFindings(file, proc)...)
+		}
 	}
 	if plan.runs(procedureDomainArray) {
-		findings = append(findings, a.arrayLifecycleFindings(file, proc, analysisCtx, moduleDecls)...)
+		if arrayResult != nil {
+			findings = append(findings, arrayResult.lifecycle()...)
+		} else {
+			findings = append(findings, a.arrayLifecycleFindings(file, proc, analysisCtx, moduleDecls)...)
+		}
 		findings = suppressDeterministicArrayWarningDuplicates(findings)
 	}
 	if plan.runs(procedureDomainArray) && a.Config.Analyze.DetectRedimPreserveInLoops {
-		findings = append(findings, a.redimPreserveLoopFindings(file, proc, moduleDecls)...)
+		if arrayResult != nil {
+			findings = append(findings, arrayResult.redim()...)
+		} else {
+			findings = append(findings, a.redimPreserveLoopFindings(file, proc, moduleDecls)...)
+		}
 	}
 	if plan.runs(procedureDomainError) && a.Config.Analyze.DetectErrorHandlerFallthrough {
 		findings = append(findings, a.errorHandlerFallthroughFindings(file, proc)...)
@@ -2244,6 +2269,19 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	var candidateCounters uint64
 	plan := proc.analysisPlan(a.Config.Analyze, moduleDecls)
 	profile.plannerDecisions(plan)
+	var arrayResult *ArrayAnalysisResult
+	if plan.runs(procedureDomainArray) {
+		arrayResult = a.buildArrayAnalysisResult(file, proc, ctx, moduleDecls)
+		if arrayResult != nil {
+			profile.kernel()
+			profile.add(analysisstats.CounterArrayKernelRuns, 1)
+			profile.add(analysisstats.CounterArrayCFGWalks, arrayResult.cfgWalks)
+			profile.add(analysisstats.CounterArrayProjectionRuns, arrayResult.projectionRuns)
+			if arrayResult.projectionRuns > 0 {
+				profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
+			}
+		}
+	}
 	otherMeasurement := profile.begin(procedureDomainOther)
 	opaqueFindings := a.opaqueBooleanArgumentFindings(file, proc, ctx.procedures)
 	if a.Config.Analyze.DetectOpaqueBooleanArguments {
@@ -2253,7 +2291,7 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	findings = append(findings, opaqueFindings...)
 	if plan.runs(procedureDomainRuntime) {
 		runtimeMeasurement := profile.begin(procedureDomainRuntime)
-		runtimeFindings := a.deterministicRuntimeErrorFindings(file, proc, ctx, moduleDecls)
+		runtimeFindings := a.deterministicRuntimeErrorFindingsWithArrayResult(file, proc, ctx, moduleDecls, arrayResult)
 		if enabled, known := config.AnalyzeRuleEnabled(a.Config.Analyze, "VBA249"); known && enabled {
 			profile.kernel()
 			profile.candidate(&candidateCounters, analysisstats.CounterRuntimeCandidateProcedures)
@@ -2452,8 +2490,13 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	}
 	if plan.runs(procedureDomainArray) {
 		arrayMeasurement := profile.begin(procedureDomainArray)
-		arrayFindings := a.arrayLifecycleFindings(file, proc, ctx, moduleDecls)
-		if a.Config.Analyze.DetectArrayLifecycleSafety || a.Config.Analyze.DetectRedimPreserveDimension || a.Config.Analyze.DetectObjectArrayComparison {
+		arrayFindings := []Finding(nil)
+		if arrayResult != nil {
+			arrayFindings = arrayResult.lifecycle()
+		} else {
+			arrayFindings = a.arrayLifecycleFindings(file, proc, ctx, moduleDecls)
+		}
+		if arrayResult == nil && (a.Config.Analyze.DetectArrayLifecycleSafety || a.Config.Analyze.DetectRedimPreserveDimension || a.Config.Analyze.DetectObjectArrayComparison) {
 			profile.kernel()
 			profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
 			if proc.Graph != nil {
@@ -2469,11 +2512,18 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	}
 	if plan.runs(procedureDomainArray) && a.Config.Analyze.DetectRedimPreserveInLoops {
 		arrayMeasurement := profile.begin(procedureDomainArray)
-		redimFindings := a.redimPreserveLoopFindings(file, proc, moduleDecls)
-		profile.kernel()
-		profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
-		if proc.Graph != nil {
-			profile.add(analysisstats.CounterArrayCFGWalks, 1)
+		redimFindings := []Finding(nil)
+		if arrayResult != nil {
+			redimFindings = arrayResult.redim()
+		} else {
+			redimFindings = a.redimPreserveLoopFindings(file, proc, moduleDecls)
+		}
+		if arrayResult == nil {
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
+			if proc.Graph != nil {
+				profile.add(analysisstats.CounterArrayCFGWalks, 1)
+			}
 		}
 		arrayMeasurement.finish(len(redimFindings))
 		findings = append(findings, redimFindings...)
@@ -2609,11 +2659,18 @@ func (a Analyzer) analyzeProcedureContext(cancelCtx context.Context, file parsed
 	}
 	if plan.runs(procedureDomainArray) && a.Config.Analyze.DetectRangeValueArrayShape {
 		arrayMeasurement := profile.begin(procedureDomainArray)
-		arrayFindings := a.rangeValueShapeFindings(file, proc)
-		profile.kernel()
-		profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
-		if proc.Graph != nil {
-			profile.add(analysisstats.CounterArrayCFGWalks, 1)
+		arrayFindings := []Finding(nil)
+		if arrayResult != nil {
+			arrayFindings = arrayResult.rangeShape()
+		} else {
+			arrayFindings = a.rangeValueShapeFindings(file, proc)
+		}
+		if arrayResult == nil {
+			profile.kernel()
+			profile.candidate(&candidateCounters, analysisstats.CounterArrayCandidateProcedures)
+			if proc.Graph != nil {
+				profile.add(analysisstats.CounterArrayCFGWalks, 1)
+			}
 		}
 		arrayMeasurement.finish(len(arrayFindings))
 		findings = append(findings, arrayFindings...)

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -273,6 +273,9 @@ func rangeValueShapeApplicable(file parsedFile, proc sourceProcedure) bool {
 }
 
 func rangeValueProjectionUnknown(proc sourceProcedure) bool {
+	if rangeValueHasUnknownExpression(proc) {
+		return true
+	}
 	if proc.Features.unknown&featureRangeArray == 0 {
 		return false
 	}
@@ -288,6 +291,29 @@ func rangeValueProjectionUnknown(proc sourceProcedure) bool {
 		}
 	}
 	return false
+}
+
+func rangeValueHasUnknownExpression(proc sourceProcedure) bool {
+	rangeStatements := map[int]bool{}
+	for _, statement := range proc.Statements {
+		if rangeValueTextLooksRelevant(statement.Text) {
+			rangeStatements[statement.ID] = true
+		}
+	}
+	for _, expression := range proc.Expressions {
+		if !expression.Recovered && expression.Kind != procedureir.ExpressionUnknown {
+			continue
+		}
+		if rangeValueTextLooksRelevant(expression.Text) || (expression.StatementID != 0 && rangeStatements[expression.StatementID]) {
+			return true
+		}
+	}
+	return false
+}
+
+func rangeValueTextLooksRelevant(text string) bool {
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, ".value") || strings.Contains(lower, "range(") || strings.Contains(lower, "resize(") || strings.Contains(lower, "cells(")
 }
 
 func (r *ArrayAnalysisResult) lifecycle() []Finding  { return r.findings("lifecycle") }

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -60,10 +60,11 @@ func arrayAnalysisEnabled(cfg config.AnalyzeConfig) bool {
 // once.  Project-wide ByRef/module/return summaries are supplied by ctx and
 // remain owned by the existing analysis-context fixed points.
 func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration) *ArrayAnalysisResult {
-	if !arrayAnalysisEnabled(a.Config.Analyze) {
+	variables := arrayVariables(file, proc, moduleDecls)
+	objectArrayApplicable := arrayObjectArrayApplicable(variables)
+	if !arrayAnalysisEnabled(a.Config.Analyze) && !objectArrayApplicable {
 		return nil
 	}
-	variables := arrayVariables(file, proc, moduleDecls)
 	result := &ArrayAnalysisResult{
 		variables:      variables,
 		constants:      arrayIntegerConstants(file, proc, a.visibleConstantValues, a.visibleConstants),
@@ -84,13 +85,6 @@ func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure
 	// A procedure can contain an object array even when the explicit lifecycle
 	// switches are disabled. The shared transfer owns the always-on VBA101/
 	// VBA102 projection for that case.
-	objectArrayApplicable := false
-	for _, variable := range variables {
-		if variable.isArray && variable.isObject {
-			objectArrayApplicable = true
-			break
-		}
-	}
 	coreFlowRequested := a.Config.Analyze.DetectArrayLifecycleSafety ||
 		a.Config.Analyze.DetectRedimPreserveDimension ||
 		objectArrayApplicable ||
@@ -130,6 +124,15 @@ func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure
 		}
 	}
 	return result
+}
+
+func arrayObjectArrayApplicable(variables map[string]arrayVariable) bool {
+	for _, variable := range variables {
+		if variable.isArray && variable.isObject {
+			return true
+		}
+	}
+	return false
 }
 
 // arrayCoreProjectionRuns counts the compatible projections fed by the shared

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -80,10 +80,7 @@ func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure
 		}
 	}
 	runtimeRequested := hasArrayVariable && a.Config.Analyze.DetectDeterministicRuntimeErrors && (!knownRuntimeRule || runtimeEnabled)
-	coreRequested := a.Config.Analyze.DetectArrayLifecycleSafety ||
-		a.Config.Analyze.DetectRedimPreserveDimension ||
-		a.Config.Analyze.DetectObjectArrayComparison ||
-		runtimeRequested
+	comparisonRequested := a.Config.Analyze.DetectObjectArrayComparison && hasArrayVariable && arrayHasComparisonExpression(proc)
 	// A procedure can contain an object array even when the explicit lifecycle
 	// switches are disabled. The shared transfer owns the always-on VBA101/
 	// VBA102 projection for that case.
@@ -98,12 +95,19 @@ func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure
 		a.Config.Analyze.DetectRedimPreserveDimension ||
 		objectArrayApplicable ||
 		runtimeRequested
-	if coreRequested || objectArrayApplicable {
+	if coreFlowRequested || comparisonRequested {
 		var runtimeSink *[]Finding
 		if runtimeRequested {
 			runtimeSink = &result.runtimeFindings
 		}
-		result.lifecycleFindings = a.arrayLifecycleFindingsPreparedWithRuntimeEntry(file, proc, ctx, moduleDecls, result.variables, result.constants, result.capacityGuards, runtimeSink, entryState)
+		if coreFlowRequested {
+			result.lifecycleFindings = a.arrayLifecycleFindingsPreparedWithRuntimeEntry(file, proc, ctx, moduleDecls, result.variables, result.constants, result.capacityGuards, runtimeSink, entryState)
+		} else {
+			// VBA209 is an expression-only projection. Keep it out of the
+			// allocation worklist when no other core lane is applicable; this
+			// makes array_cfg_walks reflect actual fixed-point work.
+			result.lifecycleFindings = a.arrayComparisonFindings(file, proc, result.variables)
+		}
 		if proc.Graph != nil && coreFlowRequested {
 			result.cfgWalks++
 		}

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -46,7 +46,21 @@ func (r *ArrayAnalysisResult) findings(kind string) []Finding {
 	case "range":
 		source = r.rangeFindings
 	}
-	return append([]Finding(nil), source...)
+	if source == nil {
+		return nil
+	}
+	findings := make([]Finding, len(source))
+	for index, finding := range source {
+		findings[index] = finding
+		if finding.NearbyCode != nil {
+			findings[index].NearbyCode = append([]string(nil), finding.NearbyCode...)
+		}
+		if finding.RuntimeError != nil {
+			runtimeError := *finding.RuntimeError
+			findings[index].RuntimeError = &runtimeError
+		}
+	}
+	return findings
 }
 
 func arrayAnalysisEnabled(cfg config.AnalyzeConfig) bool {

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 // ArrayAnalysisResult is the immutable, procedure-local semantic result used
@@ -203,6 +204,12 @@ func arrayHasComparisonExpression(proc sourceProcedure) bool {
 // source. Unknown/recovered statements are left applicable so the existing
 // conservative scanner remains fail-open.
 func rangeValueShapeApplicable(file parsedFile, proc sourceProcedure) bool {
+	if rangeValueProjectionUnknown(proc) {
+		// A partial/recovered projection is not proof that the source lacks a
+		// Range.Value operation. Keep the domain enabled so the source fallback
+		// can make a conservative attempt.
+		return true
+	}
 	// A recovered/empty IR projection is not proof that the procedure has no
 	// Range.Value operation. Use the source lines in that case; the fallback is
 	// deliberately limited to procedures with no statement projection so the
@@ -234,6 +241,21 @@ func rangeValueShapeApplicable(file parsedFile, proc sourceProcedure) bool {
 		}
 		lower := strings.ToLower(expression.Text)
 		if strings.Contains(lower, ".value") || strings.Contains(lower, "range(") || strings.Contains(lower, "resize(") || strings.Contains(lower, "cells(") {
+			return true
+		}
+	}
+	return false
+}
+
+func rangeValueProjectionUnknown(proc sourceProcedure) bool {
+	if proc.Features.unknown&featureRangeArray == 0 {
+		return false
+	}
+	if len(proc.Statements) == 0 || len(proc.Expressions) == 0 || proc.Graph == nil {
+		return true
+	}
+	for _, statement := range proc.Statements {
+		if statement.Recovered || statement.Kind == procedureir.StatementRecovered || statement.Kind == procedureir.StatementUnknown {
 			return true
 		}
 	}

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -106,7 +106,7 @@ func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure
 		if proc.Graph != nil && coreFlowRequested {
 			result.cfgWalks++
 		}
-		result.projectionRuns += arrayCoreProjectionRuns(a.Config.Analyze, proc, variables, objectArrayApplicable, runtimeRequested)
+		result.projectionRuns += arrayCoreProjectionRuns(a.Config.Analyze, file, proc, variables, objectArrayApplicable, runtimeRequested)
 	}
 	if a.Config.Analyze.DetectRedimPreserveInLoops {
 		var redimApplicable bool
@@ -140,7 +140,7 @@ func arrayObjectArrayApplicable(variables map[string]arrayVariable) bool {
 // core lane. The lane itself is one worklist, but telemetry reports the
 // enabled, applicable diagnostic projections rather than treating that lane as
 // one diagnostic. This keeps the counter independent from finding multiplicity.
-func arrayCoreProjectionRuns(cfg config.AnalyzeConfig, proc sourceProcedure, variables map[string]arrayVariable, objectArrayApplicable, runtimeRequested bool) uint64 {
+func arrayCoreProjectionRuns(cfg config.AnalyzeConfig, file parsedFile, proc sourceProcedure, variables map[string]arrayVariable, objectArrayApplicable, runtimeRequested bool) uint64 {
 	var runs uint64
 	hasArray := false
 	for _, variable := range variables {
@@ -149,7 +149,7 @@ func arrayCoreProjectionRuns(cfg config.AnalyzeConfig, proc sourceProcedure, var
 			break
 		}
 	}
-	if cfg.DetectArrayLifecycleSafety && arrayLifecycleProjectionApplicable(proc, variables) {
+	if cfg.DetectArrayLifecycleSafety && arrayLifecycleProjectionApplicable(file, proc, variables) {
 		runs++ // VBA227 lifecycle and For Each projection
 	}
 	if runtimeRequested {
@@ -167,19 +167,41 @@ func arrayCoreProjectionRuns(cfg config.AnalyzeConfig, proc sourceProcedure, var
 	return runs
 }
 
-func arrayLifecycleProjectionApplicable(proc sourceProcedure, variables map[string]arrayVariable) bool {
-	if len(variables) > 0 {
-		for _, statement := range proc.Statements {
-			lower := strings.ToLower(statement.Text)
-			if strings.Contains(lower, "redim") || strings.Contains(lower, "erase ") || strings.Contains(lower, "lbound(") || strings.Contains(lower, "ubound(") || strings.Contains(lower, "for each") {
-				return true
-			}
-			if len(arrayIndexedUses(statement.Text, variables)) > 0 {
+func arrayLifecycleProjectionApplicable(file parsedFile, proc sourceProcedure, variables map[string]arrayVariable) bool {
+	if len(variables) == 0 {
+		return false
+	}
+	for _, statement := range proc.Statements {
+		if arrayLifecycleTextApplicable(statement.Text, variables) {
+			return true
+		}
+	}
+	if proc.Features.unknown&featureArray != 0 {
+		return true
+	}
+	start, end := proc.StartLine, proc.EndLine
+	if start < 1 {
+		start = 1
+	}
+	if end <= 0 || end > len(file.Lines) {
+		end = len(file.Lines)
+	}
+	if start <= end {
+		for line := start; line <= end; line++ {
+			if arrayLifecycleTextApplicable(normalizedCodeLine(file.Lines[line-1]), variables) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func arrayLifecycleTextApplicable(text string, variables map[string]arrayVariable) bool {
+	lower := strings.ToLower(text)
+	if strings.Contains(lower, "redim") || strings.Contains(lower, "erase ") || strings.Contains(lower, "lbound(") || strings.Contains(lower, "ubound(") || strings.Contains(lower, "for each") {
+		return true
+	}
+	return len(arrayIndexedUses(text, variables)) > 0
 }
 
 func arrayHasRedimPreserveOperation(proc sourceProcedure) bool {

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -116,10 +116,12 @@ func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure
 			result.projectionRuns++
 		}
 	}
-	if a.Config.Analyze.DetectRangeValueArrayShape && rangeValueShapeApplicable(proc) {
+	if a.Config.Analyze.DetectRangeValueArrayShape && rangeValueShapeApplicable(file, proc) {
 		result.rangeFindings = a.rangeValueShapeFindings(file, proc)
 		result.projectionRuns++
-		if proc.Graph != nil {
+		// An empty statement projection uses the source-line fallback and does
+		// not start the graph worklist, even when a recovered CFG object exists.
+		if proc.Graph != nil && len(proc.Statements) > 0 {
 			result.cfgWalks++
 		}
 	}
@@ -193,7 +195,23 @@ func arrayHasComparisonExpression(proc sourceProcedure) bool {
 // start a Range.Value worklist when the procedure has no Range.Value-shaped
 // source. Unknown/recovered statements are left applicable so the existing
 // conservative scanner remains fail-open.
-func rangeValueShapeApplicable(proc sourceProcedure) bool {
+func rangeValueShapeApplicable(file parsedFile, proc sourceProcedure) bool {
+	// A recovered/empty IR projection is not proof that the procedure has no
+	// Range.Value operation. Use the source lines in that case; the fallback is
+	// deliberately limited to procedures with no statement projection so the
+	// normal IR gate remains unchanged for complete procedures.
+	if len(proc.Statements) == 0 {
+		for _, expression := range proc.Expressions {
+			if expression.Recovered {
+				return true
+			}
+			lower := strings.ToLower(expression.Text)
+			if strings.Contains(lower, ".value") || strings.Contains(lower, "range(") || strings.Contains(lower, "resize(") || strings.Contains(lower, "cells(") {
+				return true
+			}
+		}
+		return rangeValueSourceLinesApplicable(file, proc)
+	}
 	for _, statement := range proc.Statements {
 		if statement.Recovered {
 			return true

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -276,9 +276,12 @@ func rangeValueProjectionUnknown(proc sourceProcedure) bool {
 	if proc.Features.unknown&featureRangeArray == 0 {
 		return false
 	}
-	if len(proc.Statements) == 0 || len(proc.Expressions) == 0 || proc.Graph == nil {
+	if len(proc.Statements) == 0 || len(proc.Expressions) == 0 {
 		return true
 	}
+	// A graphless procedure can still have a complete statement/expression
+	// projection. Keep the existing linear IR transfer for that case; only an
+	// actually incomplete projection should fall back to source text.
 	for _, statement := range proc.Statements {
 		if statement.Recovered || statement.Kind == procedureir.StatementRecovered || statement.Kind == procedureir.StatementUnknown {
 			return true

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -1,0 +1,228 @@
+package analyze
+
+import (
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+)
+
+// ArrayAnalysisResult is the immutable, procedure-local semantic result used
+// by array diagnostic projections.  It intentionally has no public fields:
+// the result is an implementation detail of one analysis revision and must
+// not become a cross-revision cache or a mutable rule API.
+//
+// The slices and maps are populated before the result is handed to any
+// projector.  Projectors only read them and create Finding values, which makes
+// the result safe for concurrent read-only consumers.
+type ArrayAnalysisResult struct {
+	variables      map[string]arrayVariable
+	constants      map[string]int
+	capacityGuards []arrayResumeNextCapacityGuard
+	// cfgWalks counts only fixed-point worklists owned by this result. The
+	// ReDim-in-loop inspection is intentionally not included; Range.Value
+	// shape is the only explicitly separate secondary lattice.
+	cfgWalks       uint64
+	projectionRuns uint64
+
+	lifecycleFindings []Finding
+	runtimeFindings   []Finding
+	redimFindings     []Finding
+	rangeFindings     []Finding
+}
+
+func (r *ArrayAnalysisResult) findings(kind string) []Finding {
+	if r == nil {
+		return nil
+	}
+	var source []Finding
+	switch kind {
+	case "lifecycle":
+		source = r.lifecycleFindings
+	case "runtime":
+		source = r.runtimeFindings
+	case "redim":
+		source = r.redimFindings
+	case "range":
+		source = r.rangeFindings
+	}
+	return append([]Finding(nil), source...)
+}
+
+func arrayAnalysisEnabled(cfg config.AnalyzeConfig) bool {
+	if cfg.DetectArrayLifecycleSafety || cfg.DetectRedimPreserveDimension || cfg.DetectObjectArrayComparison || cfg.DetectRedimPreserveInLoops || cfg.DetectRangeValueArrayShape {
+		return true
+	}
+	enabled, known := config.AnalyzeRuleEnabled(cfg, "VBA249")
+	return (!known || enabled) && cfg.DetectDeterministicRuntimeErrors
+}
+
+// buildArrayAnalysisResult materializes all procedure-local array preparation
+// once.  Project-wide ByRef/module/return summaries are supplied by ctx and
+// remain owned by the existing analysis-context fixed points.
+func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration) *ArrayAnalysisResult {
+	if !arrayAnalysisEnabled(a.Config.Analyze) {
+		return nil
+	}
+	variables := arrayVariables(file, proc, moduleDecls)
+	result := &ArrayAnalysisResult{
+		variables:      variables,
+		constants:      arrayIntegerConstants(file, proc, a.visibleConstantValues, a.visibleConstants),
+		capacityGuards: arrayResumeNextCapacityGuards(file, proc, variables),
+	}
+	entryState := arrayEntryStateForProcedure(file, proc, ctx, moduleDecls, variables)
+
+	runtimeEnabled, knownRuntimeRule := config.AnalyzeRuleEnabled(a.Config.Analyze, "VBA249")
+	hasArrayVariable := false
+	for _, variable := range variables {
+		if variable.isArray {
+			hasArrayVariable = true
+			break
+		}
+	}
+	runtimeRequested := hasArrayVariable && a.Config.Analyze.DetectDeterministicRuntimeErrors && (!knownRuntimeRule || runtimeEnabled)
+	coreRequested := a.Config.Analyze.DetectArrayLifecycleSafety ||
+		a.Config.Analyze.DetectRedimPreserveDimension ||
+		a.Config.Analyze.DetectObjectArrayComparison ||
+		runtimeRequested
+	// A procedure can contain an object array even when the explicit lifecycle
+	// switches are disabled. The shared transfer owns the always-on VBA101/
+	// VBA102 projection for that case.
+	objectArrayApplicable := false
+	for _, variable := range variables {
+		if variable.isArray && variable.isObject {
+			objectArrayApplicable = true
+			break
+		}
+	}
+	coreFlowRequested := a.Config.Analyze.DetectArrayLifecycleSafety ||
+		a.Config.Analyze.DetectRedimPreserveDimension ||
+		objectArrayApplicable ||
+		runtimeRequested
+	if coreRequested || objectArrayApplicable {
+		var runtimeSink *[]Finding
+		if runtimeRequested {
+			runtimeSink = &result.runtimeFindings
+		}
+		result.lifecycleFindings = a.arrayLifecycleFindingsPreparedWithRuntimeEntry(file, proc, ctx, moduleDecls, result.variables, result.constants, result.capacityGuards, runtimeSink, entryState)
+		if proc.Graph != nil && coreFlowRequested {
+			result.cfgWalks++
+		}
+		result.projectionRuns += arrayCoreProjectionRuns(a.Config.Analyze, proc, variables, objectArrayApplicable, runtimeRequested)
+	}
+	if a.Config.Analyze.DetectRedimPreserveInLoops {
+		var redimApplicable bool
+		result.redimFindings, redimApplicable = a.redimPreserveLoopFindingsPreparedWithApplicability(file, proc, moduleDecls, result.variables)
+		if redimApplicable {
+			result.projectionRuns++
+		}
+	}
+	if a.Config.Analyze.DetectRangeValueArrayShape && rangeValueShapeApplicable(proc) {
+		result.rangeFindings = a.rangeValueShapeFindings(file, proc)
+		result.projectionRuns++
+		if proc.Graph != nil {
+			result.cfgWalks++
+		}
+	}
+	return result
+}
+
+// arrayCoreProjectionRuns counts the compatible projections fed by the shared
+// core lane. The lane itself is one worklist, but telemetry reports the
+// enabled, applicable diagnostic projections rather than treating that lane as
+// one diagnostic. This keeps the counter independent from finding multiplicity.
+func arrayCoreProjectionRuns(cfg config.AnalyzeConfig, proc sourceProcedure, variables map[string]arrayVariable, objectArrayApplicable, runtimeRequested bool) uint64 {
+	var runs uint64
+	hasArray := false
+	for _, variable := range variables {
+		if variable.isArray {
+			hasArray = true
+			break
+		}
+	}
+	if cfg.DetectArrayLifecycleSafety && arrayLifecycleProjectionApplicable(proc, variables) {
+		runs++ // VBA227 lifecycle and For Each projection
+	}
+	if runtimeRequested {
+		runs++ // deterministic array VBA249 projection
+	}
+	if cfg.DetectRedimPreserveDimension && arrayHasRedimPreserveOperation(proc) {
+		runs++ // VBA208
+	}
+	if cfg.DetectObjectArrayComparison && hasArray && arrayHasComparisonExpression(proc) {
+		runs++ // VBA209
+	}
+	if objectArrayApplicable {
+		runs++ // VBA101/VBA102
+	}
+	return runs
+}
+
+func arrayLifecycleProjectionApplicable(proc sourceProcedure, variables map[string]arrayVariable) bool {
+	if len(variables) > 0 {
+		for _, statement := range proc.Statements {
+			lower := strings.ToLower(statement.Text)
+			if strings.Contains(lower, "redim") || strings.Contains(lower, "erase ") || strings.Contains(lower, "lbound(") || strings.Contains(lower, "ubound(") || strings.Contains(lower, "for each") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func arrayHasRedimPreserveOperation(proc sourceProcedure) bool {
+	for _, statement := range proc.Statements {
+		if strings.Contains(strings.ToLower(statement.Text), "redim preserve") {
+			return true
+		}
+	}
+	return false
+}
+
+func arrayHasComparisonExpression(proc sourceProcedure) bool {
+	for _, expression := range proc.Expressions {
+		if expression.SyntaxKind == "comparison_expression" && !expression.Recovered {
+			return true
+		}
+	}
+	return false
+}
+
+// rangeValueShapeApplicable is the cheap procedure-level gate for the
+// deliberately independent Range.Value lattice.  The planner can schedule
+// the array domain for another rule (for example ReDim), but that must not
+// start a Range.Value worklist when the procedure has no Range.Value-shaped
+// source. Unknown/recovered statements are left applicable so the existing
+// conservative scanner remains fail-open.
+func rangeValueShapeApplicable(proc sourceProcedure) bool {
+	for _, statement := range proc.Statements {
+		if statement.Recovered {
+			return true
+		}
+		lower := strings.ToLower(statement.Text)
+		if strings.Contains(lower, ".value") || strings.Contains(lower, "range(") || strings.Contains(lower, "resize(") || strings.Contains(lower, "cells(") {
+			return true
+		}
+	}
+	for _, expression := range proc.Expressions {
+		if expression.Recovered {
+			return true
+		}
+		lower := strings.ToLower(expression.Text)
+		if strings.Contains(lower, ".value") || strings.Contains(lower, "range(") || strings.Contains(lower, "resize(") || strings.Contains(lower, "cells(") {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ArrayAnalysisResult) lifecycle() []Finding  { return r.findings("lifecycle") }
+func (r *ArrayAnalysisResult) runtime() []Finding    { return r.findings("runtime") }
+func (r *ArrayAnalysisResult) redim() []Finding      { return r.findings("redim") }
+func (r *ArrayAnalysisResult) rangeShape() []Finding { return r.findings("range") }
+
+func arrayEntryStateForProcedure(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration, variables map[string]arrayVariable) arrayFlowState {
+	state := arrayInitialState(variables)
+	state = applyArrayInternalStorageConfiguration(state, file, proc, variables, moduleDecls, ctx.arrayModuleConfigurations[file.Path])
+	state = applyArrayByRefEntryStates(state, proc, variables, ctx.arrayByRefEntryStates, ctx.arrayByRefEntryConditions)
+	return applyArrayModuleEntryState(state, file, proc, variables, moduleDecls, ctx.arrayModuleEntryStates)
+}

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -120,7 +120,7 @@ func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure
 		result.projectionRuns++
 		// An empty statement projection uses the source-line fallback and does
 		// not start the graph worklist, even when a recovered CFG object exists.
-		if proc.Graph != nil && len(proc.Statements) > 0 {
+		if proc.Graph != nil && len(proc.Statements) > 0 && !rangeValueProjectionUnknown(proc) {
 			result.cfgWalks++
 		}
 	}
@@ -172,6 +172,9 @@ func arrayLifecycleProjectionApplicable(proc sourceProcedure, variables map[stri
 		for _, statement := range proc.Statements {
 			lower := strings.ToLower(statement.Text)
 			if strings.Contains(lower, "redim") || strings.Contains(lower, "erase ") || strings.Contains(lower, "lbound(") || strings.Contains(lower, "ubound(") || strings.Contains(lower, "for each") {
+				return true
+			}
+			if len(arrayIndexedUses(statement.Text, variables)) > 0 {
 				return true
 			}
 		}

--- a/internal/analyze/array_analysis_test.go
+++ b/internal/analyze/array_analysis_test.go
@@ -15,8 +15,8 @@ func TestArrayAnalysisResultConcurrentRead(t *testing.T) {
 		variables: map[string]arrayVariable{
 			"values": {name: "values", isArray: true},
 		},
-		lifecycleFindings: []Finding{{Code: "VBA227", Message: "array"}},
-		runtimeFindings:   []Finding{{Code: "VBA249", Message: "runtime"}},
+		lifecycleFindings: []Finding{{Code: "VBA227", Message: "array", NearbyCode: []string{"original nearby"}}},
+		runtimeFindings:   []Finding{{Code: "VBA249", Message: "runtime", RuntimeError: &RuntimeErrorContext{Kind: "original runtime"}}},
 		redimFindings:     []Finding{{Code: "VBA208", Message: "redim"}},
 		rangeFindings:     []Finding{{Code: "VBA226", Message: "shape"}},
 	}
@@ -49,8 +49,17 @@ func TestArrayAnalysisResultConcurrentRead(t *testing.T) {
 
 	copyOfFindings := result.lifecycle()
 	copyOfFindings[0].Code = "mutated-copy"
+	copyOfFindings[0].NearbyCode[0] = "mutated-nearby-copy"
 	if result.lifecycle()[0].Code != "VBA227" {
 		t.Fatal("projector copy mutated the immutable result")
+	}
+	if result.lifecycle()[0].NearbyCode[0] != "original nearby" {
+		t.Fatal("projector copy mutated nested nearby code in the immutable result")
+	}
+	runtimeCopy := result.runtime()
+	runtimeCopy[0].RuntimeError.Kind = "mutated-runtime-copy"
+	if result.runtime()[0].RuntimeError.Kind != "original runtime" {
+		t.Fatal("projector copy mutated nested runtime error in the immutable result")
 	}
 }
 

--- a/internal/analyze/array_analysis_test.go
+++ b/internal/analyze/array_analysis_test.go
@@ -57,7 +57,16 @@ func TestArrayAnalysisResultConcurrentRead(t *testing.T) {
 func TestArrayLifecycleProjectionApplicableIncludesIndexedAccess(t *testing.T) {
 	proc := sourceProcedure{Statements: []procedureir.Statement{{Text: "Debug.Print values(2)"}}}
 	variables := map[string]arrayVariable{"values": {name: "values", isArray: true}}
-	if !arrayLifecycleProjectionApplicable(proc, variables) {
+	if !arrayLifecycleProjectionApplicable(parsedFile{}, proc, variables) {
 		t.Fatal("indexed array access should make the VBA227 projection applicable")
+	}
+}
+
+func TestArrayLifecycleProjectionApplicableIncludesRecoveredSource(t *testing.T) {
+	proc := sourceProcedure{StartLine: 1, EndLine: 3}
+	file := parsedFile{Lines: []string{"Sub Run()", "  Debug.Print values(2)", "End Sub"}}
+	variables := map[string]arrayVariable{"values": {name: "values", isArray: true}}
+	if !arrayLifecycleProjectionApplicable(file, proc, variables) {
+		t.Fatal("recovered source indexed access should make the VBA227 projection applicable")
 	}
 }

--- a/internal/analyze/array_analysis_test.go
+++ b/internal/analyze/array_analysis_test.go
@@ -1,0 +1,53 @@
+package analyze
+
+import (
+	"sync"
+	"testing"
+)
+
+// ArrayAnalysisResult is handed to independent diagnostic projectors after
+// materialization. This test exercises the read-only contract and, when run
+// with -race, catches accidental lazy mutation of projection-owned slices.
+func TestArrayAnalysisResultConcurrentRead(t *testing.T) {
+	result := &ArrayAnalysisResult{
+		variables: map[string]arrayVariable{
+			"values": {name: "values", isArray: true},
+		},
+		lifecycleFindings: []Finding{{Code: "VBA227", Message: "array"}},
+		runtimeFindings:   []Finding{{Code: "VBA249", Message: "runtime"}},
+		redimFindings:     []Finding{{Code: "VBA208", Message: "redim"}},
+		rangeFindings:     []Finding{{Code: "VBA226", Message: "shape"}},
+	}
+
+	const readers = 8
+	const iterations = 200
+	var wait sync.WaitGroup
+	wait.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wait.Done()
+			for j := 0; j < iterations; j++ {
+				for _, finding := range result.lifecycle() {
+					if finding.Code != "VBA227" {
+						t.Errorf("lifecycle code = %q", finding.Code)
+					}
+				}
+				for _, finding := range result.runtime() {
+					if finding.Code != "VBA249" {
+						t.Errorf("runtime code = %q", finding.Code)
+					}
+				}
+				if len(result.redim()) != 1 || len(result.rangeShape()) != 1 {
+					t.Errorf("projection result was mutated")
+				}
+			}
+		}()
+	}
+	wait.Wait()
+
+	copyOfFindings := result.lifecycle()
+	copyOfFindings[0].Code = "mutated-copy"
+	if result.lifecycle()[0].Code != "VBA227" {
+		t.Fatal("projector copy mutated the immutable result")
+	}
+}

--- a/internal/analyze/array_analysis_test.go
+++ b/internal/analyze/array_analysis_test.go
@@ -3,6 +3,8 @@ package analyze
 import (
 	"sync"
 	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 // ArrayAnalysisResult is handed to independent diagnostic projectors after
@@ -49,5 +51,13 @@ func TestArrayAnalysisResultConcurrentRead(t *testing.T) {
 	copyOfFindings[0].Code = "mutated-copy"
 	if result.lifecycle()[0].Code != "VBA227" {
 		t.Fatal("projector copy mutated the immutable result")
+	}
+}
+
+func TestArrayLifecycleProjectionApplicableIncludesIndexedAccess(t *testing.T) {
+	proc := sourceProcedure{Statements: []procedureir.Statement{{Text: "Debug.Print values(2)"}}}
+	variables := map[string]arrayVariable{"values": {name: "values", isArray: true}}
+	if !arrayLifecycleProjectionApplicable(proc, variables) {
+		t.Fatal("indexed array access should make the VBA227 projection applicable")
 	}
 }

--- a/internal/analyze/array_kernel_benchmark_test.go
+++ b/internal/analyze/array_kernel_benchmark_test.go
@@ -1,0 +1,352 @@
+package analyze
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/typedb"
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+)
+
+// arrayKernelBenchmarkWorkload describes the source shapes used to compare
+// array-heavy procedure analysis. Source construction is deliberately outside
+// the timed benchmark loop; the benchmark therefore measures analyzer work,
+// including any procedure-local array preparation and CFG traversal.
+type arrayKernelBenchmarkWorkload struct {
+	name          string
+	source        string
+	lines         int
+	procedures    int
+	arrayMarkers  int
+	statementHint int
+}
+
+// BenchmarkArrayAnalysisKernel covers the workload classes called out by the
+// array semantic-kernel design. The single/all projection modes make it
+// possible to compare a representative array rule with the simultaneously
+// enabled array rule set. Recorder metrics are emitted through the shared
+// benchmark helper, so newly added array_kernel_runs, array_cfg_walks, and
+// array_projection_runs counters are reported without coupling this fixture to
+// their eventual Go identifiers.
+func BenchmarkArrayAnalysisKernel(b *testing.B) {
+	for _, workload := range arrayKernelBenchmarkWorkloads() {
+		workload := workload
+		b.Run(workload.name, func(b *testing.B) {
+			for _, mode := range []struct {
+				name string
+				cfg  func(*config.Config)
+			}{
+				{name: "no-array-rules", cfg: configureArrayBenchmarkRulesNone},
+				{name: "VBA227", cfg: configureArrayBenchmarkRulesVBA227},
+				{name: "all-array-rules", cfg: configureArrayBenchmarkRulesAll},
+			} {
+				mode := mode
+				b.Run(mode.name, func(b *testing.B) {
+					root := b.TempDir()
+					fixture := writeArrayKernelBenchmarkProject(b, root, workload)
+					b.Setenv(typedb.EnvDir, filepath.Join(b.TempDir(), "typelib"))
+					cfg := config.Default()
+					mode.cfg(&cfg)
+					recorder := analysisstats.NewRecorder()
+					ctx := analysisstats.WithRecorder(context.Background(), recorder)
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					findings := 0
+					warnings := 0
+					for i := 0; i < b.N; i++ {
+						result, err := (Analyzer{RootDir: root, Config: cfg}).RunResultContext(ctx)
+						if err != nil {
+							b.Fatalf("analyze %s array fixture (%s): %v", workload.name, mode.name, err)
+						}
+						findings += len(result.Findings)
+						warnings += len(result.Warnings)
+					}
+					b.StopTimer()
+
+					b.ReportMetric(float64(fixture.lines), "lines/op")
+					b.ReportMetric(float64(fixture.procedures), "procedures/op")
+					b.ReportMetric(float64(fixture.arrayMarkers), "array-markers/op")
+					b.ReportMetric(float64(fixture.statementHint), "statement-hint/op")
+					b.ReportMetric(float64(findings)/float64(b.N), "findings/op")
+					b.ReportMetric(float64(warnings)/float64(b.N), "warnings/op")
+					reportAnalysisRecorderMetrics(b, recorder, b.N)
+				})
+			}
+		})
+	}
+}
+
+// TestArrayKernelBenchmarkFixtureScale keeps the benchmark matrix visible to
+// ordinary test runs without executing the analyzer for every workload.
+func TestArrayKernelBenchmarkFixtureScale(t *testing.T) {
+	for _, workload := range arrayKernelBenchmarkWorkloads() {
+		workload := workload
+		t.Run(workload.name, func(t *testing.T) {
+			fixture := writeArrayKernelBenchmarkProject(t, t.TempDir(), workload)
+			if fixture.lines != workload.lines || fixture.procedures != workload.procedures {
+				t.Fatalf("fixture dimensions = lines %d/procedures %d, want %d/%d", fixture.lines, fixture.procedures, workload.lines, workload.procedures)
+			}
+			if fixture.arrayMarkers != workload.arrayMarkers {
+				t.Fatalf("fixture array markers = %d, want %d", fixture.arrayMarkers, workload.arrayMarkers)
+			}
+			if fixture.source == "" {
+				t.Fatal("fixture source path is empty")
+			}
+		})
+	}
+}
+
+// TestArrayKernelProjectionWorkCounters is intentionally feature-gated while
+// the shared kernel is being introduced. It becomes an executable contract as
+// soon as the three telemetry counters from #696 are published; older
+// revisions keep the benchmark fixture useful without making this scaffolding
+// depend on an unfinished recorder API.
+func TestArrayKernelProjectionWorkCounters(t *testing.T) {
+	workload := arrayKernelBenchmarkWorkloads()[2] // redim-heavy
+	single := runArrayKernelBenchmarkCounterFixture(t, workload, configureArrayBenchmarkRulesVBA227)
+	all := runArrayKernelBenchmarkCounterFixture(t, workload, configureArrayBenchmarkRulesAll)
+	if !hasArrayKernelTelemetry(single) || !hasArrayKernelTelemetry(all) {
+		t.Skip("array kernel telemetry is not available yet")
+	}
+	if single["array_kernel_runs"] != 1 || all["array_kernel_runs"] != 1 {
+		t.Fatalf("array kernel runs = single %d/all %d, want one per procedure revision", single["array_kernel_runs"], all["array_kernel_runs"])
+	}
+	if all["array_projection_runs"] <= single["array_projection_runs"] {
+		t.Fatalf("array projection runs = single %d/all %d, want additional enabled projections", single["array_projection_runs"], all["array_projection_runs"])
+	}
+	// VBA226 is the documented exceptional secondary pass. Any increase in
+	// CFG walks beyond that one pass would indicate that projections are still
+	// rebuilding the main array fixed point.
+	if all["array_cfg_walks"] > single["array_cfg_walks"]+1 {
+		t.Fatalf("array CFG walks = single %d/all %d, want at most one secondary pass", single["array_cfg_walks"], all["array_cfg_walks"])
+	}
+}
+
+func hasArrayKernelTelemetry(counters map[string]uint64) bool {
+	for _, name := range []string{"array_kernel_runs", "array_cfg_walks", "array_projection_runs"} {
+		if _, ok := counters[name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func runArrayKernelBenchmarkCounterFixture(t *testing.T, workload arrayKernelBenchmarkWorkload, configure func(*config.Config)) map[string]uint64 {
+	t.Helper()
+	root := t.TempDir()
+	writeArrayKernelBenchmarkProject(t, root, workload)
+	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
+	cfg := config.Default()
+	configure(&cfg)
+	recorder := analysisstats.NewRecorder()
+	if _, err := (Analyzer{RootDir: root, Config: cfg}).RunResultContext(analysisstats.WithRecorder(context.Background(), recorder)); err != nil {
+		t.Fatalf("analyze %s array fixture: %v", workload.name, err)
+	}
+	_, counters := recorder.Totals()
+	values := make(map[string]uint64, len(counters))
+	for _, counter := range counters {
+		values[counter.Name] = counter.Value
+	}
+	return values
+}
+
+func arrayKernelBenchmarkWorkloads() []arrayKernelBenchmarkWorkload {
+	workloads := []arrayKernelBenchmarkWorkload{
+		arrayKernelBenchmarkWorkload{
+			name:          "no-arrays",
+			source:        arrayBenchmarkNoArraysSource(),
+			procedures:    1,
+			arrayMarkers:  0,
+			statementHint: 8,
+		},
+		arrayKernelBenchmarkWorkload{
+			name:          "simple-dynamic",
+			source:        arrayBenchmarkSimpleDynamicSource(),
+			procedures:    1,
+			arrayMarkers:  4,
+			statementHint: 8,
+		},
+		arrayKernelBenchmarkWorkload{
+			name:          "redim-heavy",
+			source:        arrayBenchmarkRedimHeavySource(32),
+			procedures:    1,
+			arrayMarkers:  35,
+			statementHint: 40,
+		},
+		arrayKernelBenchmarkWorkload{
+			name:          "branch-heavy",
+			source:        arrayBenchmarkBranchHeavySource(16),
+			procedures:    1,
+			arrayMarkers:  33,
+			statementHint: 64,
+		},
+		arrayKernelBenchmarkWorkload{
+			name:          "multidimensional",
+			source:        arrayBenchmarkMultidimensionalSource(),
+			procedures:    1,
+			arrayMarkers:  8,
+			statementHint: 12,
+		},
+		arrayKernelBenchmarkWorkload{
+			name:          "byref-array-flow",
+			source:        arrayBenchmarkByRefSource(),
+			procedures:    2,
+			arrayMarkers:  7,
+			statementHint: 14,
+		},
+		arrayKernelBenchmarkWorkload{
+			name:          "large-cfg",
+			source:        arrayBenchmarkBranchHeavySource(96),
+			procedures:    1,
+			arrayMarkers:  193,
+			statementHint: 384,
+		},
+	}
+	for i := range workloads {
+		workloads[i].lines = len(normalizedSourceLines(workloads[i].source)) - 1
+	}
+	return workloads
+}
+
+func configureArrayBenchmarkRulesNone(cfg *config.Config) {
+	configureArrayBenchmarkRules(cfg, false)
+}
+
+func configureArrayBenchmarkRulesVBA227(cfg *config.Config) {
+	configureArrayBenchmarkRules(cfg, false)
+	cfg.Analyze.DetectArrayLifecycleSafety = true
+}
+
+func configureArrayBenchmarkRulesAll(cfg *config.Config) {
+	configureArrayBenchmarkRules(cfg, true)
+}
+
+func configureArrayBenchmarkRules(cfg *config.Config, enabled bool) {
+	cfg.Analyze.DetectRedimPreserveDimension = enabled
+	cfg.Analyze.DetectObjectArrayComparison = enabled
+	cfg.Analyze.DetectRangeValueArrayShape = enabled
+	cfg.Analyze.DetectArrayLifecycleSafety = enabled
+	cfg.Analyze.DetectRedimPreserveInLoops = enabled
+	cfg.Analyze.DetectDeterministicRuntimeErrors = enabled
+}
+
+type arrayKernelBenchmarkFixture struct {
+	source        string
+	lines         int
+	procedures    int
+	arrayMarkers  int
+	statementHint int
+}
+
+func writeArrayKernelBenchmarkProject(tb testing.TB, root string, workload arrayKernelBenchmarkWorkload) arrayKernelBenchmarkFixture {
+	tb.Helper()
+	modules := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(modules, 0o755); err != nil {
+		tb.Fatalf("create array benchmark source directory: %v", err)
+	}
+	path := filepath.Join(modules, "Arrays.bas")
+	if err := os.WriteFile(path, []byte(workload.source), 0o644); err != nil {
+		tb.Fatalf("write %s array benchmark fixture: %v", workload.name, err)
+	}
+	return arrayKernelBenchmarkFixture{
+		source:        path,
+		lines:         len(normalizedSourceLines(workload.source)) - 1,
+		procedures:    workload.procedures,
+		arrayMarkers:  workload.arrayMarkers,
+		statementHint: workload.statementHint,
+	}
+}
+
+func arrayBenchmarkNoArraysSource() string {
+	return `Option Explicit
+
+Public Sub Run()
+    Dim value As Long
+    Dim branch As Long
+    value = 1
+    For branch = 1 To 8
+        If value Mod 2 = 0 Then
+            value = value + branch
+        Else
+            value = value - branch
+        End If
+    Next branch
+    Debug.Print value
+End Sub
+`
+}
+
+func arrayBenchmarkSimpleDynamicSource() string {
+	return `Option Explicit
+
+Public Sub Run()
+    Dim values() As Long
+    ReDim values(0 To 31)
+    values(1) = values(2) + 1
+    If values(1) > 0 Then
+        Debug.Print UBound(values)
+    End If
+End Sub
+`
+}
+
+func arrayBenchmarkRedimHeavySource(count int) string {
+	var source strings.Builder
+	source.WriteString("Option Explicit\n\nPublic Sub Run()\n    Dim values() As Long\n    Dim index As Long\n    ReDim values(0 To 1)\n    For index = 0 To 1\n        ReDim Preserve values(0 To index + 2)\n    Next index\n")
+	for i := 0; i < count; i++ {
+		fmt.Fprintf(&source, "    ReDim Preserve values(0 To %d)\n", i+2)
+	}
+	source.WriteString("    values(1) = UBound(values)\nEnd Sub\n")
+	return source.String()
+}
+
+func arrayBenchmarkBranchHeavySource(branches int) string {
+	var source strings.Builder
+	source.WriteString("Option Explicit\n\nPublic Sub Run()\n    Dim values() As Long\n    Dim selector As Long\n    selector = 1\n")
+	for i := 0; i < branches; i++ {
+		if i == 0 {
+			source.WriteString("    If selector = 0 Then\n")
+		} else {
+			source.WriteString("    ElseIf selector = 0 Then\n")
+		}
+		fmt.Fprintf(&source, "        ReDim values(0 To %d)\n", i+1)
+	}
+	source.WriteString("    Else\n        ReDim values(0 To 1)\n    End If\n    Debug.Print UBound(values)\nEnd Sub\n")
+	return source.String()
+}
+
+func arrayBenchmarkMultidimensionalSource() string {
+	return `Option Explicit
+
+Public Sub Run()
+    Dim matrix() As Double
+    ReDim matrix(0 To 31, 0 To 15, 0 To 3)
+    matrix(1, 2, 3) = matrix(2, 3, 1)
+    ReDim Preserve matrix(0 To 31, 0 To 15, 0 To 7)
+    Debug.Print LBound(matrix, 1), UBound(matrix, 3)
+End Sub
+`
+}
+
+func arrayBenchmarkByRefSource() string {
+	return `Option Explicit
+
+Private Sub Fill(ByRef values() As Long)
+    ReDim values(0 To 31)
+    values(0) = 1
+End Sub
+
+Public Sub Run()
+    Dim values() As Long
+    Fill values
+    values(1) = values(0) + 1
+    Debug.Print UBound(values)
+End Sub
+`
+}

--- a/internal/analyze/array_kernel_benchmark_test.go
+++ b/internal/analyze/array_kernel_benchmark_test.go
@@ -130,6 +130,21 @@ func TestArrayKernelProjectionWorkCounters(t *testing.T) {
 	}
 }
 
+func TestArrayKernelComparisonOnlyDoesNotStartCFGWalk(t *testing.T) {
+	workload := arrayKernelBenchmarkWorkload{
+		name:          "comparison-only",
+		source:        arrayBenchmarkComparisonOnlySource(),
+		lines:         6,
+		procedures:    1,
+		arrayMarkers:  2,
+		statementHint: 4,
+	}
+	counters := runArrayKernelBenchmarkCounterFixture(t, workload, configureArrayBenchmarkRulesVBA209)
+	if counters["array_kernel_runs"] != 1 || counters["array_cfg_walks"] != 0 || counters["array_projection_runs"] != 1 {
+		t.Fatalf("VBA209-only counters = %+v, want kernel=1/cfg=0/projection=1", counters)
+	}
+}
+
 func runArrayKernelBenchmarkCounterFixture(t *testing.T, workload arrayKernelBenchmarkWorkload, configure func(*config.Config)) map[string]uint64 {
 	t.Helper()
 	root := t.TempDir()
@@ -216,6 +231,11 @@ func configureArrayBenchmarkRulesVBA227(cfg *config.Config) {
 	cfg.Analyze.DetectArrayLifecycleSafety = true
 }
 
+func configureArrayBenchmarkRulesVBA209(cfg *config.Config) {
+	configureArrayBenchmarkRules(cfg, false)
+	cfg.Analyze.DetectObjectArrayComparison = true
+}
+
 func configureArrayBenchmarkRulesAll(cfg *config.Config) {
 	configureArrayBenchmarkRules(cfg, true)
 }
@@ -284,6 +304,18 @@ Public Sub Run()
     values(1) = values(2) + 1
     If values(1) > 0 Then
         Debug.Print UBound(values)
+    End If
+End Sub
+`
+}
+
+func arrayBenchmarkComparisonOnlySource() string {
+	return `Option Explicit
+
+Public Sub Run()
+    Dim values() As Long
+    If values = 1 Then
+        Debug.Print 1
     End If
 End Sub
 `

--- a/internal/analyze/array_kernel_benchmark_test.go
+++ b/internal/analyze/array_kernel_benchmark_test.go
@@ -145,6 +145,21 @@ func TestArrayKernelComparisonOnlyDoesNotStartCFGWalk(t *testing.T) {
 	}
 }
 
+func TestArrayKernelAlwaysOnObjectArrayRunsWithRulesDisabled(t *testing.T) {
+	workload := arrayKernelBenchmarkWorkload{
+		name:          "object-array-only",
+		source:        arrayBenchmarkObjectArrayOnlySource(),
+		lines:         7,
+		procedures:    1,
+		arrayMarkers:  3,
+		statementHint: 6,
+	}
+	counters := runArrayKernelBenchmarkCounterFixture(t, workload, configureArrayBenchmarkRulesNone)
+	if counters["array_kernel_runs"] != 1 || counters["array_projection_runs"] != 1 {
+		t.Fatalf("object-array-only counters = %+v, want kernel=1/projection=1", counters)
+	}
+}
+
 func runArrayKernelBenchmarkCounterFixture(t *testing.T, workload arrayKernelBenchmarkWorkload, configure func(*config.Config)) map[string]uint64 {
 	t.Helper()
 	root := t.TempDir()
@@ -317,6 +332,17 @@ Public Sub Run()
     If values = 1 Then
         Debug.Print 1
     End If
+End Sub
+`
+}
+
+func arrayBenchmarkObjectArrayOnlySource() string {
+	return `Option Explicit
+
+Public Sub Run()
+    Dim values() As Object
+    ReDim values(0 To 0)
+    values(0) = Nothing
 End Sub
 `
 }

--- a/internal/analyze/array_kernel_benchmark_test.go
+++ b/internal/analyze/array_kernel_benchmark_test.go
@@ -102,23 +102,25 @@ func TestArrayKernelBenchmarkFixtureScale(t *testing.T) {
 	}
 }
 
-// TestArrayKernelProjectionWorkCounters is intentionally feature-gated while
-// the shared kernel is being introduced. It becomes an executable contract as
-// soon as the three telemetry counters from #696 are published; older
-// revisions keep the benchmark fixture useful without making this scaffolding
-// depend on an unfinished recorder API.
+// TestArrayKernelProjectionWorkCounters makes the shared-kernel telemetry an
+// executable contract. The counters are part of the current recorder API, so
+// a missing counter is a test failure rather than a reason to skip coverage.
 func TestArrayKernelProjectionWorkCounters(t *testing.T) {
 	workload := arrayKernelBenchmarkWorkloads()[2] // redim-heavy
 	single := runArrayKernelBenchmarkCounterFixture(t, workload, configureArrayBenchmarkRulesVBA227)
 	all := runArrayKernelBenchmarkCounterFixture(t, workload, configureArrayBenchmarkRulesAll)
-	if !hasArrayKernelTelemetry(single) || !hasArrayKernelTelemetry(all) {
-		t.Skip("array kernel telemetry is not available yet")
+	for mode, counters := range map[string]map[string]uint64{"single": single, "all": all} {
+		for _, name := range []string{"array_kernel_runs", "array_cfg_walks", "array_projection_runs"} {
+			if _, ok := counters[name]; !ok {
+				t.Fatalf("%s telemetry is missing %q: %+v", mode, name, counters)
+			}
+		}
 	}
 	if single["array_kernel_runs"] != 1 || all["array_kernel_runs"] != 1 {
 		t.Fatalf("array kernel runs = single %d/all %d, want one per procedure revision", single["array_kernel_runs"], all["array_kernel_runs"])
 	}
-	if all["array_projection_runs"] <= single["array_projection_runs"] {
-		t.Fatalf("array projection runs = single %d/all %d, want additional enabled projections", single["array_projection_runs"], all["array_projection_runs"])
+	if single["array_projection_runs"] != 1 || all["array_projection_runs"] != 5 {
+		t.Fatalf("array projection runs = single %d/all %d, want exact single=1/all=5", single["array_projection_runs"], all["array_projection_runs"])
 	}
 	// VBA226 is the documented exceptional secondary pass. Any increase in
 	// CFG walks beyond that one pass would indicate that projections are still
@@ -126,15 +128,6 @@ func TestArrayKernelProjectionWorkCounters(t *testing.T) {
 	if all["array_cfg_walks"] > single["array_cfg_walks"]+1 {
 		t.Fatalf("array CFG walks = single %d/all %d, want at most one secondary pass", single["array_cfg_walks"], all["array_cfg_walks"])
 	}
-}
-
-func hasArrayKernelTelemetry(counters map[string]uint64) bool {
-	for _, name := range []string{"array_kernel_runs", "array_cfg_walks", "array_projection_runs"} {
-		if _, ok := counters[name]; !ok {
-			return false
-		}
-	}
-	return true
 }
 
 func runArrayKernelBenchmarkCounterFixture(t *testing.T, workload arrayKernelBenchmarkWorkload, configure func(*config.Config)) map[string]uint64 {

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -137,6 +137,27 @@ var (
 func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration) []Finding {
 	variables := arrayVariables(file, proc, moduleDecls)
 	capacityGuards := arrayResumeNextCapacityGuards(file, proc, variables)
+	constants := arrayIntegerConstants(file, proc, a.visibleConstantValues, a.visibleConstants)
+	return a.arrayLifecycleFindingsPrepared(file, proc, ctx, moduleDecls, variables, constants, capacityGuards)
+}
+
+// arrayLifecycleFindingsPrepared is used by the shared procedure-local array
+// result. Its preparation inputs are explicit so enabled projections do not
+// rebuild the same variable catalog, constant environment, or capacity guard
+// facts independently.
+func (a Analyzer) arrayLifecycleFindingsPrepared(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration, variables map[string]arrayVariable, constants map[string]int, capacityGuards []arrayResumeNextCapacityGuard) []Finding {
+	return a.arrayLifecycleFindingsPreparedWithRuntime(file, proc, ctx, moduleDecls, variables, constants, capacityGuards, nil)
+}
+
+// arrayLifecycleFindingsPreparedWithRuntime optionally collects the
+// deterministic array runtime projection while the shared array worklist is
+// already visiting the procedure. A non-nil sink removes the historical
+// second VBA249 array walk without changing the standalone helper contract.
+func (a Analyzer) arrayLifecycleFindingsPreparedWithRuntime(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration, variables map[string]arrayVariable, constants map[string]int, capacityGuards []arrayResumeNextCapacityGuard, runtimeSink *[]Finding) []Finding {
+	return a.arrayLifecycleFindingsPreparedWithRuntimeEntry(file, proc, ctx, moduleDecls, variables, constants, capacityGuards, runtimeSink, nil)
+}
+
+func (a Analyzer) arrayLifecycleFindingsPreparedWithRuntimeEntry(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration, variables map[string]arrayVariable, constants map[string]int, capacityGuards []arrayResumeNextCapacityGuard, runtimeSink *[]Finding, preparedEntry arrayFlowState) []Finding {
 	objectArrayDiagnosticsApplicable := false
 	for _, variable := range variables {
 		if variable.isArray && variable.isObject {
@@ -144,7 +165,7 @@ func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, 
 			break
 		}
 	}
-	if !a.Config.Analyze.DetectArrayLifecycleSafety && !a.Config.Analyze.DetectRedimPreserveDimension && !a.Config.Analyze.DetectObjectArrayComparison && !objectArrayDiagnosticsApplicable {
+	if !a.Config.Analyze.DetectArrayLifecycleSafety && !a.Config.Analyze.DetectRedimPreserveDimension && !a.Config.Analyze.DetectObjectArrayComparison && !objectArrayDiagnosticsApplicable && runtimeSink == nil {
 		return nil
 	}
 	vba227Variables := variables
@@ -153,34 +174,77 @@ func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, 
 	}
 	comparisonFindings := a.arrayComparisonFindings(file, proc, variables)
 	comparisonFindings = append(comparisonFindings, a.arrayForEachFindings(file, proc, variables, ctx)...)
-	initial := arrayInitialState(variables)
-	initial = applyArrayInternalStorageConfiguration(initial, file, proc, variables, moduleDecls, ctx.arrayModuleConfigurations[file.Path])
-	initial = applyArrayByRefEntryStates(initial, proc, variables, ctx.arrayByRefEntryStates, ctx.arrayByRefEntryConditions)
-	initial = applyArrayModuleEntryState(initial, file, proc, variables, moduleDecls, ctx.arrayModuleEntryStates)
-	// Constant bounds are scoped to the current procedure. Resolve them once
-	// for this CFG walk so every ReDim transfer shares the same table without
-	// repeatedly reparsing the module and procedure declarations.
-	constants := arrayIntegerConstants(file, proc, a.visibleConstantValues, a.visibleConstants)
+	baseLaneRequested := a.Config.Analyze.DetectArrayLifecycleSafety || a.Config.Analyze.DetectRedimPreserveDimension || objectArrayDiagnosticsApplicable
+	initial := preparedEntry
+	if initial == nil {
+		initial = arrayEntryStateForProcedure(file, proc, ctx, moduleDecls, variables)
+	}
 	if proc.Graph == nil {
 		findings := append([]Finding(nil), comparisonFindings...)
-		legacyFindings := a.arrayLifecycleLinearFindings(file, proc, ctx, variables, initial, constants, capacityGuards)
-		if !a.Config.Analyze.DetectArrayLifecycleSafety {
-			findings = append(findings, legacyFindings...)
+		if !baseLaneRequested && runtimeSink == nil {
+			findings = append(findings, a.arrayLifecycleLinearFindings(file, proc, ctx, variables, initial, constants, capacityGuards)...)
 			return uniqueArrayFindings(findings)
 		}
-		for _, finding := range legacyFindings {
-			if finding.Code != "VBA227" {
-				findings = append(findings, finding)
+		seen := map[string]bool{}
+		for _, finding := range findings {
+			seen[arrayFindingKey(finding)] = true
+		}
+		vba227Initial := arrayEntryStateForProcedure(file, proc, ctx, moduleDecls, vba227Variables)
+		baseState := initial
+		vba227State := vba227Initial
+		runtimeState := arrayInitialState(variables)
+		probe := a
+		probe.Config.Analyze.DetectArrayLifecycleSafety = true
+		runtimeSeen := map[string]bool{}
+		for line := proc.StartLine; line <= proc.EndLine && line <= len(file.Lines); line++ {
+			text := normalizedCodeLine(file.Lines[line-1])
+			if baseLaneRequested {
+				var baseIssues []Finding
+				baseState, baseIssues = a.arrayTransfer(file, proc, ctx, variables, baseState, text, line, constants, capacityGuards)
+				for _, finding := range baseIssues {
+					if a.Config.Analyze.DetectArrayLifecycleSafety && finding.Code == "VBA227" {
+						continue
+					}
+					key := arrayFindingKey(finding)
+					if !seen[key] {
+						seen[key] = true
+						findings = append(findings, finding)
+					}
+				}
+				if a.Config.Analyze.DetectArrayLifecycleSafety {
+					var lifecycleIssues []Finding
+					vba227State, lifecycleIssues = a.arrayVBA227Transfer(file, proc, ctx, vba227Variables, vba227State, text, line, constants, capacityGuards)
+					for _, finding := range lifecycleIssues {
+						if finding.Code != "VBA227" {
+							continue
+						}
+						key := arrayFindingKey(finding)
+						if !seen[key] {
+							seen[key] = true
+							findings = append(findings, finding)
+						}
+					}
+				}
+			}
+			if runtimeSink != nil {
+				for _, issue := range deterministicArrayRuntimeIssues(text, line, runtimeState, variables, constants) {
+					key := strconv.Itoa(issue.line) + ":" + issue.kind + ":" + issue.operationKey
+					if runtimeSeen[key] {
+						continue
+					}
+					runtimeSeen[key] = true
+					message, reason, suggestion := deterministicRuntimeFailureText(issue.kind)
+					finding := a.simpleFinding(file, proc, issue.line, "VBA249", "error", message, reason, suggestion)
+					finding.RuntimeError = &RuntimeErrorContext{Kind: issue.kind}
+					finding.arrayOperationKey = issue.operationKey
+					*runtimeSink = append(*runtimeSink, finding)
+				}
+				runtimeState, _ = probe.arrayTransfer(file, proc, ctx, variables, runtimeState, text, line, constants, nil)
 			}
 		}
-		vba227Initial := arrayInitialState(vba227Variables)
-		vba227Initial = applyArrayInternalStorageConfiguration(vba227Initial, file, proc, vba227Variables, moduleDecls, ctx.arrayModuleConfigurations[file.Path])
-		vba227Initial = applyArrayByRefEntryStates(vba227Initial, proc, vba227Variables, ctx.arrayByRefEntryStates, ctx.arrayByRefEntryConditions)
-		vba227Initial = applyArrayModuleEntryState(vba227Initial, file, proc, vba227Variables, moduleDecls, ctx.arrayModuleEntryStates)
-		for _, finding := range a.arrayVBA227LinearFindings(file, proc, ctx, vba227Variables, vba227Initial, constants, capacityGuards) {
-			if finding.Code == "VBA227" {
-				findings = append(findings, finding)
-			}
+		sortFindings(findings)
+		if runtimeSink != nil {
+			sortFindings(*runtimeSink)
 		}
 		return uniqueArrayFindings(findings)
 	}
@@ -190,58 +254,94 @@ func (a Analyzer) arrayLifecycleFindings(file parsedFile, proc sourceProcedure, 
 	for _, finding := range findings {
 		seen[arrayFindingKey(finding)] = true
 	}
-	walkArrayCFGWithEdges(proc.Graph, file.Lines, initial, func(text string, line int, in arrayFlowState) arrayFlowState {
-		out, issues := a.arrayTransfer(file, proc, ctx, variables, in, text, line, constants, capacityGuards)
-		for _, call := range arrayCallsAtLine(proc.Calls, line) {
-			out = applyArrayModuleCallEffects(out, file, proc, call, ctx, variables, moduleDecls)
-		}
-		for _, finding := range issues {
-			// VBA227 is recomputed by the source-line pass below. Keeping the
-			// historical block-level pass for the other array rules preserves
-			// their existing branch and shape contracts.
-			if finding.Code == "VBA227" {
-				continue
-			}
-			key := arrayFindingKey(finding)
-			if !seen[key] {
-				seen[key] = true
-				findings = append(findings, finding)
-			}
-		}
-		return out
-	}, func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
-		out = applyArrayConditionalAllocationBranch(out, proc.Graph, block, edge)
-		out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, variables)
-		return applyArrayModuleConfigurationBranch(out, block.Statement, edge, ctx.arrayModuleConfigurations[file.Path], variables, file, proc, moduleDecls)
-	})
+	lanes := make([]arrayCFGWorklistLane, 0, 3)
+	if baseLaneRequested {
+		lanes = append(lanes, arrayCFGWorklistLane{
+			Graph: proc.Graph, Initial: initial,
+			Visit: func(text string, line int, in arrayFlowState) arrayFlowState {
+				out, issues := a.arrayTransfer(file, proc, ctx, variables, in, text, line, constants, capacityGuards)
+				for _, call := range arrayCallsAtLine(proc.Calls, line) {
+					out = applyArrayModuleCallEffects(out, file, proc, call, ctx, variables, moduleDecls)
+				}
+				for _, finding := range issues {
+					if finding.Code == "VBA227" {
+						continue
+					}
+					key := arrayFindingKey(finding)
+					if !seen[key] {
+						seen[key] = true
+						findings = append(findings, finding)
+					}
+				}
+				return out
+			},
+			EdgeState: func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
+				out = applyArrayConditionalAllocationBranch(out, proc.Graph, block, edge)
+				out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, variables)
+				return applyArrayModuleConfigurationBranch(out, block.Statement, edge, ctx.arrayModuleConfigurations[file.Path], variables, file, proc, moduleDecls)
+			},
+		})
+	}
 	if a.Config.Analyze.DetectArrayLifecycleSafety {
 		vba227Graph := arrayVBA227Graph(proc, ctx)
-		vba227Initial := arrayInitialState(vba227Variables)
-		vba227Initial = applyArrayInternalStorageConfiguration(vba227Initial, file, proc, vba227Variables, moduleDecls, ctx.arrayModuleConfigurations[file.Path])
-		vba227Initial = applyArrayByRefEntryStates(vba227Initial, proc, vba227Variables, ctx.arrayByRefEntryStates, ctx.arrayByRefEntryConditions)
-		vba227Initial = applyArrayModuleEntryState(vba227Initial, file, proc, vba227Variables, moduleDecls, ctx.arrayModuleEntryStates)
-		vba227CapacityGuards := arrayResumeNextCapacityGuards(file, proc, vba227Variables)
-		walkArrayCFGWithSourceLines(&vba227Graph, file.Lines, vba227Initial, func(text string, line int, in arrayFlowState) arrayFlowState {
-			out, issues := a.arrayVBA227Transfer(file, proc, ctx, vba227Variables, in, text, line, constants, vba227CapacityGuards)
-			for _, call := range arrayCallsAtLine(proc.Calls, line) {
-				out = applyArrayModuleCallEffects(out, file, proc, call, ctx, vba227Variables, moduleDecls)
-			}
-			for _, finding := range issues {
-				if finding.Code != "VBA227" {
-					continue
+		vba227Initial := arrayEntryStateForProcedure(file, proc, ctx, moduleDecls, vba227Variables)
+		lanes = append(lanes, arrayCFGWorklistLane{
+			Graph: &vba227Graph, Initial: vba227Initial, SourceLines: true,
+			ReliableExceptional: func(statement *procedureir.Statement, in, out arrayFlowState) bool {
+				return arrayAllocationTransferIsReliable(statement, in, out)
+			},
+			Visit: func(text string, line int, in arrayFlowState) arrayFlowState {
+				out, issues := a.arrayVBA227Transfer(file, proc, ctx, vba227Variables, in, text, line, constants, capacityGuards)
+				for _, call := range arrayCallsAtLine(proc.Calls, line) {
+					out = applyArrayModuleCallEffects(out, file, proc, call, ctx, vba227Variables, moduleDecls)
 				}
-				key := arrayFindingKey(finding)
-				if !seen[key] {
-					seen[key] = true
-					findings = append(findings, finding)
+				for _, finding := range issues {
+					if finding.Code != "VBA227" {
+						continue
+					}
+					key := arrayFindingKey(finding)
+					if !seen[key] {
+						seen[key] = true
+						findings = append(findings, finding)
+					}
 				}
-			}
-			return out
-		}, func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
-			out = applyArrayConditionalAllocationBranch(out, &vba227Graph, block, edge)
-			out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, vba227Variables)
-			return applyArrayModuleConfigurationBranch(out, block.Statement, edge, ctx.arrayModuleConfigurations[file.Path], vba227Variables, file, proc, moduleDecls)
+				return out
+			},
+			EdgeState: func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
+				out = applyArrayConditionalAllocationBranch(out, &vba227Graph, block, edge)
+				out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, vba227Variables)
+				return applyArrayModuleConfigurationBranch(out, block.Statement, edge, ctx.arrayModuleConfigurations[file.Path], vba227Variables, file, proc, moduleDecls)
+			},
 		})
+	}
+	if runtimeSink != nil {
+		probe := a
+		probe.Config.Analyze.DetectArrayLifecycleSafety = true
+		runtimeSeen := map[string]bool{}
+		runtimeState := arrayInitialState(variables)
+		lanes = append(lanes, arrayCFGWorklistLane{
+			Graph: proc.Graph, Initial: runtimeState,
+			Visit: func(text string, line int, in arrayFlowState) arrayFlowState {
+				for _, issue := range deterministicArrayRuntimeIssues(text, line, in, variables, constants) {
+					key := strconv.Itoa(issue.line) + ":" + issue.kind + ":" + issue.operationKey
+					if runtimeSeen[key] {
+						continue
+					}
+					runtimeSeen[key] = true
+					message, reason, suggestion := deterministicRuntimeFailureText(issue.kind)
+					finding := a.simpleFinding(file, proc, issue.line, "VBA249", "error", message, reason, suggestion)
+					finding.RuntimeError = &RuntimeErrorContext{Kind: issue.kind}
+					finding.arrayOperationKey = issue.operationKey
+					*runtimeSink = append(*runtimeSink, finding)
+				}
+				out, _ := probe.arrayTransfer(file, proc, ctx, variables, in, text, line, constants, nil)
+				return out
+			},
+		})
+	}
+	walkArrayCFGCombined(file.Lines, lanes)
+	if runtimeSink != nil {
+		sortFindings(*runtimeSink)
 	}
 	sortFindings(findings)
 	return findings
@@ -383,24 +483,6 @@ func (a Analyzer) arrayLifecycleLinearFindings(file parsedFile, proc sourceProce
 	for line := proc.StartLine; line <= proc.EndLine && line <= len(file.Lines); line++ {
 		var issues []Finding
 		state, issues = a.arrayTransfer(file, proc, ctx, variables, state, normalizedCodeLine(file.Lines[line-1]), line, constants, capacityGuards)
-		for _, finding := range issues {
-			key := finding.Code + ":" + strconv.Itoa(finding.Line) + ":" + finding.Message
-			if !seen[key] {
-				seen[key] = true
-				findings = append(findings, finding)
-			}
-		}
-	}
-	sortFindings(findings)
-	return findings
-}
-
-func (a Analyzer) arrayVBA227LinearFindings(file parsedFile, proc sourceProcedure, ctx analysisContext, variables map[string]arrayVariable, state arrayFlowState, constants map[string]int, capacityGuards []arrayResumeNextCapacityGuard) []Finding {
-	var findings []Finding
-	seen := map[string]bool{}
-	for line := proc.StartLine; line <= proc.EndLine && line <= len(file.Lines); line++ {
-		var issues []Finding
-		state, issues = a.arrayVBA227Transfer(file, proc, ctx, variables, state, normalizedCodeLine(file.Lines[line-1]), line, constants, capacityGuards)
 		for _, finding := range issues {
 			key := finding.Code + ":" + strconv.Itoa(finding.Line) + ":" + finding.Message
 			if !seen[key] {
@@ -920,6 +1002,212 @@ func walkArrayCFGWorklist(graph *vbacfg.Graph, lines []string, initial arrayFlow
 			}
 		}
 	}
+}
+
+// arrayCFGWorklistLane describes one array state policy that can be advanced
+// by walkArrayCFGCombined.  Lanes deliberately own their state and transfer
+// callbacks: sharing a queue must not force the block-level, source-line, and
+// runtime policies to share a merge or edge interpretation.
+//
+// Graph is normally the same graph for every lane.  It is allowed to be a
+// policy-specific copy, however (for example arrayVBA227Graph removes
+// impossible normal continuations).  Block IDs are stable across those copies
+// and the worklist remains shared even when an edge is absent from one lane.
+type arrayCFGWorklistLane struct {
+	Graph   *vbacfg.Graph
+	Initial arrayFlowState
+
+	// Visit receives a private copy of the lane's block input state and returns
+	// the state to propagate to outgoing edges.  In source-line mode it is
+	// called once for each physical line owned by the block.
+	Visit func(text string, line int, in arrayFlowState) arrayFlowState
+
+	// EdgeState applies a lane-specific normal-edge refinement (guards,
+	// Select Case facts, module configuration, and so on). It is not called for
+	// exceptional or uncertain edges, which retain the predecessor state.
+	EdgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState
+
+	// Stop can terminate propagation for this lane after visiting a statement.
+	// A stopped lane does not prevent other lanes from processing the same block.
+	Stop func(text string, line int) bool
+
+	// ReliableExceptional permits a source-line lane to carry a deterministic
+	// allocation across an exceptional edge. The historical default is the
+	// predecessor state; callers should set this only for the existing narrow
+	// reliable-allocation contract.
+	ReliableExceptional func(statement *procedureir.Statement, in, out arrayFlowState) bool
+
+	// SourceLines restores physical source order inside a CFG block.  False
+	// retains the historical single-statement block semantics.
+	SourceLines bool
+}
+
+// arrayCFGWorklistLaneResult contains the converged input states for a lane.
+// It is returned as a separate value per lane so callers can project facts
+// after all lanes have converged without retaining mutable worklist internals.
+type arrayCFGWorklistLaneResult struct {
+	InStates map[vbacfg.BlockID]arrayFlowState
+}
+
+// walkArrayCFGCombined advances multiple array policies with one deterministic
+// block/edge index and one queue. Each lane still has an independent state
+// lattice and callback policy, preserving semantic compatibility while
+// avoiding repeated graph scheduling and indexing work.
+//
+// Exceptional and uncertain edges retain each lane's predecessor input state.
+// A lane may opt into the existing reliable-allocation exception through
+// ReliableExceptional; this is intentionally independent from SourceLines so
+// runtime or other block-level lanes cannot accidentally inherit it.
+func walkArrayCFGCombined(lines []string, lanes []arrayCFGWorklistLane) []arrayCFGWorklistLaneResult {
+	results := make([]arrayCFGWorklistLaneResult, len(lanes))
+	if len(lanes) == 0 {
+		return results
+	}
+
+	type graphIndex struct {
+		blocks   map[vbacfg.BlockID]vbacfg.Block
+		outgoing map[vbacfg.BlockID][]vbacfg.Edge
+	}
+	type laneIndex struct {
+		graphIndex
+		inStates map[vbacfg.BlockID]arrayFlowState
+	}
+	indexes := make([]laneIndex, len(lanes))
+	graphIndexes := make(map[*vbacfg.Graph]graphIndex, len(lanes))
+	queued := map[vbacfg.BlockID]bool{}
+	for index, lane := range lanes {
+		if lane.Graph == nil {
+			continue
+		}
+		shared, ok := graphIndexes[lane.Graph]
+		if !ok {
+			blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(lane.Graph.Blocks))
+			for _, block := range lane.Graph.Blocks {
+				blocks[block.ID] = block
+			}
+			outgoing := make(map[vbacfg.BlockID][]vbacfg.Edge)
+			for _, edge := range lane.Graph.Edges {
+				outgoing[edge.From] = append(outgoing[edge.From], edge)
+			}
+			shared = graphIndex{blocks: blocks, outgoing: outgoing}
+			graphIndexes[lane.Graph] = shared
+		}
+		inStates := map[vbacfg.BlockID]arrayFlowState{
+			lane.Graph.Entry: cloneArrayState(lane.Initial),
+		}
+		indexes[index] = laneIndex{graphIndex: shared, inStates: inStates}
+		queued[lane.Graph.Entry] = true
+		results[index].InStates = inStates
+	}
+
+	for len(queued) > 0 {
+		// Block IDs are ordered so convergence does not depend on Go map
+		// iteration order. A shared queue is safe even when a policy-specific
+		// graph omits an edge: that lane simply has no outgoing edge to merge.
+		var id vbacfg.BlockID
+		first := true
+		for candidate := range queued {
+			if first || candidate < id {
+				id = candidate
+				first = false
+			}
+		}
+		delete(queued, id)
+
+		for index, lane := range lanes {
+			stateIndex := &indexes[index]
+			if lane.Graph == nil || lane.Visit == nil {
+				continue
+			}
+			in, ok := stateIndex.inStates[id]
+			if !ok {
+				continue
+			}
+			block, ok := stateIndex.blocks[id]
+			if !ok {
+				continue
+			}
+
+			in = cloneArrayState(in)
+			out := cloneArrayState(in)
+			stopped := false
+			if block.Statement != nil {
+				if !lane.SourceLines {
+					line := block.Statement.Range.StartLine
+					if line == 0 {
+						line = block.Range.StartLine
+					}
+					text := block.Statement.Text
+					if strings.TrimSpace(text) == "" && line >= 1 && line <= len(lines) {
+						text = normalizedCodeLine(lines[line-1])
+					}
+					out = lane.Visit(text, line, in)
+					stopped = lane.Stop != nil && lane.Stop(text, line)
+				} else {
+					start := block.Statement.Range.StartLine
+					if start == 0 {
+						start = block.Range.StartLine
+					}
+					end := block.Statement.Range.EndLine
+					if end < start {
+						end = start
+					}
+					if block.Statement.Kind == procedureir.StatementSelect && start >= 1 && start <= len(lines) {
+						// Select Case owns separate CFG blocks for each Case clause;
+						// do not scan all clause lines before applying the edge fact.
+						text := normalizedCodeLine(lines[start-1])
+						out = lane.Visit(text, start, out)
+						stopped = lane.Stop != nil && lane.Stop(text, start)
+					} else if start == end && start >= 1 && start <= len(lines) {
+						text := block.Statement.Text
+						if strings.TrimSpace(text) == "" {
+							text = normalizedCodeLine(lines[start-1])
+						}
+						out = lane.Visit(text, start, out)
+						stopped = lane.Stop != nil && lane.Stop(text, start)
+					} else if start >= 1 && end <= len(lines) {
+						for line := start; line <= end; line++ {
+							text := normalizedCodeLine(lines[line-1])
+							if strings.TrimSpace(text) == "" {
+								continue
+							}
+							out = lane.Visit(text, line, out)
+							if lane.Stop != nil && lane.Stop(text, line) {
+								stopped = true
+								break
+							}
+						}
+					} else {
+						text := block.Statement.Text
+						if strings.TrimSpace(text) == "" && start >= 1 && start <= len(lines) {
+							text = normalizedCodeLine(lines[start-1])
+						}
+						out = lane.Visit(text, start, out)
+						stopped = lane.Stop != nil && lane.Stop(text, start)
+					}
+				}
+			}
+			if stopped {
+				continue
+			}
+
+			for _, edge := range stateIndex.outgoing[id] {
+				next := out
+				if edge.Class == vbacfg.EdgeExceptional || edge.Uncertain {
+					next = in
+					if lane.SourceLines && edge.Class == vbacfg.EdgeExceptional && lane.ReliableExceptional != nil && lane.ReliableExceptional(block.Statement, in, out) {
+						next = out
+					}
+				} else if lane.EdgeState != nil {
+					next = lane.EdgeState(block, edge, next)
+				}
+				if mergeArrayState(stateIndex.inStates, edge.To, next) {
+					queued[edge.To] = true
+				}
+			}
+		}
+	}
+	return results
 }
 
 func arrayAllocationTransferIsReliable(statement *procedureir.Statement, in, out arrayFlowState) bool {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -75,9 +75,14 @@ type rangeValueSourceGuardFrame struct {
 }
 
 type rangeValueSourceBranchFrame struct {
-	before      rangeValueFlowState
-	branches    rangeValueFlowState
-	hasBranches bool
+	before       rangeValueFlowState
+	branches     rangeValueFlowState
+	hasBranches  bool
+	hasElse      bool
+	thenExited   bool
+	exited       bool
+	guardName    string
+	guardNegated bool
 }
 
 var (
@@ -203,8 +208,17 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 		}
 		if match := rangeValueInlineGuardRe.FindStringSubmatch(statement.Text); len(match) == 4 {
 			name := strings.ToLower(match[2])
+			negated := strings.TrimSpace(match[1]) != ""
+			if rangeValueSourceEarlyExit(match[3]) {
+				if negated {
+					state.arrayGuards[name] = true
+				} else {
+					delete(state.arrayGuards, name)
+				}
+				continue
+			}
 			priorGuard := state.arrayGuards[name]
-			if strings.TrimSpace(match[1]) == "" {
+			if !negated {
 				state.arrayGuards[name] = true
 			} else {
 				delete(state.arrayGuards, name)
@@ -221,26 +235,55 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 		}
 		lower := strings.ToLower(strings.TrimSpace(statement.Text))
 		if isRangeValueBlockIf(statement.Text) {
-			branches = append(branches, rangeValueSourceBranchFrame{before: cloneRangeValueFlowState(state)})
+			frame := rangeValueSourceBranchFrame{before: cloneRangeValueFlowState(state)}
+			if match := rangeValueGuardRe.FindStringSubmatch(statement.Text); len(match) == 3 {
+				frame.guardName = strings.ToLower(match[2])
+				frame.guardNegated = strings.TrimSpace(match[1]) != ""
+			}
+			branches = append(branches, frame)
 		} else if strings.HasPrefix(lower, "else") && len(branches) > 0 {
 			frame := &branches[len(branches)-1]
 			current := cloneRangeValueFlowState(state)
-			if frame.hasBranches {
+			frame.hasElse = true
+			if frame.exited {
+				frame.thenExited = true
+			} else if frame.hasBranches {
 				frame.branches = mergeRangeValueSourceStates(frame.branches, current)
 			} else {
 				frame.branches = current
 				frame.hasBranches = true
 			}
+			frame.exited = false
 			state = cloneRangeValueFlowState(frame.before)
 		} else if strings.HasPrefix(lower, "end if") && len(branches) > 0 {
 			current := cloneRangeValueFlowState(state)
 			frame := branches[len(branches)-1]
 			branches = branches[:len(branches)-1]
-			if frame.hasBranches {
+			if frame.hasElse && frame.exited {
+				if frame.hasBranches {
+					state = frame.branches
+				} else {
+					state = cloneRangeValueFlowState(frame.before)
+				}
+			} else if frame.hasElse && frame.thenExited {
+				state = current
+			} else if frame.hasBranches {
 				state = mergeRangeValueSourceStates(frame.branches, current)
+			} else if frame.exited {
+				state = cloneRangeValueFlowState(frame.before)
+				if frame.guardName != "" {
+					if frame.guardNegated {
+						state.arrayGuards[frame.guardName] = true
+					} else {
+						delete(state.arrayGuards, frame.guardName)
+					}
+				}
 			} else {
 				state = mergeRangeValueSourceStates(frame.before, current)
 			}
+		}
+		if rangeValueSourceEarlyExit(statement.Text) && len(branches) > 0 {
+			branches[len(branches)-1].exited = true
 		}
 		updateRangeValueSourceGuard(&state, &guards, statement.Text)
 		issues, next := rangeValueStatement(state, statement, facts)
@@ -345,6 +388,16 @@ func rangeValueSourceLinesApplicable(file parsedFile, proc sourceProcedure) bool
 	return false
 }
 
+func rangeValueSourceEarlyExit(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	for _, prefix := range []string{"exit sub", "exit function", "exit property", "return"} {
+		if lower == prefix || strings.HasPrefix(lower, prefix+" ") {
+			return true
+		}
+	}
+	return false
+}
+
 func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeValueSourceStatement {
 	lines := file.Lines
 	if len(lines) == 0 && len(file.Source) > 0 {
@@ -372,6 +425,10 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 		text := strings.TrimSpace(continued.String())
 		if text != "" {
 			for _, part := range splitRangeValueSourceStatements(text) {
+				if rangeValueIsRemComment(part) {
+					break
+				}
+				part = rangeValueStripRemComment(part)
 				if strings.TrimSpace(part) != "" {
 					out = append(out, rangeValueSourceStatement{line: line, text: strings.TrimSpace(part)})
 				}
@@ -381,7 +438,8 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 		continuedLine = 0
 	}
 	for line := start; line <= end; line++ {
-		text := strings.TrimSpace(rawWorksheetCodeLine(lines[line-1]))
+		text := rangeValueStripRemComment(rawWorksheetCodeLine(lines[line-1]))
+		text = strings.TrimSpace(text)
 		if text == "" {
 			continue
 		}
@@ -404,6 +462,27 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 		flush(continuedLine)
 	}
 	return out
+}
+
+func rangeValueStripRemComment(text string) string {
+	if rangeValueIsRemComment(text) {
+		return ""
+	}
+	return text
+}
+
+func rangeValueIsRemComment(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if len(trimmed) == 3 && strings.EqualFold(trimmed, "rem") {
+		return true
+	}
+	if len(trimmed) > 3 && strings.EqualFold(trimmed[:3], "rem") {
+		next := trimmed[3]
+		if next == ' ' || next == '\t' {
+			return true
+		}
+	}
+	return false
 }
 
 func splitRangeValueSourceStatements(text string) []string {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -377,7 +377,7 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 		issues, next := rangeValueStatement(state, statement, facts)
 		findings = appendRangeValueFindings(findings, file, proc, statement, issues, a)
 		state = next
-		if rangeValueSourceEarlyExit(statement.Text) && len(branches) == 0 {
+		if rangeValueSourceEarlyExit(statement.Text) && len(branches) == 0 && len(selects) == 0 {
 			break
 		}
 	}
@@ -1366,14 +1366,7 @@ func rangeValueTextCellsPairShape(arguments []string, facts rangeValueFacts) (ra
 	if !startOK || !endOK {
 		return rangeShape{}, false
 	}
-	rows, rowsKnown := rangeValueAxisLength(startRow, startRowKnown, endRow, endRowKnown)
-	cols, colsKnown := rangeValueAxisLength(startColumn, startColumnKnown, endColumn, endColumnKnown)
-	return rangeShape{
-		known:   rowsKnown && colsKnown,
-		array2D: (rowsKnown && rows > 1) || (colsKnown && cols > 1),
-		rows:    rows,
-		cols:    cols,
-	}, true
+	return rangeValueCellsPairShapeFromCoordinates(startRow, startRowKnown, startColumn, startColumnKnown, endRow, endRowKnown, endColumn, endColumnKnown), true
 }
 
 func rangeValueTextCellsCoordinates(expression string, facts rangeValueFacts) (int, bool, int, bool, bool) {
@@ -1411,36 +1404,7 @@ func rangeValueTextLiteralRangeShape(arguments []string) (rangeShape, bool) {
 		}
 		addresses[index] = strings.ReplaceAll(text[1:len(text)-1], `""`, `"`)
 	}
-	if len(addresses) == 1 {
-		match := rangeValueAddressRe.FindStringSubmatch(addresses[0])
-		if len(match) != 5 {
-			return rangeShape{}, false
-		}
-		startColumn := excelColumnNumber(match[1])
-		startRow, _ := strconv.Atoi(match[2])
-		endColumn, endRow := startColumn, startRow
-		if match[3] != "" {
-			endColumn = excelColumnNumber(match[3])
-			endRow, _ = strconv.Atoi(match[4])
-		}
-		if startColumn <= 0 || endColumn < startColumn || endRow < startRow {
-			return rangeShape{}, false
-		}
-		return rangeShape{known: true, array2D: endColumn > startColumn || endRow > startRow, rows: endRow - startRow + 1, cols: endColumn - startColumn + 1}, true
-	}
-	startMatch := rangeValueAddressRe.FindStringSubmatch(addresses[0])
-	endMatch := rangeValueAddressRe.FindStringSubmatch(addresses[1])
-	if len(startMatch) != 5 || len(endMatch) != 5 || startMatch[3] != "" || endMatch[3] != "" {
-		return rangeShape{}, false
-	}
-	startColumn := excelColumnNumber(startMatch[1])
-	startRow, _ := strconv.Atoi(startMatch[2])
-	endColumn := excelColumnNumber(endMatch[1])
-	endRow, _ := strconv.Atoi(endMatch[2])
-	if startColumn <= 0 || endColumn < startColumn || endRow < startRow {
-		return rangeShape{}, false
-	}
-	return rangeShape{known: true, array2D: endColumn > startColumn || endRow > startRow, rows: endRow - startRow + 1, cols: endColumn - startColumn + 1}, true
+	return rangeValueLiteralRangeShapeFromAddresses(addresses)
 }
 
 func rangeValueMemberReceiver(expression *procedureir.Expression, facts rangeValueFacts, members ...string) (procedureir.Expression, bool) {
@@ -1557,47 +1521,18 @@ func rangeValueTerminalExpressionName(expression procedureir.Expression, facts r
 }
 
 func rangeValueLiteralRangeShape(arguments []procedureir.Expression, facts rangeValueFacts) (rangeShape, bool) {
-	if len(arguments) == 1 {
-		address, ok := rangeValueStringLiteral(arguments[0], facts)
+	if len(arguments) != 1 && len(arguments) != 2 {
+		return rangeShape{}, false
+	}
+	addresses := make([]string, len(arguments))
+	for index, argument := range arguments {
+		address, ok := rangeValueStringLiteral(argument, facts)
 		if !ok {
 			return rangeShape{}, false
 		}
-		match := rangeValueAddressRe.FindStringSubmatch(address)
-		if len(match) != 5 {
-			return rangeShape{}, false
-		}
-		startCol := excelColumnNumber(match[1])
-		startRow, _ := strconv.Atoi(match[2])
-		endCol, endRow := startCol, startRow
-		if match[3] != "" {
-			endCol = excelColumnNumber(match[3])
-			endRow, _ = strconv.Atoi(match[4])
-		}
-		if startCol > 0 && endCol >= startCol && endRow >= startRow {
-			return rangeShape{known: true, array2D: endCol > startCol || endRow > startRow, rows: endRow - startRow + 1, cols: endCol - startCol + 1}, true
-		}
-		return rangeShape{}, false
+		addresses[index] = address
 	}
-	if len(arguments) == 2 {
-		startAddress, startOK := rangeValueStringLiteral(arguments[0], facts)
-		endAddress, endOK := rangeValueStringLiteral(arguments[1], facts)
-		if !startOK || !endOK {
-			return rangeShape{}, false
-		}
-		startMatch := rangeValueAddressRe.FindStringSubmatch(startAddress)
-		endMatch := rangeValueAddressRe.FindStringSubmatch(endAddress)
-		if len(startMatch) != 5 || len(endMatch) != 5 || startMatch[3] != "" || endMatch[3] != "" {
-			return rangeShape{}, false
-		}
-		startCol := excelColumnNumber(startMatch[1])
-		startRow, _ := strconv.Atoi(startMatch[2])
-		endCol := excelColumnNumber(endMatch[1])
-		endRow, _ := strconv.Atoi(endMatch[2])
-		if startCol > 0 && endCol >= startCol && endRow >= startRow {
-			return rangeShape{known: true, array2D: endCol > startCol || endRow > startRow, rows: endRow - startRow + 1, cols: endCol - startCol + 1}, true
-		}
-	}
-	return rangeShape{}, false
+	return rangeValueLiteralRangeShapeFromAddresses(addresses)
 }
 
 func rangeValueStringLiteral(expression procedureir.Expression, facts rangeValueFacts) (string, bool) {
@@ -1618,13 +1553,54 @@ func rangeValueCellsPairShape(start, end procedureir.Expression, facts rangeValu
 	if !startOK || !endOK {
 		return rangeShape{}, false
 	}
+	return rangeValueCellsPairShapeFromCoordinates(startRow, startRowKnown, startCol, startColKnown, endRow, endRowKnown, endCol, endColKnown), true
+}
+
+func rangeValueCellsPairShapeFromCoordinates(startRow int, startRowKnown bool, startColumn int, startColumnKnown bool, endRow int, endRowKnown bool, endColumn int, endColumnKnown bool) rangeShape {
 	rows, rowsKnown := rangeValueAxisLength(startRow, startRowKnown, endRow, endRowKnown)
-	cols, colsKnown := rangeValueAxisLength(startCol, startColKnown, endCol, endColKnown)
+	cols, colsKnown := rangeValueAxisLength(startColumn, startColumnKnown, endColumn, endColumnKnown)
 	return rangeShape{
 		known:   rowsKnown && colsKnown,
 		array2D: (rowsKnown && rows > 1) || (colsKnown && cols > 1),
 		rows:    rows,
 		cols:    cols,
+	}
+}
+
+func rangeValueLiteralRangeShapeFromAddresses(addresses []string) (rangeShape, bool) {
+	if len(addresses) != 1 && len(addresses) != 2 {
+		return rangeShape{}, false
+	}
+	startMatch := rangeValueAddressRe.FindStringSubmatch(addresses[0])
+	if len(startMatch) != 5 {
+		return rangeShape{}, false
+	}
+	if len(addresses) == 1 {
+		return rangeValueLiteralRangeCoordinatesShape(startMatch[1], startMatch[2], startMatch[3], startMatch[4])
+	}
+	endMatch := rangeValueAddressRe.FindStringSubmatch(addresses[1])
+	if len(endMatch) != 5 || startMatch[3] != "" || endMatch[3] != "" {
+		return rangeShape{}, false
+	}
+	return rangeValueLiteralRangeCoordinatesShape(startMatch[1], startMatch[2], endMatch[1], endMatch[2])
+}
+
+func rangeValueLiteralRangeCoordinatesShape(startColumnText, startRowText, endColumnText, endRowText string) (rangeShape, bool) {
+	startColumn := excelColumnNumber(startColumnText)
+	startRow, _ := strconv.Atoi(startRowText)
+	endColumn, endRow := startColumn, startRow
+	if endColumnText != "" {
+		endColumn = excelColumnNumber(endColumnText)
+		endRow, _ = strconv.Atoi(endRowText)
+	}
+	if startColumn <= 0 || endColumn < startColumn || endRow < startRow {
+		return rangeShape{}, false
+	}
+	return rangeShape{
+		known:   true,
+		array2D: endColumn > startColumn || endRow > startRow,
+		rows:    endRow - startRow + 1,
+		cols:    endColumn - startColumn + 1,
 	}, true
 }
 

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -64,8 +64,9 @@ type rangeValueIssue struct {
 }
 
 type rangeValueSourceStatement struct {
-	line int
-	text string
+	line    int
+	endLine int
+	text    string
 }
 
 type rangeValueSourceGuardFrame struct {
@@ -89,6 +90,10 @@ type rangeValueSourceConditionalFrame struct {
 	active        bool
 	branchTaken   bool
 	branchUnknown bool
+}
+
+type rangeValueSourceLoopFrame struct {
+	before rangeValueFlowState
 }
 
 var (
@@ -202,14 +207,19 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 	state := newRangeValueFlowState()
 	var guards []rangeValueSourceGuardFrame
 	var branches []rangeValueSourceBranchFrame
+	var loops []rangeValueSourceLoopFrame
 	var findings []Finding
 	for index, source := range sourceStatements {
+		line := source.endLine
+		if line <= 0 {
+			line = source.line
+		}
 		statement := procedureir.Statement{
 			ID:   index + 1,
 			Text: source.text,
 			Range: vbaast.Range{
-				StartLine: source.line,
-				EndLine:   source.line,
+				StartLine: line,
+				EndLine:   line,
 			},
 		}
 		if match := rangeValueInlineGuardRe.FindStringSubmatch(statement.Text); len(match) == 4 {
@@ -240,7 +250,13 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 			continue
 		}
 		lower := strings.ToLower(strings.TrimSpace(statement.Text))
-		if isRangeValueBlockIf(statement.Text) {
+		if rangeValueSourceLoopStart(statement.Text) {
+			loops = append(loops, rangeValueSourceLoopFrame{before: cloneRangeValueFlowState(state)})
+		} else if rangeValueSourceLoopEnd(statement.Text) && len(loops) > 0 {
+			frame := loops[len(loops)-1]
+			loops = loops[:len(loops)-1]
+			state = mergeRangeValueSourceStates(frame.before, state)
+		} else if isRangeValueBlockIf(statement.Text) {
 			frame := rangeValueSourceBranchFrame{before: cloneRangeValueFlowState(state)}
 			if match := rangeValueGuardRe.FindStringSubmatch(statement.Text); len(match) == 3 {
 				frame.guardName = strings.ToLower(match[2])
@@ -407,6 +423,16 @@ func isRangeValueBlockIf(text string) bool {
 	return then >= 0 && strings.TrimSpace(lower[then+len(" then"):]) == ""
 }
 
+func rangeValueSourceLoopStart(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	return strings.HasPrefix(lower, "for ") || lower == "do" || strings.HasPrefix(lower, "do while ") || strings.HasPrefix(lower, "do until ") || strings.HasPrefix(lower, "while ")
+}
+
+func rangeValueSourceLoopEnd(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	return strings.HasPrefix(lower, "next") || strings.HasPrefix(lower, "loop") || lower == "wend"
+}
+
 func rangeValueSourceLinesApplicable(file parsedFile, proc sourceProcedure) bool {
 	for _, source := range rangeValueSourceStatements(file, proc) {
 		code := strings.ToLower(normalizedCodeLine(source.text))
@@ -456,7 +482,8 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 	var out []rangeValueSourceStatement
 	var continued strings.Builder
 	continuedLine := 0
-	flush := func(line int) {
+	continuedEndLine := 0
+	flush := func(line, endLine int) {
 		text := strings.TrimSpace(continued.String())
 		if text != "" {
 			for _, part := range splitRangeValueSourceStatements(text) {
@@ -465,7 +492,7 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 				}
 				part = rangeValueStripRemComment(part)
 				if strings.TrimSpace(part) != "" {
-					out = append(out, rangeValueSourceStatement{line: line, text: strings.TrimSpace(part)})
+					out = append(out, rangeValueSourceStatement{line: line, endLine: endLine, text: strings.TrimSpace(part)})
 				}
 			}
 		}
@@ -488,6 +515,7 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 		if continued.Len() == 0 {
 			continuedLine = line
 		}
+		continuedEndLine = line
 		continuedLineText := text
 		if vbaLineContinues(text) {
 			text = strings.TrimSpace(strings.TrimSuffix(text, "_"))
@@ -497,11 +525,11 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 		}
 		continued.WriteString(text)
 		if !vbaLineContinues(continuedLineText) {
-			flush(continuedLine)
+			flush(continuedLine, continuedEndLine)
 		}
 	}
 	if continued.Len() > 0 {
-		flush(continuedLine)
+		flush(continuedLine, continuedEndLine)
 	}
 	return out
 }

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -223,15 +223,36 @@ func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValu
 		if len(*guards) == 0 {
 			return
 		}
+		if strings.HasPrefix(lower, "elseif ") {
+			frame := &(*guards)[len(*guards)-1]
+			if frame.name == "" {
+				return
+			}
+			if frame.active {
+				delete(state.arrayGuards, frame.name)
+				frame.active = false
+			}
+			trimmed := strings.TrimSpace(text)
+			match := rangeValueGuardRe.FindStringSubmatch("If " + strings.TrimSpace(trimmed[len("ElseIf "):]))
+			if len(match) == 3 && strings.TrimSpace(match[1]) == "" {
+				frame.active = true
+				state.arrayGuards[frame.name] = true
+			}
+			return
+		}
 		frame := &(*guards)[len(*guards)-1]
-		if frame.active {
+		if frame.name != "" && frame.active {
 			delete(state.arrayGuards, frame.name)
 			frame.active = false
 		}
 		return
 	}
+	if !isRangeValueBlockIf(text) {
+		return
+	}
 	match := rangeValueGuardRe.FindStringSubmatch(text)
 	if len(match) != 3 {
+		*guards = append(*guards, rangeValueSourceGuardFrame{})
 		return
 	}
 	name := strings.ToLower(match[2])
@@ -243,6 +264,15 @@ func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValu
 	} else {
 		delete(state.arrayGuards, name)
 	}
+}
+
+func isRangeValueBlockIf(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if !strings.HasPrefix(lower, "if ") {
+		return false
+	}
+	then := strings.LastIndex(lower, " then")
+	return then >= 0 && strings.TrimSpace(lower[then+len(" then"):]) == ""
 }
 
 func rangeValueSourceLinesApplicable(file parsedFile, proc sourceProcedure) bool {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
@@ -62,6 +63,11 @@ type rangeValueIssue struct {
 	suggestion string
 }
 
+type rangeValueSourceStatement struct {
+	line int
+	text string
+}
+
 var (
 	rangeValueAddressRe     = regexp.MustCompile(`(?i)^([A-Z]+)([0-9]+)(?::([A-Z]+)([0-9]+))?$`)
 	rangeValueBoundRe       = regexp.MustCompile(`(?i)\b([UL])Bound\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*([^)]*))?\)`)
@@ -74,8 +80,11 @@ var (
 )
 
 func (a Analyzer) rangeValueShapeFindings(file parsedFile, proc sourceProcedure) []Finding {
-	if !a.Config.Analyze.DetectRangeValueArrayShape || len(proc.Statements) == 0 {
+	if !a.Config.Analyze.DetectRangeValueArrayShape {
 		return nil
+	}
+	if len(proc.Statements) == 0 {
+		return a.rangeValueShapeFindingsFromSource(file, proc)
 	}
 	facts := rangeValueFactsForProcedure(file, proc)
 	if proc.Graph == nil {
@@ -151,6 +160,139 @@ func (a Analyzer) rangeValueShapeFindings(file parsedFile, proc sourceProcedure)
 		}
 		return out[i].Message < out[j].Message
 	})
+	return out
+}
+
+// rangeValueShapeFindingsFromSource is a deliberately narrow recovery path.
+// Procedure IR normally supplies canonical expressions and CFG edges; when a
+// recovered procedure has no statement projection, source lines are the only
+// available evidence. The textual transfer remains conservative and is used
+// only for this unpopulated projection, so it cannot change complete-IR CFG
+// semantics or add another fixed-point walk.
+func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc sourceProcedure) []Finding {
+	sourceStatements := rangeValueSourceStatements(file, proc)
+	if len(sourceStatements) == 0 {
+		return nil
+	}
+	facts := rangeValueFactsForProcedure(file, proc)
+	state := newRangeValueFlowState()
+	var findings []Finding
+	for index, source := range sourceStatements {
+		statement := procedureir.Statement{
+			ID:   index + 1,
+			Text: source.text,
+			Range: vbaast.Range{
+				StartLine: source.line,
+				EndLine:   source.line,
+			},
+		}
+		issues, next := rangeValueStatement(state, statement, facts)
+		findings = appendRangeValueFindings(findings, file, proc, statement, issues, a)
+		state = next
+	}
+	return findings
+}
+
+func rangeValueSourceLinesApplicable(file parsedFile, proc sourceProcedure) bool {
+	for _, source := range rangeValueSourceStatements(file, proc) {
+		code := strings.ToLower(normalizedCodeLine(source.text))
+		if strings.Contains(code, ".value") || strings.Contains(code, "range(") || strings.Contains(code, "resize(") || strings.Contains(code, "cells(") {
+			return true
+		}
+	}
+	return false
+}
+
+func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeValueSourceStatement {
+	lines := file.Lines
+	if len(lines) == 0 && len(file.Source) > 0 {
+		lines = normalizedSourceLines(string(file.Source))
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	start := proc.StartLine
+	if start < 1 {
+		start = 1
+	}
+	end := proc.EndLine
+	if end <= 0 || end > len(lines) {
+		end = len(lines)
+	}
+	if start > end {
+		return nil
+	}
+
+	var out []rangeValueSourceStatement
+	var continued strings.Builder
+	continuedLine := 0
+	flush := func(line int) {
+		text := strings.TrimSpace(continued.String())
+		if text != "" {
+			for _, part := range splitRangeValueSourceStatements(text) {
+				if strings.TrimSpace(part) != "" {
+					out = append(out, rangeValueSourceStatement{line: line, text: strings.TrimSpace(part)})
+				}
+			}
+		}
+		continued.Reset()
+		continuedLine = 0
+	}
+	for line := start; line <= end; line++ {
+		text := strings.TrimSpace(rawWorksheetCodeLine(lines[line-1]))
+		if text == "" {
+			continue
+		}
+		if continued.Len() == 0 {
+			continuedLine = line
+		}
+		continuedLineText := text
+		if vbaLineContinues(text) {
+			text = strings.TrimSpace(strings.TrimSuffix(text, "_"))
+		}
+		if continued.Len() > 0 && text != "" {
+			continued.WriteByte(' ')
+		}
+		continued.WriteString(text)
+		if !vbaLineContinues(continuedLineText) {
+			flush(continuedLine)
+		}
+	}
+	if continued.Len() > 0 {
+		flush(continuedLine)
+	}
+	return out
+}
+
+func splitRangeValueSourceStatements(text string) []string {
+	var out []string
+	start := 0
+	inString := false
+	depth := 0
+	for index := 0; index < len(text); index++ {
+		switch text[index] {
+		case '"':
+			if inString && index+1 < len(text) && text[index+1] == '"' {
+				index++
+				continue
+			}
+			inString = !inString
+		case '(':
+			if !inString {
+				depth++
+			}
+		case ')':
+			if !inString && depth > 0 {
+				depth--
+			}
+		case ':':
+			if !inString && depth == 0 {
+				out = append(out, strings.TrimSpace(text[start:index]))
+				start = index + 1
+			}
+		}
+	}
+	out = append(out, strings.TrimSpace(text[start:]))
 	return out
 }
 
@@ -427,18 +569,28 @@ func rangeValueStatement(state rangeValueFlowState, statement procedureir.Statem
 	}
 
 	if left, right, ok := rangeValueAssignment(raw); ok {
-		if target, ok := rangeValueMemberReceiver(statement.Target, facts, "value", "value2"); ok {
-			if sourceName := rangeValueBareName(right); sourceName != "" {
-				if source, found := state.values[sourceName]; found {
+		if sourceName := rangeValueBareName(right); sourceName != "" {
+			if source, found := state.values[sourceName]; found {
+				if target, foundTarget := rangeValueMemberReceiver(statement.Target, facts, "value", "value2"); foundTarget {
 					if issue := rangeValueDestinationIssue(target, source, state, facts); issue != nil {
 						issues = append(issues, *issue)
+					}
+				} else if receiver, foundTarget := rangeValueMemberReceiverText(left, "value", "value2"); foundTarget {
+					if destination, recognized := rangeValueRangeShapeText(receiver, state, facts); recognized {
+						if issue := rangeValueDestinationShapeIssue(destination, source); issue != nil {
+							issues = append(issues, *issue)
+						}
 					}
 				}
 			}
 		}
 		if targetName := rangeValueBareName(left); targetName != "" {
 			delete(state.arrayGuards, targetName)
-			if source, ok := rangeValueSourceShape(statement.Value, state, facts); ok {
+			source, sourceKnown := rangeValueSourceShape(statement.Value, state, facts)
+			if !sourceKnown {
+				source, sourceKnown = rangeValueSourceShapeText(right, state, facts)
+			}
+			if sourceKnown {
 				state.values[targetName] = source
 				delete(state.ranges, targetName)
 			} else if sourceName := rangeValueBareName(right); sourceName != "" {
@@ -462,7 +614,11 @@ func rangeValueStatement(state rangeValueFlowState, statement procedureir.Statem
 
 	if match := rangeValueSetRe.FindStringSubmatch(raw); len(match) == 3 {
 		name := strings.ToLower(match[1])
-		if shape, ok := rangeValueRangeShapeExpression(statement.Value, state, facts); ok {
+		shape, ok := rangeValueRangeShapeExpression(statement.Value, state, facts)
+		if !ok {
+			shape, ok = rangeValueRangeShapeText(match[2], state, facts)
+		}
+		if ok {
 			state.ranges[name] = shape
 		} else {
 			state.ranges[name] = rangeShape{}
@@ -652,6 +808,125 @@ func rangeValueSourceShape(value *procedureir.Expression, state rangeValueFlowSt
 		return rangeValueShape{kind: rangeValueShapeArray2D, rows: shape.rows, cols: shape.cols}, true
 	}
 	return rangeValueShape{kind: rangeValueShapeUnknown}, true
+}
+
+func rangeValueSourceShapeText(value string, state rangeValueFlowState, facts rangeValueFacts) (rangeValueShape, bool) {
+	receiver, ok := rangeValueMemberReceiverText(value, "value", "value2")
+	if !ok {
+		return rangeValueShape{}, false
+	}
+	shape, recognized := rangeValueRangeShapeText(receiver, state, facts)
+	if !recognized {
+		return rangeValueShape{}, false
+	}
+	if shape.known && shape.rows == 1 && shape.cols == 1 {
+		return rangeValueShape{kind: rangeValueShapeScalar}, true
+	}
+	if shape.known || shape.array2D {
+		return rangeValueShape{kind: rangeValueShapeArray2D, rows: shape.rows, cols: shape.cols}, true
+	}
+	return rangeValueShape{kind: rangeValueShapeUnknown}, true
+}
+
+func rangeValueMemberReceiverText(expression string, members ...string) (string, bool) {
+	text := strings.TrimSpace(expression)
+	for _, member := range members {
+		suffix := "." + strings.ToLower(member)
+		lower := strings.ToLower(text)
+		if strings.HasSuffix(lower, suffix) {
+			receiver := strings.TrimSpace(text[:len(text)-len(suffix)])
+			if receiver != "" {
+				return receiver, true
+			}
+		}
+	}
+	return "", false
+}
+
+func rangeValueRangeShapeText(expression string, state rangeValueFlowState, facts rangeValueFacts) (rangeShape, bool) {
+	text := strings.TrimSpace(expression)
+	for len(text) >= 2 && text[0] == '(' && text[len(text)-1] == ')' && matchingParen(text, 0) == len(text)-1 {
+		text = strings.TrimSpace(text[1 : len(text)-1])
+	}
+	if name := rangeValueBareName(text); name != "" {
+		if shape, found := state.ranges[name]; found {
+			return shape, true
+		}
+		if facts.rangeVariables[name] {
+			return rangeShape{}, true
+		}
+		return rangeShape{}, false
+	}
+	open := firstParenOutsideString(text)
+	if open < 0 {
+		return rangeShape{}, false
+	}
+	close := matchingParen(text, open)
+	if close < 0 || strings.TrimSpace(text[close+1:]) != "" {
+		return rangeShape{}, false
+	}
+	name := strings.ToLower(cleanIdentifier(lastName(strings.TrimSpace(text[:open]))))
+	args := splitArgs(text[open+1 : close])
+	switch name {
+	case "cells":
+		if len(args) == 2 {
+			return rangeShape{known: true, rows: 1, cols: 1}, true
+		}
+		return rangeShape{}, true
+	case "range":
+		if shape, found := rangeValueTextLiteralRangeShape(args); found {
+			return shape, true
+		}
+		return rangeShape{}, true
+	case "offset", "resize":
+		return rangeShape{}, true
+	default:
+		return rangeShape{}, false
+	}
+}
+
+func rangeValueTextLiteralRangeShape(arguments []string) (rangeShape, bool) {
+	if len(arguments) != 1 && len(arguments) != 2 {
+		return rangeShape{}, false
+	}
+	addresses := make([]string, len(arguments))
+	for index, argument := range arguments {
+		text := strings.TrimSpace(argument)
+		if len(text) < 2 || text[0] != '"' || text[len(text)-1] != '"' {
+			return rangeShape{}, false
+		}
+		addresses[index] = strings.ReplaceAll(text[1:len(text)-1], `""`, `"`)
+	}
+	if len(addresses) == 1 {
+		match := rangeValueAddressRe.FindStringSubmatch(addresses[0])
+		if len(match) != 5 {
+			return rangeShape{}, false
+		}
+		startColumn := excelColumnNumber(match[1])
+		startRow, _ := strconv.Atoi(match[2])
+		endColumn, endRow := startColumn, startRow
+		if match[3] != "" {
+			endColumn = excelColumnNumber(match[3])
+			endRow, _ = strconv.Atoi(match[4])
+		}
+		if startColumn <= 0 || endColumn < startColumn || endRow < startRow {
+			return rangeShape{}, false
+		}
+		return rangeShape{known: true, array2D: endColumn > startColumn || endRow > startRow, rows: endRow - startRow + 1, cols: endColumn - startColumn + 1}, true
+	}
+	startMatch := rangeValueAddressRe.FindStringSubmatch(addresses[0])
+	endMatch := rangeValueAddressRe.FindStringSubmatch(addresses[1])
+	if len(startMatch) != 5 || len(endMatch) != 5 || startMatch[3] != "" || endMatch[3] != "" {
+		return rangeShape{}, false
+	}
+	startColumn := excelColumnNumber(startMatch[1])
+	startRow, _ := strconv.Atoi(startMatch[2])
+	endColumn := excelColumnNumber(endMatch[1])
+	endRow, _ := strconv.Atoi(endMatch[2])
+	if startColumn <= 0 || endColumn < startColumn || endRow < startRow {
+		return rangeShape{}, false
+	}
+	return rangeShape{known: true, array2D: endColumn > startColumn || endRow > startRow, rows: endRow - startRow + 1, cols: endColumn - startColumn + 1}, true
 }
 
 func rangeValueMemberReceiver(expression *procedureir.Expression, facts rangeValueFacts, members ...string) (procedureir.Expression, bool) {
@@ -864,11 +1139,15 @@ func rangeValueAxisLength(start int, startKnown bool, end int, endKnown bool) (i
 }
 
 func rangeValueDestinationIssue(target procedureir.Expression, source rangeValueShape, state rangeValueFlowState, facts rangeValueFacts) *rangeValueIssue {
-	if source.kind != rangeValueShapeArray2D || source.rows <= 0 || source.cols <= 0 {
-		return nil
-	}
 	destination, recognized := rangeValueRangeShapeExpression(&target, state, facts)
 	if !recognized || !destination.known {
+		return nil
+	}
+	return rangeValueDestinationShapeIssue(destination, source)
+}
+
+func rangeValueDestinationShapeIssue(destination rangeShape, source rangeValueShape) *rangeValueIssue {
+	if source.kind != rangeValueShapeArray2D || source.rows <= 0 || source.cols <= 0 || !destination.known {
 		return nil
 	}
 	if destination.rows == source.rows && destination.cols == source.cols {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -365,16 +365,15 @@ func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValu
 		}
 		if strings.HasPrefix(lower, "elseif ") {
 			frame := &(*guards)[len(*guards)-1]
-			if frame.name == "" {
-				return
-			}
-			if frame.active {
+			if frame.name != "" && frame.active {
 				delete(state.arrayGuards, frame.name)
-				frame.active = false
 			}
+			frame.name = ""
+			frame.active = false
 			trimmed := strings.TrimSpace(text)
 			match := rangeValueGuardRe.FindStringSubmatch("If " + strings.TrimSpace(trimmed[len("ElseIf "):]))
 			if len(match) == 3 {
+				frame.name = strings.ToLower(match[2])
 				frame.negated = strings.TrimSpace(match[1]) != ""
 				frame.active = !frame.negated
 				if frame.active {
@@ -800,6 +799,9 @@ func rangeValueFactsForProcedure(file parsedFile, proc sourceProcedure) rangeVal
 		facts.expressions[expression.ID] = expression
 	}
 	constants := rangeValueIntegerConstants(file.RangeValueModuleConstants, proc)
+	if len(proc.Statements) == 0 || rangeValueProjectionUnknown(proc) {
+		constants = rangeValueSourceIntegerConstants(file, proc, constants)
+	}
 	facts.constants = constants
 	for _, statement := range proc.Statements {
 		text := strings.TrimSpace(excelLoopHeaderText(statement.Text))
@@ -874,6 +876,23 @@ func rangeValueIntegerConstants(moduleConstants map[string]int, proc sourceProce
 			continue
 		}
 		match := constIntegerRe.FindStringSubmatch(strings.TrimSpace(normalizedCodeLine(statement.Text)))
+		if len(match) != 3 {
+			continue
+		}
+		if value, err := constantIntegerExpression(match[2], constants); err == nil {
+			constants[strings.ToLower(match[1])] = value
+		}
+	}
+	return constants
+}
+
+func rangeValueSourceIntegerConstants(file parsedFile, proc sourceProcedure, base map[string]int) map[string]int {
+	constants := make(map[string]int, len(base)+4)
+	for name, value := range base {
+		constants[name] = value
+	}
+	for _, source := range rangeValueSourceStatements(file, proc) {
+		match := constIntegerRe.FindStringSubmatch(strings.TrimSpace(normalizedCodeLine(source.text)))
 		if len(match) != 3 {
 			continue
 		}

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -84,6 +84,7 @@ var (
 	rangeValueForEachRe     = regexp.MustCompile(`(?i)^\s*For\s+Each\s+([A-Za-z_][A-Za-z0-9_]*)\s+In\b`)
 	rangeValueForVariableRe = regexp.MustCompile(`(?i)^\s*For\s+([A-Za-z_][A-Za-z0-9_]*)\s*=`)
 	rangeValueIdentifierRe  = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	rangeValueInlineGuardRe = regexp.MustCompile(`(?i)^\s*If\s+(Not\s+)?IsArray\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s+Then\s+(.+)$`)
 )
 
 func (a Analyzer) rangeValueShapeFindings(file parsedFile, proc sourceProcedure) []Finding {
@@ -193,6 +194,24 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 				StartLine: source.line,
 				EndLine:   source.line,
 			},
+		}
+		if match := rangeValueInlineGuardRe.FindStringSubmatch(statement.Text); len(match) == 4 {
+			name := strings.ToLower(match[2])
+			priorGuard := state.arrayGuards[name]
+			if strings.TrimSpace(match[1]) == "" {
+				state.arrayGuards[name] = true
+			} else {
+				delete(state.arrayGuards, name)
+			}
+			body := statement
+			body.Text = strings.TrimSpace(match[3])
+			issues, next := rangeValueStatement(state, body, facts)
+			if !next.arrayGuards[name] || !priorGuard {
+				delete(next.arrayGuards, name)
+			}
+			findings = appendRangeValueFindings(findings, file, proc, body, issues, a)
+			state = next
+			continue
 		}
 		updateRangeValueSourceGuard(&state, &guards, statement.Text)
 		issues, next := rangeValueStatement(state, statement, facts)

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -276,7 +276,7 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 			}
 			frame.exited = false
 			state = cloneRangeValueFlowState(frame.before)
-		} else if strings.HasPrefix(lower, "else") && len(branches) > 0 {
+		} else if rangeValueSourceElse(statement.Text) && len(branches) > 0 {
 			frame := &branches[len(branches)-1]
 			current := cloneRangeValueFlowState(state)
 			frame.hasElse = true
@@ -359,7 +359,7 @@ func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValu
 		}
 		return
 	}
-	if strings.HasPrefix(lower, "else") {
+	if rangeValueSourceElse(text) || strings.HasPrefix(lower, "elseif ") {
 		if len(*guards) == 0 {
 			return
 		}
@@ -430,7 +430,16 @@ func rangeValueSourceLoopStart(text string) bool {
 
 func rangeValueSourceLoopEnd(text string) bool {
 	lower := strings.ToLower(strings.TrimSpace(text))
-	return strings.HasPrefix(lower, "next") || strings.HasPrefix(lower, "loop") || lower == "wend"
+	return rangeValueSourceKeywordLine(lower, "next") || rangeValueSourceKeywordLine(lower, "loop") || rangeValueSourceKeywordLine(lower, "wend")
+}
+
+func rangeValueSourceElse(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	return rangeValueSourceKeywordLine(lower, "else")
+}
+
+func rangeValueSourceKeywordLine(lower, keyword string) bool {
+	return lower == keyword || strings.HasPrefix(lower, keyword+" ")
 }
 
 func rangeValueSourceLinesApplicable(file parsedFile, proc sourceProcedure) bool {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -68,6 +68,12 @@ type rangeValueSourceStatement struct {
 	text string
 }
 
+type rangeValueSourceGuardFrame struct {
+	name     string
+	previous bool
+	active   bool
+}
+
 var (
 	rangeValueAddressRe     = regexp.MustCompile(`(?i)^([A-Z]+)([0-9]+)(?::([A-Z]+)([0-9]+))?$`)
 	rangeValueBoundRe       = regexp.MustCompile(`(?i)\b([UL])Bound\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*([^)]*))?\)`)
@@ -176,6 +182,7 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 	}
 	facts := rangeValueFactsForProcedure(file, proc)
 	state := newRangeValueFlowState()
+	var guards []rangeValueSourceGuardFrame
 	var findings []Finding
 	for index, source := range sourceStatements {
 		statement := procedureir.Statement{
@@ -186,11 +193,56 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 				EndLine:   source.line,
 			},
 		}
+		updateRangeValueSourceGuard(&state, &guards, statement.Text)
 		issues, next := rangeValueStatement(state, statement, facts)
 		findings = appendRangeValueFindings(findings, file, proc, statement, issues, a)
 		state = next
 	}
 	return findings
+}
+
+func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValueSourceGuardFrame, text string) {
+	if state == nil || guards == nil {
+		return
+	}
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if strings.HasPrefix(lower, "end if") {
+		if len(*guards) == 0 {
+			return
+		}
+		frame := (*guards)[len(*guards)-1]
+		*guards = (*guards)[:len(*guards)-1]
+		if frame.previous {
+			state.arrayGuards[frame.name] = true
+		} else {
+			delete(state.arrayGuards, frame.name)
+		}
+		return
+	}
+	if strings.HasPrefix(lower, "else") {
+		if len(*guards) == 0 {
+			return
+		}
+		frame := &(*guards)[len(*guards)-1]
+		if frame.active {
+			delete(state.arrayGuards, frame.name)
+			frame.active = false
+		}
+		return
+	}
+	match := rangeValueGuardRe.FindStringSubmatch(text)
+	if len(match) != 3 {
+		return
+	}
+	name := strings.ToLower(match[2])
+	previous := state.arrayGuards[name]
+	frame := rangeValueSourceGuardFrame{name: name, previous: previous, active: strings.TrimSpace(match[1]) == ""}
+	*guards = append(*guards, frame)
+	if frame.active {
+		state.arrayGuards[name] = true
+	} else {
+		delete(state.arrayGuards, name)
+	}
 }
 
 func rangeValueSourceLinesApplicable(file parsedFile, proc sourceProcedure) bool {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -102,6 +102,8 @@ type rangeValueSourceConditionalFlowFrame struct {
 
 type rangeValueSourceLoopFrame struct {
 	before rangeValueFlowState
+	kind   string
+	exited bool
 }
 
 type rangeValueSourceSelectFrame struct {
@@ -282,6 +284,9 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 			}
 			continue
 		}
+		if len(loops) > 0 && loops[len(loops)-1].exited && !rangeValueSourceLoopEnd(statement.Text) {
+			continue
+		}
 		if match := rangeValueInlineGuardRe.FindStringSubmatch(statement.Text); len(match) == 4 {
 			name := strings.ToLower(match[2])
 			negated := strings.TrimSpace(match[1]) != ""
@@ -366,7 +371,7 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 				state = cloneRangeValueFlowState(frame.before)
 			}
 		} else if rangeValueSourceLoopStart(statement.Text) {
-			loops = append(loops, rangeValueSourceLoopFrame{before: cloneRangeValueFlowState(state)})
+			loops = append(loops, rangeValueSourceLoopFrame{before: cloneRangeValueFlowState(state), kind: rangeValueSourceLoopKind(statement.Text)})
 		} else if rangeValueSourceLoopEnd(statement.Text) && len(loops) > 0 {
 			frame := loops[len(loops)-1]
 			loops = loops[:len(loops)-1]
@@ -437,6 +442,17 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 				}
 			} else {
 				state = mergeRangeValueSourceStates(frame.before, current)
+			}
+		}
+		if exitKind := rangeValueSourceLoopExitKind(statement.Text); exitKind != "" && len(branches) == 0 && len(selects) == 0 && len(conditionals) == 0 && !strings.HasPrefix(strings.ToLower(strings.TrimSpace(statement.Text)), "if ") {
+			for index := len(loops) - 1; index >= 0; index-- {
+				if loops[index].kind != exitKind {
+					continue
+				}
+				for exited := index; exited < len(loops); exited++ {
+					loops[exited].exited = true
+				}
+				break
 			}
 		}
 		if rangeValueSourceEarlyExit(statement.Text) && len(branches) > 0 {
@@ -546,6 +562,33 @@ func isRangeValueBlockIf(text string) bool {
 func rangeValueSourceLoopStart(text string) bool {
 	lower := strings.ToLower(strings.TrimSpace(text))
 	return strings.HasPrefix(lower, "for ") || lower == "do" || strings.HasPrefix(lower, "do while ") || strings.HasPrefix(lower, "do until ") || strings.HasPrefix(lower, "while ")
+}
+
+func rangeValueSourceLoopKind(text string) string {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if strings.HasPrefix(lower, "for ") {
+		return "for"
+	}
+	if lower == "do" || strings.HasPrefix(lower, "do while ") || strings.HasPrefix(lower, "do until ") {
+		return "do"
+	}
+	if strings.HasPrefix(lower, "while ") {
+		return "while"
+	}
+	return ""
+}
+
+func rangeValueSourceLoopExitKind(text string) string {
+	switch strings.ToLower(strings.TrimSpace(text)) {
+	case "exit for":
+		return "for"
+	case "exit do":
+		return "do"
+	case "exit while":
+		return "while"
+	default:
+		return ""
+	}
 }
 
 func rangeValueSourceSelectStart(text string) bool {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -69,10 +69,15 @@ type rangeValueSourceStatement struct {
 }
 
 type rangeValueSourceGuardFrame struct {
-	name     string
-	previous bool
-	negated  bool
-	active   bool
+	name    string
+	negated bool
+	active  bool
+}
+
+type rangeValueSourceBranchFrame struct {
+	before      rangeValueFlowState
+	branches    rangeValueFlowState
+	hasBranches bool
 }
 
 var (
@@ -91,7 +96,7 @@ func (a Analyzer) rangeValueShapeFindings(file parsedFile, proc sourceProcedure)
 	if !a.Config.Analyze.DetectRangeValueArrayShape {
 		return nil
 	}
-	if len(proc.Statements) == 0 {
+	if len(proc.Statements) == 0 || rangeValueProjectionUnknown(proc) {
 		return a.rangeValueShapeFindingsFromSource(file, proc)
 	}
 	facts := rangeValueFactsForProcedure(file, proc)
@@ -185,6 +190,7 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 	facts := rangeValueFactsForProcedure(file, proc)
 	state := newRangeValueFlowState()
 	var guards []rangeValueSourceGuardFrame
+	var branches []rangeValueSourceBranchFrame
 	var findings []Finding
 	for index, source := range sourceStatements {
 		statement := procedureir.Statement{
@@ -213,12 +219,40 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 			state = next
 			continue
 		}
+		lower := strings.ToLower(strings.TrimSpace(statement.Text))
+		if isRangeValueBlockIf(statement.Text) {
+			branches = append(branches, rangeValueSourceBranchFrame{before: cloneRangeValueFlowState(state)})
+		} else if strings.HasPrefix(lower, "else") && len(branches) > 0 {
+			frame := &branches[len(branches)-1]
+			current := cloneRangeValueFlowState(state)
+			if frame.hasBranches {
+				frame.branches = mergeRangeValueSourceStates(frame.branches, current)
+			} else {
+				frame.branches = current
+				frame.hasBranches = true
+			}
+			state = cloneRangeValueFlowState(frame.before)
+		} else if strings.HasPrefix(lower, "end if") && len(branches) > 0 {
+			current := cloneRangeValueFlowState(state)
+			frame := branches[len(branches)-1]
+			branches = branches[:len(branches)-1]
+			if frame.hasBranches {
+				state = mergeRangeValueSourceStates(frame.branches, current)
+			} else {
+				state = mergeRangeValueSourceStates(frame.before, current)
+			}
+		}
 		updateRangeValueSourceGuard(&state, &guards, statement.Text)
 		issues, next := rangeValueStatement(state, statement, facts)
 		findings = appendRangeValueFindings(findings, file, proc, statement, issues, a)
 		state = next
 	}
 	return findings
+}
+
+func mergeRangeValueSourceStates(first, second rangeValueFlowState) rangeValueFlowState {
+	merged, _ := mergeRangeValueFlowState(first, second, true)
+	return merged
 }
 
 func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValueSourceGuardFrame, text string) {
@@ -232,9 +266,7 @@ func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValu
 		}
 		frame := (*guards)[len(*guards)-1]
 		*guards = (*guards)[:len(*guards)-1]
-		if frame.previous {
-			state.arrayGuards[frame.name] = true
-		} else {
+		if frame.name != "" && !state.arrayGuards[frame.name] {
 			delete(state.arrayGuards, frame.name)
 		}
 		return
@@ -284,9 +316,8 @@ func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValu
 		return
 	}
 	name := strings.ToLower(match[2])
-	previous := state.arrayGuards[name]
 	negated := strings.TrimSpace(match[1]) != ""
-	frame := rangeValueSourceGuardFrame{name: name, previous: previous, negated: negated, active: !negated}
+	frame := rangeValueSourceGuardFrame{name: name, negated: negated, active: !negated}
 	*guards = append(*guards, frame)
 	if frame.active {
 		state.arrayGuards[name] = true

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -71,6 +71,7 @@ type rangeValueSourceStatement struct {
 type rangeValueSourceGuardFrame struct {
 	name     string
 	previous bool
+	negated  bool
 	active   bool
 }
 
@@ -234,16 +235,24 @@ func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValu
 			}
 			trimmed := strings.TrimSpace(text)
 			match := rangeValueGuardRe.FindStringSubmatch("If " + strings.TrimSpace(trimmed[len("ElseIf "):]))
-			if len(match) == 3 && strings.TrimSpace(match[1]) == "" {
-				frame.active = true
-				state.arrayGuards[frame.name] = true
+			if len(match) == 3 {
+				frame.negated = strings.TrimSpace(match[1]) != ""
+				frame.active = !frame.negated
+				if frame.active {
+					state.arrayGuards[frame.name] = true
+				}
 			}
 			return
 		}
 		frame := &(*guards)[len(*guards)-1]
-		if frame.name != "" && frame.active {
-			delete(state.arrayGuards, frame.name)
-			frame.active = false
+		if frame.name != "" {
+			if frame.active {
+				delete(state.arrayGuards, frame.name)
+			}
+			frame.active = frame.negated
+			if frame.active {
+				state.arrayGuards[frame.name] = true
+			}
 		}
 		return
 	}
@@ -257,7 +266,8 @@ func updateRangeValueSourceGuard(state *rangeValueFlowState, guards *[]rangeValu
 	}
 	name := strings.ToLower(match[2])
 	previous := state.arrayGuards[name]
-	frame := rangeValueSourceGuardFrame{name: name, previous: previous, active: strings.TrimSpace(match[1]) == ""}
+	negated := strings.TrimSpace(match[1]) != ""
+	frame := rangeValueSourceGuardFrame{name: name, previous: previous, negated: negated, active: !negated}
 	*guards = append(*guards, frame)
 	if frame.active {
 		state.arrayGuards[name] = true

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -79,7 +79,6 @@ type rangeValueSourceBranchFrame struct {
 	branches     rangeValueFlowState
 	hasBranches  bool
 	hasElse      bool
-	thenExited   bool
 	exited       bool
 	guardName    string
 	guardNegated bool
@@ -241,17 +240,30 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 				frame.guardNegated = strings.TrimSpace(match[1]) != ""
 			}
 			branches = append(branches, frame)
+		} else if strings.HasPrefix(lower, "elseif ") && len(branches) > 0 {
+			frame := &branches[len(branches)-1]
+			current := cloneRangeValueFlowState(state)
+			if !frame.exited {
+				if frame.hasBranches {
+					frame.branches = mergeRangeValueSourceStates(frame.branches, current)
+				} else {
+					frame.branches = current
+					frame.hasBranches = true
+				}
+			}
+			frame.exited = false
+			state = cloneRangeValueFlowState(frame.before)
 		} else if strings.HasPrefix(lower, "else") && len(branches) > 0 {
 			frame := &branches[len(branches)-1]
 			current := cloneRangeValueFlowState(state)
 			frame.hasElse = true
-			if frame.exited {
-				frame.thenExited = true
-			} else if frame.hasBranches {
-				frame.branches = mergeRangeValueSourceStates(frame.branches, current)
-			} else {
-				frame.branches = current
-				frame.hasBranches = true
+			if !frame.exited {
+				if frame.hasBranches {
+					frame.branches = mergeRangeValueSourceStates(frame.branches, current)
+				} else {
+					frame.branches = current
+					frame.hasBranches = true
+				}
 			}
 			frame.exited = false
 			state = cloneRangeValueFlowState(frame.before)
@@ -259,16 +271,23 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 			current := cloneRangeValueFlowState(state)
 			frame := branches[len(branches)-1]
 			branches = branches[:len(branches)-1]
-			if frame.hasElse && frame.exited {
-				if frame.hasBranches {
-					state = frame.branches
+			if frame.hasElse {
+				if frame.exited {
+					if frame.hasBranches {
+						state = frame.branches
+					} else {
+						state = cloneRangeValueFlowState(frame.before)
+					}
+				} else if frame.hasBranches {
+					state = mergeRangeValueSourceStates(frame.branches, current)
 				} else {
-					state = cloneRangeValueFlowState(frame.before)
+					state = current
 				}
-			} else if frame.hasElse && frame.thenExited {
-				state = current
 			} else if frame.hasBranches {
-				state = mergeRangeValueSourceStates(frame.branches, current)
+				state = mergeRangeValueSourceStates(frame.before, frame.branches)
+				if !frame.exited {
+					state = mergeRangeValueSourceStates(state, current)
+				}
 			} else if frame.exited {
 				state = cloneRangeValueFlowState(frame.before)
 				if frame.guardName != "" {
@@ -289,6 +308,9 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 		issues, next := rangeValueStatement(state, statement, facts)
 		findings = appendRangeValueFindings(findings, file, proc, statement, issues, a)
 		state = next
+		if rangeValueSourceEarlyExit(statement.Text) && len(branches) == 0 {
+			break
+		}
 	}
 	return findings
 }

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -96,6 +96,13 @@ type rangeValueSourceLoopFrame struct {
 	before rangeValueFlowState
 }
 
+type rangeValueSourceSelectFrame struct {
+	before      rangeValueFlowState
+	branches    rangeValueFlowState
+	hasBranches bool
+	exited      bool
+}
+
 var (
 	rangeValueAddressRe     = regexp.MustCompile(`(?i)^([A-Z]+)([0-9]+)(?::([A-Z]+)([0-9]+))?$`)
 	rangeValueBoundRe       = regexp.MustCompile(`(?i)\b([UL])Bound\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*([^)]*))?\)`)
@@ -208,6 +215,7 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 	var guards []rangeValueSourceGuardFrame
 	var branches []rangeValueSourceBranchFrame
 	var loops []rangeValueSourceLoopFrame
+	var selects []rangeValueSourceSelectFrame
 	var findings []Finding
 	for index, source := range sourceStatements {
 		line := source.endLine
@@ -225,6 +233,9 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 		if match := rangeValueInlineGuardRe.FindStringSubmatch(statement.Text); len(match) == 4 {
 			name := strings.ToLower(match[2])
 			negated := strings.TrimSpace(match[1]) != ""
+			if state.arrayGuards[name] && negated {
+				continue
+			}
 			if rangeValueSourceEarlyExit(match[3]) {
 				if negated {
 					state.arrayGuards[name] = true
@@ -250,7 +261,39 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 			continue
 		}
 		lower := strings.ToLower(strings.TrimSpace(statement.Text))
-		if rangeValueSourceLoopStart(statement.Text) {
+		if rangeValueSourceSelectStart(statement.Text) {
+			selects = append(selects, rangeValueSourceSelectFrame{before: cloneRangeValueFlowState(state)})
+		} else if rangeValueSourceSelectCase(statement.Text) && len(selects) > 0 {
+			frame := &selects[len(selects)-1]
+			current := cloneRangeValueFlowState(state)
+			if !frame.exited {
+				if frame.hasBranches {
+					frame.branches = mergeRangeValueSourceStates(frame.branches, current)
+				} else {
+					frame.branches = current
+					frame.hasBranches = true
+				}
+			}
+			frame.exited = false
+			state = cloneRangeValueFlowState(frame.before)
+		} else if rangeValueSourceSelectEnd(statement.Text) && len(selects) > 0 {
+			current := cloneRangeValueFlowState(state)
+			frame := selects[len(selects)-1]
+			selects = selects[:len(selects)-1]
+			if !frame.exited {
+				if frame.hasBranches {
+					frame.branches = mergeRangeValueSourceStates(frame.branches, current)
+				} else {
+					frame.branches = current
+					frame.hasBranches = true
+				}
+			}
+			if frame.hasBranches {
+				state = mergeRangeValueSourceStates(frame.before, frame.branches)
+			} else {
+				state = cloneRangeValueFlowState(frame.before)
+			}
+		} else if rangeValueSourceLoopStart(statement.Text) {
 			loops = append(loops, rangeValueSourceLoopFrame{before: cloneRangeValueFlowState(state)})
 		} else if rangeValueSourceLoopEnd(statement.Text) && len(loops) > 0 {
 			frame := loops[len(loops)-1]
@@ -326,6 +369,9 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 		}
 		if rangeValueSourceEarlyExit(statement.Text) && len(branches) > 0 {
 			branches[len(branches)-1].exited = true
+		}
+		if rangeValueSourceEarlyExit(statement.Text) && len(branches) == 0 && len(selects) > 0 {
+			selects[len(selects)-1].exited = true
 		}
 		updateRangeValueSourceGuard(&state, &guards, statement.Text)
 		issues, next := rangeValueStatement(state, statement, facts)
@@ -425,6 +471,18 @@ func isRangeValueBlockIf(text string) bool {
 func rangeValueSourceLoopStart(text string) bool {
 	lower := strings.ToLower(strings.TrimSpace(text))
 	return strings.HasPrefix(lower, "for ") || lower == "do" || strings.HasPrefix(lower, "do while ") || strings.HasPrefix(lower, "do until ") || strings.HasPrefix(lower, "while ")
+}
+
+func rangeValueSourceSelectStart(text string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(text)), "select case ")
+}
+
+func rangeValueSourceSelectCase(text string) bool {
+	return rangeValueSourceKeywordLine(strings.ToLower(strings.TrimSpace(text)), "case")
+}
+
+func rangeValueSourceSelectEnd(text string) bool {
+	return rangeValueSourceKeywordLine(strings.ToLower(strings.TrimSpace(text)), "end select")
 }
 
 func rangeValueSourceLoopEnd(text string) bool {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -84,6 +84,13 @@ type rangeValueSourceBranchFrame struct {
 	guardNegated bool
 }
 
+type rangeValueSourceConditionalFrame struct {
+	parentActive  bool
+	active        bool
+	branchTaken   bool
+	branchUnknown bool
+}
+
 var (
 	rangeValueAddressRe     = regexp.MustCompile(`(?i)^([A-Z]+)([0-9]+)(?::([A-Z]+)([0-9]+))?$`)
 	rangeValueBoundRe       = regexp.MustCompile(`(?i)\b([UL])Bound\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*([^)]*))?\)`)
@@ -440,6 +447,12 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 		return nil
 	}
 
+	conditionalConstants := file.RangeValueModuleConstants
+	if conditionalConstants == nil {
+		conditionalConstants = rangeValueModuleIntegerConstants(lines, file.IR)
+	}
+	conditionalActive := true
+	conditionals := []rangeValueSourceConditionalFrame{}
 	var out []rangeValueSourceStatement
 	var continued strings.Builder
 	continuedLine := 0
@@ -459,9 +472,16 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 		continued.Reset()
 		continuedLine = 0
 	}
-	for line := start; line <= end; line++ {
+	for line := 1; line <= end; line++ {
 		text := rangeValueStripRemComment(rawWorksheetCodeLine(lines[line-1]))
 		text = strings.TrimSpace(text)
+		if handled, active := rangeValueSourceConditionalDirective(text, &conditionals, conditionalActive, conditionalConstants); handled {
+			conditionalActive = active
+			continue
+		}
+		if line < start || !conditionalActive {
+			continue
+		}
 		if text == "" {
 			continue
 		}
@@ -484,6 +504,98 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 		flush(continuedLine)
 	}
 	return out
+}
+
+func rangeValueSourceConditionalDirective(text string, stack *[]rangeValueSourceConditionalFrame, active bool, constants map[string]int) (bool, bool) {
+	if stack == nil {
+		return false, active
+	}
+	lower := strings.ToLower(strings.TrimSpace(text))
+	switch {
+	case strings.HasPrefix(lower, "#if "):
+		condition := strings.TrimSpace(text[4:])
+		condition = rangeValueSourceConditionalExpression(condition)
+		parentActive := active
+		frame := rangeValueSourceConditionalFrame{parentActive: parentActive}
+		if parentActive {
+			switch rangeValueSourceConditionalValue(condition, constants) {
+			case 1:
+				frame.active, frame.branchTaken = true, true
+			case 0:
+				frame.active = false
+			default:
+				frame.active, frame.branchUnknown = true, true
+			}
+		}
+		*stack = append(*stack, frame)
+		return true, frame.active
+	case strings.HasPrefix(lower, "#elseif "):
+		if len(*stack) == 0 {
+			return true, active
+		}
+		frame := &(*stack)[len(*stack)-1]
+		if !frame.parentActive || frame.branchTaken {
+			frame.active = false
+			return true, false
+		}
+		if frame.branchUnknown {
+			frame.active = true
+			return true, true
+		}
+		condition := strings.TrimSpace(text[len("#ElseIf "):])
+		condition = rangeValueSourceConditionalExpression(condition)
+		switch rangeValueSourceConditionalValue(condition, constants) {
+		case 1:
+			frame.active, frame.branchTaken = true, true
+		case 0:
+			frame.active = false
+		default:
+			frame.active, frame.branchUnknown = true, true
+		}
+		return true, frame.active
+	case strings.HasPrefix(lower, "#else"):
+		if len(*stack) == 0 {
+			return true, active
+		}
+		frame := &(*stack)[len(*stack)-1]
+		frame.active = frame.parentActive && !frame.branchTaken
+		frame.branchTaken = frame.parentActive
+		return true, frame.active
+	case strings.HasPrefix(lower, "#end if"):
+		if len(*stack) == 0 {
+			return true, active
+		}
+		frame := (*stack)[len(*stack)-1]
+		*stack = (*stack)[:len(*stack)-1]
+		return true, frame.parentActive
+	default:
+		return false, active
+	}
+}
+
+func rangeValueSourceConditionalValue(text string, constants map[string]int) int {
+	switch strings.ToLower(strings.TrimSpace(text)) {
+	case "true":
+		return 1
+	case "false":
+		return 0
+	}
+	value, err := constantIntegerExpression(text, constants)
+	if err != nil {
+		return -1
+	}
+	if value == 0 {
+		return 0
+	}
+	return 1
+}
+
+func rangeValueSourceConditionalExpression(text string) string {
+	text = strings.TrimSpace(text)
+	if strings.HasSuffix(strings.ToLower(text), " then") {
+		return strings.TrimSpace(text[:len(text)-len(" then")])
+	}
+	return text
 }
 
 func rangeValueStripRemComment(text string) string {
@@ -1117,6 +1229,9 @@ func rangeValueRangeShapeText(expression string, state rangeValueFlowState, fact
 		}
 		return rangeShape{}, true
 	case "range":
+		if shape, found := rangeValueTextCellsPairShape(args, facts); found {
+			return shape, true
+		}
 		if shape, found := rangeValueTextLiteralRangeShape(args); found {
 			return shape, true
 		}
@@ -1126,6 +1241,48 @@ func rangeValueRangeShapeText(expression string, state rangeValueFlowState, fact
 	default:
 		return rangeShape{}, false
 	}
+}
+
+func rangeValueTextCellsPairShape(arguments []string, facts rangeValueFacts) (rangeShape, bool) {
+	if len(arguments) != 2 {
+		return rangeShape{}, false
+	}
+	startRow, startRowKnown, startColumn, startColumnKnown, startOK := rangeValueTextCellsCoordinates(arguments[0], facts)
+	endRow, endRowKnown, endColumn, endColumnKnown, endOK := rangeValueTextCellsCoordinates(arguments[1], facts)
+	if !startOK || !endOK {
+		return rangeShape{}, false
+	}
+	rows, rowsKnown := rangeValueAxisLength(startRow, startRowKnown, endRow, endRowKnown)
+	cols, colsKnown := rangeValueAxisLength(startColumn, startColumnKnown, endColumn, endColumnKnown)
+	return rangeShape{
+		known:   rowsKnown && colsKnown,
+		array2D: (rowsKnown && rows > 1) || (colsKnown && cols > 1),
+		rows:    rows,
+		cols:    cols,
+	}, true
+}
+
+func rangeValueTextCellsCoordinates(expression string, facts rangeValueFacts) (int, bool, int, bool, bool) {
+	text := strings.TrimSpace(expression)
+	open := firstParenOutsideString(text)
+	if open < 0 {
+		return 0, false, 0, false, false
+	}
+	close := matchingParen(text, open)
+	if close < 0 || strings.TrimSpace(text[close+1:]) != "" {
+		return 0, false, 0, false, false
+	}
+	name := strings.ToLower(cleanIdentifier(lastName(strings.TrimSpace(text[:open]))))
+	if name != "cells" {
+		return 0, false, 0, false, false
+	}
+	arguments := splitArgs(text[open+1 : close])
+	if len(arguments) != 2 {
+		return 0, false, 0, false, false
+	}
+	row, rowErr := constantIntegerExpression(arguments[0], facts.constantValues())
+	column, columnErr := constantIntegerExpression(arguments[1], facts.constantValues())
+	return row, rowErr == nil, column, columnErr == nil, true
 }
 
 func rangeValueTextLiteralRangeShape(arguments []string) (rangeShape, bool) {

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -92,6 +92,14 @@ type rangeValueSourceConditionalFrame struct {
 	branchUnknown bool
 }
 
+type rangeValueSourceConditionalFlowFrame struct {
+	before      rangeValueFlowState
+	branches    rangeValueFlowState
+	hasBranches bool
+	hasElse     bool
+	exited      bool
+}
+
 type rangeValueSourceLoopFrame struct {
 	before rangeValueFlowState
 }
@@ -216,6 +224,7 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 	var branches []rangeValueSourceBranchFrame
 	var loops []rangeValueSourceLoopFrame
 	var selects []rangeValueSourceSelectFrame
+	var conditionals []rangeValueSourceConditionalFlowFrame
 	var findings []Finding
 	for index, source := range sourceStatements {
 		line := source.endLine
@@ -229,6 +238,49 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 				StartLine: line,
 				EndLine:   line,
 			},
+		}
+		if rangeValueSourceConditionalStart(statement.Text) {
+			conditionals = append(conditionals, rangeValueSourceConditionalFlowFrame{before: cloneRangeValueFlowState(state)})
+			continue
+		}
+		if (rangeValueSourceConditionalElseIf(statement.Text) || rangeValueSourceConditionalElse(statement.Text)) && len(conditionals) > 0 {
+			frame := &conditionals[len(conditionals)-1]
+			if rangeValueSourceConditionalElse(statement.Text) {
+				frame.hasElse = true
+			}
+			if !frame.exited {
+				if frame.hasBranches {
+					frame.branches = mergeRangeValueSourceStates(frame.branches, state)
+				} else {
+					frame.branches = cloneRangeValueFlowState(state)
+					frame.hasBranches = true
+				}
+			}
+			frame.exited = false
+			state = cloneRangeValueFlowState(frame.before)
+			continue
+		}
+		if rangeValueSourceConditionalEnd(statement.Text) && len(conditionals) > 0 {
+			frame := conditionals[len(conditionals)-1]
+			conditionals = conditionals[:len(conditionals)-1]
+			if !frame.exited {
+				if frame.hasBranches {
+					frame.branches = mergeRangeValueSourceStates(frame.branches, state)
+				} else {
+					frame.branches = cloneRangeValueFlowState(state)
+					frame.hasBranches = true
+				}
+			}
+			if frame.hasBranches {
+				if frame.hasElse {
+					state = cloneRangeValueFlowState(frame.branches)
+				} else {
+					state = mergeRangeValueSourceStates(frame.before, frame.branches)
+				}
+			} else {
+				state = cloneRangeValueFlowState(frame.before)
+			}
+			continue
 		}
 		if match := rangeValueInlineGuardRe.FindStringSubmatch(statement.Text); len(match) == 4 {
 			name := strings.ToLower(match[2])
@@ -244,20 +296,40 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 				}
 				continue
 			}
-			priorGuard := state.arrayGuards[name]
+			prior := cloneRangeValueFlowState(state)
+			thenState := cloneRangeValueFlowState(prior)
 			if !negated {
-				state.arrayGuards[name] = true
+				thenState.arrayGuards[name] = true
 			} else {
-				delete(state.arrayGuards, name)
+				delete(thenState.arrayGuards, name)
 			}
-			body := statement
-			body.Text = strings.TrimSpace(match[3])
-			issues, next := rangeValueStatement(state, body, facts)
-			if !next.arrayGuards[name] || !priorGuard {
-				delete(next.arrayGuards, name)
+			thenText, elseText, hasElse := splitRangeValueInlineElse(match[3])
+			thenStatement := statement
+			thenStatement.Text = thenText
+			issues, thenNext := rangeValueStatement(thenState, thenStatement, facts)
+			findings = appendRangeValueFindings(findings, file, proc, thenStatement, issues, a)
+			if !hasElse {
+				if !thenNext.arrayGuards[name] || !prior.arrayGuards[name] {
+					delete(thenNext.arrayGuards, name)
+				}
+				state = thenNext
+				continue
 			}
-			findings = appendRangeValueFindings(findings, file, proc, body, issues, a)
-			state = next
+			if prior.arrayGuards[name] && !negated {
+				state = thenNext
+				continue
+			}
+			elseState := cloneRangeValueFlowState(prior)
+			if negated {
+				elseState.arrayGuards[name] = true
+			} else {
+				delete(elseState.arrayGuards, name)
+			}
+			elseStatement := statement
+			elseStatement.Text = elseText
+			elseIssues, elseNext := rangeValueStatement(elseState, elseStatement, facts)
+			findings = appendRangeValueFindings(findings, file, proc, elseStatement, elseIssues, a)
+			state = mergeRangeValueSourceStates(thenNext, elseNext)
 			continue
 		}
 		lower := strings.ToLower(strings.TrimSpace(statement.Text))
@@ -373,11 +445,14 @@ func (a Analyzer) rangeValueShapeFindingsFromSource(file parsedFile, proc source
 		if rangeValueSourceEarlyExit(statement.Text) && len(branches) == 0 && len(selects) > 0 {
 			selects[len(selects)-1].exited = true
 		}
+		if rangeValueSourceEarlyExit(statement.Text) && len(conditionals) > 0 {
+			conditionals[len(conditionals)-1].exited = true
+		}
 		updateRangeValueSourceGuard(&state, &guards, statement.Text)
 		issues, next := rangeValueStatement(state, statement, facts)
 		findings = appendRangeValueFindings(findings, file, proc, statement, issues, a)
 		state = next
-		if rangeValueSourceEarlyExit(statement.Text) && len(branches) == 0 && len(selects) == 0 {
+		if rangeValueSourceEarlyExit(statement.Text) && len(branches) == 0 && len(selects) == 0 && len(conditionals) == 0 {
 			break
 		}
 	}
@@ -485,6 +560,22 @@ func rangeValueSourceSelectEnd(text string) bool {
 	return rangeValueSourceKeywordLine(strings.ToLower(strings.TrimSpace(text)), "end select")
 }
 
+func rangeValueSourceConditionalStart(text string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(text)), "#if ")
+}
+
+func rangeValueSourceConditionalElseIf(text string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(text)), "#elseif ")
+}
+
+func rangeValueSourceConditionalElse(text string) bool {
+	return rangeValueSourceKeywordLine(strings.ToLower(strings.TrimSpace(text)), "#else")
+}
+
+func rangeValueSourceConditionalEnd(text string) bool {
+	return rangeValueSourceKeywordLine(strings.ToLower(strings.TrimSpace(text)), "#end if")
+}
+
 func rangeValueSourceLoopEnd(text string) bool {
 	lower := strings.ToLower(strings.TrimSpace(text))
 	return rangeValueSourceKeywordLine(lower, "next") || rangeValueSourceKeywordLine(lower, "loop") || rangeValueSourceKeywordLine(lower, "wend")
@@ -517,6 +608,42 @@ func rangeValueSourceEarlyExit(text string) bool {
 		}
 	}
 	return false
+}
+
+func splitRangeValueInlineElse(text string) (string, string, bool) {
+	lower := strings.ToLower(text)
+	inString := false
+	parenDepth := 0
+	for index := 0; index < len(text); index++ {
+		switch text[index] {
+		case '"':
+			if inString && index+1 < len(text) && text[index+1] == '"' {
+				index++
+				continue
+			}
+			inString = !inString
+		case '(':
+			if !inString {
+				parenDepth++
+			}
+		case ')':
+			if !inString && parenDepth > 0 {
+				parenDepth--
+			}
+		}
+		if inString || parenDepth != 0 || index+4 > len(text) || lower[index:index+4] != "else" {
+			continue
+		}
+		if (index > 0 && rangeValueInlineIdentifierByte(text[index-1])) || (index+4 < len(text) && rangeValueInlineIdentifierByte(text[index+4])) {
+			continue
+		}
+		return strings.TrimSpace(text[:index]), strings.TrimSpace(text[index+4:]), true
+	}
+	return strings.TrimSpace(text), "", false
+}
+
+func rangeValueInlineIdentifierByte(value byte) bool {
+	return value == '_' || value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9'
 }
 
 func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeValueSourceStatement {
@@ -568,7 +695,10 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 	for line := 1; line <= end; line++ {
 		text := rangeValueStripRemComment(rawWorksheetCodeLine(lines[line-1]))
 		text = strings.TrimSpace(text)
-		if handled, active := rangeValueSourceConditionalDirective(text, &conditionals, conditionalActive, conditionalConstants); handled {
+		if handled, active, unknown := rangeValueSourceConditionalDirective(text, &conditionals, conditionalActive, conditionalConstants); handled {
+			if unknown {
+				out = append(out, rangeValueSourceStatement{line: line, endLine: line, text: text})
+			}
 			conditionalActive = active
 			continue
 		}
@@ -600,9 +730,9 @@ func rangeValueSourceStatements(file parsedFile, proc sourceProcedure) []rangeVa
 	return out
 }
 
-func rangeValueSourceConditionalDirective(text string, stack *[]rangeValueSourceConditionalFrame, active bool, constants map[string]int) (bool, bool) {
+func rangeValueSourceConditionalDirective(text string, stack *[]rangeValueSourceConditionalFrame, active bool, constants map[string]int) (bool, bool, bool) {
 	if stack == nil {
-		return false, active
+		return false, active, false
 	}
 	lower := strings.ToLower(strings.TrimSpace(text))
 	switch {
@@ -622,19 +752,19 @@ func rangeValueSourceConditionalDirective(text string, stack *[]rangeValueSource
 			}
 		}
 		*stack = append(*stack, frame)
-		return true, frame.active
+		return true, frame.active, frame.branchUnknown
 	case strings.HasPrefix(lower, "#elseif "):
 		if len(*stack) == 0 {
-			return true, active
+			return true, active, false
 		}
 		frame := &(*stack)[len(*stack)-1]
 		if !frame.parentActive || frame.branchTaken {
 			frame.active = false
-			return true, false
+			return true, false, false
 		}
 		if frame.branchUnknown {
 			frame.active = true
-			return true, true
+			return true, true, true
 		}
 		condition := strings.TrimSpace(text[len("#ElseIf "):])
 		condition = rangeValueSourceConditionalExpression(condition)
@@ -646,24 +776,25 @@ func rangeValueSourceConditionalDirective(text string, stack *[]rangeValueSource
 		default:
 			frame.active, frame.branchUnknown = true, true
 		}
-		return true, frame.active
+		return true, frame.active, frame.branchUnknown
 	case strings.HasPrefix(lower, "#else"):
 		if len(*stack) == 0 {
-			return true, active
+			return true, active, false
 		}
 		frame := &(*stack)[len(*stack)-1]
+		unknown := frame.branchUnknown
 		frame.active = frame.parentActive && !frame.branchTaken
 		frame.branchTaken = frame.parentActive
-		return true, frame.active
+		return true, frame.active, unknown
 	case strings.HasPrefix(lower, "#end if"):
 		if len(*stack) == 0 {
-			return true, active
+			return true, active, false
 		}
 		frame := (*stack)[len(*stack)-1]
 		*stack = (*stack)[:len(*stack)-1]
-		return true, frame.parentActive
+		return true, frame.parentActive, frame.branchUnknown
 	default:
-		return false, active
+		return false, active, false
 	}
 }
 

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -602,7 +602,9 @@ func rangeValueSourceLinesApplicable(file parsedFile, proc sourceProcedure) bool
 
 func rangeValueSourceEarlyExit(text string) bool {
 	lower := strings.ToLower(strings.TrimSpace(text))
-	for _, prefix := range []string{"exit sub", "exit function", "exit property", "return"} {
+	// VBA Return only returns from a GoSub. It is not a procedure terminator;
+	// treating it as one would stop source recovery before the caller resumes.
+	for _, prefix := range []string{"exit sub", "exit function", "exit property"} {
 		if lower == prefix || strings.HasPrefix(lower, prefix+" ") {
 			return true
 		}

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -440,6 +440,38 @@ End Sub
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(blockEarlyExitFile, blockEarlyExitProc), "VBA226"); len(got) != 0 {
 		t.Fatalf("block early-exit negative IsArray guard should preserve the surviving array path: %+v", got)
 	}
+
+	elseIfSource := `Option Explicit
+Public Sub Run(ByVal first As Boolean, ByVal second As Boolean)
+  Dim values As Variant
+  values = Range("A1").Value2
+  If first Then
+    values = Range("A1:B2").Value2
+  ElseIf second Then
+    values = Range("A1:B2").Value2
+  End If
+  Debug.Print values(1, 1)
+End Sub
+`
+	elseIfFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(elseIfSource), Source: []byte(elseIfSource)}
+	elseIfProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 10}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(elseIfFile, elseIfProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("ElseIf fallthrough should retain the scalar path: %+v", got)
+	}
+
+	procedureExitSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  Exit Sub
+  Debug.Print values(1)
+End Sub
+`
+	procedureExitFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(procedureExitSource), Source: []byte(procedureExitSource)}
+	procedureExitProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 7}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(procedureExitFile, procedureExitProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("source after Exit Sub must be unreachable: %+v", got)
+	}
 }
 
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -585,6 +585,23 @@ End Sub
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(procedureExitFile, procedureExitProc), "VBA226"); len(got) != 0 {
 		t.Fatalf("source after Exit Sub must be unreachable: %+v", got)
 	}
+
+	selectEarlyExitSource := `Option Explicit
+Public Sub Run(ByVal mode As Long)
+  Dim values As Variant
+  Select Case mode
+    Case 1
+      Exit Sub
+  End Select
+  values = Range("A1").Value2
+  Debug.Print values(1)
+End Sub
+`
+	selectEarlyExitFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(selectEarlyExitSource), Source: []byte(selectEarlyExitSource)}
+	selectEarlyExitProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 10}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(selectEarlyExitFile, selectEarlyExitProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("source after Select Case branch Exit Sub should still be analyzed: %+v", got)
+	}
 }
 
 func TestVBA226GraphlessCompleteIRDoesNotUseRecoveryFallback(t *testing.T) {

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -441,6 +441,37 @@ End Sub
 		t.Fatalf("source fallback should preserve nested Cells pair shape: %+v", got)
 	}
 
+	loopSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  For index = 1 To 1
+    values = Range("A1:B2").Value2
+  Next index
+  Debug.Print values(1, 1)
+End Sub
+`
+	loopFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(loopSource), Source: []byte(loopSource)}
+	loopProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 9}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(loopFile, loopProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("loop recovery should merge the zero-iteration scalar path: %+v", got)
+	}
+
+	continuedSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  Debug.Print values( _
+    1)
+End Sub
+`
+	continuedFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(continuedSource), Source: []byte(continuedSource)}
+	continuedProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 7}
+	continuedFindings := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(continuedFile, continuedProc), "VBA226")
+	if len(continuedFindings) != 1 || continuedFindings[0].Line != 6 {
+		t.Fatalf("continued-line finding should use the physical index line: %+v", continuedFindings)
+	}
+
 	earlyExitSource := `Option Explicit
 Public Sub Run(ByVal lastCell As String)
   Dim values As Variant

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -336,6 +336,19 @@ End Sub
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(negatedFile, negatedProc), "VBA226"); len(got) != 0 {
 		t.Fatalf("negative IsArray guard Else branch should suppress uncertain two-dimensional access: %+v", got)
 	}
+
+	inlineSource := `Option Explicit
+Public Sub Run(ByVal lastCell As String)
+  Dim values As Variant
+  values = Range("A1:" & lastCell).Value2
+  If IsArray(values) Then Debug.Print values(1, 1)
+End Sub
+`
+	inlineFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(inlineSource), Source: []byte(inlineSource)}
+	inlineProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 6}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(inlineFile, inlineProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("single-line IsArray guard should suppress uncertain two-dimensional access: %+v", got)
+	}
 }
 
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -305,14 +305,17 @@ End Sub
 	guardedSource := `Option Explicit
 Public Sub Run(ByVal lastCell As String)
   Dim values As Variant
-  values = Range("A1:" & lastCell).Value2
-  If IsArray(values) Then
-    Debug.Print values(1, 1)
-  End If
+	values = Range("A1:" & lastCell).Value2
+	If IsArray(values) Then
+	    If lastCell <> "" Then
+	      Debug.Print values(1, 1)
+	    End If
+	    Debug.Print values(1, 1)
+	End If
 End Sub
 `
 	guardedFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(guardedSource), Source: []byte(guardedSource)}
-	guardedProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 8}
+	guardedProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 10}
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(guardedFile, guardedProc), "VBA226"); len(got) != 0 {
 		t.Fatalf("source-line IsArray guard should suppress uncertain two-dimensional access: %+v", got)
 	}

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -490,6 +490,25 @@ End Sub
 		t.Fatalf("source fallback should retain procedure-local constants for bounds: %+v", got)
 	}
 
+	selectSource := `Option Explicit
+Public Sub Run(ByVal mode As Long)
+  Dim values As Variant
+  values = Range("A1").Value2
+  Select Case mode
+    Case 1
+      values = Range("A1:B2").Value2
+    Case 2
+      values = Range("A1:B2").Value2
+  End Select
+  Debug.Print values(1, 1)
+End Sub
+`
+	selectFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(selectSource), Source: []byte(selectSource)}
+	selectProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 12}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(selectFile, selectProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("Select Case recovery should merge the scalar path: %+v", got)
+	}
+
 	continuedSource := `Option Explicit
 Public Sub Run()
   Dim values As Variant

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -319,6 +319,23 @@ End Sub
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(guardedFile, guardedProc), "VBA226"); len(got) != 0 {
 		t.Fatalf("source-line IsArray guard should suppress uncertain two-dimensional access: %+v", got)
 	}
+
+	negatedSource := `Option Explicit
+Public Sub Run(ByVal lastCell As String)
+  Dim values As Variant
+  values = Range("A1:" & lastCell).Value2
+  If Not IsArray(values) Then
+    Debug.Print values
+  Else
+    Debug.Print values(1, 1)
+  End If
+End Sub
+`
+	negatedFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(negatedSource), Source: []byte(negatedSource)}
+	negatedProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 9}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(negatedFile, negatedProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("negative IsArray guard Else branch should suppress uncertain two-dimensional access: %+v", got)
+	}
 }
 
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -278,6 +278,31 @@ End Sub
 	}
 }
 
+func TestVBA226FallsBackToSourceLinesForEmptyProcedureIR(t *testing.T) {
+	t.Parallel()
+	source := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  Debug.Print values(1)
+End Sub
+`
+	file := parsedFile{
+		Path:   "Main.bas",
+		Lines:  normalizedSourceLines(source),
+		Source: []byte(source),
+	}
+	proc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 6}
+	if !rangeValueShapeApplicable(file, proc) {
+		t.Fatal("empty procedure projection should use source-line applicability")
+	}
+	findings := (Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(file, proc)
+	got := findingsByCode(findings, "VBA226")
+	if len(got) != 1 || got[0].Line != 5 || !strings.Contains(got[0].Message, "Single-cell") {
+		t.Fatalf("source-line fallback findings = %+v, want one scalar-index finding on line 5", got)
+	}
+}
+
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -485,6 +485,16 @@ func TestVBA226GraphlessCompleteIRDoesNotUseRecoveryFallback(t *testing.T) {
 	}
 }
 
+func TestVBA226RecoveredRangeValueExpressionUsesRecoveryFallback(t *testing.T) {
+	proc := sourceProcedure{
+		Statements:  []procedureir.Statement{{ID: 1, Text: "values = ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}},
+		Expressions: []procedureir.Expression{{ID: 1, StatementID: 1, Kind: procedureir.ExpressionUnknown, Text: "ws.Cells(2, 1)", Recovered: true}},
+	}
+	if !rangeValueProjectionUnknown(proc) {
+		t.Fatal("recovered Range.Value child expressions should select source recovery")
+	}
+}
+
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -338,6 +338,23 @@ End Sub
 		t.Fatalf("negative IsArray guard Else branch should suppress uncertain two-dimensional access: %+v", got)
 	}
 
+	elseIfGuardSource := `Option Explicit
+Public Sub Run(ByVal lastCell As String, ByVal useArray As Boolean)
+  Dim values As Variant
+  values = Range("A1:" & lastCell).Value2
+  If useArray Then
+    Debug.Print values
+  ElseIf IsArray(values) Then
+    Debug.Print values(1, 1)
+  End If
+End Sub
+`
+	elseIfGuardFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(elseIfGuardSource), Source: []byte(elseIfGuardSource)}
+	elseIfGuardProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 9}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(elseIfGuardFile, elseIfGuardProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("ElseIf IsArray guard should suppress uncertain indexing in source recovery: %+v", got)
+	}
+
 	inlineSource := `Option Explicit
 Public Sub Run(ByVal lastCell As String)
   Dim values As Variant
@@ -455,6 +472,22 @@ End Sub
 	loopProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 9}
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(loopFile, loopProc), "VBA226"); len(got) != 1 {
 		t.Fatalf("loop recovery should merge the zero-iteration scalar path: %+v", got)
+	}
+
+	localConstSource := `Option Explicit
+Public Sub Run(ByVal ws As Worksheet, ByVal lastRow As Long)
+  Const COLUMN_COUNT As Long = 14
+  Dim values As Variant
+  values = ws.Range(ws.Cells(2, 1), ws.Cells(lastRow, COLUMN_COUNT)).Value2
+  If IsArray(values) Then
+    Debug.Print values(1, 15)
+  End If
+End Sub
+`
+	localConstFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(localConstSource), Source: []byte(localConstSource)}
+	localConstProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 9}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(localConstFile, localConstProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("source fallback should retain procedure-local constants for bounds: %+v", got)
 	}
 
 	continuedSource := `Option Explicit

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -556,6 +556,14 @@ func TestVBA226RecoveredRangeValueExpressionUsesRecoveryFallback(t *testing.T) {
 	}
 }
 
+func TestVBA226RecoveryControlKeywordsRequireTokenBoundaries(t *testing.T) {
+	for _, text := range []string{"ElseValue = Range(\"A1\").Value2", "NextValue = Range(\"A1\").Value2", "LoopCount = Range(\"A1\").Value2"} {
+		if rangeValueSourceElse(text) || rangeValueSourceLoopEnd(text) {
+			t.Fatalf("identifier %q must not be treated as a control keyword", text)
+		}
+	}
+}
+
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -410,6 +410,36 @@ End Sub
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(colonCommentFile, colonCommentProc), "VBA226"); len(got) != 0 {
 		t.Fatalf("colon-separated Rem comments must ignore the rest of the line: %+v", got)
 	}
+	conditionalSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+#If False Then
+  values = Range("A1").Value2
+  Debug.Print values(1)
+#Else
+  values = Range("A1:B2").Value2
+  Debug.Print values(1, 1)
+#End If
+End Sub
+`
+	conditionalFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(conditionalSource), Source: []byte(conditionalSource)}
+	conditionalProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 11}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(conditionalFile, conditionalProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("inactive conditional-compilation source must be ignored: %+v", got)
+	}
+
+	nestedCellsSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2
+  Debug.Print values(1, 3)
+End Sub
+`
+	nestedCellsFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(nestedCellsSource), Source: []byte(nestedCellsSource)}
+	nestedCellsProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 6}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(nestedCellsFile, nestedCellsProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("source fallback should preserve nested Cells pair shape: %+v", got)
+	}
 
 	earlyExitSource := `Option Explicit
 Public Sub Run(ByVal lastCell As String)

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -665,6 +665,40 @@ End Sub
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(goSubReturnFile, goSubReturnProc), "VBA226"); len(got) != 1 {
 		t.Fatalf("GoSub Return must not terminate source recovery before the caller resumes: %+v", got)
 	}
+
+	loopExitSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  For index = 1 To 1
+    Exit For
+    values = Range("A1:B2").Value2
+  Next index
+  Debug.Print values(1, 1)
+End Sub
+`
+	loopExitFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(loopExitSource), Source: []byte(loopExitSource)}
+	loopExitProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 10}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(loopExitFile, loopExitProc), "VBA226"); len(got) != 1 || !strings.Contains(got[0].Message, "Single-cell") {
+		t.Fatalf("Exit For must skip unreachable loop statements before merging: %+v", got)
+	}
+
+	doExitSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  Do
+    Exit Do
+    values = Range("A1:B2").Value2
+  Loop
+  Debug.Print values(1, 1)
+End Sub
+`
+	doExitFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(doExitSource), Source: []byte(doExitSource)}
+	doExitProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 10}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(doExitFile, doExitProc), "VBA226"); len(got) != 1 || !strings.Contains(got[0].Message, "Single-cell") {
+		t.Fatalf("Exit Do must skip unreachable loop statements before merging: %+v", got)
+	}
 }
 
 func TestVBA226GraphlessCompleteIRDoesNotUseRecoveryFallback(t *testing.T) {

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 func TestVBA226DetectsOneDimensionalRangeValueUse(t *testing.T) {
@@ -348,6 +349,41 @@ End Sub
 	inlineProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 6}
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(inlineFile, inlineProc), "VBA226"); len(got) != 0 {
 		t.Fatalf("single-line IsArray guard should suppress uncertain two-dimensional access: %+v", got)
+	}
+
+	branchSource := `Option Explicit
+Public Sub Run(ByVal useArray As Boolean)
+  Dim values As Variant
+  values = Range("A1").Value2
+  If useArray Then
+    values = Range("A1:B2").Value2
+  End If
+  Debug.Print values(1, 1)
+End Sub
+`
+	branchFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(branchSource), Source: []byte(branchSource)}
+	branchProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 9}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(branchFile, branchProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("empty-IR branch merge should retain the scalar path: %+v", got)
+	}
+
+	partialSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  Debug.Print values(1)
+End Sub
+`
+	partialFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(partialSource), Source: []byte(partialSource)}
+	partialProc := sourceProcedure{
+		Name:       "Run",
+		StartLine:  2,
+		EndLine:    6,
+		Statements: []procedureir.Statement{{Text: "Debug.Print values(1)"}},
+		Features:   procedureFeatureSet{unknown: featureRangeArray},
+	}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(partialFile, partialProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("unknown partial projection should use source fallback: %+v", got)
 	}
 }
 

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -301,6 +301,21 @@ End Sub
 	if len(got) != 1 || got[0].Line != 5 || !strings.Contains(got[0].Message, "Single-cell") {
 		t.Fatalf("source-line fallback findings = %+v, want one scalar-index finding on line 5", got)
 	}
+
+	guardedSource := `Option Explicit
+Public Sub Run(ByVal lastCell As String)
+  Dim values As Variant
+  values = Range("A1:" & lastCell).Value2
+  If IsArray(values) Then
+    Debug.Print values(1, 1)
+  End If
+End Sub
+`
+	guardedFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(guardedSource), Source: []byte(guardedSource)}
+	guardedProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 8}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(guardedFile, guardedProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("source-line IsArray guard should suppress uncertain two-dimensional access: %+v", got)
+	}
 }
 
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -474,6 +474,17 @@ End Sub
 	}
 }
 
+func TestVBA226GraphlessCompleteIRDoesNotUseRecoveryFallback(t *testing.T) {
+	proc := sourceProcedure{
+		Statements:  []procedureir.Statement{{Text: "values = ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}},
+		Expressions: []procedureir.Expression{{Text: "ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}},
+		Features:    procedureFeatureSet{unknown: featureRangeArray},
+	}
+	if rangeValueProjectionUnknown(proc) {
+		t.Fatal("graphless procedures with complete statement and expression IR should retain linear analysis")
+	}
+}
+
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -368,6 +368,19 @@ End Sub
 		t.Fatalf("single-line IsArray guard should suppress uncertain two-dimensional access: %+v", got)
 	}
 
+	inlineElseSource := `Option Explicit
+Public Sub Run(ByVal lastCell As String)
+  Dim values As Variant
+  values = Range("A1:" & lastCell).Value2
+  If IsArray(values) Then Debug.Print values(1, 1) Else Debug.Print values(1, 1)
+End Sub
+`
+	inlineElseFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(inlineElseSource), Source: []byte(inlineElseSource)}
+	inlineElseProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 6}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(inlineElseFile, inlineElseProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("inline IsArray Else branch should retain the unguarded access finding: %+v", got)
+	}
+
 	branchSource := `Option Explicit
 Public Sub Run(ByVal useArray As Boolean)
   Dim values As Variant
@@ -443,6 +456,38 @@ End Sub
 	conditionalProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 11}
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(conditionalFile, conditionalProc), "VBA226"); len(got) != 0 {
 		t.Fatalf("inactive conditional-compilation source must be ignored: %+v", got)
+	}
+	unknownConditionalSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+#If UNKNOWN_BUILD_FLAG Then
+  values = Range("A1:B2").Value2
+#Else
+  values = Range("A1").Value2
+#End If
+  Debug.Print values(1)
+End Sub
+`
+	unknownConditionalFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(unknownConditionalSource), Source: []byte(unknownConditionalSource)}
+	unknownConditionalProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 10}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(unknownConditionalFile, unknownConditionalProc), "VBA226"); len(got) != 1 || !strings.Contains(got[0].Message, "used with one array index") {
+		t.Fatalf("unknown conditional branches should merge to an uncertain shape: %+v", got)
+	}
+	sameConditionalSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+#If UNKNOWN_BUILD_FLAG Then
+  values = Range("A1:B2").Value2
+#Else
+  values = Range("A1:B2").Value2
+#End If
+  Debug.Print values(1, 1)
+End Sub
+`
+	sameConditionalFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(sameConditionalSource), Source: []byte(sameConditionalSource)}
+	sameConditionalProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 10}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(sameConditionalFile, sameConditionalProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("unknown conditional branches with an Else should retain their common shape: %+v", got)
 	}
 
 	nestedCellsSource := `Option Explicit

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -647,6 +647,24 @@ End Sub
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(selectEarlyExitFile, selectEarlyExitProc), "VBA226"); len(got) != 1 {
 		t.Fatalf("source after Select Case branch Exit Sub should still be analyzed: %+v", got)
 	}
+
+	goSubReturnSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  GoTo Main
+Handler:
+  Return
+Main:
+  GoSub Handler
+  values = Range("A1").Value2
+  Debug.Print values(1)
+End Sub
+`
+	goSubReturnFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(goSubReturnSource), Source: []byte(goSubReturnSource)}
+	goSubReturnProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 11}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(goSubReturnFile, goSubReturnProc), "VBA226"); len(got) != 1 {
+		t.Fatalf("GoSub Return must not terminate source recovery before the caller resumes: %+v", got)
+	}
 }
 
 func TestVBA226GraphlessCompleteIRDoesNotUseRecoveryFallback(t *testing.T) {

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -385,6 +385,61 @@ End Sub
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(partialFile, partialProc), "VBA226"); len(got) != 1 {
 		t.Fatalf("unknown partial projection should use source fallback: %+v", got)
 	}
+
+	commentSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  Rem values(1)
+End Sub
+`
+	commentFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(commentSource), Source: []byte(commentSource)}
+	commentProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 6}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(commentFile, commentProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("Rem comments must be ignored by source fallback: %+v", got)
+	}
+	colonCommentSource := `Option Explicit
+Public Sub Run()
+  Dim values As Variant
+  values = Range("A1").Value2
+  values = values: Rem values(1): values(1)
+End Sub
+`
+	colonCommentFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(colonCommentSource), Source: []byte(colonCommentSource)}
+	colonCommentProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 6}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(colonCommentFile, colonCommentProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("colon-separated Rem comments must ignore the rest of the line: %+v", got)
+	}
+
+	earlyExitSource := `Option Explicit
+Public Sub Run(ByVal lastCell As String)
+  Dim values As Variant
+  values = Range("A1:" & lastCell).Value2
+  If Not IsArray(values) Then Exit Sub
+  Debug.Print values(1, 1)
+End Sub
+`
+	earlyExitFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(earlyExitSource), Source: []byte(earlyExitSource)}
+	earlyExitProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 7}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(earlyExitFile, earlyExitProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("early-exit negative IsArray guard should preserve the surviving array path: %+v", got)
+	}
+
+	blockEarlyExitSource := `Option Explicit
+Public Sub Run(ByVal lastCell As String)
+  Dim values As Variant
+  values = Range("A1:" & lastCell).Value2
+  If Not IsArray(values) Then
+    Exit Sub
+  End If
+  Debug.Print values(1, 1)
+End Sub
+`
+	blockEarlyExitFile := parsedFile{Path: "Main.bas", Lines: normalizedSourceLines(blockEarlyExitSource), Source: []byte(blockEarlyExitSource)}
+	blockEarlyExitProc := sourceProcedure{Name: "Run", StartLine: 2, EndLine: 8}
+	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(blockEarlyExitFile, blockEarlyExitProc), "VBA226"); len(got) != 0 {
+		t.Fatalf("block early-exit negative IsArray guard should preserve the surviving array path: %+v", got)
+	}
 }
 
 func TestVBA226TracksOnlyRangeValueOrigins(t *testing.T) {

--- a/internal/analyze/redim_preserve_loop.go
+++ b/internal/analyze/redim_preserve_loop.go
@@ -11,15 +11,24 @@ import (
 // repeated loop path. ReDim parsing deliberately stays shared with the array
 // lifecycle rules; this rule only adds the loop/performance context.
 func (a Analyzer) redimPreserveLoopFindings(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration) []Finding {
+	findings, _ := a.redimPreserveLoopFindingsPreparedWithApplicability(file, proc, moduleDecls, arrayVariables(file, proc, moduleDecls))
+	return findings
+}
+
+// redimPreserveLoopFindingsPreparedWithApplicability reuses the immutable
+// array catalog owned by ArrayAnalysisResult. The loop-performance projection
+// has its own reachability/dependency policy, but it must not rescan
+// declarations merely because another array projector already did so.
+func (a Analyzer) redimPreserveLoopFindingsPreparedWithApplicability(file parsedFile, proc sourceProcedure, moduleDecls map[string]sourceDeclaration, variables map[string]arrayVariable) ([]Finding, bool) {
 	regions := excelLoopRegions(proc)
 	if len(regions) == 0 {
-		return nil
+		return nil, false
 	}
-	variables := arrayVariables(file, proc, moduleDecls)
 	if len(variables) == 0 {
-		return nil
+		return nil, false
 	}
 	var findings []Finding
+	applicable := false
 	seen := map[string]bool{}
 	for _, statement := range proc.Statements {
 		if statement.Recovered || !arrayRedimPreserveStatement(statement.Text) {
@@ -62,6 +71,7 @@ func (a Analyzer) redimPreserveLoopFindings(file parsedFile, proc sourceProcedur
 			// VBA227 owns fixed arrays, scalar values, and unknown targets.
 			continue
 		}
+		applicable = true
 
 		dependent := false
 		for _, loop := range bodyLoops {
@@ -114,7 +124,7 @@ func (a Analyzer) redimPreserveLoopFindings(file parsedFile, proc sourceProcedur
 		}
 	}
 	sortFindings(findings)
-	return findings
+	return findings, applicable
 }
 
 // redimLoopVariables extends the shared loop-variable extraction for Do loops.

--- a/internal/analyze/runtime_error.go
+++ b/internal/analyze/runtime_error.go
@@ -27,10 +27,13 @@ type RuntimeErrorContext struct {
 
 type runtimeConstantState map[string]constexpr.Value
 
-// deterministicRuntimeErrorFindings reports only failures that the shared
-// constant evaluator can prove from a complete expression. Runtime values and
-// unresolved identifiers stay unknown by construction.
-func (a Analyzer) deterministicRuntimeErrorFindings(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration) []Finding {
+// deterministicRuntimeErrorFindingsWithArrayResult reports only failures that
+// the shared constant evaluator can prove from a complete expression, projects
+// the array facts from the procedure-local result when available, and retains
+// a nil-result fallback for focused helper callers that do not run through
+// procedure orchestration. Runtime values and unresolved identifiers stay
+// unknown by construction.
+func (a Analyzer) deterministicRuntimeErrorFindingsWithArrayResult(file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration, arrayResult *ArrayAnalysisResult) []Finding {
 	if enabled, known := config.AnalyzeRuleEnabled(a.Config.Analyze, "VBA249"); !known || !enabled {
 		return nil
 	}
@@ -71,6 +74,9 @@ func (a Analyzer) deterministicRuntimeErrorFindings(file parsedFile, proc source
 			findings = appendRuntimeStatementFindings(findings, seen, a, file, proc, statement, facts, env)
 			state = runtimeTransfer(statement, state, env, writes[statement.ID])
 		}
+		if arrayResult != nil {
+			return append(findings, arrayResult.runtime()...)
+		}
 		return append(findings, a.deterministicArrayRuntimeFindings(file, proc, ctx, moduleDecls)...)
 	}
 
@@ -87,6 +93,9 @@ func (a Analyzer) deterministicRuntimeErrorFindings(file parsedFile, proc source
 		}
 		env := runtimeConstantEnvironment(base, state)
 		findings = appendRuntimeStatementFindings(findings, seen, a, file, proc, *block.Statement, facts, env)
+	}
+	if arrayResult != nil {
+		return append(findings, arrayResult.runtime()...)
 	}
 	return append(findings, a.deterministicArrayRuntimeFindings(file, proc, ctx, moduleDecls)...)
 }

--- a/internal/vba/analysisstats/recorder.go
+++ b/internal/vba/analysisstats/recorder.go
@@ -125,9 +125,11 @@ const (
 	CounterExcelSkippedRuns
 	CounterApplicationStatePlannedRuns
 	CounterApplicationStateSkippedRuns
+	CounterArrayKernelRuns
+	CounterArrayProjectionRuns
 )
 
-const counterCount = int(CounterApplicationStateSkippedRuns) + 1
+const counterCount = int(CounterArrayProjectionRuns) + 1
 
 // WorkCounterCount is the fixed number of counter slots used by
 // DomainAggregate. It is exposed for compile-time guards in lightweight
@@ -171,6 +173,8 @@ const (
 	ExcelSkippedRunsCounter                    = "skipped_excel_runs"
 	ApplicationStatePlannedRunsCounter         = "planned_application_state_runs"
 	ApplicationStateSkippedRunsCounter         = "skipped_application_state_runs"
+	ArrayKernelRunsCounter                     = "array_kernel_runs"
+	ArrayProjectionRunsCounter                 = "array_projection_runs"
 )
 
 var counterNames = [...]string{
@@ -210,6 +214,8 @@ var counterNames = [...]string{
 	ExcelSkippedRunsCounter,
 	ApplicationStatePlannedRunsCounter,
 	ApplicationStateSkippedRunsCounter,
+	ArrayKernelRunsCounter,
+	ArrayProjectionRunsCounter,
 }
 
 // These paired array declarations fail compilation if a counter is added

--- a/internal/vba/analysisstats/recorder_test.go
+++ b/internal/vba/analysisstats/recorder_test.go
@@ -195,6 +195,18 @@ func TestDomainAndCounterNamesAreStable(t *testing.T) {
 	if CounterRuntimeCandidateProcedures.String() != RuntimeCandidateProceduresCounter || CounterSemanticKernelRuns.String() != SemanticKernelRunsCounter {
 		t.Fatalf("counter names = %q, %q", CounterRuntimeCandidateProcedures, CounterSemanticKernelRuns)
 	}
+	arrayCounterNames := []struct {
+		counter WorkCounter
+		want    string
+	}{
+		{CounterArrayKernelRuns, ArrayKernelRunsCounter},
+		{CounterArrayProjectionRuns, ArrayProjectionRunsCounter},
+	}
+	for _, test := range arrayCounterNames {
+		if got := test.counter.String(); got != test.want {
+			t.Errorf("array counter %d name = %q, want %q", test.counter, got, test.want)
+		}
+	}
 	plannerCounterNames := []struct {
 		counter WorkCounter
 		want    string

--- a/vitepress/commands/analyze.md
+++ b/vitepress/commands/analyze.md
@@ -103,6 +103,16 @@ Procedure-local work counters include candidate counts
 `semantic_kernel_runs`. They describe work performed: candidates pass the
 relevant rule gate, traversals start a source/CFG walk, and kernel runs invoke
 a valid semantic-domain kernel. Findings are not counted by these counters.
+Array analysis also reports `array_kernel_runs`, `array_cfg_walks`, and
+`array_projection_runs`. The kernel counter records one immutable array
+semantic-result materialization per applicable procedure revision, the walk
+counter records started array fixed-point traversals, and the projection
+counter records enabled, applicable array projectors. Enabling several array
+rules therefore increases projection work without multiplying the canonical
+kernel or its main CFG walk. `VBA241` consumes shared facts without another
+walk; an applicable `VBA226` shape policy may use an explicitly separate
+secondary pass. These counters are stderr-only performance telemetry and do
+not change findings, JSON output, or LSP diagnostics.
 Applicability planning also reports one decision per procedure and gated
 domain: `planned_*_runs` and `skipped_*_runs` for runtime, array, object,
 dictionary, error, dataflow, resource, Excel, and application-state domains
@@ -378,6 +388,15 @@ counts alone do not trigger a finding; use `VBA202` for object use-before-`Set`.
 `VBA226` is enabled in batch and real-time analysis and tracks procedure-local `Range.Value` / `Value2` shapes. It reports one-dimensional or scalar assumptions for definite multi-cell ranges, dimensionless bounds, statically provable dimension/order/bounds mistakes, and incompatible known destination ranges. Multi-cell values are modeled as two-dimensional arrays; single-cell values are modeled as scalars. Dynamic, reassigned, and branch-merged shapes remain uncertain, so only unsafe consumption or a statically proven shape mismatch is reported. Use `values(row, column)`, dimension-specific bounds, and a dominating `IsArray` guard for dynamic values when appropriate.
 
 `VBA227` is enabled in batch and real-time analysis and tracks array allocation through the CFG. Fixed arrays start allocated; dynamic arrays start unallocated; `ReDim`, `Erase`, array assignments, and proven project-local array returns update the state, while unknown `Variant` and external values remain conservative. In real-time analysis, array-return summaries are limited to the active document. It reports unsafe `LBound` / `UBound` and indexed access, invalid dimensions or known bounds, fixed-array `ReDim`, incompatible `Erase`, known scalar bound/iterable sources, and impossible constant `ReDim` bounds. Unknown Variant operations remain fail-open. `VBA208` remains the owner of `ReDim Preserve` findings, while object-array missing-`Set` findings remain owned by `VBA101` / `VBA102`. `Range.Value` / `Value2` shape cases remain owned by `VBA226`; use `xlflow:disable-line VBA227`, `xlflow:disable-next-line VBA227`, or `[analyze].disabled_rules = ["VBA227"]` for intentional exceptions.
+Compatible array diagnostics read one immutable procedure-local semantic result
+for the current analysis revision. It consolidates variable metadata, entry
+state, allocation/shape/bounds, operation facts, ReDim transitions, branch
+refinements, and proven runtime failures before projecting findings. The
+result is shared by batch and realtime analysis but is not retained across
+revisions. Rule-specific conservatism remains visible: `VBA227` keeps its
+source-line lifecycle policy, `VBA249` reports only deterministic failures,
+`VBA241` does not add a CFG walk, and `VBA226` retains its independent
+`Range.Value` shape policy.
 The shared shape also distinguishes scalar, fixed-array rank,
 dynamic-array rank/unknown, `Variant`, and unknown values. Accordingly,
 `VBA227` covers statically provable scalar/fixed-array `ReDim`, incompatible

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -25,6 +25,8 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `array_bounds`
 - `array_candidate_procedures`
 - `array_cfg_walks`
+- `array_kernel_runs`
+- `array_projection_runs`
 - `array_subscript_out_of_bounds`
 - `array_unallocated`
 - `as_type_clause`


### PR DESCRIPTION
## Summary

- Introduce an immutable, procedure-local `ArrayAnalysisResult` shared by compatible array diagnostics in batch and realtime analysis.
- Consolidate compatible array CFG policies onto one deterministic worklist while keeping VBA227 source-line semantics and VBA226's independent Range.Value lattice explicit.
- Reuse array preparation facts, add array-kernel telemetry and benchmarks, and update ADR/specification/developer documentation for #696.
- Preserve diagnostic snapshots, ordering, suppression, severity, and Batch/LSP behavior.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/analyze -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/analyze -run '^TestArrayAnalysisResultConcurrentRead$' -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/vba/analysisstats ./internal/cli -count=1`
- `rtk task lint`
- `rtk task corpus:test` (verify-only; no snapshot changes)
- `rtk proxy task review:codex`

## Performance

- ReDim-heavy all-array-rules benchmark: `array_kernel_runs=1`, `array_cfg_walks=1`, `array_projection_runs=5`.
- ROneCOne analyze-only, five serial `-benchtime=1x` samples: median `19.458s`; this is approximately `0.58%` below the preceding `19.572s` median and `19.6%` below the #694 `24.198s` reference (the latter includes earlier performance work).
- The full `task test` command was attempted but stopped in the existing Windows Excel named-pipe test `TestRunnerDotNetTestUsesDotNetProviderAndPreservesEnvelopeFields`; package-focused tests and lint passed.

Closes #696


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Consolidated array analysis to reduce repeated work while preserving findings and output.
  * Added performance-log counters for kernel runs, CFG walks, and diagnostic projections.

* **Bug Fixes**
  * Improved array shape diagnostics for incomplete or recovered source information, including control flow, expressions, and constants.

* **Documentation**
  * Documented shared array-analysis behavior, performance counters, lifecycle, and compatibility guarantees.
  * Added guidance and benchmark requirements for array-heavy workloads.

* **Tests**
  * Added concurrency, immutability, benchmark, fixture-scale, recovery, and telemetry coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->