### PR TITLE
perf(analyze): replace copied procedure projections with zero-copy IR views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Reduced giant-module analyzer allocation pressure by representing procedure
+  projections as immutable views over canonical Procedure IR. Facts now retain
+  compact indexes and read-only access paths instead of copied declaration,
+  statement, expression, call, access, and parameter collections. Diagnostic
+  and JSON/LSP contracts remain unchanged.
+
 - Added immutable tri-state procedure feature summaries and applicability-based
   planning for expensive semantic analyzer domains. Proven-irrelevant domains
   can be skipped before setup, while recovered, unresolved, dynamic, or

--- a/docs/adr/ADR-0021-procedure-analysis-ir.md
+++ b/docs/adr/ADR-0021-procedure-analysis-ir.md
@@ -88,6 +88,16 @@ CLI JSON, and LSP ranges remain unchanged. Existing `inspect calls` output is
 also a compatibility contract; projecting call facts from the IR must not
 change its JSON shape or resolution meaning.
 
+Analyzer procedure projections are revision-local immutable views over the
+canonical `DocumentIR`/`ProcedureIR` storage. They may retain pointers to
+owned IR and CFG elements, plus compact facts and analysis overlays, but must
+not copy complete procedure collections or retain parser leases, tree-sitter
+nodes, source buffers, or obsolete revisions. Internal analyzer readers use
+read-only views/iterators; snapshot and public compatibility boundaries keep
+their existing defensive-copy behavior. This decision is limited to analyzer
+projection storage and does not change the separate `Resolve` or CFG ownership
+contracts.
+
 ## Consequences
 
 - Positive: lint, analyze, inspect, LSP, and later project-wide analyses can
@@ -104,11 +114,10 @@ change its JSON shape or resolution meaning.
   of expanding rule-specific CST walkers.
 - Negative: the normalized model must evolve when tree-sitter-vba adds syntax
   that cannot be represented by current statement or expression kinds.
-- Negative: defensive copies and normalization allocate more Go values than a
-  consumer-specific walk.
-- Negative: compatibility projections remain necessary while existing calls,
-  symbols, analyzer, and LSP result types continue to serve their public
-  contracts.
+- Negative: revision-local analyzer views require every consumer and worker to
+  honor the immutable ownership contract; mutable rule state must remain local.
+- Negative: snapshot and public compatibility projections still retain their
+  defensive-copy cost even though analyzer hot paths use zero-copy views.
 - Limitation: issue #426 provides syntactic structure, not executable-path
   truth, type-complete member binding, COM type-library resolution, or
   interprocedural effects.

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1215,6 +1215,56 @@ the profile-producing command itself remains a single `-count=1` run so profile
 files are not overwritten. These are developer observations for same-machine
 comparison, not fixed CI thresholds.
 
+### Analyzer procedure-view allocation record (#698)
+
+Issue #698 removes the complete declaration, statement, expression, call, and
+access slice projections from the normal analyzer procedure path. The
+projection-only benchmark keeps IR fixture construction outside the timed
+region and compares view materialization with iteration over the cached view.
+The local run used Go 1.26.6 on the same Windows 11 / Intel Core i7-12700
+developer machine as the preceding corpus records.
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^$' -bench '^BenchmarkParsedFileProcedureProjection$' -benchmem -benchtime=1x -count=3
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^$' -bench 'BenchmarkSingleModuleSynthetic/(independent|declarations|chain|cfg-independent)/2000-' -benchmem -benchtime=1x -count=1
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=5
+```
+
+The projection-only median observations were:
+
+| procedures | materialize `B/op` / `allocs/op` | cached iteration `B/op` / `allocs/op` |
+| ---------: | -------------------------------: | ------------------------------------: |
+|        100 |                  175,360 / 1,501 |                            41,440 / 2 |
+|        500 |                  860,416 / 7,501 |                           188,896 / 2 |
+|      1,000 |               1,720,832 / 15,001 |                           377,312 / 2 |
+|      2,000 |               3,441,664 / 30,001 |                           754,144 / 2 |
+
+The previous 500-procedure projection baseline was 1,461,257 B/op and 10,002
+allocs/op; the new normal-path materialization is 41% lower in bytes and 25%
+lower in allocation count. End-to-end synthetic 2,000-procedure observations
+were 1,481,884,216 B/op and 11,500,704 allocs/op for `independent`,
+1,510,002,272 / 11,989,668 for `chain`, 3,579,487,696 / 1,045,050 for
+`declarations`, and 7,978,821,776 / 8,008,097 for `cfg-independent`.
+Findings and fact-build counters remained unchanged for these fixtures.
+
+The five ROneCOne `analyze-only` samples produced 23.135, 24.952, 25.329,
+33.490, and 37.966 seconds, with 26,642,309,208--26,661,017,936 B/op and
+177,339,816--177,458,969 allocs/op. The median was 25,328,943,600 ns/op,
+26,649,626,264 B/op, and 177,360,666 allocs/op. The wide timing spread is a
+developer-machine observation; allocation volume did not regress. All five
+samples reported 1,565 procedures and 1,565 procedure fact builds, with the
+same 510 findings and planner counters.
+
+The single profile run used the documented `-cpuprofile`/`-memprofile` command.
+Its allocation-space top entries were state/CFG/data-flow working storage
+(`cloneHTTPState`, `cloneArrayState`, `MakeNoZero`, and `meetArrayState`), not
+procedure projection copies. Allocation-object top entries were likewise
+dominated by `MakeNoZero`, reflection, `strings.Fields`, state clones, and CFG
+query construction. The in-use profile was startup/runtime dominated, so these
+profiles are evidence that the removed projection copies are no longer a
+material corpus allocation leaf rather than a claim that all corpus allocation
+has been eliminated.
+
 ## Verification requirements
 
 Manifest tests cover valid v2 data and rejection of unknown fields, unsupported

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -263,23 +263,28 @@ module build.
 ### Analyzer-derived facts
 
 The analyzer may derive a `moduleAnalysisFacts` value and one
-`procedureAnalysisFacts` value for each procedure from the owned IR projection.
-These are implementation-level projections for one analysis revision, not a
-second snapshot cache. File facts own compact declaration, source-ordered
-constant, procedure-name, and line-ownership indexes; procedure facts own
-read-only ID lookups and statement-grouped call, access, and member-expression
-indexes. The file facts also keep a compact declaration-start-to-procedure-facts
-pointer index, without duplicating procedure IR. Empty projections do not
-eagerly allocate maps.
+`procedureAnalysisFacts` value for each procedure from a revision-local
+immutable view of the canonical `DocumentIR`/`ProcedureIR`. These are
+implementation-level projections for one analysis revision, not a second
+snapshot cache. A procedure view retains the owned procedure/CFG elements and
+analysis overlays; it does not materialize replacement declaration, statement,
+expression, call, access, or parameter collections. File facts own compact
+declaration, source-ordered constant, procedure-name, and line-ownership
+indexes; procedure facts own compact offsets plus read-only ID lookups and
+statement-grouped call, access, and member-expression indexes. The file facts
+also keep a compact declaration-start-to-procedure-facts pointer index, without
+duplicating procedure IR. Empty projections do not eagerly allocate maps.
 
-Facts are immutable after construction. Rule families and future procedure
-workers may read the same facts concurrently through lookup/iterator helpers,
-while flow state, findings, CFG worklists, object variables, and other
-rule-specific overlays remain local and mutable. Fact indexes retain only
-Go-owned IR values and compact offsets: they must not retain tree-sitter nodes,
-`ParsedDocument` instances, source snapshots, or obsolete revisions. Their
-lifetime is bounded by the parsed file/procedure revision and they are released
-with that analysis result.
+Facts and views are immutable after construction. Rule families and future
+procedure workers may read the same canonical IR through lookup/iterator
+helpers concurrently, while flow state, findings, CFG worklists, object
+variables, and other rule-specific overlays remain local and mutable. Fact
+indexes retain only Go-owned IR references and compact offsets: they must not
+retain tree-sitter nodes, `ParsedDocument` instances, source snapshots, or
+obsolete revisions. Their lifetime is bounded by the parsed file/procedure
+revision and they are released with that analysis result. Snapshot and public
+compatibility getters may continue to return defensive copies at their
+ownership boundary.
 
 Batch and realtime entry points construct and attach facts before rule workers
 run. The performance recorder reports `module_fact_builds` and

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -356,17 +356,9 @@ type procedureSignature struct {
 	Params     []parameterInfo
 }
 
-type parameterInfo struct {
-	Name        string
-	Type        string
-	Passing     string
-	Optional    bool
-	ParamArray  bool
-	ValueShape  procedureir.ValueShapeKind
-	ArrayShape  procedureir.ArrayShape
-	ArrayBounds []procedureir.ArrayBound
-	Range       vbaast.Range
-}
+// parameterInfo is an internal compatibility alias. Procedure parameters are
+// owned by ProcedureIR and are never copied into an analyzer projection.
+type parameterInfo = procedureir.Parameter
 
 type parsedFile struct {
 	Path       string
@@ -417,6 +409,12 @@ type batchByRefDiagnostics struct {
 }
 
 type sourceProcedure struct {
+	// Document and IR retain the Go-owned immutable IR for this analysis
+	// revision.  IR points at Document.Procedures[Index]; the projection must
+	// never retain parser/tree-sitter state.
+	Document         *procedureir.DocumentIR
+	IR               *procedureir.ProcedureIR
+	Index            int
 	Kind             string
 	ProcedureKind    procedureir.ProcedureKind
 	Name             string
@@ -430,11 +428,15 @@ type sourceProcedure struct {
 	StartByte        int
 	EndByte          int
 	Params           []parameterInfo
-	Declarations     []procedureir.Declaration
-	Statements       []procedureir.Statement
-	Expressions      []procedureir.Expression
-	Calls            []procedureir.CallSite
-	Accesses         []procedureir.VariableAccess
+	// These are read-only views over IR.  The type is deliberately private; it
+	// provides range/len compatibility for the analyzer while exposing no
+	// mutable slice through a package boundary.  New consumers should prefer
+	// the view/facts accessors.
+	Declarations readOnlySpan[procedureir.Declaration]
+	Statements   readOnlySpan[procedureir.Statement]
+	Expressions  readOnlySpan[procedureir.Expression]
+	Calls        readOnlySpan[procedureir.CallSite]
+	Accesses     readOnlySpan[procedureir.VariableAccess]
 	// Features is the immutable, analyzer-owned applicability summary built
 	// with the procedure facts. It contains no parser-owned values.
 	Features procedureFeatureSet
@@ -444,8 +446,8 @@ type sourceProcedure struct {
 	Plan      procedureAnalysisPlan
 	PlanReady bool
 	// Facts is the immutable procedure-local index shared by analysis rules.
-	// Its backing slices are the projections above; both are owned by this
-	// source-procedure revision and must be treated as read-only.
+	// Its canonical backing storage is IR.  Synthetic focused tests may use
+	// the compatibility constructors in procedure_facts.go.
 	Facts   *procedureAnalysisFacts
 	Graph   *vbacfg.Graph
 	Effects *effects.ProcedureSummary
@@ -645,7 +647,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		recorder.AddSum("effect_summary_total_propagated_facts", stats.TotalPropagatedFacts)
 	}
 	for i := range parsedFiles {
-		procedures := sourceProceduresFromIR(parsedFiles[i].IR, parsedFiles[i].CFG)
+		procedures := sourceProceduresFromIRRef(&parsedFiles[i].IR, parsedFiles[i].CFG)
 		parsedFiles[i].Procedures = procedures
 		parsedFiles[i].ModuleFacts = buildModuleAnalysisFacts(parsedFiles[i].Lines, parsedFiles[i].IR, procedures)
 		parsedFiles[i].ModuleDeclarations = parsedFiles[i].ModuleFacts.moduleDeclarations
@@ -1430,7 +1432,7 @@ func SourceNonShortCircuitObjectGuardFindingsParsedContext(ctx context.Context, 
 	}
 	var findings []Finding
 	err = doc.ReadContext(ctx, func(view vbaast.ParsedView) error {
-		procedures := sourceProceduresFromIR(ir)
+		procedures := sourceProceduresFromIRRef(&ir)
 		file := parsedFile{
 			Path:       view.Path,
 			Lines:      normalizedSourceLines(string(view.Source)),
@@ -1582,7 +1584,7 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 		if cfg.Analyze.DetectUntrustedDataFlow || cfg.Analyze.DetectUnsafeCommandConstruction || cfg.Analyze.DetectUnsafeSQLConstruction {
 			dataFlowModuleBindings = dataFlowBindings(ir.Declarations)
 		}
-		procedures := sourceProceduresFromIR(ir, controlFlow)
+		procedures := sourceProceduresFromIRRef(&ir, controlFlow)
 		file := parsedFile{
 			Path:                      view.Path,
 			Lines:                     lines,
@@ -2763,7 +2765,7 @@ func (file parsedFile) procedureProjection() []sourceProcedure {
 	if file.Procedures != nil {
 		return file.Procedures
 	}
-	return sourceProceduresFromIR(file.IR, file.CFG)
+	return sourceProceduresFromIRRef(&file.IR, file.CFG)
 }
 
 func (file parsedFile) moduleDecls() map[string]sourceDeclaration {
@@ -2784,13 +2786,21 @@ func procedureEffectIdentity(document procedureir.DocumentIR, symbol procedureir
 	}
 }
 
-func sourceProceduresFromIR(document procedureir.DocumentIR, controlFlow ...vbacfg.Document) []sourceProcedure {
+// sourceProceduresFromIRRef materializes lightweight analyzer views over the
+// canonical, Go-owned DocumentIR. It intentionally does not copy any of the
+// procedure IR collections; facts and views alias the ProcedureIR storage for
+// the lifetime of the document revision.
+func sourceProceduresFromIRRef(document *procedureir.DocumentIR, controlFlow ...vbacfg.Document) []sourceProcedure {
+	if document == nil {
+		return nil
+	}
 	procedures := make([]sourceProcedure, 0, len(document.Procedures))
 	module := strings.TrimSpace(document.ModuleName)
 	if module == "" {
 		module = strings.TrimSuffix(filepath.Base(document.Path), filepath.Ext(document.Path))
 	}
-	for procedureIndex, procedure := range document.Procedures {
+	for procedureIndex := range document.Procedures {
+		procedure := &document.Procedures[procedureIndex]
 		kind := "Sub"
 		switch procedure.Symbol.Kind {
 		case procedureir.ProcedureFunction:
@@ -2799,16 +2809,10 @@ func sourceProceduresFromIR(document procedureir.DocumentIR, controlFlow ...vbac
 			procedureir.ProcedurePropertyLet, procedureir.ProcedurePropertySet:
 			kind = "Property"
 		}
-		params := make([]parameterInfo, len(procedure.Symbol.Parameters))
-		for i, parameter := range procedure.Symbol.Parameters {
-			params[i] = parameterInfo{
-				Name: parameter.Name, Type: parameter.Type, Passing: parameter.Passing,
-				Optional: parameter.Optional, ParamArray: parameter.ParamArray,
-				ValueShape: parameter.ValueShape, ArrayShape: parameter.ArrayShape,
-				ArrayBounds: append([]procedureir.ArrayBound(nil), parameter.ArrayBounds...), Range: parameter.Range,
-			}
-		}
 		source := sourceProcedure{
+			Document:         document,
+			IR:               procedure,
+			Index:            procedureIndex,
 			Kind:             kind,
 			ProcedureKind:    procedure.Symbol.Kind,
 			Name:             procedure.Symbol.Name,
@@ -2821,20 +2825,19 @@ func sourceProceduresFromIR(document procedureir.DocumentIR, controlFlow ...vbac
 			EndLine:          procedure.Symbol.DeclarationRange.EndLine,
 			StartByte:        procedure.Symbol.DeclarationRange.StartByte,
 			EndByte:          procedure.Symbol.DeclarationRange.EndByte,
-			Params:           params,
-			Declarations:     append([]procedureir.Declaration(nil), procedure.Declarations...),
-			Statements:       append([]procedureir.Statement(nil), procedure.Statements...),
-			Expressions:      append([]procedureir.Expression(nil), procedure.Expressions...),
-			Calls:            append([]procedureir.CallSite(nil), procedure.Calls...),
-			Accesses:         append([]procedureir.VariableAccess(nil), procedure.Accesses...),
+			Params:           procedure.Symbol.Parameters,
+			Declarations:     readOnlySpan[procedureir.Declaration](procedure.Declarations),
+			Statements:       readOnlySpan[procedureir.Statement](procedure.Statements),
+			Expressions:      readOnlySpan[procedureir.Expression](procedure.Expressions),
+			Calls:            readOnlySpan[procedureir.CallSite](procedure.Calls),
+			Accesses:         readOnlySpan[procedureir.VariableAccess](procedure.Accesses),
 		}
-		source.Facts = newProcedureAnalysisFactsWithDeclarations(source.Declarations, source.Statements, source.Expressions, source.Calls, source.Accesses)
+		source.Facts = newProcedureAnalysisFactsForProcedure(procedure)
 		if len(controlFlow) > 0 && procedureIndex < len(controlFlow[0].Graphs) {
-			graph := controlFlow[0].Graphs[procedureIndex]
-			source.Graph = &graph
+			source.Graph = &controlFlow[0].Graphs[procedureIndex]
 		}
 		graphUnknown := source.Graph != nil && len(source.Graph.UnknownFlowSources) > 0
-		source.Features = finalizeProcedureFeatures(source.Facts.features, document, procedure, source.Graph != nil, graphUnknown)
+		source.Features = finalizeProcedureFeatures(source.Facts.features, *document, *procedure, source.Graph != nil, graphUnknown)
 		source.Facts.features = source.Features
 		procedures = append(procedures, source)
 	}

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -353,7 +353,7 @@ type analysisContext struct {
 type procedureSignature struct {
 	Name       string
 	ReturnType string
-	Params     []parameterInfo
+	Params     readOnlySpan[parameterInfo]
 }
 
 // parameterInfo is an internal compatibility alias. Procedure parameters are
@@ -427,7 +427,7 @@ type sourceProcedure struct {
 	EndLine          int
 	StartByte        int
 	EndByte          int
-	Params           []parameterInfo
+	Params           readOnlySpan[parameterInfo]
 	// These are read-only views over IR.  The type is deliberately private; it
 	// provides range/len compatibility for the analyzer while exposing no
 	// mutable slice through a package boundary.  New consumers should prefer
@@ -2825,12 +2825,12 @@ func sourceProceduresFromIRRef(document *procedureir.DocumentIR, controlFlow ...
 			EndLine:          procedure.Symbol.DeclarationRange.EndLine,
 			StartByte:        procedure.Symbol.DeclarationRange.StartByte,
 			EndByte:          procedure.Symbol.DeclarationRange.EndByte,
-			Params:           procedure.Symbol.Parameters,
-			Declarations:     readOnlySpan[procedureir.Declaration](procedure.Declarations),
-			Statements:       readOnlySpan[procedureir.Statement](procedure.Statements),
-			Expressions:      readOnlySpan[procedureir.Expression](procedure.Expressions),
-			Calls:            readOnlySpan[procedureir.CallSite](procedure.Calls),
-			Accesses:         readOnlySpan[procedureir.VariableAccess](procedure.Accesses),
+			Params:           newReadOnlySpan(procedure.Symbol.Parameters),
+			Declarations:     newReadOnlySpan(procedure.Declarations),
+			Statements:       newReadOnlySpan(procedure.Statements),
+			Expressions:      newReadOnlySpan(procedure.Expressions),
+			Calls:            newReadOnlySpan(procedure.Calls),
+			Accesses:         newReadOnlySpan(procedure.Accesses),
 		}
 		source.Facts = newProcedureAnalysisFactsForProcedure(procedure)
 		if len(controlFlow) > 0 && procedureIndex < len(controlFlow[0].Graphs) {
@@ -3074,17 +3074,17 @@ func vba205NonExecutableStatement(stmt string) bool {
 }
 
 func vba205ShadowedIdentifiersWithFacts(proc sourceProcedure, decls declarationScope, ctx analysisContext, facts *moduleAnalysisFacts) map[string]bool {
-	shadowed := make(map[string]bool, decls.len()+len(proc.Accesses)+len(proc.Declarations)+len(ctx.procedures))
+	shadowed := make(map[string]bool, decls.len()+proc.Accesses.Len()+proc.Declarations.Len()+len(ctx.procedures))
 	decls.forEach(func(name string, _ sourceDeclaration) {
 		shadowed[strings.ToLower(name)] = true
 	})
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		switch declaration.Scope {
 		case procedureir.ScopeParameter, procedureir.ScopeLocal, procedureir.ScopeModule, procedureir.ScopeProject:
 			shadowed[strings.ToLower(declaration.Name)] = true
 		}
 	}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		switch access.Scope {
 		case procedureir.ScopeParameter, procedureir.ScopeLocal, procedureir.ScopeModule, procedureir.ScopeProject:
 			shadowed[strings.ToLower(access.Name)] = true
@@ -3283,7 +3283,7 @@ func (a Analyzer) objectArrayComparisonFindings(file parsedFile, proc sourceProc
 			reported[key] = true
 		}
 	})
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if declaration.Scope != procedureir.ScopeParameter || !sourceDeclarationIsObject(declaration, declaration.Type) {
 			continue
 		}
@@ -3302,7 +3302,7 @@ func objectNothingEqualityLineIsExecutable(proc sourceProcedure, lineNo int, stm
 	if lineNo == proc.StartLine && isProcedureHeaderLine(lower) {
 		return false
 	}
-	for _, parameter := range proc.Params {
+	for parameter := range proc.Params.All() {
 		if !parameter.Optional || parameter.Range.StartLine == 0 || lineNo < parameter.Range.StartLine || lineNo > parameter.Range.EndLine {
 			continue
 		}
@@ -3809,7 +3809,7 @@ func applicationStateGuardBindingsStable(proc sourceProcedure, savedGuard, resto
 	}
 	savedBindings := map[binding]bool{}
 	restoreBindings := map[binding]bool{}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.Mode != procedureir.AccessRead || access.Scope == procedureir.ScopeUnresolved {
 			continue
 		}
@@ -3833,13 +3833,13 @@ func applicationStateGuardBindingsStable(proc sourceProcedure, savedGuard, resto
 		if key.scope != procedureir.ScopeModule && key.scope != procedureir.ScopeProject {
 			continue
 		}
-		for _, call := range proc.Calls {
+		for call := range proc.Calls.All() {
 			if call.StatementID > savedGuard.ID && call.StatementID < restoreGuard.ID {
 				return false
 			}
 		}
 	}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.StatementID <= savedGuard.ID || access.StatementID >= restoreGuard.ID ||
 			(access.Mode != procedureir.AccessWrite && access.Mode != procedureir.AccessReadWrite) {
 			continue
@@ -3876,7 +3876,7 @@ func applicationStateVariable(proc sourceProcedure, statementID int, expression 
 	if name == "" || strings.ContainsAny(name, ".() ") {
 		return "", false
 	}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.StatementID != statementID || !strings.EqualFold(access.Name, name) {
 			continue
 		}
@@ -4062,7 +4062,7 @@ func isProjectVisibleProcedure(identity effects.ProcedureIdentity) bool {
 
 func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourceProcedure) []Finding {
 	handlerLabels := map[string]bool{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Kind != procedureir.StatementOnError {
 			continue
 		}
@@ -4081,7 +4081,7 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 		for _, blockID := range proc.Graph.Reachable(vbacfg.EdgeFilter{NormalOnly: true}) {
 			reachable[blockID] = true
 		}
-		for _, statement := range proc.Statements {
+		for statement := range proc.Statements.All() {
 			if statement.Kind != procedureir.StatementLabel {
 				continue
 			}
@@ -4100,7 +4100,7 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 					edge.Kind != vbacfg.EdgeGoto && edge.Kind != vbacfg.EdgeUnknown {
 					implicitEntry = true
 					if edge.Kind == vbacfg.EdgeLoopExit {
-						for _, candidate := range proc.Statements {
+						for candidate := range proc.Statements.All() {
 							if candidate.ID == edge.StatementID && candidate.Control != nil && candidate.Control.LoopVariable != "" {
 								loopExitVariables[strings.ToLower(candidate.Control.LoopVariable)] = true
 							}
@@ -4121,7 +4121,7 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 	}
 
 	lastCodeByParent := map[int]string{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Kind == procedureir.StatementLabel {
 			label := cleanIdentifier(statement.Label)
 			if handlerLabels[strings.ToLower(label)] &&
@@ -4170,7 +4170,7 @@ func (a Analyzer) leakedOnErrorResumeNextFindings(file parsedFile, proc sourcePr
 		reachable[id] = true
 	}
 	outcomes := map[string]resumeNextScopeOutcome{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if !isOnErrorResumeNext(statement) {
 			continue
 		}
@@ -4330,8 +4330,8 @@ func resumeNextScopeControlStatement(statement procedureir.Statement) bool {
 	}
 }
 
-func resumeNextScopeCallRisk(calls []procedureir.CallSite, statementID int) (call bool, projectCall bool) {
-	for _, candidate := range calls {
+func resumeNextScopeCallRisk(calls readOnlySpan[procedureir.CallSite], statementID int) (call bool, projectCall bool) {
+	for candidate := range calls.All() {
 		if candidate.StatementID != statementID {
 			continue
 		}
@@ -4841,7 +4841,7 @@ func isCleanupAssignment(statement procedureir.Statement) bool {
 }
 
 func isCleanupCall(proc sourceProcedure, statement procedureir.Statement) bool {
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if call.StatementID != statement.ID {
 			continue
 		}

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -6992,7 +6992,7 @@ func TestArrayModuleEntryStateDoesNotInitializeShadowingParameter(t *testing.T) 
 	}
 	proc := sourceProcedure{
 		Name: "Consume", Module: "Main", StartLine: 1, EndLine: 2,
-		Params: []parameterInfo{{Name: "values", Type: "Byte()", Passing: "ByRef", ValueShape: procedureir.ValueShapeDynamicArray}},
+		Params: newReadOnlySpan([]parameterInfo{{Name: "values", Type: "Byte()", Passing: "ByRef", ValueShape: procedureir.ValueShapeDynamicArray}}),
 	}
 	file := parsedFile{
 		Lines:              []string{"Private Sub Consume(ByRef values() As Byte)", "End Sub"},

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -81,56 +81,81 @@ func TestSortFindingsUsesProcedureTieBreaker(t *testing.T) {
 
 func TestParsedFileProceduresReusesMaterializedProjection(t *testing.T) {
 	t.Parallel()
-	file := parsedFile{
-		IR:         procedureir.DocumentIR{Path: "Main.bas"},
-		Procedures: []sourceProcedure{{Name: "Run", StartLine: 1, EndLine: 2, Declarations: []procedureir.Declaration{{Name: "cached"}}}},
-	}
+	file := parsedFile{IR: procedureir.DocumentIR{
+		Path: "Main.bas",
+		Procedures: []procedureir.ProcedureIR{{
+			Symbol: procedureir.ProcedureSymbol{
+				Name:             "Run",
+				Kind:             procedureir.ProcedureSub,
+				DeclarationRange: vbaast.Range{StartLine: 1, EndLine: 2},
+			},
+			Declarations: []procedureir.Declaration{{Name: "cached"}},
+		}},
+	}}
+	file.Procedures = sourceProceduresFromIRRef(&file.IR)
 	first := file.procedures()
 	second := file.procedures()
 	if len(first) != 1 || len(second) != 1 || &first[0] == &second[0] {
 		t.Fatal("parsed file exposed or failed to copy its cached procedure projection")
 	}
-	first[0].Name = "Changed"
-	if second[0].Name != "Run" || file.Procedures[0].Name != "Run" {
+	first[0].IR = nil
+	if second[0].IR == nil || file.Procedures[0].IR == nil {
 		t.Fatal("procedure field mutation leaked into the cached projection")
 	}
-	if &first[0].Declarations[0] != &file.Procedures[0].Declarations[0] {
-		t.Fatal("cached procedure metadata was unnecessarily rebuilt")
+	if first[0].IR != nil || second[0].IR != &file.IR.Procedures[0] || file.Procedures[0].IR != &file.IR.Procedures[0] {
+		t.Fatal("procedure views do not retain the canonical IR owner")
+	}
+	if first[0].Facts != second[0].Facts || first[0].Facts != file.Procedures[0].Facts {
+		t.Fatal("cached procedure projection rebuilt immutable view state")
+	}
+	if &second[0].IR.Declarations[0] != &file.IR.Procedures[0].Declarations[0] {
+		t.Fatal("procedure view does not use canonical declaration storage")
 	}
 }
 
 var benchmarkProcedureProjectionSink []sourceProcedure
 
 func BenchmarkParsedFileProcedureProjection(b *testing.B) {
+	for _, procedureCount := range []int{100, 500, 1000, 2000} {
+		b.Run(fmt.Sprintf("%d-procedures", procedureCount), func(b *testing.B) {
+			ir := benchmarkProcedureProjectionIR(procedureCount)
+			b.Run("materialize", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					benchmarkProcedureProjectionSink = sourceProceduresFromIRRef(&ir)
+				}
+			})
+
+			file := parsedFile{IR: ir}
+			file.Procedures = sourceProceduresFromIRRef(&file.IR)
+			b.Run("cached", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					benchmarkProcedureProjectionSink = file.procedures()
+				}
+			})
+		})
+	}
+}
+
+func benchmarkProcedureProjectionIR(procedureCount int) procedureir.DocumentIR {
 	ir := procedureir.DocumentIR{Path: "Benchmark.bas", ModuleName: "Benchmark"}
-	for i := 0; i < 500; i++ {
-		ir.Procedures = append(ir.Procedures, procedureir.ProcedureIR{
+	ir.Procedures = make([]procedureir.ProcedureIR, procedureCount)
+	for i := range ir.Procedures {
+		ir.Procedures[i] = procedureir.ProcedureIR{
 			Symbol: procedureir.ProcedureSymbol{
-				Name:             fmt.Sprintf("Procedure%03d", i),
+				Name:             fmt.Sprintf("Procedure%04d", i),
 				Kind:             procedureir.ProcedureSub,
 				DeclarationRange: vbaast.Range{StartLine: i*4 + 1, EndLine: i*4 + 3},
 			},
-			Declarations: []procedureir.Declaration{{ID: i + 1, Name: fmt.Sprintf("value%03d", i), Type: "Long"}},
+			Declarations: []procedureir.Declaration{{ID: i + 1, Name: fmt.Sprintf("value%04d", i), Type: "Long"}},
 			Statements:   []procedureir.Statement{{ID: i + 1, Kind: procedureir.StatementAssignment, Text: "value = 1"}},
 			Expressions:  []procedureir.Expression{{ID: i + 1, Kind: procedureir.ExpressionLiteral, Text: "1"}},
 			Calls:        []procedureir.CallSite{{ID: i + 1, Callee: procedureir.Callee{BaseName: "Helper"}}},
-			Accesses:     []procedureir.VariableAccess{{Name: fmt.Sprintf("value%03d", i), Mode: procedureir.AccessWrite}},
-		})
+			Accesses:     []procedureir.VariableAccess{{Name: fmt.Sprintf("value%04d", i), Mode: procedureir.AccessWrite}},
+		}
 	}
-
-	b.Run("rebuild", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			benchmarkProcedureProjectionSink = sourceProceduresFromIR(ir)
-		}
-	})
-	b.Run("cached", func(b *testing.B) {
-		file := parsedFile{IR: ir, Procedures: sourceProceduresFromIR(ir)}
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			benchmarkProcedureProjectionSink = file.procedures()
-		}
-	})
+	return ir
 }
 
 func TestVBA225DetectsIndexedCellReadsWritesAndFormatting(t *testing.T) {

--- a/internal/analyze/application_state_calls.go
+++ b/internal/analyze/application_state_calls.go
@@ -52,7 +52,7 @@ func applicationStateLeakOrigins(proc sourceProcedure, project effects.ProjectSu
 		if len(unsafe) == 0 || hasPairedApplicationRestoreProcedure(proc, property.Key, project) {
 			continue
 		}
-		for _, statement := range proc.Statements {
+		for statement := range proc.Statements.All() {
 			witness, found := unsafe[statement.ID]
 			if !found {
 				continue
@@ -125,7 +125,7 @@ func (a Analyzer) applicationStateCallEffectFindings(file parsedFile, proc sourc
 	}
 	var out []Finding
 	reported := map[string]bool{}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if !applicationStateCallReachable(proc, call) || call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 {
 			continue
 		}
@@ -164,7 +164,7 @@ func (a Analyzer) applicationStateCallEffectFindings(file parsedFile, proc sourc
 }
 
 func applicationStateCallReachable(proc sourceProcedure, call procedureir.CallSite) bool {
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == call.StatementID && statement.Recovered {
 			return false
 		}

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -134,7 +134,7 @@ func (a Analyzer) buildArrayAnalysisResult(file parsedFile, proc sourceProcedure
 		result.projectionRuns++
 		// An empty statement projection uses the source-line fallback and does
 		// not start the graph worklist, even when a recovered CFG object exists.
-		if proc.Graph != nil && len(proc.Statements) > 0 && !rangeValueProjectionUnknown(proc) {
+		if proc.Graph != nil && proc.Statements.Len() > 0 && !rangeValueProjectionUnknown(proc) {
 			result.cfgWalks++
 		}
 	}
@@ -185,7 +185,7 @@ func arrayLifecycleProjectionApplicable(file parsedFile, proc sourceProcedure, v
 	if len(variables) == 0 {
 		return false
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if arrayLifecycleTextApplicable(statement.Text, variables) {
 			return true
 		}
@@ -219,7 +219,7 @@ func arrayLifecycleTextApplicable(text string, variables map[string]arrayVariabl
 }
 
 func arrayHasRedimPreserveOperation(proc sourceProcedure) bool {
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if strings.Contains(strings.ToLower(statement.Text), "redim preserve") {
 			return true
 		}
@@ -228,7 +228,7 @@ func arrayHasRedimPreserveOperation(proc sourceProcedure) bool {
 }
 
 func arrayHasComparisonExpression(proc sourceProcedure) bool {
-	for _, expression := range proc.Expressions {
+	for expression := range proc.Expressions.All() {
 		if expression.SyntaxKind == "comparison_expression" && !expression.Recovered {
 			return true
 		}
@@ -253,8 +253,8 @@ func rangeValueShapeApplicable(file parsedFile, proc sourceProcedure) bool {
 	// Range.Value operation. Use the source lines in that case; the fallback is
 	// deliberately limited to procedures with no statement projection so the
 	// normal IR gate remains unchanged for complete procedures.
-	if len(proc.Statements) == 0 {
-		for _, expression := range proc.Expressions {
+	if proc.Statements.Len() == 0 {
+		for expression := range proc.Expressions.All() {
 			if expression.Recovered {
 				return true
 			}
@@ -265,7 +265,7 @@ func rangeValueShapeApplicable(file parsedFile, proc sourceProcedure) bool {
 		}
 		return rangeValueSourceLinesApplicable(file, proc)
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Recovered {
 			return true
 		}
@@ -274,7 +274,7 @@ func rangeValueShapeApplicable(file parsedFile, proc sourceProcedure) bool {
 			return true
 		}
 	}
-	for _, expression := range proc.Expressions {
+	for expression := range proc.Expressions.All() {
 		if expression.Recovered {
 			return true
 		}
@@ -293,13 +293,13 @@ func rangeValueProjectionUnknown(proc sourceProcedure) bool {
 	if proc.Features.unknown&featureRangeArray == 0 {
 		return false
 	}
-	if len(proc.Statements) == 0 || len(proc.Expressions) == 0 {
+	if proc.Statements.Len() == 0 || proc.Expressions.Len() == 0 {
 		return true
 	}
 	// A graphless procedure can still have a complete statement/expression
 	// projection. Keep the existing linear IR transfer for that case; only an
 	// actually incomplete projection should fall back to source text.
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Recovered || statement.Kind == procedureir.StatementRecovered || statement.Kind == procedureir.StatementUnknown {
 			return true
 		}
@@ -309,12 +309,12 @@ func rangeValueProjectionUnknown(proc sourceProcedure) bool {
 
 func rangeValueHasUnknownExpression(proc sourceProcedure) bool {
 	rangeStatements := map[int]bool{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if rangeValueTextLooksRelevant(statement.Text) {
 			rangeStatements[statement.ID] = true
 		}
 	}
-	for _, expression := range proc.Expressions {
+	for expression := range proc.Expressions.All() {
 		if !expression.Recovered && expression.Kind != procedureir.ExpressionUnknown {
 			continue
 		}

--- a/internal/analyze/array_analysis_test.go
+++ b/internal/analyze/array_analysis_test.go
@@ -64,7 +64,7 @@ func TestArrayAnalysisResultConcurrentRead(t *testing.T) {
 }
 
 func TestArrayLifecycleProjectionApplicableIncludesIndexedAccess(t *testing.T) {
-	proc := sourceProcedure{Statements: []procedureir.Statement{{Text: "Debug.Print values(2)"}}}
+	proc := sourceProcedure{Statements: newReadOnlySpan([]procedureir.Statement{{Text: "Debug.Print values(2)"}})}
 	variables := map[string]arrayVariable{"values": {name: "values", isArray: true}}
 	if !arrayLifecycleProjectionApplicable(parsedFile{}, proc, variables) {
 		t.Fatal("indexed array access should make the VBA227 projection applicable")

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -352,7 +352,7 @@ func (a Analyzer) arrayForEachFindings(file parsedFile, proc sourceProcedure, va
 		return nil
 	}
 	var findings []Finding
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Recovered || statement.Kind != procedureir.StatementForEach {
 			continue
 		}
@@ -447,7 +447,7 @@ func (a Analyzer) arrayComparisonFindings(file parsedFile, proc sourceProcedure,
 
 func procedureIRNonArrayNames(proc sourceProcedure) map[string]bool {
 	names := map[string]bool{}
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if declaration.Recovered || declaration.Name == "" {
 			continue
 		}
@@ -757,7 +757,7 @@ func arrayResumeNextCapacityStartsAtZero(file parsedFile, proc sourceProcedure, 
 		return false
 	}
 	declarationLine := 0
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if declaration.Scope != procedureir.ScopeLocal || !strings.EqualFold(cleanIdentifier(declaration.Name), cleanIdentifier(capacityName)) || declaration.IsArray || !arrayKnownScalarType(declaration.Type) {
 			continue
 		}
@@ -1483,7 +1483,7 @@ func arrayVBA227Graph(proc sourceProcedure, ctx analysisContext) vbacfg.Graph {
 	}
 	graph := proc.Graph.WithoutNormalErrRaiseContinuation()
 	removed := map[vbacfg.BlockID]bool{}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		_, target, ok := arrayPrivateTargetForCall(ctx, ctx.arrayPrivateTargets, call)
 		if !ok || !arrayProcedureAlwaysRaises(target) {
 			continue
@@ -1796,10 +1796,10 @@ func applyArrayByRefEntryStates(state arrayFlowState, proc sourceProcedure, vari
 	}
 	updated := cloneArrayState(state)
 	for index, allocated := range parameters {
-		if !allocated || index < 0 || index >= len(proc.Params) {
+		if !allocated || index < 0 || index >= proc.Params.Len() {
 			continue
 		}
-		name := strings.ToLower(proc.Params[index].Name)
+		name := strings.ToLower(proc.Params.valueAt(index).Name)
 		variable, known := variables[name]
 		value, exists := updated[name]
 		if !known || !exists || !variable.isArray {
@@ -1810,10 +1810,10 @@ func applyArrayByRefEntryStates(state arrayFlowState, proc sourceProcedure, vari
 		updated[name] = value
 	}
 	for index, source := range conditionalParameters {
-		if source == "" || index < 0 || index >= len(proc.Params) {
+		if source == "" || index < 0 || index >= proc.Params.Len() {
 			continue
 		}
-		name := strings.ToLower(proc.Params[index].Name)
+		name := strings.ToLower(proc.Params.valueAt(index).Name)
 		variable, known := variables[name]
 		value, exists := updated[name]
 		if !known || !exists || !variable.isArray || value.kind == arrayAllocated && value.knownArray {
@@ -1940,7 +1940,7 @@ func arrayByRefAllocationSummaryForProcedure(file parsedFile, proc sourceProcedu
 		return nil
 	}
 	parameters := map[string]int{}
-	for index, parameter := range proc.Params {
+	for index, parameter := range proc.Params.AllIndexed() {
 		if parameterIsByRefArray(parameter) {
 			parameters[strings.ToLower(parameter.Name)] = index
 		}
@@ -1956,7 +1956,7 @@ func arrayByRefAllocationSummaryForProcedure(file parsedFile, proc sourceProcedu
 		}
 		allocated[index] = true
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		text := strings.TrimSpace(statement.Text)
 		if match := arrayRedimRe.FindStringSubmatch(text); len(match) > 0 && strings.TrimSpace(match[1]) == "" {
 			for _, clause := range splitArgs(match[2]) {
@@ -1972,7 +1972,7 @@ func arrayByRefAllocationSummaryForProcedure(file parsedFile, proc sourceProcedu
 			}
 		}
 	}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if arrayProcedureLineHasInlineConditional(file, call.Range.StartLine) || !arrayProcedureBlockDominatesNormalExit(proc, call.StatementID, dominators) {
 			continue
 		}
@@ -1989,7 +1989,7 @@ func arrayByRefAllocationSummaryForProcedure(file parsedFile, proc sourceProcedu
 			continue
 		}
 		for index := range calleeParameters {
-			if index >= len(arguments) || index >= len(target.Params) || !parameterIsByRefArray(target.Params[index]) {
+			if index >= len(arguments) || index >= target.Params.Len() || !parameterIsByRefArray(target.Params.valueAt(index)) {
 				continue
 			}
 			if parameterIndex, ok := parameters[directArrayArgumentName(arguments[index])]; ok {
@@ -2046,7 +2046,7 @@ func arrayByRefFlowAllocations(file parsedFile, proc sourceProcedure, ctx analys
 		return nil
 	}
 	allocated := map[int]bool{}
-	for index, parameter := range proc.Params {
+	for index, parameter := range proc.Params.AllIndexed() {
 		if !parameterIsByRefArray(parameter) {
 			continue
 		}
@@ -2076,7 +2076,7 @@ func inferArrayByRefConditionalAllocations(files []parsedFile) arrayByRefConditi
 				continue
 			}
 			parameters := map[string]int{}
-			for index, parameter := range proc.Params {
+			for index, parameter := range proc.Params.AllIndexed() {
 				parameters[strings.ToLower(cleanIdentifier(parameter.Name))] = index
 			}
 			if len(parameters) == 0 {
@@ -2087,7 +2087,7 @@ func inferArrayByRefConditionalAllocations(files []parsedFile) arrayByRefConditi
 				line        int
 				parameter   int
 			}{}
-			for _, statement := range proc.Statements {
+			for statement := range proc.Statements.All() {
 				match := arrayByRefCountExitRe.FindStringSubmatch(strings.TrimSpace(normalizedCodeLine(statement.Text)))
 				if len(match) != 2 {
 					continue
@@ -2105,7 +2105,7 @@ func inferArrayByRefConditionalAllocations(files []parsedFile) arrayByRefConditi
 			if len(guards) == 0 {
 				continue
 			}
-			for _, statement := range proc.Statements {
+			for statement := range proc.Statements.All() {
 				match := arrayByRefCountRedimRe.FindStringSubmatch(strings.TrimSpace(normalizedCodeLine(statement.Text)))
 				if len(match) != 3 || arrayProcedureLineHasInlineConditional(file, statement.Range.StartLine) {
 					continue
@@ -2115,7 +2115,7 @@ func inferArrayByRefConditionalAllocations(files []parsedFile) arrayByRefConditi
 				if !outputOK || !guardOK || statement.Range.StartLine <= guard.line {
 					continue
 				}
-				if output < 0 || output >= len(proc.Params) || !parameterIsByRefArray(proc.Params[output]) {
+				if output < 0 || output >= proc.Params.Len() || !parameterIsByRefArray(proc.Params.valueAt(output)) {
 					continue
 				}
 				guardBlock, guardBlockOK := proc.Graph.BlockForStatement(guard.statementID)
@@ -2174,14 +2174,14 @@ func inferArrayByRefLengthAllocations(files []parsedFile) arrayByRefLengthAlloca
 				continue
 			}
 			parameters := map[string]int{}
-			for index, parameter := range proc.Params {
+			for index, parameter := range proc.Params.AllIndexed() {
 				parameters[strings.ToLower(cleanIdentifier(parameter.Name))] = index
 			}
 			if len(parameters) == 0 {
 				continue
 			}
 			dominators := arrayProcedureNormalExitDominators(proc)
-			for _, statement := range proc.Statements {
+			for statement := range proc.Statements.All() {
 				text := strings.TrimSpace(normalizedCodeLine(statement.Text))
 				match := arrayByRefLengthFullRe.FindStringSubmatch(text)
 				if len(match) == 4 && !strings.EqualFold(cleanIdentifier(match[2]), cleanIdentifier(match[3])) {
@@ -2198,7 +2198,7 @@ func inferArrayByRefLengthAllocations(files []parsedFile) arrayByRefLengthAlloca
 				}
 				lengthIndex, lengthOK := parameters[strings.ToLower(cleanIdentifier(match[1]))]
 				arrayIndex, arrayOK := parameters[strings.ToLower(cleanIdentifier(match[2]))]
-				if !lengthOK || !arrayOK || lengthIndex == arrayIndex || !parameterIsByRefScalar(proc.Params[lengthIndex]) || !parameterIsByRefArray(proc.Params[arrayIndex]) {
+				if !lengthOK || !arrayOK || lengthIndex == arrayIndex || !parameterIsByRefScalar(proc.Params.valueAt(lengthIndex)) || !parameterIsByRefArray(proc.Params.valueAt(arrayIndex)) {
 					continue
 				}
 				dominatesExit := arrayProcedureBlockDominatesNormalExit(proc, statement.ID, dominators)
@@ -2227,7 +2227,7 @@ func inferArrayByRefLengthAllocations(files []parsedFile) arrayByRefLengthAlloca
 }
 
 func arrayProcedureStatementByID(proc sourceProcedure, id int) (procedureir.Statement, bool) {
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == id {
 			return statement, true
 		}
@@ -2252,7 +2252,7 @@ func arrayByRefLengthGuard(proc sourceProcedure, statementID int) (procedureir.S
 }
 
 func arrayByRefLengthHasZeroBranch(proc sourceProcedure, parentID, formulaID int, lengthName string) bool {
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == formulaID || statement.ParentID != parentID {
 			continue
 		}
@@ -2301,7 +2301,7 @@ func arrayFalseBranchRequiresBlock(graph vbacfg.Graph, guardBlock, requiredBlock
 }
 
 func statementLine(proc sourceProcedure, statementID int) int {
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == statementID {
 			return statement.Range.StartLine
 		}
@@ -2418,7 +2418,7 @@ func applyArrayModuleCallEffects(state arrayFlowState, file parsedFile, proc sou
 	arguments := arrayCallArgumentTexts(proc, call)
 	if len(call.Arguments.Named) == 0 && len(arguments) == call.Arguments.Count {
 		for index := range ctx.arrayByRefAllocations[key] {
-			if index >= len(arguments) || index >= len(target.Params) || !parameterIsByRefArray(target.Params[index]) {
+			if index >= len(arguments) || index >= target.Params.Len() || !parameterIsByRefArray(target.Params.valueAt(index)) {
 				continue
 			}
 			markArgument(arguments[index])
@@ -2586,7 +2586,7 @@ func arrayGuardProcedureRejectsInvalidState(file parsedFile, target sourceProced
 }
 
 func arrayGuardTargetsCurrentObject(target sourceProcedure, arguments []string) bool {
-	if len(target.Params) <= 1 {
+	if target.Params.Len() <= 1 {
 		return true
 	}
 	return len(arguments) > 0 && strings.EqualFold(strings.TrimSpace(arguments[0]), "me")
@@ -2717,7 +2717,7 @@ func arrayModuleAllocationSummaryForProcedure(file parsedFile, proc sourceProced
 		}
 		allocated[name] = true
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		text := strings.TrimSpace(statement.Text)
 		if match := arrayRedimRe.FindStringSubmatch(text); len(match) > 0 && strings.TrimSpace(match[1]) == "" {
 			for _, clause := range splitArgs(match[2]) {
@@ -2738,7 +2738,7 @@ func arrayModuleAllocationSummaryForProcedure(file parsedFile, proc sourceProced
 			}
 		}
 	}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		key, target, ok := arrayPrivateTargetForCall(ctx, targets, call)
 		if !ok {
 			continue
@@ -2764,7 +2764,7 @@ func arrayModuleAllocationSummaryForProcedure(file parsedFile, proc sourceProced
 			arguments := arrayCallArgumentTexts(proc, call)
 			if len(call.Arguments.Named) == 0 && len(arguments) == call.Arguments.Count {
 				for index := range calleeByRefArrays {
-					if index >= len(arguments) || index >= len(target.Params) || !parameterIsByRefArray(target.Params[index]) {
+					if index >= len(arguments) || index >= target.Params.Len() || !parameterIsByRefArray(target.Params.valueAt(index)) {
 						continue
 					}
 					name := strings.ToLower(directArrayArgumentName(arguments[index]))
@@ -3265,7 +3265,7 @@ func inferArrayByRefEntryStates(a Analyzer, files []parsedFile, ctx analysisCont
 		moduleDecls := file.moduleDecls()
 		for _, caller := range file.procedureProjection() {
 			eligibleCaller := false
-			for _, call := range caller.Calls {
+			for call := range caller.Calls.All() {
 				_, target, ok := arrayPrivateTargetForCall(ctx, targets, call)
 				if ok && procedureHasByRefArrayParameter(target) {
 					eligibleCaller = true
@@ -3431,9 +3431,9 @@ func arrayOptionPrivateModule(lines []string) bool {
 	return false
 }
 
-func arrayCallsAtLine(calls []procedureir.CallSite, line int) []procedureir.CallSite {
+func arrayCallsAtLine(calls readOnlySpan[procedureir.CallSite], line int) []procedureir.CallSite {
 	matched := make([]procedureir.CallSite, 0, 1)
-	for _, call := range calls {
+	for call := range calls.All() {
 		if call.IsRaiseEvent || call.Range.StartLine != line {
 			continue
 		}
@@ -3453,7 +3453,7 @@ func arrayPrivateTargetForCall(ctx analysisContext, targets map[string]sourcePro
 }
 
 func procedureHasByRefArrayParameter(proc sourceProcedure) bool {
-	for _, parameter := range proc.Params {
+	for parameter := range proc.Params.All() {
 		if parameterIsByRefArray(parameter) {
 			return true
 		}
@@ -3473,7 +3473,7 @@ func arrayRecordByRefCall(evidence map[string]map[int]arrayByRefEntryEvidence, t
 	if len(call.Arguments.Named) > 0 || len(arguments) != call.Arguments.Count {
 		return
 	}
-	for index, parameter := range target.Params {
+	for index, parameter := range target.Params.AllIndexed() {
 		if !parameterIsByRefArray(parameter) {
 			continue
 		}
@@ -3542,7 +3542,7 @@ func arrayByRefCallHasProvenArrayArguments(target, caller sourceProcedure, call 
 		return false, false
 	}
 	foundExpression := false
-	for index, parameter := range target.Params {
+	for index, parameter := range target.Params.AllIndexed() {
 		if !parameterIsByRefArray(parameter) {
 			continue
 		}
@@ -3590,22 +3590,22 @@ func arrayCallRangeContains(outer, inner procedureir.CallSite) bool {
 }
 
 func arrayByRefCallArrayVacuouslyUnused(target sourceProcedure, arrayIndex int, arguments []string) bool {
-	if arrayIndex < 0 || arrayIndex >= len(target.Params) {
+	if arrayIndex < 0 || arrayIndex >= target.Params.Len() {
 		return false
 	}
-	arrayName := strings.ToLower(cleanIdentifier(target.Params[arrayIndex].Name))
+	arrayName := strings.ToLower(cleanIdentifier(target.Params.valueAt(arrayIndex).Name))
 	if arrayName == "" {
 		return false
 	}
-	statements := make(map[int]procedureir.Statement, len(target.Statements))
-	for _, statement := range target.Statements {
+	statements := make(map[int]procedureir.Statement, target.Statements.Len())
+	for statement := range target.Statements.All() {
 		statements[statement.ID] = statement
 	}
 	variables := map[string]arrayVariable{
 		arrayName: {name: arrayName, isArray: true},
 	}
 	found := false
-	for _, statement := range target.Statements {
+	for statement := range target.Statements.All() {
 		if !arrayStatementReferencesArray(statement.Text, arrayName, variables) {
 			continue
 		}
@@ -3672,7 +3672,7 @@ func arrayConditionHasFalseCallArgument(condition string, target sourceProcedure
 
 func arrayProcedureParameterIndex(proc sourceProcedure, name string) (int, bool) {
 	name = strings.ToLower(cleanIdentifier(name))
-	for index, parameter := range proc.Params {
+	for index, parameter := range proc.Params.AllIndexed() {
 		if strings.ToLower(cleanIdentifier(parameter.Name)) == name {
 			return index, true
 		}
@@ -3707,10 +3707,10 @@ func arrayConditionalEntrySource(target sourceProcedure, arguments []string, arr
 		if index == arrayParameterIndex || !arrayCountExpressionMatches(argument, source) {
 			continue
 		}
-		if index < 0 || index >= len(target.Params) || parameterIsByRefArray(target.Params[index]) {
+		if index < 0 || index >= target.Params.Len() || parameterIsByRefArray(target.Params.valueAt(index)) {
 			continue
 		}
-		return strings.ToLower(target.Params[index].Name)
+		return strings.ToLower(target.Params.valueAt(index).Name)
 	}
 	return ""
 }
@@ -4043,7 +4043,7 @@ func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 	// The legacy line scanner intentionally ignores Const and Enum syntax.
 	// Fill those gaps from the shared procedure IR so a known scalar constant
 	// can still be classified as a non-iterable/non-array operation target.
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		key := strings.ToLower(declaration.Name)
 		if key == "" {
 			continue
@@ -4055,7 +4055,7 @@ func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 			Dimensions: parameterArrayDimensions(declaration.ArrayBounds, base),
 		})
 	}
-	for _, param := range proc.Params {
+	for param := range proc.Params.All() {
 		array := param.ParamArray || strings.Contains(param.Type, "()") || param.ValueShape == procedureir.ValueShapeFixedArray || param.ValueShape == procedureir.ValueShapeDynamicArray
 		decls.parameters[strings.ToLower(param.Name)] = sourceDeclaration{
 			Name: param.Name, Type: param.Type, Array: array,
@@ -4098,7 +4098,7 @@ func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 func arrayVBA227Variables(baseVariables map[string]arrayVariable, file parsedFile, proc sourceProcedure) map[string]arrayVariable {
 	overlays := make([]procedureir.Declaration, 0)
 	base := arrayOptionBase(file)
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		key := strings.ToLower(strings.TrimSpace(declaration.Name))
 		if key == "" || !declaration.IsArray || declaration.ValueShape != procedureir.ValueShapeDynamicArray || !arrayDeclarationHasInlineRedim(file.Lines, declaration) {
 			continue
@@ -4876,10 +4876,10 @@ func arrayAllocationGuardParameter(proc sourceProcedure) (string, bool) {
 	if proc.ProcedureKind != procedureir.ProcedureFunction && proc.ProcedureKind != procedureir.ProcedurePropertyGet {
 		return "", false
 	}
-	if !arrayKnownScalarType(proc.ReturnType) || isObjectType(proc.ReturnType) || len(proc.Params) != 1 {
+	if !arrayKnownScalarType(proc.ReturnType) || isObjectType(proc.ReturnType) || proc.Params.Len() != 1 {
 		return "", false
 	}
-	parameter := proc.Params[0]
+	parameter := proc.Params.valueAt(0)
 	variantParameter := strings.EqualFold(cleanIdentifier(strings.TrimSpace(parameter.Type)), "variant")
 	if parameter.Name == "" || (!parameterIsArray(parameter) && !variantParameter) || proc.Name == "" {
 		return "", false
@@ -4892,7 +4892,7 @@ func arrayAllocationGuardParameter(proc sourceProcedure) (string, bool) {
 	positiveReturns := 0
 	recoveryZeroReturns := 0
 	invalidReturn := false
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		text := strings.TrimSpace(normalizedCodeLine(statement.Text))
 		if match := arrayOnErrorGotoRe.FindStringSubmatch(text); len(match) == 2 {
 			errorLabel = strings.ToLower(match[1])
@@ -5056,7 +5056,7 @@ func inferArrayReturnSummaries(files []parsedFile, arrayAllocationGuards map[str
 }
 
 func arrayProcedureHasErrorHandling(proc sourceProcedure) bool {
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(statement.Text)), "on error ") {
 			return true
 		}

--- a/internal/analyze/dataflow.go
+++ b/internal/analyze/dataflow.go
@@ -343,12 +343,12 @@ func (a Analyzer) commandFinding(file parsedFile, proc sourceProcedure, command 
 // carries the argument expression, so the adapter can recover cmd/PowerShell
 // guidance without exposing parser nodes in the public finding.
 func commandInterpreterForProcedure(proc sourceProcedure, execution vbadf.CommandExecution) string {
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if call.Range.StartByte != execution.Range.StartByte || execution.Argument < 0 || execution.Argument >= len(call.Arguments.ExpressionIDs) {
 			continue
 		}
 		expressionID := call.Arguments.ExpressionIDs[execution.Argument]
-		for _, expression := range proc.Expressions {
+		for expression := range proc.Expressions.All() {
 			if expression.ID == expressionID {
 				return commandInterpreter(expression.Text)
 			}
@@ -389,12 +389,12 @@ func commandRiskClassification(flow vbadf.Finding, role string) (string, string)
 }
 
 func commandCallForFlow(proc sourceProcedure, flow vbadf.Finding) (procedureir.CallSite, bool) {
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if call.StatementID == flow.Sink.StatementID && call.Range.StartByte == flow.Sink.Range.StartByte {
 			return call, true
 		}
 	}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if call.StatementID == flow.Sink.StatementID {
 			return call, true
 		}
@@ -411,7 +411,7 @@ func commandLauncherDetails(flow vbadf.Finding, call procedureir.CallSite, proc 
 	command := ""
 	if len(call.Arguments.ExpressionIDs) > 0 {
 		for _, expressionID := range call.Arguments.ExpressionIDs {
-			for _, expression := range proc.Expressions {
+			for expression := range proc.Expressions.All() {
 				if expression.ID == expressionID {
 					command = expression.Text
 					break

--- a/internal/analyze/dataflow.go
+++ b/internal/analyze/dataflow.go
@@ -486,6 +486,12 @@ func (a Analyzer) isKnownDataFlowConstant(file parsedFile, name string) bool {
 }
 
 func procedureIRForSource(document procedureir.DocumentIR, proc sourceProcedure) (procedureir.ProcedureIR, bool) {
+	if proc.IR != nil {
+		return *proc.IR, true
+	}
+	// Focused compatibility callers may still construct a sourceProcedure
+	// without the canonical view. Keep their conservative name/range lookup,
+	// but never use it on the normal projection path.
 	for _, candidate := range document.Procedures {
 		if !strings.EqualFold(candidate.Symbol.Name, proc.Name) {
 			continue

--- a/internal/analyze/declaration_scope.go
+++ b/internal/analyze/declaration_scope.go
@@ -17,9 +17,9 @@ func newDeclarationScope(file parsedFile, proc sourceProcedure) declarationScope
 	scope := declarationScope{
 		module:     file.moduleDecls(),
 		local:      file.procedureDeclarationsFor(proc),
-		parameters: make(map[string]sourceDeclaration, len(proc.Params)),
+		parameters: make(map[string]sourceDeclaration, proc.Params.Len()),
 	}
-	for _, parameter := range proc.Params {
+	for parameter := range proc.Params.All() {
 		name := strings.ToLower(strings.TrimSpace(parameter.Name))
 		if name == "" {
 			continue

--- a/internal/analyze/dictionary_collection_safety.go
+++ b/internal/analyze/dictionary_collection_safety.go
@@ -124,11 +124,11 @@ func buildDictionaryCollectionIndex(files []parsedFile) *dictionaryCollectionInd
 
 func dcPropagateHelperSummary(proc sourceProcedure, summary *dcHelperSummary, helpers map[string]dcHelperSummary) bool {
 	params := map[string]int{}
-	for i, param := range proc.Params {
+	for i, param := range proc.Params.AllIndexed() {
 		params[strings.ToLower(param.Name)] = i
 	}
 	changed := false
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		text := dcStatementSource(statement)
 		if assignment := dcSetAssignment(text); assignment != nil && strings.EqualFold(assignment.target, proc.Name) {
 			if name, args, ok := dcSimpleFunctionCall(assignment.rhs); ok {
@@ -195,11 +195,11 @@ func dcHasHelperEffect(effects []dcHelperEffect, candidate dcHelperEffect) bool 
 func directDictionaryCollectionSummary(file parsedFile, proc sourceProcedure) dcHelperSummary {
 	summary := dcHelperSummary{Name: proc.Name, ExistsObject: -1, ExistsKey: -1, SourceFile: file.Path, DeclarationAt: proc.StartLine}
 	params := map[string]int{}
-	for i, param := range proc.Params {
+	for i, param := range proc.Params.AllIndexed() {
 		params[strings.ToLower(param.Name)] = i
 	}
 	returnName := strings.ToLower(proc.Name)
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		text := dcStatementSource(statement)
 		lower := strings.ToLower(text)
 		if match := dcSetAssignment(text); match != nil && strings.EqualFold(match.target, returnName) {
@@ -249,12 +249,12 @@ func directDictionaryCollectionSummary(file parsedFile, proc sourceProcedure) dc
 }
 
 func dcDeclaredKind(proc sourceProcedure, name string) dictionaryCollectionKind {
-	for _, decl := range proc.Declarations {
+	for decl := range proc.Declarations.All() {
 		if strings.EqualFold(decl.Name, name) {
 			return dcKindFromType(decl.Type)
 		}
 	}
-	for _, param := range proc.Params {
+	for param := range proc.Params.All() {
 		if strings.EqualFold(param.Name, name) {
 			return dcKindFromType(param.Type)
 		}
@@ -325,7 +325,7 @@ func (a Analyzer) dictionaryCollectionSafetyFindings(file parsedFile, proc sourc
 	seen := map[string]bool{}
 	var findings []Finding
 	linear := initial.clone()
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		block, ok := proc.Graph.BlockForStatement(statement.ID)
 		if !ok {
 			continue
@@ -361,7 +361,7 @@ func dcInitialState(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 	for key, decl := range file.procedureDeclarationsFor(proc) {
 		add(key, decl, true)
 	}
-	for _, param := range proc.Params {
+	for param := range proc.Params.All() {
 		kind := dcKindFromType(param.Type)
 		if kind == dcUnknown {
 			continue
@@ -764,7 +764,7 @@ func dcAccessGuarded(proc sourceProcedure, statement procedureir.Statement, rece
 		return false
 	}
 	statements := map[int]procedureir.Statement{}
-	for _, candidate := range proc.Statements {
+	for candidate := range proc.Statements.All() {
 		statements[candidate.ID] = candidate
 	}
 	for current := statement; current.ID != 0; current = statements[current.ParentID] {
@@ -787,7 +787,7 @@ func dcCollectionIndexGuarded(proc sourceProcedure, statement procedureir.Statem
 		return false
 	}
 	statements := map[int]procedureir.Statement{}
-	for _, candidate := range proc.Statements {
+	for candidate := range proc.Statements.All() {
 		statements[candidate.ID] = candidate
 	}
 	for current := statement; current.ID != 0; current = statements[current.ParentID] {
@@ -1388,14 +1388,14 @@ func dcConstantNamesForProcedure(file parsedFile, proc sourceProcedure) map[stri
 
 func dcNarrowProbeStatements(proc sourceProcedure) map[int]bool {
 	out := map[int]bool{}
-	for i, statement := range proc.Statements {
+	for i, statement := range proc.Statements.AllIndexed() {
 		if !isOnErrorResumeNext(statement) {
 			continue
 		}
 		operations := 0
 		var candidate int
-		for j := i + 1; j < len(proc.Statements); j++ {
-			next := proc.Statements[j]
+		for j := i + 1; j < proc.Statements.Len(); j++ {
+			next := proc.Statements.valueAt(j)
 			if next.Kind == procedureir.StatementDeclaration || next.Kind == procedureir.StatementLabel || resumeNextScopeErrProbeStatement(next) {
 				continue
 			}
@@ -1449,7 +1449,7 @@ func dcForEach(text string) (string, string, bool) {
 
 func dcMutatesEnumeratedCollection(statement procedureir.Statement, objectID string, state *dcFlowState, proc sourceProcedure, loops []excelLoopRegion) bool {
 	statements := map[int]procedureir.Statement{}
-	for _, candidate := range proc.Statements {
+	for candidate := range proc.Statements.All() {
 		statements[candidate.ID] = candidate
 	}
 	for current := statement; current.ParentID != 0; {
@@ -1520,7 +1520,7 @@ func dcMutationCanContinueIteration(proc sourceProcedure, mutation procedureir.S
 
 func dcMutationHasUnconditionalExit(proc sourceProcedure, mutation procedureir.Statement, loopStatementID int) bool {
 	byID := map[int]procedureir.Statement{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		byID[statement.ID] = statement
 	}
 	ancestors := map[int]bool{}
@@ -1530,7 +1530,7 @@ func dcMutationHasUnconditionalExit(proc sourceProcedure, mutation procedureir.S
 			break
 		}
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Range.StartByte <= mutation.Range.StartByte {
 			continue
 		}
@@ -1568,7 +1568,7 @@ func dcZeroIndex(arg string, statement procedureir.Statement, proc sourceProcedu
 		return false
 	}
 	statements := map[int]procedureir.Statement{}
-	for _, candidate := range proc.Statements {
+	for candidate := range proc.Statements.All() {
 		statements[candidate.ID] = candidate
 	}
 	for current := statement; current.ParentID != 0; {
@@ -1619,7 +1619,7 @@ func dcArrayHasExplicitZeroLowerBound(proc sourceProcedure, arrayName string, be
 	}
 	needle := strings.ToLower(arrayName) + "(0 to "
 	compactNeedle := strings.ReplaceAll(needle, " ", "")
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Range.StartByte >= beforeByte {
 			continue
 		}

--- a/internal/analyze/error_suppression.go
+++ b/internal/analyze/error_suppression.go
@@ -66,7 +66,7 @@ func (a Analyzer) errorSuppressionFindings(file parsedFile, proc sourceProcedure
 	}
 
 	facts := proc.analysisFacts()
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 || !applicationStateCallReachable(proc, call) {
 			continue
 		}
@@ -203,7 +203,7 @@ func callerArgumentExpression(proc sourceProcedure, call procedureir.CallSite, o
 }
 
 func procedureLocal(proc sourceProcedure, name string) bool {
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if strings.EqualFold(declaration.Name, name) {
 			return true
 		}
@@ -266,7 +266,7 @@ func errorEntryProcedure(identity effects.ProcedureIdentity) bool {
 }
 
 func errorSuccessResultUseUncertain(proc sourceProcedure, call procedureir.CallSite, statement procedureir.Statement) bool {
-	for _, other := range proc.Calls {
+	for other := range proc.Calls.All() {
 		if other.ID != call.ID && other.StatementID == call.StatementID {
 			return true
 		}
@@ -382,7 +382,7 @@ func errorResultCondition(kind procedureir.StatementKind) bool {
 }
 
 func booleanProcedureLocal(proc sourceProcedure, name string) bool {
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if strings.EqualFold(declaration.Name, name) && strings.EqualFold(strings.TrimSpace(declaration.Type), "Boolean") {
 			return true
 		}
@@ -391,7 +391,7 @@ func booleanProcedureLocal(proc sourceProcedure, name string) bool {
 }
 
 func statementReadsName(proc sourceProcedure, statementID int, name string) bool {
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.StatementID == statementID && strings.EqualFold(access.Name, name) &&
 			(access.Mode == procedureir.AccessRead || access.Mode == procedureir.AccessReadWrite) {
 			return true
@@ -401,7 +401,7 @@ func statementReadsName(proc sourceProcedure, statementID int, name string) bool
 }
 
 func statementWritesName(proc sourceProcedure, statementID int, name string) bool {
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.StatementID == statementID && strings.EqualFold(access.Name, name) &&
 			(access.Mode == procedureir.AccessWrite || access.Mode == procedureir.AccessReadWrite) {
 			return true

--- a/internal/analyze/event_reentry.go
+++ b/internal/analyze/event_reentry.go
@@ -89,7 +89,7 @@ func (a Analyzer) eventHandlerReentryFindings(file parsedFile, proc sourceProced
 	for _, uncertainty := range proc.Effects.DirectUncertainty {
 		record(uncertainty.Range.StartLine, uncertainty.StatementID, eventStatementBoundary(uncertainty.StatementID), effects.Evidence{}, string(uncertainty.Kind))
 	}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 {
 			continue
 		}
@@ -248,7 +248,7 @@ func eventSafeProcedures(files []parsedFile, project effects.ProjectSummary) map
 					}
 				}
 			}
-			for _, call := range proc.Calls {
+			for call := range proc.Calls.All() {
 				if call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 {
 					continue
 				}
@@ -291,7 +291,7 @@ func eventGuardedAt(proc sourceProcedure, statementID int) bool {
 		return false
 	}
 	dominators := proc.Graph.Dominators(vbacfg.EdgeFilter{NormalOnly: true})[target.ID]
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		property, value, ok := applicationPropertyAssignment(statement, facts)
 		if !ok || property != "enableevents" || unsafe[statement.ID].Kind != "" || !eventDisableValue(value) {
 			continue

--- a/internal/analyze/excel_loop_access.go
+++ b/internal/analyze/excel_loop_access.go
@@ -244,7 +244,7 @@ func directExcelAccessSummary(file parsedFile, proc sourceProcedure, db *vbadb.D
 		// compatibility facts once for this procedure, not once per statement.
 		facts = proc.analysisFacts()
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		for _, access := range classifyExcelStatement(file, proc, statement, db, loopVars, rootDir, cfg, facts) {
 			summary.Categories[access.Category] = true
 			if access.Member != "" {
@@ -288,13 +288,13 @@ func (a Analyzer) excelLoopAccessFindings(file parsedFile, proc sourceProcedure)
 		facts = proc.analysisFacts()
 	}
 	byStatement := map[int][]excelLoopAccess{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		accesses := classifyExcelStatement(file, proc, statement, a.typeDB, loopVars, a.RootDir, a.Config, facts)
 		if len(accesses) > 0 {
 			byStatement[statement.ID] = accesses
 		}
 	}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if a.excelLoopAccess != nil && (call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1) {
 			continue
 		}
@@ -415,7 +415,7 @@ func excelProcedureHasLocalLoopCall(file parsedFile, proc sourceProcedure, regio
 	for _, procedure := range file.IR.Procedures {
 		localNames[strings.ToLower(procedure.Symbol.Name)]++
 	}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if call.Callee.Receiver != nil || strings.TrimSpace(call.Callee.BaseName) == "" {
 			continue
 		}
@@ -543,12 +543,12 @@ func excelLoopRegions(proc sourceProcedure) []excelLoopRegion {
 	statementByBlock := excelCFGStatementsByBlock(proc.Graph)
 	children := map[int][]int{}
 	statements := map[int]procedureir.Statement{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		children[statement.ParentID] = append(children[statement.ParentID], statement.ID)
 		statements[statement.ID] = statement
 	}
 	regions := make([]excelLoopRegion, 0)
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if !isExcelLoopKind(statement.Kind) || statement.Recovered {
 			continue
 		}
@@ -607,7 +607,7 @@ func excelLoopRegions(proc sourceProcedure) []excelLoopRegion {
 
 func excelIntegerConstants(proc sourceProcedure) map[string]int {
 	constants := map[string]int{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		match := constIntegerRe.FindStringSubmatch(strings.TrimSpace(statement.Text))
 		if len(match) != 3 {
 			continue
@@ -904,12 +904,12 @@ func rangeVariablesForProcedure(proc sourceProcedure, file parsedFile, db *vbadb
 			vars.Shadowed[name] = true
 		}
 	}
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if isExcelRangeType(declaration.Type) {
 			vars.Range[strings.ToLower(declaration.Name)] = true
 		}
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		match := forEachRangeRe.FindStringSubmatch(strings.TrimSpace(excelLoopHeaderText(statement.Text)))
 		if len(match) == 0 || !strings.Contains(strings.ToLower(match[2]), ".cells") {
 			continue
@@ -1054,12 +1054,12 @@ func isPerCellExcelExpression(file parsedFile, proc sourceProcedure, db *vbadb.D
 }
 
 func excelRootBindingType(file parsedFile, proc sourceProcedure, name string, rootBindings excelRootBindingIndex) string {
-	for _, parameter := range proc.Params {
+	for parameter := range proc.Params.All() {
 		if strings.EqualFold(strings.TrimSpace(parameter.Name), name) {
 			return parameter.Type
 		}
 	}
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if strings.EqualFold(strings.TrimSpace(declaration.Name), name) {
 			return declaration.Type
 		}

--- a/internal/analyze/excel_loop_invariant.go
+++ b/internal/analyze/excel_loop_invariant.go
@@ -50,8 +50,8 @@ func (a Analyzer) excelLoopInvariantFindings(file parsedFile, proc sourceProcedu
 	if len(regions) == 0 {
 		return nil
 	}
-	statements := make(map[int]procedureir.Statement, len(proc.Statements))
-	for _, statement := range proc.Statements {
+	statements := make(map[int]procedureir.Statement, proc.Statements.Len())
+	for statement := range proc.Statements.All() {
 		statements[statement.ID] = statement
 	}
 	facts := proc.Facts
@@ -62,11 +62,11 @@ func (a Analyzer) excelLoopInvariantFindings(file parsedFile, proc sourceProcedu
 	}
 	constants := loopInvariantStringConstants(file, proc)
 	expressionsByStatement := make(map[int][]procedureir.Expression)
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		expressionsByStatement[statement.ID] = statementMemberExpressions(facts, statement)
 	}
 	seen := map[string]loopInvariantCandidate{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		for _, expression := range expressionsByStatement[statement.ID] {
 			candidate, ok := a.loopInvariantCandidate(file, proc, statement, expression, constants, statements)
 			if !ok {
@@ -296,7 +296,7 @@ func loopInvariantDependsOnLoopVariable(proc sourceProcedure, expression procedu
 	if len(variables) == 0 && len(withStatements) == 0 {
 		return false
 	}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if !loopInvariantRangeContains(expression.Range, access.Range) {
 			continue
 		}
@@ -305,7 +305,7 @@ func loopInvariantDependsOnLoopVariable(proc sourceProcedure, expression procedu
 		}
 	}
 	for _, statement := range withStatements {
-		for _, access := range proc.Accesses {
+		for access := range proc.Accesses.All() {
 			if access.StatementID == statement.ID && variables[strings.ToLower(access.Name)] {
 				return true
 			}
@@ -316,13 +316,13 @@ func loopInvariantDependsOnLoopVariable(proc sourceProcedure, expression procedu
 
 func loopInvariantRootWritten(proc sourceProcedure, expression procedureir.Expression, withStatements []procedureir.Statement, owner excelLoopRegion) bool {
 	dependencies := map[string]bool{}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if loopInvariantRangeContains(expression.Range, access.Range) {
 			dependencies[strings.ToLower(access.Name)] = true
 		}
 	}
 	for _, statement := range withStatements {
-		for _, access := range proc.Accesses {
+		for access := range proc.Accesses.All() {
 			if access.StatementID == statement.ID {
 				dependencies[strings.ToLower(access.Name)] = true
 			}
@@ -331,7 +331,7 @@ func loopInvariantRootWritten(proc sourceProcedure, expression procedureir.Expre
 	if len(dependencies) == 0 {
 		return false
 	}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if !owner.Body[access.StatementID] || !dependencies[strings.ToLower(access.Name)] {
 			continue
 		}
@@ -345,7 +345,7 @@ func loopInvariantRootWritten(proc sourceProcedure, expression procedureir.Expre
 func loopInvariantLoopVariables(owner excelLoopRegion, proc sourceProcedure) map[string]bool {
 	variables := map[string]bool{}
 	var header procedureir.Statement
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == owner.StatementID {
 			header = statement
 			break
@@ -362,7 +362,7 @@ func loopInvariantLoopVariables(owner excelLoopRegion, proc sourceProcedure) map
 		// Do/While headers have no dedicated iterator syntax. Treat variables
 		// read by the header condition as loop controls so dynamic selectors
 		// such as Worksheets(names(i)) remain conservative.
-		for _, access := range proc.Accesses {
+		for access := range proc.Accesses.All() {
 			if access.StatementID == owner.StatementID && access.Mode != procedureir.AccessWrite {
 				variables[strings.ToLower(access.Name)] = true
 			}
@@ -586,7 +586,7 @@ func loopInvariantStringConstants(file parsedFile, proc sourceProcedure) map[str
 			constants[strings.ToLower(match[1])] = match[2]
 		}
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		line := strings.TrimSpace(gui.StripComment(statement.Text))
 		match := loopInvariantConstStringRe.FindStringSubmatch(line)
 		if len(match) == 2 {
@@ -703,13 +703,13 @@ func loopInvariantVariableName(proc sourceProcedure, typ string, issued map[stri
 	for name := range issued {
 		used[name] = true
 	}
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		used[strings.ToLower(declaration.Name)] = true
 	}
-	for _, param := range proc.Params {
+	for param := range proc.Params.All() {
 		used[strings.ToLower(param.Name)] = true
 	}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		used[strings.ToLower(access.Name)] = true
 	}
 	name := base

--- a/internal/analyze/file_path_safety.go
+++ b/internal/analyze/file_path_safety.go
@@ -75,7 +75,7 @@ func (a Analyzer) filePathSafetyFindings(file parsedFile, proc sourceProcedure) 
 	}
 	values["vbnullstring"] = filePathValue{raw: "vbNullString", constant: "", origin: "clean", known: true}
 	params := map[string]bool{}
-	for _, p := range proc.Params {
+	for p := range proc.Params.All() {
 		params[strings.ToLower(p.Name)] = true
 		values[strings.ToLower(p.Name)] = filePathValue{raw: p.Name, origin: "tainted", known: false}
 	}
@@ -92,7 +92,7 @@ func (a Analyzer) filePathSafetyFindings(file parsedFile, proc sourceProcedure) 
 	}
 	fsos := map[string]bool{}
 	workbooks := map[string]bool{}
-	for _, d := range proc.Declarations {
+	for d := range proc.Declarations.All() {
 		name := strings.ToLower(strings.TrimSpace(d.Name))
 		if strings.Contains(strings.ToLower(d.Type), "filesystemobject") || name == "fso" || name == "fs" || name == "filesystemobject" {
 			fsos[strings.ToLower(d.Name)] = true

--- a/internal/analyze/full_range_operations.go
+++ b/internal/analyze/full_range_operations.go
@@ -71,7 +71,7 @@ func (a Analyzer) expensiveFullRangeOperationFindings(file parsedFile, proc sour
 	shadowed := vba242ShadowedRoots(file, proc)
 	var findings []Finding
 	seen := map[int]int{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Recovered {
 			continue
 		}
@@ -231,7 +231,7 @@ func (a Analyzer) vba242Shapes(file parsedFile, shadowed map[string]bool, code s
 
 func vba242ShadowedRoots(file parsedFile, proc sourceProcedure) map[string]bool {
 	shadowed := map[string]bool{}
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		name := strings.ToLower(strings.TrimSpace(declaration.Name))
 		if vba242IsRootName(name) {
 			shadowed[name] = true
@@ -249,7 +249,7 @@ func vba242ShadowedRoots(file parsedFile, proc sourceProcedure) map[string]bool 
 			shadowed[name] = true
 		}
 	}
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.Scope != procedureir.ScopeLocal && access.Scope != procedureir.ScopeParameter && access.Scope != procedureir.ScopeModule && access.Scope != procedureir.ScopeProject {
 			continue
 		}
@@ -258,7 +258,7 @@ func vba242ShadowedRoots(file parsedFile, proc sourceProcedure) map[string]bool 
 			shadowed[name] = true
 		}
 	}
-	for _, parameter := range proc.Params {
+	for parameter := range proc.Params.All() {
 		name := strings.ToLower(strings.TrimSpace(parameter.Name))
 		if vba242IsRootName(name) {
 			shadowed[name] = true

--- a/internal/analyze/function_return_paths.go
+++ b/internal/analyze/function_return_paths.go
@@ -143,7 +143,7 @@ func returnAssignmentKindForStatement(proc sourceProcedure, statement procedurei
 }
 
 func statementWritesReturnSlot(proc sourceProcedure, statementID int) bool {
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.StatementID != statementID || access.Scope != procedureir.ScopeLocal {
 			continue
 		}

--- a/internal/analyze/module_facts_test.go
+++ b/internal/analyze/module_facts_test.go
@@ -177,7 +177,7 @@ func TestDeclarationScopeLayersWithoutModuleMapCopy(t *testing.T) {
 	proc := sourceProcedure{
 		StartLine: 1,
 		EndLine:   1,
-		Params:    []parameterInfo{{Name: "value", Type: "String"}},
+		Params:    newReadOnlySpan([]parameterInfo{{Name: "value", Type: "String"}}),
 	}
 	file := parsedFile{ModuleDeclarations: module, Lines: []string{""}}
 	scope := newDeclarationScope(file, proc)
@@ -199,7 +199,7 @@ func TestDeclarationScopeLayersWithoutModuleMapCopy(t *testing.T) {
 	arrayScope := newDeclarationScope(file, sourceProcedure{
 		StartLine: 1,
 		EndLine:   1,
-		Params:    []parameterInfo{{Name: "moduleOnly", Type: "Long()"}},
+		Params:    newReadOnlySpan([]parameterInfo{{Name: "moduleOnly", Type: "Long()"}}),
 	})
 	if !arrayScope.shadowsModule("moduleOnly") {
 		t.Fatalf("parameter declaration should shadow module array names")
@@ -212,9 +212,9 @@ func TestVBA212DeclarationScopeRetainsIRProcedureDeclarations(t *testing.T) {
 		StartLine: 1,
 		EndLine:   1,
 		StartByte: 1,
-		Declarations: []procedureir.Declaration{{
+		Declarations: newReadOnlySpan([]procedureir.Declaration{{
 			Name: "service", Type: "LocalService", Scope: procedureir.ScopeLocal,
-		}},
+		}}),
 	}
 	scope := declarationScope{module: module}
 	addVBA212ProcedureIRDeclarations(&scope, proc)

--- a/internal/analyze/object_use_before_set.go
+++ b/internal/analyze/object_use_before_set.go
@@ -781,17 +781,12 @@ func (a Analyzer) objectUseBeforeSetIRFindingsPlan(plan *objectProcedurePlan, su
 	flow := objectStateFlowPlan(plan, summaries, objectFlowOptions{Entry: entry})
 	facts := plan.flowContext.facts
 
-	accesses := append([]procedureir.VariableAccess(nil), proc.Accesses...)
-	sort.SliceStable(accesses, func(i, j int) bool {
-		if accesses[i].Range.StartByte != accesses[j].Range.StartByte {
-			return accesses[i].Range.StartByte < accesses[j].Range.StartByte
-		}
-		return accesses[i].ExpressionID < accesses[j].ExpressionID
-	})
 	reported := map[string]bool{}
 	guardCache := &objectFlowGuardCache{}
 	var findings []Finding
-	for _, access := range accesses {
+	// ProcedureIR emits accesses in source order. Keep that order directly;
+	// sorting a copied collection (or an index permutation) only adds work.
+	for _, access := range proc.Accesses {
 		if access.Scope != procedureir.ScopeLocal && access.Scope != procedureir.ScopeModule && access.Scope != procedureir.ScopeParameter {
 			continue
 		}
@@ -853,9 +848,8 @@ func (a Analyzer) objectUseBeforeSetIRFindingsPlan(plan *objectProcedurePlan, su
 	// object used as a default item/index call, however, is a receiver read:
 	// `dict(key)`, `collection(i)`, and `obj.Property(...)` all dereference the
 	// object before invoking the call.  Recover those roots from CallSite.
-	calls := append([]procedureir.CallSite(nil), proc.Calls...)
-	sort.SliceStable(calls, func(i, j int) bool { return calls[i].Range.StartByte < calls[j].Range.StartByte })
-	for _, call := range calls {
+	// Calls are likewise source ordered in the canonical IR.
+	for _, call := range proc.Calls {
 		name := objectCallReceiverName(call)
 		if name == "" {
 			continue

--- a/internal/analyze/object_use_before_set.go
+++ b/internal/analyze/object_use_before_set.go
@@ -213,7 +213,7 @@ func newObjectProcedurePlan(file parsedFile, proc sourceProcedure, moduleDecls m
 	}
 	plan.flowContext.vars = plan.vars
 	plan.unknownFlow = proc.Graph == nil || len(proc.Graph.UnknownFlowSources) > 0
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		plan.unknownFlow = plan.unknownFlow || statement.Recovered
 	}
 	plan.relevant = objectProcedureRelevant(proc, moduleDecls)
@@ -226,7 +226,7 @@ func newObjectProcedurePlan(file parsedFile, proc sourceProcedure, moduleDecls m
 		}
 	}
 	if !plan.relevant {
-		for _, parameter := range proc.Params {
+		for parameter := range proc.Params.All() {
 			if isObjectType(parameter.Type) {
 				plan.relevant = true
 				break
@@ -253,7 +253,7 @@ func (analysis *objectAnalysisContext) initializeObjectSummaries() {
 			ModuleAssigned: map[string]bool{},
 			ModuleWritten:  map[string]bool{},
 		}
-		for index, parameter := range plan.proc.Params {
+		for index, parameter := range plan.proc.Params.AllIndexed() {
 			summary.Params = append(summary.Params, objectParameterSummary{
 				Name:   parameter.Name,
 				Object: isObjectType(parameter.Type),
@@ -276,7 +276,7 @@ func objectInitialEntryState(plan *objectProcedurePlan) map[string]bool {
 			state[(objectVariable{Scope: procedureir.ScopeModule, Name: name}).key()] = false
 		}
 	}
-	for _, parameter := range plan.proc.Params {
+	for parameter := range plan.proc.Params.All() {
 		if isObjectType(parameter.Type) {
 			state[(objectVariable{Scope: procedureir.ScopeParameter, Name: parameter.Name}).key()] = false
 		}
@@ -290,7 +290,7 @@ func (analysis *objectAnalysisContext) buildObjectDependencies() {
 	}
 	for _, callerKey := range analysis.order {
 		caller := analysis.plans[callerKey]
-		for _, call := range caller.proc.Calls {
+		for call := range caller.proc.Calls.All() {
 			calleeKey, ok := analysis.objectCalleeKey(call)
 			if ok {
 				addSummaryDependency(calleeKey, callerKey)
@@ -537,7 +537,7 @@ func (analysis *objectAnalysisContext) buildEntryStates() map[string]map[string]
 			blockState := state[block.ID]
 			calleeSummary := analysis.summaries[callee.key]
 			if objectProcedureAllowsParameterEntry(callee.proc) {
-				for index, parameter := range callee.proc.Params {
+				for index, parameter := range callee.proc.Params.AllIndexed() {
 					if !isObjectType(parameter.Type) {
 						continue
 					}
@@ -688,7 +688,7 @@ func objectProcedureRelevant(proc sourceProcedure, moduleDecls map[string]source
 	if isObjectType(proc.ReturnType) {
 		return true
 	}
-	for _, parameter := range proc.Params {
+	for parameter := range proc.Params.All() {
 		if isObjectType(parameter.Type) {
 			return true
 		}
@@ -697,7 +697,7 @@ func objectProcedureRelevant(proc sourceProcedure, moduleDecls map[string]source
 }
 
 func objectProcedureUsesModuleObject(proc sourceProcedure, moduleDecls map[string]sourceDeclaration) bool {
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.Scope != procedureir.ScopeModule {
 			continue
 		}
@@ -710,7 +710,7 @@ func objectProcedureUsesModuleObject(proc sourceProcedure, moduleDecls map[strin
 }
 
 func objectProcedureWritesModuleFieldIndexed(proc sourceProcedure, name string, facts *procedureAnalysisFacts) bool {
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.Scope != procedureir.ScopeModule || (access.Mode != procedureir.AccessWrite && access.Mode != procedureir.AccessReadWrite) || !strings.EqualFold(cleanIdentifier(access.Name), cleanIdentifier(name)) {
 			continue
 		}
@@ -723,7 +723,7 @@ func objectProcedureWritesModuleFieldIndexed(proc sourceProcedure, name string, 
 }
 
 func objectProcedureWritesParameterIndexed(proc sourceProcedure, name string, summaries map[string]objectProcedureSummary, facts *procedureAnalysisFacts) bool {
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.Scope != procedureir.ScopeParameter ||
 			(access.Mode != procedureir.AccessWrite && access.Mode != procedureir.AccessReadWrite) ||
 			!strings.EqualFold(cleanIdentifier(access.Name), cleanIdentifier(name)) {
@@ -733,7 +733,7 @@ func objectProcedureWritesParameterIndexed(proc sourceProcedure, name string, su
 			return true
 		}
 	}
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		actuals := objectCallActuals(call, facts)
 		for actualIndex, actual := range actuals {
 			if actual.parenthesized {
@@ -786,7 +786,7 @@ func (a Analyzer) objectUseBeforeSetIRFindingsPlan(plan *objectProcedurePlan, su
 	var findings []Finding
 	// ProcedureIR emits accesses in source order. Keep that order directly;
 	// sorting a copied collection (or an index permutation) only adds work.
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if access.Scope != procedureir.ScopeLocal && access.Scope != procedureir.ScopeModule && access.Scope != procedureir.ScopeParameter {
 			continue
 		}
@@ -849,7 +849,7 @@ func (a Analyzer) objectUseBeforeSetIRFindingsPlan(plan *objectProcedurePlan, su
 	// `dict(key)`, `collection(i)`, and `obj.Property(...)` all dereference the
 	// object before invoking the call.  Recover those roots from CallSite.
 	// Calls are likewise source ordered in the canonical IR.
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		name := objectCallReceiverName(call)
 		if name == "" {
 			continue
@@ -909,7 +909,7 @@ func objectCallReceiverName(call procedureir.CallSite) string {
 func objectErrorResumeNextAt(proc sourceProcedure, statementID int) bool {
 	active := false
 	validated := false
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == statementID {
 			return active || validated
 		}
@@ -954,7 +954,7 @@ func objectFlowGuardedByOpenFlag(proc sourceProcedure, statementID int, objectNa
 		return false
 	}
 	dominators := cache.dominators
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		flag, negated, ok := objectBooleanGuard(statement)
 		if !ok || !objectOpenFlagForObject(flag, objectName) {
 			continue
@@ -1033,7 +1033,7 @@ func objectOpenFlagForObject(flag, objectName string) bool {
 func objectOpenFlagAssignmentDominates(proc sourceProcedure, dominators map[vbacfg.BlockID][]vbacfg.BlockID, conditionBlock vbacfg.BlockID, conditionStatementID int, flag, objectName string) bool {
 	flag = strings.ToLower(cleanIdentifier(flag))
 	objectName = strings.ToLower(cleanIdentifier(objectName))
-	for _, flagStatement := range proc.Statements {
+	for flagStatement := range proc.Statements.All() {
 		if strings.ToLower(compactStatement(flagStatement.Text)) != flag+"=true" {
 			continue
 		}
@@ -1050,7 +1050,7 @@ func objectOpenFlagAssignmentDominates(proc sourceProcedure, dominators map[vbac
 		if !flagBeforeCondition {
 			continue
 		}
-		for _, objectStatement := range proc.Statements {
+		for objectStatement := range proc.Statements.All() {
 			if !strings.HasPrefix(strings.ToLower(compactStatement(objectStatement.Text)), "set"+objectName+"=") {
 				continue
 			}
@@ -1608,7 +1608,7 @@ func objectExpressionAssigned(proc sourceProcedure, expression procedureir.Expre
 		}
 		return state[(objectVariable{Scope: scope, Name: name}).key()]
 	case procedureir.ExpressionCall:
-		for _, call := range proc.Calls {
+		for call := range proc.Calls.All() {
 			if call.StatementID != statementID || (call.ExpressionID != 0 && call.ExpressionID != expression.ID) {
 				continue
 			}
@@ -1857,7 +1857,7 @@ func objectExcelMemberExpressionAssigned(text string, proc sourceProcedure, decl
 	}
 	declaration, _, ok := objectDeclarationBinding(root, declarations)
 	if !ok || !excelObjectUseType(declaration.Type) {
-		for _, irDeclaration := range proc.Declarations {
+		for irDeclaration := range proc.Declarations.All() {
 			if strings.EqualFold(cleanIdentifier(irDeclaration.Name), root) && isObjectType(irDeclaration.Type) {
 				declaration = sourceDeclaration{Type: irDeclaration.Type}
 				ok = true

--- a/internal/analyze/opaque_boolean_arguments.go
+++ b/internal/analyze/opaque_boolean_arguments.go
@@ -26,14 +26,14 @@ func (a Analyzer) opaqueBooleanArgumentFindings(file parsedFile, proc sourceProc
 	if !a.Config.Analyze.DetectOpaqueBooleanArguments {
 		return nil
 	}
-	expressions := make(map[int]string, len(proc.Expressions))
-	for _, expression := range proc.Expressions {
+	expressions := make(map[int]string, proc.Expressions.Len())
+	for expression := range proc.Expressions.All() {
 		if expression.ID > 0 {
 			expressions[expression.ID] = expression.Text
 		}
 	}
 	findings := make([]Finding, 0)
-	for _, call := range proc.Calls {
+	for call := range proc.Calls.All() {
 		if call.Arguments.Count == 0 || len(call.Arguments.ExpressionIDs) == 0 {
 			continue
 		}
@@ -70,7 +70,7 @@ func (a Analyzer) opaqueBooleanArgumentFindings(file parsedFile, proc sourceProc
 		var optionalBooleanParameterCount *int
 		parameterNames := []string(nil)
 		if signatureOK {
-			for _, parameter := range signature.Params {
+			for parameter := range signature.Params.All() {
 				if strings.EqualFold(strings.TrimSpace(parameter.Type), "Boolean") && parameter.Optional {
 					optionalBooleanCount++
 				}
@@ -94,10 +94,14 @@ func (a Analyzer) opaqueBooleanArgumentFindings(file parsedFile, proc sourceProc
 		if len(parameterNames) > 0 {
 			examples := make([]string, 0, len(parameterNames))
 			for _, literal := range positionalLiterals {
-				if literal.ParameterIndex < 0 || literal.ParameterIndex >= len(signature.Params) {
+				if literal.ParameterIndex < 0 || literal.ParameterIndex >= signature.Params.Len() {
 					continue
 				}
-				if name := strings.TrimSpace(signature.Params[literal.ParameterIndex].Name); name != "" {
+				parameter, ok := signature.Params.At(literal.ParameterIndex)
+				if !ok {
+					continue
+				}
+				if name := strings.TrimSpace(parameter.Name); name != "" {
 					examples = append(examples, name+":="+literal.Value)
 				}
 			}
@@ -158,16 +162,20 @@ func opaqueBooleanCallSignature(call procedureir.CallSite, signatures map[string
 	return procedureSignature{}, false
 }
 
-func positionalParameterNames(parameters []parameterInfo, indexes []int) []string {
+func positionalParameterNames(parameters readOnlySpan[parameterInfo], indexes []int) []string {
 	if len(indexes) == 0 {
 		return nil
 	}
 	result := make([]string, 0, len(indexes))
 	for _, index := range indexes {
-		if index < 0 || index >= len(parameters) {
+		if index < 0 || index >= parameters.Len() {
 			continue
 		}
-		if name := strings.TrimSpace(parameters[index].Name); name != "" {
+		parameter, ok := parameters.At(index)
+		if !ok {
+			continue
+		}
+		if name := strings.TrimSpace(parameter.Name); name != "" {
 			result = append(result, name)
 		}
 	}

--- a/internal/analyze/procedure_facts.go
+++ b/internal/analyze/procedure_facts.go
@@ -1,23 +1,55 @@
 package analyze
 
 import (
+	"iter"
 	"sort"
 
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
-// procedureAnalysisFacts is the immutable, procedure-local projection shared
-// by analysis rules. The slices are owned by the sourceProcedure that created
-// these facts and are never modified after construction. The indexes contain
-// only offsets into those slices, which keeps the facts compact and avoids
-// copying IR values for every consumer.
+// readOnlySpan is an internal, allocation-free view over immutable IR
+// storage. It intentionally has no conversion to a mutable slice API; the
+// named slice representation keeps existing in-package range/len callers
+// source-compatible while new code can use Len, At, or All.
+type readOnlySpan[T any] []T
+
+func (span readOnlySpan[T]) Len() int { return len(span) }
+
+func (span readOnlySpan[T]) At(index int) (T, bool) {
+	if index < 0 || index >= len(span) {
+		var zero T
+		return zero, false
+	}
+	return span[index], true
+}
+
+func (span readOnlySpan[T]) All() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, value := range span {
+			if !yield(value) {
+				return
+			}
+		}
+	}
+}
+
+// procedureAnalysisFacts is the immutable, procedure-local index shared by
+// analysis rules. Production facts retain only the canonical ProcedureIR
+// pointer and compact offsets; they never own a second declaration,
+// statement, expression, call, or access collection. The legacy slices below
+// exist only for small synthetic fixtures that do not have a ProcedureIR
+// owner.
 //
 // The fields are deliberately private. Consumers should use the lookup and
 // iteration helpers below instead of retaining or modifying the indexes.
 // sourceProcedure itself is an immutable projection during an analysis run;
 // procedure workers may safely read the same facts concurrently.
 type procedureAnalysisFacts struct {
-	features     procedureFeatureSet
+	features procedureFeatureSet
+	// procedure is the canonical owned IR for production views. The legacy
+	// slices below are populated only by focused synthetic tests and are kept
+	// as a compatibility path while consumers migrate to the view API.
+	procedure    *procedureir.ProcedureIR
 	declarations []procedureir.Declaration
 	statements   []procedureir.Statement
 	expressions  []procedureir.Expression
@@ -38,9 +70,9 @@ type procedureAnalysisFacts struct {
 }
 
 // newProcedureAnalysisFacts constructs facts from already-owned procedure IR
-// projections. It intentionally does not copy the slices: sourceProceduresFromIR
-// makes the one ownership copy and both the legacy projection and these facts
-// read that same immutable storage.
+// projections for focused synthetic fixtures. It intentionally does not copy
+// the supplied slices; production callers use newProcedureAnalysisFactsForProcedure
+// so the canonical ProcedureIR is the explicit owner.
 func newProcedureAnalysisFacts(
 	statements []procedureir.Statement,
 	expressions []procedureir.Expression,
@@ -48,6 +80,17 @@ func newProcedureAnalysisFacts(
 	accesses []procedureir.VariableAccess,
 ) *procedureAnalysisFacts {
 	return newProcedureAnalysisFactsWithDeclarations(nil, statements, expressions, calls, accesses)
+}
+
+// newProcedureAnalysisFactsForProcedure builds compact indexes over the
+// canonical ProcedureIR. No procedure collection is copied or retained as a
+// second backing allocation.
+func newProcedureAnalysisFactsForProcedure(procedure *procedureir.ProcedureIR) *procedureAnalysisFacts {
+	if procedure == nil {
+		return newProcedureAnalysisFacts(nil, nil, nil, nil)
+	}
+	facts := &procedureAnalysisFacts{procedure: procedure}
+	return facts.initialize(procedure.Declarations, procedure.Statements, procedure.Expressions, procedure.Calls, procedure.Accesses)
 }
 
 func newProcedureAnalysisFactsWithDeclarations(
@@ -64,6 +107,16 @@ func newProcedureAnalysisFactsWithDeclarations(
 		calls:        calls,
 		accesses:     accesses,
 	}
+	return facts.initialize(declarations, statements, expressions, calls, accesses)
+}
+
+func (facts *procedureAnalysisFacts) initialize(
+	declarations []procedureir.Declaration,
+	statements []procedureir.Statement,
+	expressions []procedureir.Expression,
+	calls []procedureir.CallSite,
+	accesses []procedureir.VariableAccess,
+) *procedureAnalysisFacts {
 
 	if len(declarations) > 0 {
 		facts.declarationIndex = make(map[int]int, len(declarations))
@@ -117,13 +170,63 @@ func newProcedureAnalysisFactsWithDeclarations(
 	return facts
 }
 
-// Declarations returns a copy of procedure-local declarations in IR order.
-// Facts never expose their internally owned mutable slice to a rule.
-func (facts *procedureAnalysisFacts) Declarations() []procedureir.Declaration {
+func (facts *procedureAnalysisFacts) declarationsView() readOnlySpan[procedureir.Declaration] {
 	if facts == nil {
 		return nil
 	}
-	return append([]procedureir.Declaration(nil), facts.declarations...)
+	if facts.procedure != nil {
+		return readOnlySpan[procedureir.Declaration](facts.procedure.Declarations)
+	}
+	return readOnlySpan[procedureir.Declaration](facts.declarations)
+}
+
+func (facts *procedureAnalysisFacts) statementsView() readOnlySpan[procedureir.Statement] {
+	if facts == nil {
+		return nil
+	}
+	if facts.procedure != nil {
+		return readOnlySpan[procedureir.Statement](facts.procedure.Statements)
+	}
+	return readOnlySpan[procedureir.Statement](facts.statements)
+}
+
+func (facts *procedureAnalysisFacts) expressionsView() readOnlySpan[procedureir.Expression] {
+	if facts == nil {
+		return nil
+	}
+	if facts.procedure != nil {
+		return readOnlySpan[procedureir.Expression](facts.procedure.Expressions)
+	}
+	return readOnlySpan[procedureir.Expression](facts.expressions)
+}
+
+func (facts *procedureAnalysisFacts) callsView() readOnlySpan[procedureir.CallSite] {
+	if facts == nil {
+		return nil
+	}
+	if facts.procedure != nil {
+		return readOnlySpan[procedureir.CallSite](facts.procedure.Calls)
+	}
+	return readOnlySpan[procedureir.CallSite](facts.calls)
+}
+
+func (facts *procedureAnalysisFacts) accessesView() readOnlySpan[procedureir.VariableAccess] {
+	if facts == nil {
+		return nil
+	}
+	if facts.procedure != nil {
+		return readOnlySpan[procedureir.VariableAccess](facts.procedure.Accesses)
+	}
+	return readOnlySpan[procedureir.VariableAccess](facts.accesses)
+}
+
+// Declarations returns a read-only view of procedure-local declarations in IR
+// order. The view aliases the canonical ProcedureIR and does not allocate.
+func (facts *procedureAnalysisFacts) Declarations() readOnlySpan[procedureir.Declaration] {
+	if facts == nil {
+		return nil
+	}
+	return facts.declarationsView()
 }
 
 // Declaration returns one procedure-local declaration by its stable IR ID.
@@ -135,15 +238,17 @@ func (facts *procedureAnalysisFacts) Declaration(id int) (procedureir.Declaratio
 	if !ok {
 		return procedureir.Declaration{}, false
 	}
-	return facts.declarations[index], true
+	declarations := facts.declarationsView()
+	return declarations[index], true
 }
 
-// Statements returns a copy of the procedure's source-order statements.
-func (facts *procedureAnalysisFacts) Statements() []procedureir.Statement {
+// Statements returns a read-only view of the procedure's source-order
+// statements without allocating.
+func (facts *procedureAnalysisFacts) Statements() readOnlySpan[procedureir.Statement] {
 	if facts == nil {
 		return nil
 	}
-	return append([]procedureir.Statement(nil), facts.statements...)
+	return facts.statementsView()
 }
 
 // Statement returns one statement by its stable IR ID.
@@ -155,15 +260,17 @@ func (facts *procedureAnalysisFacts) Statement(id int) (procedureir.Statement, b
 	if !ok {
 		return procedureir.Statement{}, false
 	}
-	return facts.statements[index], true
+	statements := facts.statementsView()
+	return statements[index], true
 }
 
-// Expressions returns a copy of the procedure's expressions in IR order.
-func (facts *procedureAnalysisFacts) Expressions() []procedureir.Expression {
+// Expressions returns a read-only view of the procedure's expressions in IR
+// order without allocating.
+func (facts *procedureAnalysisFacts) Expressions() readOnlySpan[procedureir.Expression] {
 	if facts == nil {
 		return nil
 	}
-	return append([]procedureir.Expression(nil), facts.expressions...)
+	return facts.expressionsView()
 }
 
 // forEachExpression visits expressions without exposing the facts-owned slice
@@ -172,7 +279,7 @@ func (facts *procedureAnalysisFacts) forEachExpression(visit func(procedureir.Ex
 	if facts == nil || visit == nil {
 		return
 	}
-	for _, expression := range facts.expressions {
+	for _, expression := range facts.expressionsView() {
 		visit(expression)
 	}
 }
@@ -186,15 +293,17 @@ func (facts *procedureAnalysisFacts) Expression(id int) (procedureir.Expression,
 	if !ok {
 		return procedureir.Expression{}, false
 	}
-	return facts.expressions[index], true
+	expressions := facts.expressionsView()
+	return expressions[index], true
 }
 
-// Calls returns a copy of the procedure's calls in IR order.
-func (facts *procedureAnalysisFacts) Calls() []procedureir.CallSite {
+// Calls returns a read-only view of the procedure's calls in IR order without
+// allocating.
+func (facts *procedureAnalysisFacts) Calls() readOnlySpan[procedureir.CallSite] {
 	if facts == nil {
 		return nil
 	}
-	return append([]procedureir.CallSite(nil), facts.calls...)
+	return facts.callsView()
 }
 
 // CallsForStatement returns calls associated with a statement, preserving IR
@@ -203,7 +312,7 @@ func (facts *procedureAnalysisFacts) CallsForStatement(statementID int) []proced
 	if facts == nil {
 		return nil
 	}
-	return facts.callsByStatement.values(facts.calls, statementID)
+	return facts.callsByStatement.values(facts.callsView(), statementID)
 }
 
 // forEachCallForStatement visits calls without exposing the facts-owned slice
@@ -214,7 +323,7 @@ func (facts *procedureAnalysisFacts) forEachCallForStatement(statementID int, vi
 		return
 	}
 	if span, contiguous := facts.callsByStatement.groups.contiguousSpan(statementID); contiguous {
-		for _, call := range facts.calls[span.start:span.end] {
+		for _, call := range facts.callsView()[span.start:span.end] {
 			visit(call)
 		}
 		return
@@ -224,18 +333,20 @@ func (facts *procedureAnalysisFacts) forEachCallForStatement(statementID int, vi
 		return
 	}
 	for _, index := range indexes {
-		if index >= 0 && index < len(facts.calls) {
-			visit(facts.calls[index])
+		calls := facts.callsView()
+		if index >= 0 && index < len(calls) {
+			visit(calls[index])
 		}
 	}
 }
 
-// Accesses returns a copy of the procedure's variable accesses in IR order.
-func (facts *procedureAnalysisFacts) Accesses() []procedureir.VariableAccess {
+// Accesses returns a read-only view of the procedure's variable accesses in IR
+// order without allocating.
+func (facts *procedureAnalysisFacts) Accesses() readOnlySpan[procedureir.VariableAccess] {
 	if facts == nil {
 		return nil
 	}
-	return append([]procedureir.VariableAccess(nil), facts.accesses...)
+	return facts.accessesView()
 }
 
 // AccessesForStatement returns accesses associated with a statement,
@@ -245,7 +356,7 @@ func (facts *procedureAnalysisFacts) AccessesForStatement(statementID int) []pro
 	if facts == nil {
 		return nil
 	}
-	return facts.accessesByStatement.values(facts.accesses, statementID)
+	return facts.accessesByStatement.values(facts.accessesView(), statementID)
 }
 
 // forEachAccessForStatement is the allocation-free counterpart to
@@ -255,7 +366,7 @@ func (facts *procedureAnalysisFacts) forEachAccessForStatement(statementID int, 
 		return
 	}
 	if span, contiguous := facts.accessesByStatement.groups.contiguousSpan(statementID); contiguous {
-		for _, access := range facts.accesses[span.start:span.end] {
+		for _, access := range facts.accessesView()[span.start:span.end] {
 			visit(access)
 		}
 		return
@@ -265,8 +376,9 @@ func (facts *procedureAnalysisFacts) forEachAccessForStatement(statementID int, 
 		return
 	}
 	for _, index := range indexes {
-		if index >= 0 && index < len(facts.accesses) {
-			visit(facts.accesses[index])
+		accesses := facts.accessesView()
+		if index >= 0 && index < len(accesses) {
+			visit(accesses[index])
 		}
 	}
 }
@@ -277,6 +389,7 @@ func (facts *procedureAnalysisFacts) MemberExpressionsForStatement(statementID i
 	if facts == nil {
 		return nil
 	}
+	expressions := facts.expressionsView()
 	indexes := facts.memberExpressionsByStatement[statementID]
 	if !facts.memberExpressionFallback {
 		if len(indexes) == 0 {
@@ -287,7 +400,7 @@ func (facts *procedureAnalysisFacts) MemberExpressionsForStatement(statementID i
 		}
 		out := make([]procedureir.Expression, 0, len(indexes))
 		for _, index := range indexes {
-			out = append(out, facts.expressions[index])
+			out = append(out, expressions[index])
 		}
 		return out
 	}
@@ -302,8 +415,8 @@ func (facts *procedureAnalysisFacts) MemberExpressionsForStatement(statementID i
 		}
 		out := make([]procedureir.Expression, 0, len(indexes))
 		for _, index := range indexes {
-			if index >= 0 && index < len(facts.expressions) {
-				out = append(out, facts.expressions[index])
+			if index >= 0 && index < len(expressions) {
+				out = append(out, expressions[index])
 			}
 		}
 		return out
@@ -331,7 +444,7 @@ func (facts *procedureAnalysisFacts) MemberExpressionsForStatement(statementID i
 		visit(id)
 	}
 	if len(out) == 0 {
-		for _, expression := range facts.expressions {
+		for _, expression := range expressions {
 			if expression.StatementID == statement.ID && !expression.Recovered && expression.Kind == procedureir.ExpressionMember {
 				out = append(out, expression)
 			}

--- a/internal/analyze/procedure_facts.go
+++ b/internal/analyze/procedure_facts.go
@@ -8,25 +8,51 @@ import (
 )
 
 // readOnlySpan is an internal, allocation-free view over immutable IR
-// storage. It intentionally has no conversion to a mutable slice API; the
-// named slice representation keeps existing in-package range/len callers
-// source-compatible while new code can use Len, At, or All.
-type readOnlySpan[T any] []T
+// storage. The backing slice is private so callers cannot assign, append, or
+// reslice shared ProcedureIR storage. Values are returned by value through At
+// and All; callers must treat any nested IR slices as immutable as well.
+type readOnlySpan[T any] struct {
+	values []T
+}
 
-func (span readOnlySpan[T]) Len() int { return len(span) }
+func newReadOnlySpan[T any](values []T) readOnlySpan[T] {
+	return readOnlySpan[T]{values: values}
+}
+
+func (span readOnlySpan[T]) Len() int { return len(span.values) }
 
 func (span readOnlySpan[T]) At(index int) (T, bool) {
-	if index < 0 || index >= len(span) {
+	if index < 0 || index >= len(span.values) {
 		var zero T
 		return zero, false
 	}
-	return span[index], true
+	return span.values[index], true
+}
+
+// valueAt is an internal convenience for call sites that have already
+// validated an index. It still returns a value, never the backing element.
+func (span readOnlySpan[T]) valueAt(index int) T {
+	value, _ := span.At(index)
+	return value
 }
 
 func (span readOnlySpan[T]) All() iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for _, value := range span {
+		for _, value := range span.values {
 			if !yield(value) {
+				return
+			}
+		}
+	}
+}
+
+// AllIndexed visits values together with their stable source-order offset.
+// It is the read-only counterpart to ranging over the backing slice with two
+// iteration variables.
+func (span readOnlySpan[T]) AllIndexed() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		for index, value := range span.values {
+			if !yield(index, value) {
 				return
 			}
 		}
@@ -172,59 +198,59 @@ func (facts *procedureAnalysisFacts) initialize(
 
 func (facts *procedureAnalysisFacts) declarationsView() readOnlySpan[procedureir.Declaration] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.Declaration]{}
 	}
 	if facts.procedure != nil {
-		return readOnlySpan[procedureir.Declaration](facts.procedure.Declarations)
+		return newReadOnlySpan(facts.procedure.Declarations)
 	}
-	return readOnlySpan[procedureir.Declaration](facts.declarations)
+	return newReadOnlySpan(facts.declarations)
 }
 
 func (facts *procedureAnalysisFacts) statementsView() readOnlySpan[procedureir.Statement] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.Statement]{}
 	}
 	if facts.procedure != nil {
-		return readOnlySpan[procedureir.Statement](facts.procedure.Statements)
+		return newReadOnlySpan(facts.procedure.Statements)
 	}
-	return readOnlySpan[procedureir.Statement](facts.statements)
+	return newReadOnlySpan(facts.statements)
 }
 
 func (facts *procedureAnalysisFacts) expressionsView() readOnlySpan[procedureir.Expression] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.Expression]{}
 	}
 	if facts.procedure != nil {
-		return readOnlySpan[procedureir.Expression](facts.procedure.Expressions)
+		return newReadOnlySpan(facts.procedure.Expressions)
 	}
-	return readOnlySpan[procedureir.Expression](facts.expressions)
+	return newReadOnlySpan(facts.expressions)
 }
 
 func (facts *procedureAnalysisFacts) callsView() readOnlySpan[procedureir.CallSite] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.CallSite]{}
 	}
 	if facts.procedure != nil {
-		return readOnlySpan[procedureir.CallSite](facts.procedure.Calls)
+		return newReadOnlySpan(facts.procedure.Calls)
 	}
-	return readOnlySpan[procedureir.CallSite](facts.calls)
+	return newReadOnlySpan(facts.calls)
 }
 
 func (facts *procedureAnalysisFacts) accessesView() readOnlySpan[procedureir.VariableAccess] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.VariableAccess]{}
 	}
 	if facts.procedure != nil {
-		return readOnlySpan[procedureir.VariableAccess](facts.procedure.Accesses)
+		return newReadOnlySpan(facts.procedure.Accesses)
 	}
-	return readOnlySpan[procedureir.VariableAccess](facts.accesses)
+	return newReadOnlySpan(facts.accesses)
 }
 
 // Declarations returns a read-only view of procedure-local declarations in IR
 // order. The view aliases the canonical ProcedureIR and does not allocate.
 func (facts *procedureAnalysisFacts) Declarations() readOnlySpan[procedureir.Declaration] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.Declaration]{}
 	}
 	return facts.declarationsView()
 }
@@ -239,14 +265,14 @@ func (facts *procedureAnalysisFacts) Declaration(id int) (procedureir.Declaratio
 		return procedureir.Declaration{}, false
 	}
 	declarations := facts.declarationsView()
-	return declarations[index], true
+	return declarations.At(index)
 }
 
 // Statements returns a read-only view of the procedure's source-order
 // statements without allocating.
 func (facts *procedureAnalysisFacts) Statements() readOnlySpan[procedureir.Statement] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.Statement]{}
 	}
 	return facts.statementsView()
 }
@@ -261,14 +287,14 @@ func (facts *procedureAnalysisFacts) Statement(id int) (procedureir.Statement, b
 		return procedureir.Statement{}, false
 	}
 	statements := facts.statementsView()
-	return statements[index], true
+	return statements.At(index)
 }
 
 // Expressions returns a read-only view of the procedure's expressions in IR
 // order without allocating.
 func (facts *procedureAnalysisFacts) Expressions() readOnlySpan[procedureir.Expression] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.Expression]{}
 	}
 	return facts.expressionsView()
 }
@@ -279,7 +305,7 @@ func (facts *procedureAnalysisFacts) forEachExpression(visit func(procedureir.Ex
 	if facts == nil || visit == nil {
 		return
 	}
-	for _, expression := range facts.expressionsView() {
+	for expression := range facts.expressionsView().All() {
 		visit(expression)
 	}
 }
@@ -294,14 +320,14 @@ func (facts *procedureAnalysisFacts) Expression(id int) (procedureir.Expression,
 		return procedureir.Expression{}, false
 	}
 	expressions := facts.expressionsView()
-	return expressions[index], true
+	return expressions.At(index)
 }
 
 // Calls returns a read-only view of the procedure's calls in IR order without
 // allocating.
 func (facts *procedureAnalysisFacts) Calls() readOnlySpan[procedureir.CallSite] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.CallSite]{}
 	}
 	return facts.callsView()
 }
@@ -323,8 +349,12 @@ func (facts *procedureAnalysisFacts) forEachCallForStatement(statementID int, vi
 		return
 	}
 	if span, contiguous := facts.callsByStatement.groups.contiguousSpan(statementID); contiguous {
-		for _, call := range facts.callsView()[span.start:span.end] {
-			visit(call)
+		calls := facts.callsView()
+		for index := span.start; index < span.end; index++ {
+			call, ok := calls.At(index)
+			if ok {
+				visit(call)
+			}
 		}
 		return
 	}
@@ -334,8 +364,10 @@ func (facts *procedureAnalysisFacts) forEachCallForStatement(statementID int, vi
 	}
 	for _, index := range indexes {
 		calls := facts.callsView()
-		if index >= 0 && index < len(calls) {
-			visit(calls[index])
+		if index >= 0 && index < calls.Len() {
+			if call, ok := calls.At(index); ok {
+				visit(call)
+			}
 		}
 	}
 }
@@ -344,7 +376,7 @@ func (facts *procedureAnalysisFacts) forEachCallForStatement(statementID int, vi
 // order without allocating.
 func (facts *procedureAnalysisFacts) Accesses() readOnlySpan[procedureir.VariableAccess] {
 	if facts == nil {
-		return nil
+		return readOnlySpan[procedureir.VariableAccess]{}
 	}
 	return facts.accessesView()
 }
@@ -366,8 +398,12 @@ func (facts *procedureAnalysisFacts) forEachAccessForStatement(statementID int, 
 		return
 	}
 	if span, contiguous := facts.accessesByStatement.groups.contiguousSpan(statementID); contiguous {
-		for _, access := range facts.accessesView()[span.start:span.end] {
-			visit(access)
+		accesses := facts.accessesView()
+		for index := span.start; index < span.end; index++ {
+			access, ok := accesses.At(index)
+			if ok {
+				visit(access)
+			}
 		}
 		return
 	}
@@ -377,8 +413,10 @@ func (facts *procedureAnalysisFacts) forEachAccessForStatement(statementID int, 
 	}
 	for _, index := range indexes {
 		accesses := facts.accessesView()
-		if index >= 0 && index < len(accesses) {
-			visit(accesses[index])
+		if index >= 0 && index < accesses.Len() {
+			if access, ok := accesses.At(index); ok {
+				visit(access)
+			}
 		}
 	}
 }
@@ -400,7 +438,9 @@ func (facts *procedureAnalysisFacts) MemberExpressionsForStatement(statementID i
 		}
 		out := make([]procedureir.Expression, 0, len(indexes))
 		for _, index := range indexes {
-			out = append(out, expressions[index])
+			if expression, ok := expressions.At(index); ok {
+				out = append(out, expression)
+			}
 		}
 		return out
 	}
@@ -415,8 +455,8 @@ func (facts *procedureAnalysisFacts) MemberExpressionsForStatement(statementID i
 		}
 		out := make([]procedureir.Expression, 0, len(indexes))
 		for _, index := range indexes {
-			if index >= 0 && index < len(expressions) {
-				out = append(out, expressions[index])
+			if expression, ok := expressions.At(index); ok {
+				out = append(out, expression)
 			}
 		}
 		return out
@@ -444,7 +484,7 @@ func (facts *procedureAnalysisFacts) MemberExpressionsForStatement(statementID i
 		visit(id)
 	}
 	if len(out) == 0 {
-		for _, expression := range expressions {
+		for expression := range expressions.All() {
 			if expression.StatementID == statement.ID && !expression.Recovered && expression.Kind == procedureir.ExpressionMember {
 				out = append(out, expression)
 			}
@@ -482,9 +522,15 @@ func newCallFactsByStatement(calls []procedureir.CallSite) callsByStatement {
 	return callsByStatement{groups: newIndexGroups(ids)}
 }
 
-func (facts callsByStatement) values(calls []procedureir.CallSite, statementID int) []procedureir.CallSite {
+func (facts callsByStatement) values(calls readOnlySpan[procedureir.CallSite], statementID int) []procedureir.CallSite {
 	if span, contiguous := facts.groups.contiguousSpan(statementID); contiguous {
-		return append([]procedureir.CallSite(nil), calls[span.start:span.end]...)
+		out := make([]procedureir.CallSite, 0, span.end-span.start)
+		for index := span.start; index < span.end; index++ {
+			if call, ok := calls.At(index); ok {
+				out = append(out, call)
+			}
+		}
+		return out
 	}
 	indexes, ok := facts.groups.lookup(statementID)
 	if !ok {
@@ -492,8 +538,8 @@ func (facts callsByStatement) values(calls []procedureir.CallSite, statementID i
 	}
 	out := make([]procedureir.CallSite, 0, len(indexes))
 	for _, index := range indexes {
-		if index >= 0 && index < len(calls) {
-			out = append(out, calls[index])
+		if call, ok := calls.At(index); ok {
+			out = append(out, call)
 		}
 	}
 	return out
@@ -511,9 +557,15 @@ func newAccessFactsByStatement(accesses []procedureir.VariableAccess) accessesBy
 	return accessesByStatement{groups: newIndexGroups(ids)}
 }
 
-func (facts accessesByStatement) values(accesses []procedureir.VariableAccess, statementID int) []procedureir.VariableAccess {
+func (facts accessesByStatement) values(accesses readOnlySpan[procedureir.VariableAccess], statementID int) []procedureir.VariableAccess {
 	if span, contiguous := facts.groups.contiguousSpan(statementID); contiguous {
-		return append([]procedureir.VariableAccess(nil), accesses[span.start:span.end]...)
+		out := make([]procedureir.VariableAccess, 0, span.end-span.start)
+		for index := span.start; index < span.end; index++ {
+			if access, ok := accesses.At(index); ok {
+				out = append(out, access)
+			}
+		}
+		return out
 	}
 	indexes, ok := facts.groups.lookup(statementID)
 	if !ok {
@@ -521,8 +573,8 @@ func (facts accessesByStatement) values(accesses []procedureir.VariableAccess, s
 	}
 	out := make([]procedureir.VariableAccess, 0, len(indexes))
 	for _, index := range indexes {
-		if index >= 0 && index < len(accesses) {
-			out = append(out, accesses[index])
+		if access, ok := accesses.At(index); ok {
+			out = append(out, access)
 		}
 	}
 	return out
@@ -602,7 +654,29 @@ func (procedure sourceProcedure) analysisFacts() *procedureAnalysisFacts {
 	if procedure.Facts != nil {
 		return procedure.Facts
 	}
-	facts := newProcedureAnalysisFactsWithDeclarations(procedure.Declarations, procedure.Statements, procedure.Expressions, procedure.Calls, procedure.Accesses)
+	if procedure.IR != nil {
+		facts := newProcedureAnalysisFactsForProcedure(procedure.IR)
+		facts.features.addUnknown(allProcedureFeatures)
+		return facts
+	}
+	facts := newProcedureAnalysisFactsWithDeclarations(
+		spanValues(procedure.Declarations),
+		spanValues(procedure.Statements),
+		spanValues(procedure.Expressions),
+		spanValues(procedure.Calls),
+		spanValues(procedure.Accesses),
+	)
 	facts.features.addUnknown(allProcedureFeatures)
 	return facts
+}
+
+// spanValues is used only by compatibility sourceProcedure literals that do
+// not carry a canonical ProcedureIR owner. Production views never materialize
+// a second collection.
+func spanValues[T any](span readOnlySpan[T]) []T {
+	values := make([]T, 0, span.Len())
+	for value := range span.All() {
+		values = append(values, value)
+	}
+	return values
 }

--- a/internal/analyze/procedure_facts_test.go
+++ b/internal/analyze/procedure_facts_test.go
@@ -37,16 +37,45 @@ func TestSourceProceduresFromIRAttachesProcedureAnalysisFacts(t *testing.T) {
 		}},
 	}
 
-	procedures := sourceProceduresFromIR(document)
+	procedures := sourceProceduresFromIRRef(&document)
 	if len(procedures) != 1 || procedures[0].Facts == nil {
 		t.Fatalf("source procedures = %#v, want one procedure with facts", procedures)
 	}
+	if procedures[0].IR != &document.Procedures[0] {
+		t.Fatalf("procedure IR = %p, want canonical %p", procedures[0].IR, &document.Procedures[0])
+	}
+	if procedures[0].Document != &document {
+		t.Fatalf("procedure document = %p, want canonical %p", procedures[0].Document, &document)
+	}
+	if &procedures[0].IR.Declarations[0] != &document.Procedures[0].Declarations[0] ||
+		&procedures[0].IR.Statements[0] != &document.Procedures[0].Statements[0] ||
+		&procedures[0].IR.Expressions[0] != &document.Procedures[0].Expressions[0] ||
+		&procedures[0].IR.Calls[0] != &document.Procedures[0].Calls[0] ||
+		&procedures[0].IR.Accesses[0] != &document.Procedures[0].Accesses[0] {
+		t.Fatal("procedure view does not use canonical IR collection storage")
+	}
 	facts := procedures[0].Facts
+	if facts.procedure != procedures[0].IR {
+		t.Fatalf("facts procedure = %p, want canonical %p", facts.procedure, procedures[0].IR)
+	}
+	if facts.declarations != nil || facts.statements != nil || facts.expressions != nil || facts.calls != nil || facts.accesses != nil {
+		t.Fatal("production facts retained duplicate IR collection storage")
+	}
 	if got, ok := facts.Declaration(1); !ok || got.Name != "value" {
 		t.Fatalf("declaration lookup = %#v, %v", got, ok)
 	}
 	if got, ok := facts.Statement(10); !ok || got.Kind != procedureir.StatementAssignment {
 		t.Fatalf("statement lookup = %#v, %v", got, ok)
+	}
+	if got, ok := facts.Statements().At(1); !ok || got.ID != 20 {
+		t.Fatalf("statement span lookup = %#v, %v", got, ok)
+	}
+	var statementIDs []int
+	for statement := range facts.Statements().All() {
+		statementIDs = append(statementIDs, statement.ID)
+	}
+	if len(statementIDs) != 2 || statementIDs[0] != 10 || statementIDs[1] != 20 {
+		t.Fatalf("statement span iteration = %#v", statementIDs)
 	}
 	if _, ok := facts.Statement(999); ok {
 		t.Fatalf("missing statement lookup unexpectedly succeeded")
@@ -67,11 +96,12 @@ func TestSourceProceduresFromIRAttachesProcedureAnalysisFacts(t *testing.T) {
 		t.Fatalf("member expressions for call = %#v", got)
 	}
 
-	// sourceProceduresFromIR owns its IR projection. A caller changing the
-	// input document after construction cannot change the shared facts.
+	// The canonical DocumentIR owns the view storage. Facts retain compact
+	// indexes, so reading through an index observes the current canonical value
+	// without retaining a copied IR object.
 	document.Procedures[0].Statements[0].ID = 999
-	if got, ok := facts.Statement(10); !ok || got.ID != 10 {
-		t.Fatalf("facts changed after input IR mutation = %#v, %v", got, ok)
+	if got, ok := facts.Statement(10); !ok || got.ID != 999 {
+		t.Fatalf("facts did not read canonical IR after owner mutation = %#v, %v", got, ok)
 	}
 }
 

--- a/internal/analyze/procedure_planner.go
+++ b/internal/analyze/procedure_planner.go
@@ -406,7 +406,7 @@ func materializeProcedureAnalysisPlans(file *parsedFile, projectEffects effects.
 	}
 	procedures := file.Procedures
 	if procedures == nil {
-		procedures = sourceProceduresFromIR(file.IR, file.CFG)
+		procedures = sourceProceduresFromIRRef(&file.IR, file.CFG)
 	}
 	moduleFeatures := moduleDeclarationFeatures(file.moduleDecls())
 	for i := range procedures {

--- a/internal/analyze/procedure_planner_test.go
+++ b/internal/analyze/procedure_planner_test.go
@@ -151,9 +151,10 @@ func TestProcedureFeatureSetFailsOpenForRecoveredAndDynamicIR(t *testing.T) {
 		t.Fatalf("dynamic-call features = %#v, want every feature present or unknown", dynamic.features)
 	}
 
-	missingGraph := sourceProceduresFromIR(procedureir.DocumentIR{Procedures: []procedureir.ProcedureIR{{
+	missingDocument := procedureir.DocumentIR{Procedures: []procedureir.ProcedureIR{{
 		Symbol: procedureir.ProcedureSymbol{Name: "Recovered", Kind: procedureir.ProcedureSub},
-	}}})
+	}}}
+	missingGraph := sourceProceduresFromIRRef(&missingDocument)
 	if len(missingGraph) != 1 || missingGraph[0].Features.present|missingGraph[0].Features.unknown != allProcedureFeatures {
 		t.Fatalf("missing-graph features = %#v, want every feature potentially applicable", missingGraph)
 	}
@@ -363,7 +364,7 @@ func TestProcedureRuleRequirementsCoverEveryGatedRule(t *testing.T) {
 	}
 }
 
-func TestSourceProceduresFromIRFeatureSummaryIsOwnedAndSafeForConcurrentReads(t *testing.T) {
+func TestSourceProceduresFromIRFeatureSummaryUsesCanonicalIRAndIsSafeForConcurrentReads(t *testing.T) {
 	document := procedureir.DocumentIR{
 		Path: "module.bas", ModuleName: "Sheet1",
 		Procedures: []procedureir.ProcedureIR{{
@@ -376,7 +377,7 @@ func TestSourceProceduresFromIRFeatureSummaryIsOwnedAndSafeForConcurrentReads(t 
 		}},
 	}
 	flow := cfg.Document{Graphs: []cfg.Graph{{}}}
-	procedures := sourceProceduresFromIR(document, flow)
+	procedures := sourceProceduresFromIRRef(&document, flow)
 	if len(procedures) != 1 {
 		t.Fatalf("procedures = %d, want 1", len(procedures))
 	}
@@ -387,15 +388,21 @@ func TestSourceProceduresFromIRFeatureSummaryIsOwnedAndSafeForConcurrentReads(t 
 		}
 	}
 
-	// sourceProceduresFromIR copies the procedure-owned IR projection before
-	// constructing facts; changing the caller's document cannot change it.
+	// The view retains the canonical Go-owned procedure IR. Facts are immutable
+	// summaries, while their compact indexes continue to address that storage.
+	if procedures[0].IR != &document.Procedures[0] {
+		t.Fatalf("procedure IR = %p, want canonical %p", procedures[0].IR, &document.Procedures[0])
+	}
+	if procedures[0].Document != &document {
+		t.Fatalf("procedure document = %p, want canonical %p", procedures[0].Document, &document)
+	}
 	document.Procedures[0].Statements[0].Kind = procedureir.StatementRecovered
 	document.Procedures[0].Declarations[0].IsArray = false
-	if got := procedures[0].Statements[0].Kind; got != procedureir.StatementFor {
-		t.Fatalf("owned statement changed after source mutation: %v", got)
+	if got := procedures[0].IR.Statements[0].Kind; got != procedureir.StatementRecovered {
+		t.Fatalf("canonical statement was not visible through procedure view: %v", got)
 	}
 	if !procedures[0].Features.mayHave(featureArray) || procedures[0].Features.unknown&featureArray != 0 {
-		t.Fatalf("owned feature changed after source mutation: %#v", procedures[0].Features)
+		t.Fatalf("immutable feature summary changed after canonical IR mutation: %#v", procedures[0].Features)
 	}
 
 	var wait sync.WaitGroup

--- a/internal/analyze/public_api_types.go
+++ b/internal/analyze/public_api_types.go
@@ -97,7 +97,7 @@ func (a Analyzer) publicAPITypeFindings(file parsedFile, index *apiTypeIndex) []
 			procedure.Symbol.Kind == procedureir.ProcedurePropertyGet {
 			findings = append(findings, a.checkPublicAPIType(file, proc, index, procedure.Symbol.ReturnType, proc.StartLine, "return type")...)
 		}
-		for _, parameter := range proc.Params {
+		for parameter := range proc.Params.All() {
 			line := proc.StartLine
 			if parameter.Range.StartLine > 0 {
 				line = parameter.Range.StartLine

--- a/internal/analyze/range_value_shape.go
+++ b/internal/analyze/range_value_shape.go
@@ -129,14 +129,14 @@ func (a Analyzer) rangeValueShapeFindings(file parsedFile, proc sourceProcedure)
 	if !a.Config.Analyze.DetectRangeValueArrayShape {
 		return nil
 	}
-	if len(proc.Statements) == 0 || rangeValueProjectionUnknown(proc) {
+	if proc.Statements.Len() == 0 || rangeValueProjectionUnknown(proc) {
 		return a.rangeValueShapeFindingsFromSource(file, proc)
 	}
 	facts := rangeValueFactsForProcedure(file, proc)
 	if proc.Graph == nil {
 		state := newRangeValueFlowState()
 		var findings []Finding
-		for _, statement := range proc.Statements {
+		for statement := range proc.Statements.All() {
 			issues, next := rangeValueStatement(state, statement, facts)
 			findings = appendRangeValueFindings(findings, file, proc, statement, issues, a)
 			state = next
@@ -1024,20 +1024,20 @@ func rangeValueFactsForProcedure(file parsedFile, proc sourceProcedure) rangeVal
 		constants:      map[string]int{},
 		expressions:    map[int]procedureir.Expression{},
 	}
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if isExcelRangeType(declaration.Type) {
 			facts.rangeVariables[strings.ToLower(declaration.Name)] = true
 		}
 	}
-	for _, expression := range proc.Expressions {
+	for expression := range proc.Expressions.All() {
 		facts.expressions[expression.ID] = expression
 	}
 	constants := rangeValueIntegerConstants(file.RangeValueModuleConstants, proc)
-	if len(proc.Statements) == 0 || rangeValueProjectionUnknown(proc) {
+	if proc.Statements.Len() == 0 || rangeValueProjectionUnknown(proc) {
 		constants = rangeValueSourceIntegerConstants(file, proc, constants)
 	}
 	facts.constants = constants
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		text := strings.TrimSpace(excelLoopHeaderText(statement.Text))
 		if match := forBoundsRe.FindStringSubmatch(text); len(match) > 0 {
 			start, startErr := constantIntegerExpression(match[1], constants)
@@ -1105,7 +1105,7 @@ func rangeValueIntegerConstants(moduleConstants map[string]int, proc sourceProce
 	for name, value := range moduleConstants {
 		constants[name] = value
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if len(statement.ConditionalBranches) > 0 {
 			continue
 		}

--- a/internal/analyze/range_value_shape_test.go
+++ b/internal/analyze/range_value_shape_test.go
@@ -409,7 +409,7 @@ End Sub
 		Name:       "Run",
 		StartLine:  2,
 		EndLine:    6,
-		Statements: []procedureir.Statement{{Text: "Debug.Print values(1)"}},
+		Statements: newReadOnlySpan([]procedureir.Statement{{Text: "Debug.Print values(1)"}}),
 		Features:   procedureFeatureSet{unknown: featureRangeArray},
 	}
 	if got := findingsByCode((Analyzer{RootDir: ".", Config: config.Default()}).rangeValueShapeFindings(partialFile, partialProc), "VBA226"); len(got) != 1 {
@@ -703,8 +703,8 @@ End Sub
 
 func TestVBA226GraphlessCompleteIRDoesNotUseRecoveryFallback(t *testing.T) {
 	proc := sourceProcedure{
-		Statements:  []procedureir.Statement{{Text: "values = ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}},
-		Expressions: []procedureir.Expression{{Text: "ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}},
+		Statements:  newReadOnlySpan([]procedureir.Statement{{Text: "values = ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}}),
+		Expressions: newReadOnlySpan([]procedureir.Expression{{Text: "ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}}),
 		Features:    procedureFeatureSet{unknown: featureRangeArray},
 	}
 	if rangeValueProjectionUnknown(proc) {
@@ -714,8 +714,8 @@ func TestVBA226GraphlessCompleteIRDoesNotUseRecoveryFallback(t *testing.T) {
 
 func TestVBA226RecoveredRangeValueExpressionUsesRecoveryFallback(t *testing.T) {
 	proc := sourceProcedure{
-		Statements:  []procedureir.Statement{{ID: 1, Text: "values = ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}},
-		Expressions: []procedureir.Expression{{ID: 1, StatementID: 1, Kind: procedureir.ExpressionUnknown, Text: "ws.Cells(2, 1)", Recovered: true}},
+		Statements:  newReadOnlySpan([]procedureir.Statement{{ID: 1, Text: "values = ws.Range(ws.Cells(2, 1), ws.Cells(2, 2)).Value2"}}),
+		Expressions: newReadOnlySpan([]procedureir.Expression{{ID: 1, StatementID: 1, Kind: procedureir.ExpressionUnknown, Text: "ws.Cells(2, 1)", Recovered: true}}),
 	}
 	if !rangeValueProjectionUnknown(proc) {
 		t.Fatal("recovered Range.Value child expressions should select source recovery")

--- a/internal/analyze/redim_preserve_loop.go
+++ b/internal/analyze/redim_preserve_loop.go
@@ -30,7 +30,7 @@ func (a Analyzer) redimPreserveLoopFindingsPreparedWithApplicability(file parsed
 	var findings []Finding
 	applicable := false
 	seen := map[string]bool{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Recovered || !arrayRedimPreserveStatement(statement.Text) {
 			continue
 		}
@@ -76,7 +76,7 @@ func (a Analyzer) redimPreserveLoopFindingsPreparedWithApplicability(file parsed
 		dependent := false
 		for _, loop := range bodyLoops {
 			loopVars := redimLoopVariables(loop, proc)
-			for _, access := range proc.Accesses {
+			for access := range proc.Accesses.All() {
 				if access.StatementID != statement.ID || !loopVars[strings.ToLower(access.Name)] {
 					continue
 				}
@@ -141,11 +141,11 @@ func redimLoopVariables(owner excelLoopRegion, proc sourceProcedure) map[string]
 	for name := range variables {
 		conditionVariables[name] = true
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ParentID != owner.StatementID || statement.SyntaxKind != "do_condition" {
 			continue
 		}
-		for _, access := range proc.Accesses {
+		for access := range proc.Accesses.All() {
 			if access.StatementID == statement.ID && access.Mode != procedureir.AccessWrite {
 				conditionVariables[strings.ToLower(access.Name)] = true
 			}
@@ -162,7 +162,7 @@ func redimLoopVariables(owner excelLoopRegion, proc sourceProcedure) map[string]
 }
 
 func redimLoopVariableModified(owner excelLoopRegion, proc sourceProcedure, name string) bool {
-	for _, access := range proc.Accesses {
+	for access := range proc.Accesses.All() {
 		if !owner.Body[access.StatementID] || !strings.EqualFold(access.Name, name) {
 			continue
 		}
@@ -174,7 +174,7 @@ func redimLoopVariableModified(owner excelLoopRegion, proc sourceProcedure, name
 }
 
 func procedureStatementByID(proc sourceProcedure, id int) procedureir.Statement {
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == id {
 			return statement
 		}

--- a/internal/analyze/resource_leaks.go
+++ b/internal/analyze/resource_leaks.go
@@ -75,7 +75,7 @@ func (a Analyzer) resourceLeakFindings(file parsedFile, proc sourceProcedure) []
 
 func resourceAcquisitions(proc sourceProcedure) []resourceAcquisition {
 	acquisitions := make([]resourceAcquisition, 0)
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Recovered {
 			continue
 		}
@@ -289,7 +289,7 @@ func resourceName(value string) string {
 }
 
 func resourceLocalVariable(proc sourceProcedure, name string) bool {
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if declaration.Scope == procedureir.ScopeLocal && strings.EqualFold(declaration.Name, name) {
 			return true
 		}
@@ -298,7 +298,7 @@ func resourceLocalVariable(proc sourceProcedure, name string) bool {
 }
 
 func resourceWorkbookOwner(proc sourceProcedure, name string) bool {
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if declaration.Scope != procedureir.ScopeLocal || !strings.EqualFold(declaration.Name, name) {
 			continue
 		}

--- a/internal/analyze/runtime_error.go
+++ b/internal/analyze/runtime_error.go
@@ -67,9 +67,9 @@ func (a Analyzer) deterministicRuntimeErrorFindingsWithArrayResult(file parsedFi
 	if proc.Graph == nil {
 		state := initial
 		writes := runtimeWriteNames(proc.Accesses)
-		statements := append([]procedureir.Statement(nil), proc.Statements...)
-		sort.SliceStable(statements, func(i, j int) bool { return statements[i].Range.StartByte < statements[j].Range.StartByte })
-		for _, statement := range statements {
+		// The canonical ProcedureIR preserves source order, so no projection
+		// sort or temporary statement collection is needed here.
+		for _, statement := range proc.Statements {
 			env := runtimeConstantEnvironment(base, state)
 			findings = appendRuntimeStatementFindings(findings, seen, a, file, proc, statement, facts, env)
 			state = runtimeTransfer(statement, state, env, writes[statement.ID])

--- a/internal/analyze/runtime_error.go
+++ b/internal/analyze/runtime_error.go
@@ -69,7 +69,7 @@ func (a Analyzer) deterministicRuntimeErrorFindingsWithArrayResult(file parsedFi
 		writes := runtimeWriteNames(proc.Accesses)
 		// The canonical ProcedureIR preserves source order, so no projection
 		// sort or temporary statement collection is needed here.
-		for _, statement := range proc.Statements {
+		for statement := range proc.Statements.All() {
 			env := runtimeConstantEnvironment(base, state)
 			findings = appendRuntimeStatementFindings(findings, seen, a, file, proc, statement, facts, env)
 			state = runtimeTransfer(statement, state, env, writes[statement.ID])
@@ -102,17 +102,17 @@ func (a Analyzer) deterministicRuntimeErrorFindingsWithArrayResult(file parsedFi
 
 func runtimeLocalNames(proc sourceProcedure) map[string]bool {
 	names := make(map[string]bool)
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		if name := runtimeSimpleIdentifier(declaration.Name); name != "" {
 			names[name] = true
 		}
 	}
-	for _, parameter := range proc.Params {
+	for parameter := range proc.Params.All() {
 		if name := runtimeSimpleIdentifier(parameter.Name); name != "" {
 			names[name] = true
 		}
 	}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if name, ok := runtimeAssignmentTarget(statement); ok {
 			names[name] = true
 		}
@@ -327,7 +327,7 @@ func (overlay runtimeConstantOverlay) Resolve(name string) (constexpr.Value, boo
 	return overlay.base.Resolve(key)
 }
 
-func runtimeCFGStates(graph *vbacfg.Graph, initial runtimeConstantState, base constexpr.Environment, accesses []procedureir.VariableAccess) map[vbacfg.BlockID]runtimeConstantState {
+func runtimeCFGStates(graph *vbacfg.Graph, initial runtimeConstantState, base constexpr.Environment, accesses readOnlySpan[procedureir.VariableAccess]) map[vbacfg.BlockID]runtimeConstantState {
 	if graph == nil {
 		return nil
 	}
@@ -473,10 +473,10 @@ func runtimeTransfer(statement procedureir.Statement, in runtimeConstantState, e
 	return out
 }
 
-func runtimeWriteNames(accesses []procedureir.VariableAccess) map[int][]string {
+func runtimeWriteNames(accesses readOnlySpan[procedureir.VariableAccess]) map[int][]string {
 	byStatement := map[int][]string{}
 	seen := map[int]map[string]bool{}
-	for _, access := range accesses {
+	for access := range accesses.All() {
 		if access.StatementID == 0 || (access.Mode != procedureir.AccessWrite && access.Mode != procedureir.AccessReadWrite) {
 			continue
 		}

--- a/internal/analyze/value2_performance.go
+++ b/internal/analyze/value2_performance.go
@@ -48,7 +48,7 @@ type value2PerformanceCandidate struct {
 // a bulk, repeated, or Variant-array transfer signal makes the round-trip cost
 // material. It deliberately does not make a global Value2 preference claim.
 func (a Analyzer) value2PerformanceFindings(file parsedFile, proc sourceProcedure) []Finding {
-	if !a.Config.Analyze.DetectValue2PerformanceOpportunities || a.typeDB == nil || len(proc.Statements) == 0 {
+	if !a.Config.Analyze.DetectValue2PerformanceOpportunities || a.typeDB == nil || proc.Statements.Len() == 0 {
 		return nil
 	}
 	facts := rangeValueFactsForProcedure(file, proc)
@@ -64,7 +64,7 @@ func (a Analyzer) value2PerformanceFindings(file parsedFile, proc sourceProcedur
 	var candidates []value2PerformanceCandidate
 	seen := map[int]bool{}
 	seenReceivers := map[string]int{}
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.Recovered {
 			continue
 		}
@@ -169,7 +169,7 @@ func value2ScalarProcessing(proc sourceProcedure, statementID int, statementText
 	}
 	seen := false
 	nameRe := value2IdentifierPattern(name)
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == statementID {
 			seen = true
 			continue
@@ -289,15 +289,15 @@ func value2DynamicRangeAliasAt(proc sourceProcedure, statementID int, name strin
 		return false
 	}
 	visiting[name] = true
-	limit := len(proc.Statements)
-	for index, statement := range proc.Statements {
+	limit := proc.Statements.Len()
+	for index, statement := range proc.Statements.AllIndexed() {
 		if statement.ID == statementID {
 			limit = index
 			break
 		}
 	}
 	for index := limit - 1; index >= 0; index-- {
-		statement := proc.Statements[index]
+		statement := proc.Statements.valueAt(index)
 		left, right, ok := rangeValueAssignment(statement.Text)
 		left = value2TrimSetPrefix(left)
 		if !ok || !strings.EqualFold(left, name) {
@@ -378,14 +378,14 @@ func sameExpression(left *procedureir.Expression, right procedureir.Expression) 
 
 func value2ProcedureTypes(proc sourceProcedure) map[string]string {
 	types := map[string]string{}
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		typ := strings.TrimSpace(declaration.Type)
 		if typ == "" {
 			typ = "Variant"
 		}
 		types[strings.ToLower(strings.TrimSpace(declaration.Name))] = typ
 	}
-	for _, parameter := range proc.Params {
+	for parameter := range proc.Params.All() {
 		typ := strings.TrimSpace(parameter.Type)
 		if typ == "" {
 			typ = "Variant"
@@ -439,7 +439,7 @@ func value2DateCurrencyExpression(text string, declarations map[string]string) b
 func value2LaterDateCurrencyUse(proc sourceProcedure, statementID int, name string, declarations map[string]string) bool {
 	seen := false
 	nameRe := value2IdentifierPattern(name)
-	for _, statement := range proc.Statements {
+	for statement := range proc.Statements.All() {
 		if statement.ID == statementID {
 			seen = true
 			continue
@@ -580,7 +580,7 @@ func value2PerformanceIncomingStates(proc sourceProcedure, facts rangeValueFacts
 	states := map[int]rangeValueFlowState{}
 	if proc.Graph == nil {
 		state := newRangeValueFlowState()
-		for _, statement := range proc.Statements {
+		for statement := range proc.Statements.All() {
 			states[statement.ID] = cloneRangeValueFlowState(state)
 			_, state = rangeValueStatement(state, statement, facts)
 		}

--- a/internal/analyze/vba212.go
+++ b/internal/analyze/vba212.go
@@ -205,14 +205,14 @@ func vba212DeclarationIndexesForFile(file parsedFile, procedures []sourceProcedu
 }
 
 func addVBA212ProcedureIRDeclarations(scope *declarationScope, proc sourceProcedure) {
-	for _, declaration := range proc.Declarations {
+	for declaration := range proc.Declarations.All() {
 		scope.addProcedureIRDeclaration(sourceDeclaration{Name: declaration.Name, Type: declaration.Type})
 	}
 }
 
 func vba212Parameters(proc sourceProcedure) map[string]sourceDeclaration {
-	parameters := make(map[string]sourceDeclaration, len(proc.Params))
-	for _, parameter := range proc.Params {
+	parameters := make(map[string]sourceDeclaration, proc.Params.Len())
+	for parameter := range proc.Params.All() {
 		key := strings.ToLower(strings.TrimSpace(parameter.Name))
 		if key == "" {
 			continue

--- a/internal/analyze/vba212_single_pass_test.go
+++ b/internal/analyze/vba212_single_pass_test.go
@@ -42,7 +42,7 @@ End Property
 	var findings []Finding
 	err = doc.Read(func(view vbaast.ParsedView) error {
 		file := parsedFile{Path: view.Path, Module: "Guard", Source: view.Source, Root: view.Root, Lines: normalizedSourceLines(string(view.Source)), IR: ir}
-		findings, err = (Analyzer{}).nonShortCircuitObjectGuardDocumentFindings(context.Background(), file, sourceProceduresFromIR(ir), stats)
+		findings, err = (Analyzer{}).nonShortCircuitObjectGuardDocumentFindings(context.Background(), file, sourceProceduresFromIRRef(&ir), stats)
 		return err
 	})
 	if err != nil {
@@ -86,7 +86,7 @@ func TestVBA212ScannerCancellationStopsAtCheckpoint(t *testing.T) {
 	ctx := vba212CheckpointContext{stats: stats, cancelAt: 256}
 	err = doc.Read(func(view vbaast.ParsedView) error {
 		file := parsedFile{Path: view.Path, Module: "Cancel", Source: view.Source, Root: view.Root, Lines: normalizedSourceLines(string(view.Source)), IR: ir}
-		_, scanErr := (Analyzer{}).nonShortCircuitObjectGuardDocumentFindings(ctx, file, sourceProceduresFromIR(ir), stats)
+		_, scanErr := (Analyzer{}).nonShortCircuitObjectGuardDocumentFindings(ctx, file, sourceProceduresFromIRRef(&ir), stats)
 		return scanErr
 	})
 	if !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
## Summary

- Replace analyzer procedure projections that copied declarations, statements,
  expressions, calls, accesses, and parameters with revision-local views over
  canonical `procedureir.DocumentIR` / `ProcedureIR` storage.
- Keep procedure facts as compact indexes with read-only lookup and iteration
  paths, while preserving CFG, tree-sitter lease, snapshot, diagnostics, JSON,
  and LSP ownership boundaries.
- Update ownership/concurrency tests, allocation benchmarks, ADR/specification
  records, corpus measurements, and the changelog.

Closes #698

## Verification

- `rtk task test`
- `rtk task lint`
- `rtk task corpus:test`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/analyze ./internal/vba/procedureir ./internal/vba/intel -count=1`
- Projection benchmark for 100/500/1,000/2,000 procedures with `-benchmem`.
- Synthetic 2,000-procedure independent/chain/declarations/cfg-independent
  allocation benchmarks.
- ROneCOne `analyze-only` five-sample benchmark and CPU/allocation profiles.

The projection benchmark measured 500-procedure materialization at
860,416 B/op and 7,501 allocs/op, versus 1,461,257 B/op and 10,002 allocs/op
for the previous projection path. ROneCOne median allocation was
26,649,626,264 B/op with 177,360,666 allocs/op; findings and fact-build
counters remained stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory allocation during large-scale static analysis by using lightweight, read-only procedure views.
  * Preserved analysis results, diagnostics, and JSON/LSP compatibility.
  * Improved processing efficiency by avoiding unnecessary collection copies and sorting.

* **Documentation**
  * Added architecture and benchmark documentation describing procedure views, ownership, concurrency, and allocation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->