### PR TITLE
perf(procedureir): add resolution overlays for batch diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to xlflow will be documented in this file.
   statement, expression, call, access, and parameter collections. Diagnostic
   and JSON/LSP contracts remain unchanged.
 
+- Added a read-only procedure-resolution overlay for batch `VB052`-`VB054`
+  diagnostics, avoiding a second full `DocumentIR` clone while preserving
+  materialized `Resolve` compatibility and deterministic resolution results.
+
 - Added immutable tri-state procedure feature summaries and applicability-based
   planning for expensive semantic analyzer domains. Proven-irrelevant domains
   can be skipped before setup, while recovered, unresolved, dynamic, or

--- a/docs/adr/ADR-0021-procedure-analysis-ir.md
+++ b/docs/adr/ADR-0021-procedure-analysis-ir.md
@@ -23,7 +23,9 @@ the same analysis must remain reusable by source-only CLI commands.
 The foundation in issue #426 needs exact existing diagnostic locations,
 recoverable partial analysis, deterministic output, and project resolution
 that can be refreshed without rewalking unchanged syntax. It does not yet need
-control-flow graphs or effect propagation.
+control-flow graphs or effect propagation. Issue #699 adds a performance
+constraint: batch resolution diagnostics must not deep-clone all procedure
+syntax and semantic payloads when only project-dependent facts change.
 
 ## Decision
 
@@ -36,12 +38,36 @@ copies only Go-owned values: strings, enums, stable IDs, slices, and
 the read callback. `BuildSource` owns parsing and closing for one-shot callers;
 `BuildParsed` uses a caller-owned parsed document without closing it.
 
-Separate syntax extraction from project resolution. A syntax-local
+Separate syntax extraction from project resolution. A syntax-local, immutable
 `DocumentIR` records procedures, declarations, statements, expressions, calls,
-and variable accesses. `Resolve` applies a replaceable project symbol/call
-resolver to a copy of that IR without reparsing or rescanning source. Resolution
-must explicitly represent matched, ambiguous, unresolved, external,
-built-in-like, and member-call outcomes.
+and variable accesses. `ResolveView` applies a replaceable project
+symbol/call resolver to a read-only resolution overlay without reparsing,
+rescanning source, or cloning the procedure payloads. The view exposes resolved
+calls, accesses, and events through helpers so consumers do not depend on
+whether facts are stored inline or in a side table. Resolution must explicitly
+represent matched, ambiguous, unresolved, external, built-in-like, and
+member-call outcomes.
+
+The overlay is indexed by revision-local procedure identity and stable IR fact
+IDs, not source text. A procedure identity includes document/module context,
+qualified procedure name and kind, declaration start, and source-order
+ordinal. Call IDs are reused for calls; accesses and event references receive
+the corresponding revision-local IDs. These IDs are deterministic within one
+document revision but are not workspace-global identities. Access and event
+IDs remain internal metadata and are omitted from serialized IR/JSON.
+
+`DiagnosticsView` shares the existing resolution-diagnostic walker with
+`Diagnostics` and reads syntax/recovery facts from the immutable IR while
+reading project-dependent call, access, and event facts from the overlay. Batch
+analyzer resolution diagnostics use this view. Effects, ordinary analyzer
+rules, lint, LSP, metrics, and developer-only oracle consumers retain the
+materialized path unless they independently require an overlay migration.
+
+Keep `Resolve` as the compatibility API for consumers that require an
+independently owned resolved `DocumentIR`: it may materialize a view and must
+preserve the existing input-unchanged and independent-ownership guarantees.
+`ResolveView` and materialization must also preserve behavior for a nil resolver,
+including the existing unresolved/incomplete representation.
 
 Carry module kind in resolver symbols. A receiver-less call may resolve to a
 non-standard procedure only within the same module; class, document, and
@@ -104,6 +130,9 @@ contracts.
   reuse one procedure and source-location model.
 - Positive: syntax extraction is independent of changing project symbols, so
   call resolution can be refreshed without another CST walk.
+- Positive: read-only batch resolution can refresh project-dependent facts
+  without deep-cloning statements, expressions, declarations, calls, accesses,
+  and other procedure-level payloads.
 - Positive: cached analysis values are safe after the parsed document closes
   because the IR contains no borrowed parser state.
 - Positive: a body-only edit rebuilds only changed procedure IR while safely
@@ -116,8 +145,14 @@ contracts.
   that cannot be represented by current statement or expression kinds.
 - Negative: revision-local analyzer views require every consumer and worker to
   honor the immutable ownership contract; mutable rule state must remain local.
-- Negative: snapshot and public compatibility projections still retain their
-  defensive-copy cost even though analyzer hot paths use zero-copy views.
+- Negative: defensive copies and normalization allocate more Go values than a
+  consumer-specific walk.
+- Negative: compatibility projections remain necessary while existing calls,
+  symbols, analyzer, and LSP result types continue to serve their public
+  contracts.
+- Negative: overlay indexes and revision-local fact identity add bookkeeping,
+  and consumers that need independent ownership still pay the materialization
+  cost of `Resolve`.
 - Limitation: issue #426 provides syntactic structure, not executable-path
   truth, type-complete member binding, COM type-library resolution, or
   interprocedural effects.
@@ -142,6 +177,15 @@ contracts.
 6. **Rebuild syntax whenever the project symbol snapshot changes** - Rejected
    because local syntax is unchanged; a separate resolution overlay is cheaper
    and makes unresolved or ambiguous states explicit.
+7. **Deep-clone the complete IR for every read-only diagnostic pass** - Rejected
+   because large modules duplicate syntax-local and procedure-level semantic
+   collections even though batch resolution changes only a small set of facts.
+8. **Key overlay entries by source text** - Rejected because text is not a
+   stable identity when the IR already provides deterministic revision-local
+   fact IDs and procedure identity.
+9. **Migrate every materialized consumer at once** - Rejected because LSP,
+   effects, and other consumers may require independently owned snapshots; the
+   overlay is introduced first at the batch resolution-diagnostic boundary.
 
 ## Evidence
 
@@ -155,6 +199,8 @@ contracts.
   `internal/vba/intel/analysis_snapshot_test.go`.
 - Validation consumer: `internal/analyze/analyzer.go`,
   `internal/analyze/analyzer_test.go`.
+- Resolution overlay and compatibility boundary: `internal/vba/procedureir`,
+  `internal/analyze/analyzer.go`, and issue #699.
 - Public compatibility contract: `docs/specs/cli-contract.md`.
 
 ## Related
@@ -164,4 +210,4 @@ contracts.
 - `docs/adr/ADR-0022-conservative-vba-control-flow-graph.md`
 - `docs/adr/ADR-0023-procedure-effect-summaries.md`
 - `docs/specs/vba-analysis-ir.md`
-- xlflow issues #425, #426, #427, and #428
+- xlflow issues #425, #426, #427, #428, and #699

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -752,6 +752,42 @@ replacement maintains a declaration-line index, rechecks the original
 slash-normalized `EqualFold` file/name/kind and exact-line contract, preserves
 the first deterministic match, and defensively clones only that match.
 
+#### Issue #699 resolution-overlay measurements
+
+The focused overlay benchmark compares the existing materialized
+`procedureir.Resolve` path (before) with `ResolveView` construction (after) on
+the same call/access-heavy synthetic IR. Fixture and resolver construction are
+outside the timer. Run it on Windows through the CGO wrapper:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/procedureir -run '^$' -bench '^BenchmarkResolutionOverlay$' -benchmem -benchtime=1x -count 5
+```
+
+The recorded environment was Windows/amd64, 12th Gen Intel(R) Core(TM)
+i7-12700, Go 1.26.6 (`go1.26.6 windows/amd64`). Median results from five
+single-iteration samples were:
+
+| procedures | path                  |      ns/op |       B/op | allocs/op |
+| ---------: | --------------------- | ---------: | ---------: | --------: |
+|        500 | materialized (before) |  6,548,100 |  9,313,912 |    39,082 |
+|        500 | overlay (after)       |  3,154,300 |  5,189,888 |    22,574 |
+|      1,000 | materialized (before) | 13,999,000 | 18,603,200 |    78,118 |
+|      1,000 | overlay (after)       |  8,495,100 | 10,373,584 |    45,116 |
+|      2,000 | materialized (before) | 36,590,300 | 37,200,208 |   156,200 |
+|      2,000 | overlay (after)       | 17,692,100 | 20,740,944 |    90,198 |
+
+The synthetic 2,000-procedure case therefore used about 44% fewer bytes, 42%
+fewer allocations, and 52% less time. These are same-machine observations, not
+CI thresholds. The existing end-to-end ROneCOne leaf was also sampled five
+times with the same wrapper and `-benchmem -benchtime=1x -count=5`, first with
+the diagnostic-only materialized clone and then with the overlay. Median
+`analyze-only` values were 28.017 s, 26,971,730,264 B/op, and 185,107,938
+allocs/op before, versus 24.999 s, 26,739,378,024 B/op, and 181,230,979
+allocs/op after (510 findings in every run). The full analyzer is dominated by
+other stages, and the five-run after set included two scheduler outliers; keep
+the leaf benchmark as end-to-end evidence rather than a fixed performance
+gate.
+
 The focused `LibJSON.ParseChars` benchmark set a target of at least 20% lower
 median runtime and 50% lower allocated bytes per operation. On the same
 Windows machine, the pre-change five-run baseline was 1.190-1.266 s,

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -12,7 +12,15 @@ diagnostic contracts.
 ```go
 func BuildSource(BuildOptions, []byte) (DocumentIR, error)
 func BuildParsed(BuildOptions, *ast.ParsedDocument) (DocumentIR, error)
+func ResolveView(DocumentIR, Resolver) ResolvedDocumentView
 func Resolve(DocumentIR, Resolver) DocumentIR
+
+func (ResolvedDocumentView) ResolvedCall(procedureIndex, callID int) (ResolvedCall, bool)
+func (ResolvedDocumentView) ResolvedAccess(procedureIndex, accessID int) (ResolvedAccess, bool)
+func (ResolvedDocumentView) ResolvedEvent(procedureIndex, eventID int) (ResolvedEvent, bool)
+func (ResolvedDocumentView) Materialize() DocumentIR
+
+func DiagnosticsView(ResolvedDocumentView, bool) []ResolutionDiagnostic
 ```
 
 `BuildSource` parses the supplied immutable source and closes the parsed
@@ -25,6 +33,24 @@ All tree and source access occurs inside `ast.ParsedDocument.Read`. Returned IR
 values own every string and slice they expose and contain no tree-sitter node,
 tree, or borrowed `ParsedView.Source` slice. They remain safe to read after the
 parsed document is closed.
+
+`DocumentIR` is the immutable syntax-local input for project resolution.
+`ResolveView` builds a read-only, revision-scoped overlay containing only
+project-dependent call, access, and event resolution facts, including effective
+access scope. Its lookup helpers hide whether a fact is stored inline or in a
+side table. They do not expose mutable candidate storage; callers that need an
+independently owned IR use `Materialize` or the compatibility `Resolve` API.
+
+The overlay is keyed by a deterministic procedure identity composed from path,
+module name and kind, qualified procedure name and kind, declaration start
+byte, and source-order ordinal. Within that procedure, calls use their stable
+call ID and accesses and event references use revision-local IDs. The IDs are
+valid only for the document revision that created them and must not be used as
+workspace-global or source-text identities. Production IR assigns those IDs;
+hand-built IR with missing or duplicate IDs uses the corresponding procedure
+slice ordinal as a compatibility fallback. Access and event IDs are internal
+metadata omitted from serialized IR/JSON, so adding them does not change the
+existing wire shape.
 
 `BuildOptions` supplies document context that syntax alone cannot reliably
 provide, including path and module kind. A missing module name is derived using
@@ -155,10 +181,18 @@ Syntax construction does not require a project snapshot. Calls initially carry
 `not_attempted` resolution, and variable accesses that cannot be decided from
 procedure/module declarations remain unresolved until a resolver is supplied.
 
-`Resolve` returns an independently owned IR with a resolution overlay derived
-from the supplied project snapshot. It does not mutate the input IR or rescan
-source. Replacing the resolver can therefore re-resolve the same syntax after a
-workspace symbol change.
+`ResolveView` applies the supplied project snapshot without mutating the base
+IR or rescanning source. Replacing the resolver can therefore re-resolve the
+same syntax after a workspace symbol change. `Resolve` remains the compatibility
+API for consumers that require an independently owned resolved `DocumentIR`;
+it materializes equivalent overlay facts and preserves the input-unchanged,
+independent-ownership, and nil-resolver behavior of the existing API.
+
+The overlay and materialized forms have identical completeness and ambiguity
+semantics. This includes unresolved, incomplete, ambiguous, local/module/
+project scope, enum-member ambiguity, dynamic/external calls, event resolution,
+and deterministic candidate ordering. Overlay identity never uses source text
+when a stable IR identity is available.
 
 Call resolution statuses are:
 
@@ -176,6 +210,14 @@ symbols also retain module kind so receiver-less calls cannot bind non-standard
 module procedures across module boundaries. Private procedures are visible only
 from the same module. Resolution does not claim full VBA type inference, COM
 type-library binding, or Excel object-model dispatch.
+
+`Diagnostics` and `DiagnosticsView` share one resolution-diagnostic walker.
+The walker obtains syntax and recovery state from the base IR and obtains
+resolution facts through the view. Batch analyzer `VB052`-`VB054` resolution
+diagnostics use `DiagnosticsView` to avoid a second full-document clone. Other
+consumers that need independent snapshot ownership may continue to use
+materialized `Resolve`; this boundary does not change LSP, effects, lint,
+metrics, or public CLI/JSON behavior.
 
 ## Ranges and Determinism
 
@@ -199,6 +241,11 @@ All slices are deterministic:
   same source and build options; and
 - resolver candidates use stable qualified-name, kind, file, and location
   ordering.
+
+Resolution overlay entries use the same source-ordered procedure identity and
+revision-local call/access/event IDs on every lookup. Candidate slices are
+copied only when an owned result is requested, and candidate ordering remains
+the resolver's stable qualified-name, kind, file, and location order.
 
 Determinism is per document revision. IDs are not persistent identities across
 edits and must not be stored as workspace-global references.
@@ -292,6 +339,13 @@ run. The performance recorder reports `module_fact_builds` and
 and one procedure build per procedure, independent of the number of rule
 families that consume them.
 
+Batch resolution diagnostics attach a read-only `ResolvedDocumentView` to the
+immutable document facts. The view is procedure-local and contains only
+resolution side tables; it does not allocate a second full-size copy of the
+procedure IR. A consumer that needs an independently owned resolved snapshot
+continues to call `Resolve`/`Materialize`, which remains the compatibility
+boundary.
+
 ### Procedure features and applicability planning
 
 Each `procedureAnalysisFacts` value also owns one immutable applicability
@@ -372,6 +426,13 @@ symbol results, or LSP-owned values. Those projections preserve:
 - `VBA204` cleanup-label handling, message, reason, suggestion, nearby code,
   severity, and inline suppression; and
 - CLI byte-based and LSP UTF-16 diagnostic ranges.
+
+Read-only resolution consumers should use `ResolveView` and its lookup helpers
+so they do not depend on the storage location of project-dependent facts.
+Consumers that retain or publish an independently owned resolved snapshot may
+continue to use materialized `Resolve`. This overlay boundary is internal and
+does not add a public CLI flag, configuration key, JSON field, diagnostic ID, or
+LSP capability.
 
 Issue #426 intentionally stops at procedure syntax and conservative name/call
 resolution. The separate CFG layer defined by

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -757,8 +757,8 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	var resolutionPreflight []Finding
 	finishStage = analysisstats.Measure(ctx, "project_wide_diagnostics")
 	for i := range parsedFiles {
-		resolvedForDiagnostics := procedureir.Resolve(parsedFiles[i].IR, resolutionResolver)
-		for _, diagnostic := range procedureir.Diagnostics(resolvedForDiagnostics, resolutionComplete) {
+		resolvedForDiagnostics := procedureir.ResolveView(parsedFiles[i].IR, resolutionResolver)
+		for _, diagnostic := range procedureir.DiagnosticsView(resolvedForDiagnostics, resolutionComplete) {
 			finding := analysis.resolutionFinding(parsedFiles[i], diagnostic)
 			findings = append(findings, finding)
 			resolutionPreflight = append(resolutionPreflight, finding)

--- a/internal/vba/procedureir/benchmark_test.go
+++ b/internal/vba/procedureir/benchmark_test.go
@@ -1,0 +1,96 @@
+package procedureir
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// BenchmarkResolutionOverlay compares the allocation cost of the legacy
+// materialized resolution path with the read-only overlay path.  The source
+// and resolver are built before the timer starts so the measurements cover
+// only project-dependent resolution and, for Resolve, the compatibility
+// deep-copy work.
+func BenchmarkResolutionOverlay(b *testing.B) {
+	for _, procedureCount := range []int{500, 1000, 2000} {
+		procedureCount := procedureCount
+		b.Run(fmt.Sprintf("%d-procedures", procedureCount), func(b *testing.B) {
+			document, resolver := resolutionOverlayBenchmarkFixture(b, procedureCount)
+			calls, accesses := resolutionOverlayBenchmarkFactCounts(document)
+
+			b.Run("materialized", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					resolved := Resolve(document, resolver)
+					runtime.KeepAlive(resolved)
+				}
+				b.StopTimer()
+				b.ReportMetric(float64(len(document.Procedures)), "procedures/op")
+				b.ReportMetric(float64(calls), "calls/op")
+				b.ReportMetric(float64(accesses), "accesses/op")
+			})
+
+			b.Run("overlay", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					resolved := ResolveView(document, resolver)
+					runtime.KeepAlive(resolved)
+				}
+				b.StopTimer()
+				b.ReportMetric(float64(len(document.Procedures)), "procedures/op")
+				b.ReportMetric(float64(calls), "calls/op")
+				b.ReportMetric(float64(accesses), "accesses/op")
+			})
+		})
+	}
+}
+
+func resolutionOverlayBenchmarkFixture(tb testing.TB, procedureCount int) (DocumentIR, Resolver) {
+	tb.Helper()
+	var source strings.Builder
+	// Each procedure intentionally contains two calls and several accesses.
+	// This keeps the benchmark focused on resolution facts while retaining a
+	// large amount of syntax-local IR for the materialized path to clone.
+	for procedureIndex := 0; procedureIndex < procedureCount; procedureIndex++ {
+		source.WriteString("Public Sub Procedure")
+		source.WriteString(strconv.Itoa(procedureIndex))
+		source.WriteString("()\n")
+		source.WriteString("  Dim localValue As Long\n")
+		source.WriteString("  Call Helper(localValue)\n")
+		source.WriteString("  Call MissingProcedure(localValue)\n")
+		source.WriteString("  SharedValue = SharedValue + ExternalValue\n")
+		source.WriteString("  SharedValue = SharedValue + localValue\n")
+		source.WriteString("End Sub\n\n")
+	}
+
+	document, err := BuildSource(BuildOptions{
+		Path:       "ResolutionOverlayBenchmark.bas",
+		ModuleName: "ResolutionOverlayBenchmark",
+		ModuleKind: "standard",
+	}, []byte(source.String()))
+	if err != nil {
+		tb.Fatalf("build %d-procedure resolution fixture: %v", procedureCount, err)
+	}
+	if len(document.Procedures) != procedureCount {
+		tb.Fatalf("resolution fixture procedures = %d, want %d", len(document.Procedures), procedureCount)
+	}
+
+	resolver := NewResolver([]ResolverSymbol{
+		{Name: "Helper", Module: "ProjectHelpers", Kind: "procedure", Visibility: "Public", File: "ProjectHelpers.bas", Line: 1},
+		{Name: "SharedValue", Module: "ProjectState", Kind: "module_variable", Visibility: "Public", Type: "Long", File: "ProjectState.bas", Line: 1},
+		{Name: "ExternalValue", Module: "ProjectState", Kind: "module_variable", Visibility: "Public", Type: "Long", File: "ProjectState.bas", Line: 2},
+	})
+	return document, resolver
+}
+
+func resolutionOverlayBenchmarkFactCounts(document DocumentIR) (calls, accesses int) {
+	for _, procedure := range document.Procedures {
+		calls += len(procedure.Calls)
+		accesses += len(procedure.Accesses)
+	}
+	return calls, accesses
+}

--- a/internal/vba/procedureir/diagnostics.go
+++ b/internal/vba/procedureir/diagnostics.go
@@ -37,53 +37,82 @@ func ResolutionSuggestion(code string) string {
 // resolved document.  Incomplete snapshots, parser recovery, external/member
 // calls, and dynamic APIs deliberately fail open.
 func Diagnostics(doc DocumentIR, complete bool) []ResolutionDiagnostic {
+	return diagnosticsFor(doc, complete, nil)
+}
+
+// DiagnosticsView projects the same resolution diagnostics from a read-only
+// syntax IR plus overlay. The syntax/recovery policy is shared with
+// Diagnostics; only project-dependent facts are read through the view.
+func DiagnosticsView(view ResolvedDocumentView, complete bool) []ResolutionDiagnostic {
+	return diagnosticsFor(view.document, complete, &view)
+}
+
+func diagnosticsFor(doc DocumentIR, complete bool, view *ResolvedDocumentView) []ResolutionDiagnostic {
 	if !complete || documentResolutionIncomplete(doc) {
 		return nil
 	}
 	out := make([]ResolutionDiagnostic, 0)
-	for _, procedure := range doc.Procedures {
+	for procedureIndex, procedure := range doc.Procedures {
 		if procedure.Symbol.Recovered {
 			continue
 		}
-		for _, call := range procedure.Calls {
+		for callIndex, call := range procedure.Calls {
 			if call.IsRaiseEvent {
 				continue
 			}
 			if !syntacticInvocation(procedure, call) {
 				continue
 			}
-			if call.Resolution.Status == ResolutionNonCallable ||
-				(call.Resolution.Status == ResolutionUnresolved && call.Resolution.ProjectLocal) {
+			resolution := call.Resolution
+			if view != nil {
+				if resolved, ok := view.resolvedCallAt(procedureIndex, callIndex); ok {
+					resolution = resolved.Resolution
+				}
+			}
+			if resolution.Status == ResolutionNonCallable ||
+				(resolution.Status == ResolutionUnresolved && resolution.ProjectLocal) {
 				name := strings.TrimSpace(call.Callee.Text)
 				message := "Call target is missing or is not callable in this project."
 				if name != "" {
 					message = "Call target " + name + " is missing or is not callable in this project."
 				}
-				out = append(out, ResolutionDiagnostic{Code: "VB052", Message: message, Range: call.Range, Candidates: append([]Candidate(nil), call.Resolution.Candidates...)})
+				out = append(out, ResolutionDiagnostic{Code: "VB052", Message: message, Range: call.Range, Candidates: append([]Candidate(nil), resolution.Candidates...)})
 			}
 		}
-		for _, event := range procedure.RaiseEvents {
-			if event.Recovered || event.Resolution.Status != ResolutionUnresolved {
+		for eventIndex, event := range procedure.RaiseEvents {
+			resolution := event.Resolution
+			if view != nil {
+				if resolved, ok := view.resolvedEventAt(procedureIndex, eventIndex); ok {
+					resolution = resolved.Resolution
+				}
+			}
+			if event.Recovered || resolution.Status != ResolutionUnresolved {
 				continue
 			}
 			out = append(out, ResolutionDiagnostic{Code: "VB054", Message: "RaiseEvent target is not declared in this object module.", Range: event.Range})
 		}
-		for _, access := range procedure.Accesses {
+		for accessIndex, access := range procedure.Accesses {
 			if accessIsQualified(procedure, access) {
 				continue
 			}
-			if access.Resolution.Status != ResolutionAmbiguous || len(access.Resolution.Candidates) < 2 {
+			resolution := access.Resolution
+			if view != nil {
+				if resolved, ok := view.resolvedAccessAt(procedureIndex, accessIndex); ok {
+					resolution = resolved.Resolution
+				}
+			}
+			if resolution.Status != ResolutionAmbiguous || len(resolution.Candidates) < 2 {
 				continue
 			}
 			allEnum := true
-			for _, candidate := range access.Resolution.Candidates {
+			for _, candidate := range resolution.Candidates {
 				if !isEnumMemberKind(candidate.Kind) {
 					allEnum = false
 					break
 				}
 			}
 			if allEnum {
-				out = append(out, ResolutionDiagnostic{Code: "VB053", Message: "Enum member reference is ambiguous; qualify the member with its Enum name.", Range: access.Range, Candidates: append([]Candidate(nil), access.Resolution.Candidates...)})
+				out = append(out, ResolutionDiagnostic{Code: "VB053", Message: "Enum member reference is ambiguous; qualify the member with its Enum name.", Range: access.Range, Candidates: append([]Candidate(nil), resolution.Candidates...)})
 			}
 		}
 	}

--- a/internal/vba/procedureir/resolution_overlay.go
+++ b/internal/vba/procedureir/resolution_overlay.go
@@ -1,0 +1,428 @@
+package procedureir
+
+import "strings"
+
+// ProcedureIdentity identifies a procedure inside one immutable IR revision.
+// The source range and ordinal disambiguate same-named conditional or
+// overloaded declarations without using source text as a fact key.
+type ProcedureIdentity struct {
+	Path                 string
+	Module               string
+	ModuleKind           string
+	QualifiedName        string
+	Kind                 ProcedureKind
+	DeclarationStartByte int
+	Ordinal              int
+}
+
+// ResolutionFactKey is the stable key used by a resolution overlay. IDs are
+// procedure-local and source ordered; the procedure identity prevents facts
+// from one procedure being applied to another one after fragment reuse.
+type ResolutionFactKey struct {
+	Procedure ProcedureIdentity
+	ID        int
+}
+
+// ResolvedCall is the project-dependent portion of a CallSite.
+type ResolvedCall struct {
+	Resolution CallResolution
+}
+
+// ResolvedAccess is the project-dependent portion of a VariableAccess. Scope
+// is repeated because project resolution can refine an initially module or
+// unresolved access scope.
+type ResolvedAccess struct {
+	Scope      SymbolScope
+	Resolution SymbolResolution
+}
+
+// ResolvedEvent is the project-dependent portion of a RaiseEventReference.
+type ResolvedEvent struct {
+	Resolution SymbolResolution
+}
+
+// ResolutionOverlay contains only project-dependent facts. Its maps are kept
+// private so callers can use the read-only view API without mutating the
+// overlay accidentally.
+type ResolutionOverlay struct {
+	calls    map[ResolutionFactKey]ResolvedCall
+	accesses map[ResolutionFactKey]ResolvedAccess
+	events   map[ResolutionFactKey]ResolvedEvent
+}
+
+// ResolvedDocumentView combines immutable syntax-local IR with a read-only
+// resolution overlay. The source IR is never cloned or mutated while the
+// overlay is built.
+type ResolvedDocumentView struct {
+	document   DocumentIR
+	overlay    ResolutionOverlay
+	hasOverlay bool
+	callIDs    [][]int
+	accessIDs  [][]int
+	eventIDs   [][]int
+}
+
+// ResolveView builds a read-only project-resolution view over in. The input
+// document and all of its nested slices remain untouched.
+func ResolveView(in DocumentIR, resolver Resolver) ResolvedDocumentView {
+	view := ResolvedDocumentView{document: in}
+	if resolver == nil {
+		return view
+	}
+	view.hasOverlay = true
+	view.callIDs, view.accessIDs, view.eventIDs = documentFactIDs(in)
+	view.overlay = buildResolutionOverlay(in, resolver, view.callIDs, view.accessIDs, view.eventIDs)
+	return view
+}
+
+func buildResolutionOverlay(
+	in DocumentIR,
+	resolver Resolver,
+	callIDsByProcedure, accessIDsByProcedure, eventIDsByProcedure [][]int,
+) ResolutionOverlay {
+	overlay := ResolutionOverlay{
+		calls:    make(map[ResolutionFactKey]ResolvedCall),
+		accesses: make(map[ResolutionFactKey]ResolvedAccess),
+		events:   make(map[ResolutionFactKey]ResolvedEvent),
+	}
+	eventResolver, hasEventResolver := resolver.(interface {
+		ResolveEvent(SymbolReference) SymbolResolution
+	})
+	for procedureIndex, procedure := range in.Procedures {
+		identity := procedureIdentity(in, procedureIndex)
+		callIDs := callIDsByProcedure[procedureIndex]
+		accessIDs := accessIDsByProcedure[procedureIndex]
+		eventIDs := eventIDsByProcedure[procedureIndex]
+		lexicalNonCallable := declarationNames(in.Declarations, procedure.Declarations)
+		for callIndex, sourceCall := range procedure.Calls {
+			if sourceCall.IsRaiseEvent {
+				// RaiseEvent calls are filled from the syntax-local event facts
+				// below. A generic Resolver cannot prove same-object visibility.
+				continue
+			}
+			call := cloneCall(sourceCall)
+			if !isAssignmentTargetCall(sourceCall, procedure) {
+				call.NonCallableNames = append([]string(nil), lexicalNonCallable...)
+			}
+			overlay.calls[ResolutionFactKey{Procedure: identity, ID: callIDs[callIndex]}] = ResolvedCall{
+				Resolution: cloneCallResolution(resolver.ResolveCall(call)),
+			}
+		}
+		for eventIndex, event := range procedure.RaiseEvents {
+			resolution := SymbolResolution{Scope: ScopeUnresolved, Status: ResolutionIncomplete}
+			if hasEventResolver {
+				resolution = eventResolver.ResolveEvent(SymbolReference{
+					Name: event.Name, Module: in.ModuleName, Caller: event.Caller, Range: event.Range,
+				})
+			}
+			overlay.events[ResolutionFactKey{Procedure: identity, ID: eventIDs[eventIndex]}] = ResolvedEvent{
+				Resolution: cloneSymbolResolution(resolution),
+			}
+		}
+		for callIndex, call := range procedure.Calls {
+			if !call.IsRaiseEvent {
+				continue
+			}
+			resolution := CallResolution{Status: ResolutionIncomplete}
+			for eventIndex, event := range procedure.RaiseEvents {
+				if !strings.EqualFold(event.Name, call.Callee.BaseName) {
+					continue
+				}
+				resolved := overlay.events[ResolutionFactKey{Procedure: identity, ID: eventIDs[eventIndex]}]
+				resolution = CallResolution{Status: resolved.Resolution.Status, Candidates: cloneCandidates(resolved.Resolution.Candidates)}
+				break
+			}
+			overlay.calls[ResolutionFactKey{Procedure: identity, ID: callIDs[callIndex]}] = ResolvedCall{Resolution: resolution}
+		}
+		for accessIndex, access := range procedure.Accesses {
+			scope := access.Scope
+			resolution := SymbolResolution{Scope: scope}
+			if access.Scope != ScopeUnresolved && access.Scope != ScopeProject {
+				// Module-scope bindings historically bypass project resolution so
+				// local variables continue to shadow imported symbols. Enum members
+				// are the exception and are delegated to the canonical resolver.
+				if access.Scope == ScopeModule {
+					candidateResolution := resolver.ResolveSymbol(SymbolReference{
+						Name: access.Name, Module: in.ModuleName,
+						Caller: ProcedureRef{
+							Name: procedure.Symbol.Name, Kind: procedure.Symbol.Kind,
+							QualifiedName: procedure.Symbol.QualifiedName,
+						}, Range: access.Range,
+					})
+					if allEnumCandidates(candidateResolution.Candidates) {
+						resolution = candidateResolution
+						scope = candidateResolution.Scope
+					}
+				}
+			} else {
+				resolution = cloneSymbolResolution(resolver.ResolveSymbol(SymbolReference{
+					Name: access.Name, Module: in.ModuleName,
+					Caller: ProcedureRef{
+						Name: procedure.Symbol.Name, Kind: procedure.Symbol.Kind,
+						QualifiedName: procedure.Symbol.QualifiedName,
+					}, Range: access.Range,
+				}))
+				scope = resolution.Scope
+				if scope == "" {
+					scope = ScopeUnresolved
+					resolution.Scope = ScopeUnresolved
+				}
+			}
+			overlay.accesses[ResolutionFactKey{Procedure: identity, ID: accessIDs[accessIndex]}] = ResolvedAccess{
+				Scope: scope, Resolution: cloneSymbolResolution(resolution),
+			}
+		}
+	}
+	return overlay
+}
+
+// ResolvedCall returns the overlay fact for a procedure-local call ID.
+func (v ResolvedDocumentView) ResolvedCall(procedureIndex, callID int) (ResolvedCall, bool) {
+	if procedureIndex < 0 || procedureIndex >= len(v.document.Procedures) {
+		return ResolvedCall{}, false
+	}
+	key, ok := v.factKey(procedureIndex, callID, resolutionFactCall)
+	if !ok {
+		return ResolvedCall{}, false
+	}
+	resolved, ok := v.overlay.calls[key]
+	if !ok {
+		return ResolvedCall{}, false
+	}
+	resolved.Resolution = cloneCallResolution(resolved.Resolution)
+	return resolved, true
+}
+
+// ResolvedAccess returns the overlay fact for a procedure-local access ID.
+func (v ResolvedDocumentView) ResolvedAccess(procedureIndex, accessID int) (ResolvedAccess, bool) {
+	if procedureIndex < 0 || procedureIndex >= len(v.document.Procedures) {
+		return ResolvedAccess{}, false
+	}
+	key, ok := v.factKey(procedureIndex, accessID, resolutionFactAccess)
+	if !ok {
+		return ResolvedAccess{}, false
+	}
+	resolved, ok := v.overlay.accesses[key]
+	if !ok {
+		return ResolvedAccess{}, false
+	}
+	resolved.Resolution = cloneSymbolResolution(resolved.Resolution)
+	return resolved, true
+}
+
+// ResolvedEvent returns the overlay fact for a procedure-local event ID.
+func (v ResolvedDocumentView) ResolvedEvent(procedureIndex, eventID int) (ResolvedEvent, bool) {
+	if procedureIndex < 0 || procedureIndex >= len(v.document.Procedures) {
+		return ResolvedEvent{}, false
+	}
+	key, ok := v.factKey(procedureIndex, eventID, resolutionFactEvent)
+	if !ok {
+		return ResolvedEvent{}, false
+	}
+	resolved, ok := v.overlay.events[key]
+	if !ok {
+		return ResolvedEvent{}, false
+	}
+	resolved.Resolution = cloneSymbolResolution(resolved.Resolution)
+	return resolved, true
+}
+
+// Materialize returns an independently owned resolved DocumentIR. This is the
+// compatibility escape hatch for consumers that need to retain or mutate a
+// resolved snapshot.
+func (v ResolvedDocumentView) Materialize() DocumentIR {
+	out := Clone(v.document)
+	for procedureIndex := range out.Procedures {
+		procedure := &out.Procedures[procedureIndex]
+		for callIndex := range procedure.Calls {
+			call := &procedure.Calls[callIndex]
+			if resolved, ok := v.resolvedCallAt(procedureIndex, callIndex); ok {
+				call.Resolution = cloneCallResolution(resolved.Resolution)
+			}
+			if !v.hasOverlay || call.IsRaiseEvent || isAssignmentTargetCall(*call, *procedure) {
+				continue
+			}
+			call.NonCallableNames = append([]string(nil), declarationNames(out.Declarations, procedure.Declarations)...)
+		}
+		for eventIndex := range procedure.RaiseEvents {
+			if resolved, ok := v.resolvedEventAt(procedureIndex, eventIndex); ok {
+				procedure.RaiseEvents[eventIndex].Resolution = cloneSymbolResolution(resolved.Resolution)
+			}
+		}
+		for accessIndex := range procedure.Accesses {
+			if resolved, ok := v.resolvedAccessAt(procedureIndex, accessIndex); ok {
+				procedure.Accesses[accessIndex].Scope = resolved.Scope
+				procedure.Accesses[accessIndex].Resolution = cloneSymbolResolution(resolved.Resolution)
+			}
+		}
+	}
+	return out
+}
+
+type resolutionFactKind uint8
+
+const (
+	resolutionFactCall resolutionFactKind = iota
+	resolutionFactAccess
+	resolutionFactEvent
+)
+
+func (v ResolvedDocumentView) factKey(procedureIndex, id int, kind resolutionFactKind) (ResolutionFactKey, bool) {
+	if procedureIndex < 0 || procedureIndex >= len(v.document.Procedures) {
+		return ResolutionFactKey{}, false
+	}
+	procedure := v.document.Procedures[procedureIndex]
+	if id < 0 {
+		return ResolutionFactKey{}, false
+	}
+	ids := v.idsFor(procedureIndex, kind)
+	if id > 0 {
+		for _, candidate := range ids {
+			if candidate == id {
+				return v.factKeyAt(procedureIndex, candidate), true
+			}
+		}
+		return ResolutionFactKey{}, false
+	}
+	// A zero ID occurs in hand-built IR. Resolve it only when there is one
+	// zero-ID fact; otherwise the caller must use the deterministic ordinal.
+	zero := -1
+	for index := range ids {
+		var raw int
+		switch kind {
+		case resolutionFactCall:
+			raw = procedure.Calls[index].ID
+		case resolutionFactAccess:
+			raw = procedure.Accesses[index].ID
+		case resolutionFactEvent:
+			raw = procedure.RaiseEvents[index].ID
+		}
+		if raw == 0 {
+			if zero >= 0 {
+				return ResolutionFactKey{}, false
+			}
+			zero = index
+		}
+	}
+	if zero < 0 {
+		return ResolutionFactKey{}, false
+	}
+	return v.factKeyAt(procedureIndex, ids[zero]), true
+}
+
+func (v ResolvedDocumentView) factKeyAt(procedureIndex, id int) ResolutionFactKey {
+	return ResolutionFactKey{Procedure: procedureIdentity(v.document, procedureIndex), ID: id}
+}
+
+func (v ResolvedDocumentView) resolvedCallAt(procedureIndex, factIndex int) (ResolvedCall, bool) {
+	ids := v.idsFor(procedureIndex, resolutionFactCall)
+	if factIndex < 0 || factIndex >= len(ids) {
+		return ResolvedCall{}, false
+	}
+	resolved, ok := v.overlay.calls[ResolutionFactKey{Procedure: procedureIdentity(v.document, procedureIndex), ID: ids[factIndex]}]
+	if !ok {
+		return ResolvedCall{}, false
+	}
+	return resolved, true
+}
+
+func (v ResolvedDocumentView) resolvedAccessAt(procedureIndex, factIndex int) (ResolvedAccess, bool) {
+	ids := v.idsFor(procedureIndex, resolutionFactAccess)
+	if factIndex < 0 || factIndex >= len(ids) {
+		return ResolvedAccess{}, false
+	}
+	resolved, ok := v.overlay.accesses[ResolutionFactKey{Procedure: procedureIdentity(v.document, procedureIndex), ID: ids[factIndex]}]
+	return resolved, ok
+}
+
+func (v ResolvedDocumentView) resolvedEventAt(procedureIndex, factIndex int) (ResolvedEvent, bool) {
+	ids := v.idsFor(procedureIndex, resolutionFactEvent)
+	if factIndex < 0 || factIndex >= len(ids) {
+		return ResolvedEvent{}, false
+	}
+	resolved, ok := v.overlay.events[ResolutionFactKey{Procedure: procedureIdentity(v.document, procedureIndex), ID: ids[factIndex]}]
+	return resolved, ok
+}
+
+func (v ResolvedDocumentView) idsFor(procedureIndex int, kind resolutionFactKind) []int {
+	switch kind {
+	case resolutionFactCall:
+		if procedureIndex >= len(v.callIDs) {
+			return nil
+		}
+		return v.callIDs[procedureIndex]
+	case resolutionFactAccess:
+		if procedureIndex >= len(v.accessIDs) {
+			return nil
+		}
+		return v.accessIDs[procedureIndex]
+	case resolutionFactEvent:
+		if procedureIndex >= len(v.eventIDs) {
+			return nil
+		}
+		return v.eventIDs[procedureIndex]
+	default:
+		return nil
+	}
+}
+
+func documentFactIDs(document DocumentIR) ([][]int, [][]int, [][]int) {
+	calls := make([][]int, len(document.Procedures))
+	accesses := make([][]int, len(document.Procedures))
+	events := make([][]int, len(document.Procedures))
+	for procedureIndex, procedure := range document.Procedures {
+		calls[procedureIndex] = factIDs(procedure, resolutionFactCall)
+		accesses[procedureIndex] = factIDs(procedure, resolutionFactAccess)
+		events[procedureIndex] = factIDs(procedure, resolutionFactEvent)
+	}
+	return calls, accesses, events
+}
+
+func procedureIdentity(document DocumentIR, procedureIndex int) ProcedureIdentity {
+	procedure := document.Procedures[procedureIndex]
+	return ProcedureIdentity{
+		Path: document.Path, Module: document.ModuleName, ModuleKind: document.ModuleKind,
+		QualifiedName: procedure.Symbol.QualifiedName, Kind: procedure.Symbol.Kind,
+		DeclarationStartByte: procedure.Symbol.DeclarationRange.StartByte, Ordinal: procedureIndex,
+	}
+}
+
+func factIDs(procedure ProcedureIR, kind resolutionFactKind) []int {
+	var count int
+	switch kind {
+	case resolutionFactCall:
+		count = len(procedure.Calls)
+	case resolutionFactAccess:
+		count = len(procedure.Accesses)
+	case resolutionFactEvent:
+		count = len(procedure.RaiseEvents)
+	}
+	ids := make([]int, count)
+	used := make(map[int]struct{}, count)
+	for index := 0; index < count; index++ {
+		var raw int
+		switch kind {
+		case resolutionFactCall:
+			raw = procedure.Calls[index].ID
+		case resolutionFactAccess:
+			raw = procedure.Accesses[index].ID
+		case resolutionFactEvent:
+			raw = procedure.RaiseEvents[index].ID
+		}
+		if raw <= 0 {
+			raw = index + 1
+		}
+		if _, exists := used[raw]; exists {
+			raw = index + 1
+			for {
+				if _, exists := used[raw]; !exists {
+					break
+				}
+				raw++
+			}
+		}
+		used[raw] = struct{}{}
+		ids[index] = raw
+	}
+	return ids
+}

--- a/internal/vba/procedureir/resolution_overlay_test.go
+++ b/internal/vba/procedureir/resolution_overlay_test.go
@@ -1,0 +1,250 @@
+package procedureir
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+)
+
+type overlayTestResolver struct{}
+
+func (overlayTestResolver) ResolveCall(site CallSite) CallResolution {
+	return CallResolution{Status: ResolutionMatched, Candidates: []Candidate{{QualifiedName: site.Callee.BaseName, Kind: "sub"}}}
+}
+
+func (overlayTestResolver) ResolveSymbol(ref SymbolReference) SymbolResolution {
+	return SymbolResolution{Status: ResolutionAmbiguous, Scope: ScopeProject, Candidates: []Candidate{
+		{QualifiedName: "A." + ref.Name, Kind: "enum_member"},
+		{QualifiedName: "B." + ref.Name, Kind: "enum_member"},
+	}}
+}
+
+func (overlayTestResolver) ResolveEvent(ref SymbolReference) SymbolResolution {
+	return SymbolResolution{Status: ResolutionMatched, Scope: ScopeModule, Candidates: []Candidate{{QualifiedName: ref.Module + "." + ref.Name, Kind: "event"}}}
+}
+
+type overlayDiagnosticResolver struct{}
+
+func (overlayDiagnosticResolver) ResolveCall(site CallSite) CallResolution {
+	return CallResolution{
+		Status:       ResolutionNonCallable,
+		ProjectLocal: true,
+		Candidates:   []Candidate{{QualifiedName: site.Callee.BaseName, Kind: "variable"}},
+	}
+}
+
+func (overlayDiagnosticResolver) ResolveSymbol(SymbolReference) SymbolResolution {
+	return SymbolResolution{Status: ResolutionAmbiguous, Scope: ScopeProject, Candidates: []Candidate{
+		{QualifiedName: "A.Member", Kind: "enum_member"},
+		{QualifiedName: "B.Member", Kind: "enum_member"},
+	}}
+}
+
+func (overlayDiagnosticResolver) ResolveEvent(SymbolReference) SymbolResolution {
+	return SymbolResolution{Scope: ScopeUnresolved, Status: ResolutionUnresolved}
+}
+
+func overlayTestDocument() DocumentIR {
+	return DocumentIR{Path: "Main.bas", ModuleName: "Main", ModuleKind: "class", Procedures: []ProcedureIR{{
+		Symbol:      ProcedureSymbol{Name: "Run", QualifiedName: "Main.Run", Kind: ProcedureSub, DeclarationRange: vbaast.Range{StartByte: 10}},
+		Statements:  []Statement{{ID: 1, Kind: StatementCall, Text: "Helper()"}},
+		Expressions: []Expression{{ID: 1, Kind: ExpressionIdentifier, Text: "value"}},
+		Calls:       []CallSite{{ID: 0, Callee: Callee{Text: "Helper", BaseName: "Helper"}, Range: vbaast.Range{StartByte: 20, EndByte: 28}, StatementID: 1}},
+		Accesses:    []VariableAccess{{ID: 0, Name: "value", Scope: ScopeProject, ExpressionID: 1}},
+		RaiseEvents: []RaiseEventReference{{ID: 0, Name: "Changed", Module: "Main", Caller: ProcedureRef{Name: "Run"}}},
+	}}}
+}
+
+func TestResolveViewUsesFactIDsWithoutMutatingInput(t *testing.T) {
+	doc := overlayTestDocument()
+	before := overlayTestDocument()
+	view := ResolveView(doc, overlayTestResolver{})
+
+	call, ok := view.ResolvedCall(0, 1)
+	if !ok || call.Resolution.Status != ResolutionMatched {
+		t.Fatalf("ResolvedCall = (%+v, %t)", call, ok)
+	}
+	access, ok := view.ResolvedAccess(0, 0)
+	if !ok || access.Scope != ScopeProject || access.Resolution.Status != ResolutionAmbiguous {
+		t.Fatalf("ResolvedAccess = (%+v, %t)", access, ok)
+	}
+	event, ok := view.ResolvedEvent(0, 0)
+	if !ok || event.Resolution.Status != ResolutionMatched {
+		t.Fatalf("ResolvedEvent = (%+v, %t)", event, ok)
+	}
+	if !reflect.DeepEqual(doc, before) {
+		t.Fatalf("ResolveView mutated input: before=%+v after=%+v", before, doc)
+	}
+
+	call.Resolution.Candidates[0].QualifiedName = "mutated"
+	again, ok := view.ResolvedCall(0, 1)
+	if !ok || again.Resolution.Candidates[0].QualifiedName == "mutated" {
+		t.Fatal("ResolvedCall exposed mutable overlay candidates")
+	}
+}
+
+func TestResolveViewUsesOrdinalFallbackForDuplicateHandBuiltIDs(t *testing.T) {
+	doc := overlayTestDocument()
+	doc.Procedures[0].Calls = append(doc.Procedures[0].Calls,
+		CallSite{ID: 1, Callee: Callee{Text: "Other", BaseName: "Other"}},
+	)
+	doc.Procedures[0].Accesses = append(doc.Procedures[0].Accesses,
+		VariableAccess{ID: 0, Name: "other", Scope: ScopeProject},
+	)
+	view := ResolveView(doc, overlayTestResolver{})
+	if _, ok := view.ResolvedCall(0, 1); !ok {
+		t.Fatal("first duplicate call ID did not resolve")
+	}
+	if _, ok := view.ResolvedCall(0, 2); !ok {
+		t.Fatal("ordinal fallback did not resolve second duplicate call ID")
+	}
+	if _, ok := view.ResolvedAccess(0, 1); !ok {
+		t.Fatal("first zero access ID did not resolve")
+	}
+	if _, ok := view.ResolvedAccess(0, 2); !ok {
+		t.Fatal("ordinal fallback did not resolve second zero access ID")
+	}
+}
+
+func TestResolveMaterializeMatchesOverlayResolution(t *testing.T) {
+	doc := overlayTestDocument()
+	view := ResolveView(doc, overlayTestResolver{})
+	materialized := view.Materialize()
+	legacy := Resolve(doc, overlayTestResolver{})
+	if !reflect.DeepEqual(materialized, legacy) {
+		t.Fatalf("Materialize differs from Resolve:\nmaterialized=%+v\nlegacy=%+v", materialized, legacy)
+	}
+	if !reflect.DeepEqual(doc, overlayTestDocument()) {
+		t.Fatal("materialization mutated source document")
+	}
+}
+
+func TestResolveViewNilResolverPreservesCloneOnlyCompatibility(t *testing.T) {
+	doc := overlayTestDocument()
+	view := ResolveView(doc, nil)
+	if _, ok := view.ResolvedCall(0, 1); ok {
+		t.Fatal("nil-resolver view unexpectedly exposed a call resolution")
+	}
+	doc.Procedures[0].Calls[0].Resolution = CallResolution{Status: ResolutionNotAttempted}
+	doc.Procedures[0].Accesses[0].Resolution = SymbolResolution{Scope: ScopeProject, Status: ResolutionNotAttempted}
+	doc.Procedures[0].RaiseEvents[0].Resolution = SymbolResolution{Scope: ScopeUnresolved, Status: ResolutionNotAttempted}
+
+	got := view.Materialize()
+	want := Clone(doc)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("nil-resolver materialization differs from Clone:\nmaterialized=%+v\nclone=%+v", got, want)
+	}
+	if !reflect.DeepEqual(Resolve(doc, nil), want) {
+		t.Fatal("Resolve(nil) no longer has clone-only compatibility semantics")
+	}
+}
+
+func TestResolveNilResolverPreservesInputFacts(t *testing.T) {
+	doc := overlayTestDocument()
+	doc.Procedures[0].Calls[0].NonCallableNames = []string{"existing"}
+	if got, want := Resolve(doc, nil), Clone(doc); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Resolve(nil) changed facts: got=%+v want=%+v", got, want)
+	}
+}
+
+func TestDiagnosticsViewMatchesMaterializedDiagnostics(t *testing.T) {
+	doc := overlayTestDocument()
+	view := ResolveView(doc, overlayTestResolver{})
+	got := DiagnosticsView(view, true)
+	want := Diagnostics(view.Materialize(), true)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DiagnosticsView = %+v, Diagnostics(Materialize) = %+v", got, want)
+	}
+}
+
+func TestDiagnosticsViewPreservesVB052VB053VB054Parity(t *testing.T) {
+	doc := DocumentIR{
+		ModuleName: "Main",
+		Procedures: []ProcedureIR{{
+			Symbol:      ProcedureSymbol{Name: "Run", QualifiedName: "Main.Run", Kind: ProcedureSub},
+			Statements:  []Statement{{ID: 1, Kind: StatementCall, Text: "Missing()"}},
+			Expressions: []Expression{{ID: 1, Kind: ExpressionIdentifier, Text: "Member"}},
+			Calls:       []CallSite{{ID: 1, Callee: Callee{Text: "Missing()", BaseName: "Missing"}, StatementID: 1}},
+			RaiseEvents: []RaiseEventReference{{ID: 1, Name: "MissingEvent"}},
+			Accesses:    []VariableAccess{{ID: 1, Name: "Member", Scope: ScopeProject, ExpressionID: 1}},
+		}},
+	}
+	view := ResolveView(doc, overlayDiagnosticResolver{})
+	got := DiagnosticsView(view, true)
+	want := Diagnostics(view.Materialize(), true)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DiagnosticsView differs from materialized diagnostics:\nview=%+v\nmaterialized=%+v", got, want)
+	}
+	if len(got) != 3 || got[0].Code != "VB052" || got[1].Code != "VB054" || got[2].Code != "VB053" {
+		t.Fatalf("diagnostics = %+v, want VB052, VB054, VB053 in source walker order", got)
+	}
+	if !reflect.DeepEqual(got[0].Candidates, []Candidate{{QualifiedName: "Missing", Kind: "variable"}}) {
+		t.Fatalf("VB052 candidates = %+v", got[0].Candidates)
+	}
+}
+
+func TestResolveViewAssignsProductionAccessAndEventIDs(t *testing.T) {
+	doc, err := BuildSource(BuildOptions{Path: "IDs.bas", ModuleName: "IDs", ModuleKind: "class"}, []byte(`Public Sub Run()
+  Dim value As Long
+  value = value + 1
+  RaiseEvent Changed
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Procedures) != 1 {
+		t.Fatalf("procedures = %d, want 1", len(doc.Procedures))
+	}
+	procedure := doc.Procedures[0]
+	for index, access := range procedure.Accesses {
+		if access.ID != index+1 {
+			t.Fatalf("access %d ID = %d, want %d", index, access.ID, index+1)
+		}
+	}
+	for index, event := range procedure.RaiseEvents {
+		if event.ID != index+1 {
+			t.Fatalf("event %d ID = %d, want %d", index, event.ID, index+1)
+		}
+	}
+}
+
+func TestResolutionFactIDsSurviveCloneAndRebase(t *testing.T) {
+	doc := overlayTestDocument()
+	procedure := doc.Procedures[0]
+	cloned := CloneProcedureIR(procedure)
+	rebased := RebaseProcedure(procedure,
+		vbaast.Range{StartLine: 1, StartByte: 10},
+		vbaast.Range{StartLine: 5, StartByte: 100},
+	)
+	if cloned.Accesses[0].ID != procedure.Accesses[0].ID || cloned.RaiseEvents[0].ID != procedure.RaiseEvents[0].ID {
+		t.Fatalf("clone changed resolution fact IDs: clone=%+v source=%+v", cloned, procedure)
+	}
+	if rebased.Accesses[0].ID != procedure.Accesses[0].ID || rebased.RaiseEvents[0].ID != procedure.RaiseEvents[0].ID {
+		t.Fatalf("rebase changed resolution fact IDs: rebased=%+v source=%+v", rebased, procedure)
+	}
+}
+
+func TestResolutionFactIDsAreNotSerialized(t *testing.T) {
+	payload, err := json.Marshal(overlayTestDocument())
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := string(payload)
+	for _, field := range []string{"\"accesses\":[{\"id\"", "\"raiseEvents\":[{\"id\""} {
+		if containsJSONField(encoded, field) {
+			t.Fatalf("resolution fact ID leaked into JSON: %s", encoded)
+		}
+	}
+}
+
+func containsJSONField(encoded, field string) bool {
+	for i := 0; i+len(field) <= len(encoded); i++ {
+		if encoded[i:i+len(field)] == field {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/vba/procedureir/resolver.go
+++ b/internal/vba/procedureir/resolver.go
@@ -8,97 +8,10 @@ import (
 
 // Resolve returns a deep copy with project-dependent call and symbol
 // resolutions applied. Syntax-local parameter/local/module scopes are kept.
+// Consumers that only need read-only resolution should use ResolveView to
+// avoid cloning the full procedure payload.
 func Resolve(in DocumentIR, resolver Resolver) DocumentIR {
-	out := Clone(in)
-	if resolver == nil {
-		return out
-	}
-	for procedureIndex := range out.Procedures {
-		procedure := &out.Procedures[procedureIndex]
-		lexicalNonCallable := declarationNames(out.Declarations, procedure.Declarations)
-		eventResolver, hasEventResolver := resolver.(interface {
-			ResolveEvent(SymbolReference) SymbolResolution
-		})
-		for callIndex := range procedure.Calls {
-			call := &procedure.Calls[callIndex]
-			if call.IsRaiseEvent {
-				// RaiseEvent is resolved from the syntax-local event facts below.
-				// A generic Resolver cannot prove same-object event visibility, so
-				// those calls remain incomplete rather than falling through to the
-				// ordinary procedure resolver.
-				continue
-			}
-			if !isAssignmentTargetCall(*call, *procedure) {
-				call.NonCallableNames = append([]string(nil), lexicalNonCallable...)
-			}
-			call.Resolution = cloneCallResolution(resolver.ResolveCall(cloneCall(*call)))
-		}
-		for eventIndex := range procedure.RaiseEvents {
-			event := &procedure.RaiseEvents[eventIndex]
-			if hasEventResolver {
-				event.Resolution = cloneSymbolResolution(eventResolver.ResolveEvent(SymbolReference{
-					Name: event.Name, Module: out.ModuleName, Caller: event.Caller, Range: event.Range,
-				}))
-			} else {
-				event.Resolution = SymbolResolution{Scope: ScopeUnresolved, Status: ResolutionIncomplete}
-			}
-		}
-		for callIndex := range procedure.Calls {
-			call := &procedure.Calls[callIndex]
-			if !call.IsRaiseEvent {
-				continue
-			}
-			call.Resolution = CallResolution{Status: ResolutionIncomplete}
-			for _, event := range procedure.RaiseEvents {
-				if !strings.EqualFold(event.Name, call.Callee.BaseName) {
-					continue
-				}
-				call.Resolution = CallResolution{Status: event.Resolution.Status, Candidates: cloneCandidates(event.Resolution.Candidates)}
-				break
-			}
-		}
-		for accessIndex := range procedure.Accesses {
-			access := &procedure.Accesses[accessIndex]
-			if access.Scope != ScopeUnresolved && access.Scope != ScopeProject {
-				// Module-scope bindings historically bypass project resolution so
-				// local variables continue to shadow imported symbols. Enum members
-				// are the exception: two visible members can share a bare name even
-				// when one is declared in this module, and only the canonical resolver
-				// can determine whether a lexical winner is unique.
-				if access.Scope == ScopeModule {
-					resolution := resolver.ResolveSymbol(SymbolReference{
-						Name: access.Name, Module: out.ModuleName,
-						Caller: ProcedureRef{
-							Name: procedure.Symbol.Name, Kind: procedure.Symbol.Kind,
-							QualifiedName: procedure.Symbol.QualifiedName,
-						}, Range: access.Range,
-					})
-					if allEnumCandidates(resolution.Candidates) {
-						access.Resolution = cloneSymbolResolution(resolution)
-						access.Scope = resolution.Scope
-						continue
-					}
-				}
-				access.Resolution = SymbolResolution{Scope: access.Scope}
-				continue
-			}
-			resolution := resolver.ResolveSymbol(SymbolReference{
-				Name: access.Name, Module: out.ModuleName,
-				Caller: ProcedureRef{
-					Name: procedure.Symbol.Name, Kind: procedure.Symbol.Kind,
-					QualifiedName: procedure.Symbol.QualifiedName,
-				},
-				Range: access.Range,
-			})
-			access.Resolution = cloneSymbolResolution(resolution)
-			access.Scope = resolution.Scope
-			if access.Scope == "" {
-				access.Scope = ScopeUnresolved
-				access.Resolution.Scope = ScopeUnresolved
-			}
-		}
-	}
-	return out
+	return ResolveView(in, resolver).Materialize()
 }
 
 func allEnumCandidates(candidates []Candidate) bool {

--- a/internal/vba/procedureir/types.go
+++ b/internal/vba/procedureir/types.go
@@ -321,6 +321,10 @@ const (
 )
 
 type VariableAccess struct {
+	// ID is stable within the procedure's IR revision and follows source
+	// order. It is intentionally omitted from the wire representation: the
+	// identity is an implementation detail used by resolution overlays.
+	ID           int              `json:"-"`
 	Name         string           `json:"name"`
 	Mode         AccessMode       `json:"mode"`
 	Scope        SymbolScope      `json:"scope"`
@@ -434,6 +438,10 @@ type EnumResolution struct {
 // Range covers only the event identifier, making it suitable for a precise
 // diagnostic while the surrounding CallSite retains legacy call-graph data.
 type RaiseEventReference struct {
+	// ID is stable within the procedure's IR revision and follows source
+	// order. It is intentionally omitted from the wire representation: the
+	// identity is an implementation detail used by resolution overlays.
+	ID                  int                 `json:"-"`
 	Name                string              `json:"name"`
 	Module              string              `json:"module"`
 	Caller              ProcedureRef        `json:"caller"`

--- a/internal/vba/procedureir/visitor.go
+++ b/internal/vba/procedureir/visitor.go
@@ -904,6 +904,16 @@ func (v *singleVisitor) finalize() {
 		sort.SliceStable(procedure.Accesses, func(i, j int) bool {
 			return procedure.Accesses[i].Range.StartByte < procedure.Accesses[j].Range.StartByte
 		})
+		// Access and event identities are revision-local.  Assign them after
+		// access ordering is finalized so an incremental fragment and a full
+		// parse produce the same source-order IDs.  They are omitted from the
+		// serialized IR and are used only by resolution overlays.
+		for accessIndex := range procedure.Accesses {
+			procedure.Accesses[accessIndex].ID = accessIndex + 1
+		}
+		for eventIndex := range procedure.RaiseEvents {
+			procedure.RaiseEvents[eventIndex].ID = eventIndex + 1
+		}
 	}
 	sort.SliceStable(v.document.Procedures, func(i, j int) bool {
 		return v.document.Procedures[i].Symbol.DeclarationRange.StartByte < v.document.Procedures[j].Symbol.DeclarationRange.StartByte


### PR DESCRIPTION
## Summary

- Add a read-only `procedureir` resolution overlay/view so batch resolution diagnostics do not deep-clone the full `DocumentIR`.
- Migrate the batch analyzer's VB052–VB054 path to `ResolveView`/`DiagnosticsView` while retaining materialized `Resolve` for effects, lint, LSP, metrics, and oracle compatibility consumers.
- Preserve resolution completeness, ambiguity, scope, event, candidate-ordering, input-ownership, and JSON compatibility semantics.

## Implementation

- Add revision-local procedure/fact identity and production access/event IDs with hand-built IR fallback handling.
- Share the existing diagnostic walker between `Diagnostics` and `DiagnosticsView`.
- Keep `Resolve` as the independently owned materialization compatibility API.
- Add parity, fallback, clone/rebase, nil-resolver, JSON, and VB052–VB054 regression coverage.
- Amend ADR-0021 and the VBA IR/corpus specifications; record the internal performance improvement in the changelog.

## Performance

On Windows amd64 (12th Gen Intel(R) Core(TM) i7-12700, Go 1.26.6), the five-run median for the synthetic 2,000-procedure benchmark changed from 36.59 ms / 37.2 MB / 156,200 allocs to 17.69 ms / 20.7 MB / 90,198 allocs for materialized versus overlay construction. The ROneCOne analyze-only five-run median was 28.017 s / 26.97 GB / 185.1M allocs before and 24.999 s / 26.74 GB / 181.2M allocs after, with 510 findings in every run.

## Tests

- `rtk task test`
- `rtk task lint`
- `rtk task corpus:test` (snapshot unchanged)
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/vba/procedureir ./internal/analyze -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/vba/procedureir ./internal/analyze -count=1`
- `rtk proxy task review:codex`

Closes #699


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved project-wide procedure analysis efficiency by reducing unnecessary document copying and memory use.
  * Added optimized handling for large projects with hundreds or thousands of procedures.

* **Bug Fixes**
  * Preserved deterministic resolution results and diagnostic ordering.
  * Maintained compatibility with existing resolved analysis output and diagnostics.

* **Documentation**
  * Updated technical documentation with the new resolution behavior, performance benchmarks, usage guidance, and architectural decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->