### PR TITLE
perf(analyze): remove defensive-copy allocations from hot immutable fact access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to xlflow will be documented in this file.
 - Reduced giant-module analyzer allocation pressure by representing procedure
   projections as immutable views over canonical Procedure IR. Facts now retain
   compact indexes and read-only access paths instead of copied declaration,
-  statement, expression, call, access, and parameter collections. Diagnostic
-  and JSON/LSP contracts remain unchanged.
+  statement, expression, call, access, and parameter collections. Hot rule
+  consumers now iterate procedure and statement-grouped member facts without
+  defensive copies, while explicit owned-copy compatibility boundaries remain.
+  Diagnostic and JSON/LSP contracts remain unchanged.
 
 - Added a read-only procedure-resolution overlay for batch `VB052`-`VB054`
   diagnostics, avoiding a second full `DocumentIR` clone while preserving

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1301,6 +1301,42 @@ profiles are evidence that the removed projection copies are no longer a
 material corpus allocation leaf rather than a claim that all corpus allocation
 has been eliminated.
 
+### Immutable fact-read allocation record (#700)
+
+Issue #700 removes the remaining defensive copies from hot immutable analyzer
+reads. Rule consumers use the cached procedure span directly and iterate
+statement-grouped member expressions through the compact facts index. Owned
+copy APIs remain available at mutation, recovery, and compatibility boundaries.
+The focused fixtures contain 2,000 procedures and 4,096 statements,
+expressions, calls, and accesses; fixture construction remains outside the
+timed region.
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^$' -bench 'BenchmarkParsedFileProcedureProjection/2000-procedures|BenchmarkProcedureAnalysisFacts' -benchmem -benchtime=20x -count=3
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^TestSingleModuleBenchmarkFixtureScale$' -bench '^BenchmarkSingleModuleSynthetic/independent/2000-procedures$' -benchmem -benchtime=1x -count=5
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=5
+```
+
+The focused median observations were 0 B/op and 0 allocs/op for the procedure
+view; statement, expression, call, access, grouped-call, and grouped-access
+views; and statement-grouped member-expression iteration. The retained owned
+2,000-procedure copy used 753,664 B/op and one allocation. The five-sample
+synthetic median was 1,110,697,800 ns/op, 1,489,190,080 B/op, and 11,532,742
+allocs/op, with zero findings and unchanged procedure/fact counters.
+
+The pre-change ROneCOne medians were 20,146,589,800 ns/op, 26,790,001,160
+B/op, and 181,371,669 allocs/op. Post-change medians were 19,975,120,400 ns/op,
+26,820,669,096 B/op, and 181,460,151 allocs/op, with the same 510 findings.
+Elapsed time improved by 0.85%; total bytes and allocation counts moved by
+0.11% and 0.05%, respectively, inside a workload dominated by data-flow state
+cloning. These whole-workload movements are observational, not CI thresholds.
+
+The paired allocation-space profiles provide the targeted evidence. Before
+the change, `parsedFile.procedures` accounted for 13.33 MB per ROneCOne
+operation and `MemberExpressionsForStatement` accounted for 1 MB. Neither
+routine appears as an allocation leaf in the post-change profile. Profiles are
+retained locally as `%TEMP%\xlflow-ronecone-700-{before,after}.{cpu,mem}.pprof`.
+
 ### Capability-planner verification requirements (#697)
 
 Issue #697 moves the optimization boundary from procedure-local semantic

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -333,6 +333,15 @@ revision and they are released with that analysis result. Snapshot and public
 compatibility getters may continue to return defensive copies at their
 ownership boundary.
 
+Hot analyzer rules must use the private read-only procedure span and grouped
+fact iterators for immutable reads. Procedure iteration uses indexed span
+access so large procedure values do not make range-over-function closures
+escape. Statement-grouped member-expression iteration preserves canonical
+source order and uses the compact grouped index without materializing a
+temporary slice. The owned procedure and grouped-member getters remain the
+explicit boundary for callers that mutate effect overlays, recover from an
+incomplete index, or require an independently owned compatibility value.
+
 Batch and realtime entry points construct and attach facts before rule workers
 run. The performance recorder reports `module_fact_builds` and
 `procedure_fact_builds`; a normal file revision contributes one module build

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -1048,7 +1048,7 @@ func (a Analyzer) byRefArgumentFindings(file parsedFile, diagnostics []intel.Dia
 	if len(diagnostics) == 0 {
 		return nil
 	}
-	procedures := file.procedures()
+	procedures := file.procedureView()
 	out := make([]Finding, 0, len(diagnostics))
 	for _, diagnostic := range diagnostics {
 		if diagnostic.Code != "VBA206" {
@@ -1056,7 +1056,8 @@ func (a Analyzer) byRefArgumentFindings(file parsedFile, diagnostics []intel.Dia
 		}
 		line := diagnostic.Range.Start.Line + 1
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		for _, candidate := range procedures {
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			candidate := procedures.valueAt(procedureIndex)
 			if line >= candidate.StartLine && line <= candidate.EndLine {
 				proc = candidate
 				break
@@ -1103,7 +1104,7 @@ func (a Analyzer) compileEquivalentFindingsContext(ctx context.Context, file par
 	if len(diagnostics) == 0 {
 		return nil, nil
 	}
-	procedures := file.procedures()
+	procedures := file.procedureView()
 	out := make([]Finding, 0, len(diagnostics))
 	preflight := make([]Finding, 0, len(diagnostics))
 	for _, diagnostic := range diagnostics {
@@ -1113,7 +1114,8 @@ func (a Analyzer) compileEquivalentFindingsContext(ctx context.Context, file par
 		}
 		line := diagnostic.Range.Start.Line + 1
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		for _, candidate := range procedures {
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			candidate := procedures.valueAt(procedureIndex)
 			if line >= candidate.StartLine && line <= candidate.EndLine {
 				proc = candidate
 				break
@@ -1166,7 +1168,9 @@ func compileEquivalentFindingGuidance(code string) (string, string) {
 func (a Analyzer) resolutionFinding(file parsedFile, diagnostic procedureir.ResolutionDiagnostic) Finding {
 	line := diagnostic.Range.StartLine
 	proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-	for _, candidate := range file.procedures() {
+	procedures := file.procedureView()
+	for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+		candidate := procedures.valueAt(procedureIndex)
 		if line >= candidate.StartLine && line <= candidate.EndLine {
 			proc = candidate
 			break
@@ -1298,7 +1302,7 @@ func (a Analyzer) statefulExcelCallArgumentFindingsContext(ctx context.Context, 
 	if len(diagnostics) == 0 {
 		return nil, nil
 	}
-	procedures := file.procedures()
+	procedures := file.procedureView()
 	out := make([]Finding, 0, len(diagnostics))
 	for i, diagnostic := range diagnostics {
 		if i&0x3f == 0 {
@@ -1308,7 +1312,8 @@ func (a Analyzer) statefulExcelCallArgumentFindingsContext(ctx context.Context, 
 		}
 		line := diagnostic.Range.Start.Line + 1
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		for _, candidate := range procedures {
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			candidate := procedures.valueAt(procedureIndex)
 			if line >= candidate.StartLine && line <= candidate.EndLine {
 				proc = candidate
 				break
@@ -2081,7 +2086,9 @@ func (a Analyzer) buildContextWithObjectAnalysisPlan(files []parsedFile, objectA
 				})
 			}
 		}
-		for _, proc := range file.procedureProjection() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			functionName := strings.ToLower(proc.Name)
 			if functionName != "" {
 				if ctx.functionNamesSeen[functionName] {
@@ -2832,14 +2839,21 @@ func sourceProceduresWithEffects(file parsedFile, project effects.ProjectSummary
 	return procedures
 }
 
-func (file parsedFile) procedures() []sourceProcedure {
+func (file *parsedFile) procedures() []sourceProcedure {
 	return append([]sourceProcedure(nil), file.procedureProjection()...)
 }
 
-// procedureProjection returns the materialized source-procedure view for
-// read-only analysis stages. Unlike procedures, it does not copy the outer
-// slice; callers must not mutate the returned projection.
-func (file parsedFile) procedureProjection() []sourceProcedure {
+// procedureView returns an allocation-free read-only view over the cached
+// procedure projection. Callers that need to retain or mutate procedure
+// values must use procedures instead.
+func (file *parsedFile) procedureView() readOnlySpan[sourceProcedure] {
+	return newReadOnlySpan(file.procedureProjection())
+}
+
+// procedureProjection returns the cached backing projection used to construct
+// owned copies and read-only views. Rule implementations must use procedures
+// or procedureView instead of retaining this slice.
+func (file *parsedFile) procedureProjection() []sourceProcedure {
 	if file.Procedures != nil {
 		return file.Procedures
 	}

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -111,9 +111,20 @@ func TestParsedFileProceduresReusesMaterializedProjection(t *testing.T) {
 	if &second[0].IR.Declarations[0] != &file.IR.Procedures[0].Declarations[0] {
 		t.Fatal("procedure view does not use canonical declaration storage")
 	}
+	view := file.procedureView()
+	viewProcedure, ok := view.At(0)
+	if !ok || viewProcedure.IR != &file.IR.Procedures[0] {
+		t.Fatalf("read-only procedure view = %#v, %v", viewProcedure, ok)
+	}
+	viewProcedure.IR = nil
+	viewProcedure, ok = view.At(0)
+	if !ok || viewProcedure.IR != &file.IR.Procedures[0] {
+		t.Fatal("mutating a procedure value returned by the view changed the cached projection")
+	}
 }
 
 var benchmarkProcedureProjectionSink []sourceProcedure
+var benchmarkProcedureViewSink int
 
 func BenchmarkParsedFileProcedureProjection(b *testing.B) {
 	for _, procedureCount := range []int{100, 500, 1000, 2000} {
@@ -132,6 +143,17 @@ func BenchmarkParsedFileProcedureProjection(b *testing.B) {
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
 					benchmarkProcedureProjectionSink = file.procedures()
+				}
+			})
+			b.Run("read-only-view", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					total := 0
+					view := file.procedureView()
+					for index := 0; index < view.Len(); index++ {
+						total += view.valueAt(index).StartLine
+					}
+					benchmarkProcedureViewSink = total
 				}
 			})
 		})

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -1880,7 +1880,9 @@ type arrayModuleEntryStates map[string]map[string]bool
 func arrayPrivateProcedureTargets(files []parsedFile) map[string]sourceProcedure {
 	targets := map[string]sourceProcedure{}
 	for _, file := range files {
-		for _, proc := range file.procedureProjection() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			visibility := strings.TrimSpace(proc.Visibility)
 			private := strings.EqualFold(visibility, "Private") || strings.EqualFold(visibility, "Friend")
 			modulePrivate := strings.EqualFold(visibility, "Public") && arrayOptionPrivateModule(file.Lines)
@@ -1901,9 +1903,10 @@ func inferArrayByRefAllocationSummaries(files []parsedFile, ctx analysisContext,
 		moduleDecls map[string]sourceDeclaration
 	}, 0)
 	for _, file := range files {
-		procs := file.procedureProjection()
+		procs := file.procedureView()
 		moduleDecls := file.moduleDecls()
-		for _, proc := range procs {
+		for procedureIndex := 0; procedureIndex < procs.Len(); procedureIndex++ {
+			proc := procs.valueAt(procedureIndex)
 			if !procedureHasByRefArrayParameter(proc) {
 				continue
 			}
@@ -2071,7 +2074,9 @@ func arrayByRefFlowAllocations(file parsedFile, proc sourceProcedure, ctx analys
 func inferArrayByRefConditionalAllocations(files []parsedFile) arrayByRefConditionalAllocations {
 	summaries := arrayByRefConditionalAllocations{}
 	for _, file := range files {
-		for _, proc := range file.procedureProjection() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			if proc.Graph == nil {
 				continue
 			}
@@ -2169,7 +2174,9 @@ func inferArrayByRefConditionalAllocations(files []parsedFile) arrayByRefConditi
 func inferArrayByRefLengthAllocations(files []parsedFile) arrayByRefLengthAllocations {
 	summaries := arrayByRefLengthAllocations{}
 	for _, file := range files {
-		for _, proc := range file.procedureProjection() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			if proc.Graph == nil {
 				continue
 			}
@@ -2331,7 +2338,9 @@ func inferArrayModuleConfigurationStates(files []parsedFile, summaries arrayModu
 	states := map[string]arrayModuleConfigurationState{}
 	for _, file := range files {
 		state := arrayModuleConfigurationState{byProcedure: map[string]map[string]bool{}}
-		for _, proc := range file.procedureProjection() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			name := strings.ToLower(strings.TrimSpace(proc.Name))
 			if !strings.HasPrefix(name, "configure") {
 				continue
@@ -2656,9 +2665,10 @@ func inferArrayModuleAllocationSummaries(files []parsedFile, ctx analysisContext
 		moduleDecls map[string]sourceDeclaration
 	}, 0)
 	for _, file := range files {
-		procs := file.procedureProjection()
+		procs := file.procedureView()
 		moduleDecls := file.moduleDecls()
-		for _, proc := range procs {
+		for procedureIndex := 0; procedureIndex < procs.Len(); procedureIndex++ {
+			proc := procs.valueAt(procedureIndex)
 			procedures = append(procedures, struct {
 				file        parsedFile
 				proc        sourceProcedure
@@ -2996,10 +3006,11 @@ func arrayModuleInitializationStates(files []parsedFile, summaries arrayModuleAl
 		if moduleKind != "form" && moduleKind != "class" {
 			continue
 		}
-		procs := file.procedureProjection()
+		procs := file.procedureView()
 		moduleDecls := file.moduleDecls()
 		initializer := arrayModuleInitializerName(moduleKind)
-		for _, proc := range procs {
+		for procedureIndex := 0; procedureIndex < procs.Len(); procedureIndex++ {
+			proc := procs.valueAt(procedureIndex)
 			if !strings.EqualFold(strings.TrimSpace(proc.Name), initializer) {
 				continue
 			}
@@ -3076,9 +3087,10 @@ func inferArrayModuleEntryStates(a Analyzer, files []parsedFile, ctx analysisCon
 	moduleArrays := map[string]map[string]bool{}
 	moduleFiles := map[string]string{}
 	for _, file := range files {
-		procs := file.procedureProjection()
+		procs := file.procedureView()
 		moduleDecls := file.moduleDecls()
-		for _, proc := range procs {
+		for procedureIndex := 0; procedureIndex < procs.Len(); procedureIndex++ {
+			proc := procs.valueAt(procedureIndex)
 			key := arrayProcedureKey(proc)
 			procedures = append(procedures, procedureInfo{
 				file: file, proc: proc, moduleDecls: moduleDecls,
@@ -3263,7 +3275,9 @@ func inferArrayByRefEntryStates(a Analyzer, files []parsedFile, ctx analysisCont
 	callers := make([]callerInfo, 0)
 	for _, file := range files {
 		moduleDecls := file.moduleDecls()
-		for _, caller := range file.procedureProjection() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			caller := procedures.valueAt(procedureIndex)
 			eligibleCaller := false
 			for call := range caller.Calls.All() {
 				_, target, ok := arrayPrivateTargetForCall(ctx, targets, call)
@@ -4850,7 +4864,9 @@ func inferArrayAllocationGuards(files []parsedFile) map[string]bool {
 	candidates := map[string][]string{}
 	procedureNames := map[string]int{}
 	for _, file := range files {
-		for _, proc := range file.procedureProjection() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			name := strings.ToLower(proc.Name)
 			if name != "" {
 				procedureNames[name]++
@@ -4959,9 +4975,10 @@ func inferArrayReturnSummaries(files []parsedFile, arrayAllocationGuards map[str
 	}
 	procedures := make([]returnProcedure, 0)
 	for _, file := range files {
-		fileProcedures := file.procedureProjection()
+		fileProcedures := file.procedureView()
 		moduleDecls := file.moduleDecls()
-		for _, proc := range fileProcedures {
+		for procedureIndex := 0; procedureIndex < fileProcedures.Len(); procedureIndex++ {
+			proc := fileProcedures.valueAt(procedureIndex)
 			if proc.ProcedureKind != procedureir.ProcedureFunction && proc.ProcedureKind != procedureir.ProcedurePropertyGet {
 				continue
 			}

--- a/internal/analyze/dictionary_collection_safety.go
+++ b/internal/analyze/dictionary_collection_safety.go
@@ -85,7 +85,9 @@ func buildDictionaryCollectionIndex(files []parsedFile) *dictionaryCollectionInd
 	}
 	sources := map[string]source{}
 	for _, file := range files {
-		for _, proc := range file.procedures() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			if proc.Name == "" {
 				continue
 			}

--- a/internal/analyze/event_reentry.go
+++ b/internal/analyze/event_reentry.go
@@ -229,8 +229,9 @@ func eventControlTargetName(target string) string {
 func eventSafeProcedures(files []parsedFile, project effects.ProjectSummary) map[string]bool {
 	safe := map[string]bool{}
 	for _, file := range files {
-		procedures := file.procedures()
-		for index, proc := range procedures {
+		procedures := file.procedureView()
+		for index := 0; index < procedures.Len(); index++ {
+			proc := procedures.valueAt(index)
 			if index >= len(file.IR.Procedures) {
 				continue
 			}

--- a/internal/analyze/excel_api_failure_contracts.go
+++ b/internal/analyze/excel_api_failure_contracts.go
@@ -34,7 +34,7 @@ func (a Analyzer) excelAPIFailureContractFindingsContext(ctx context.Context, fi
 	if len(diagnostics) == 0 {
 		return nil, nil
 	}
-	procedures := file.procedures()
+	procedures := file.procedureView()
 	aliases := a.errorGuardAliases
 	if aliases == nil {
 		aliases = isErrorGuardAliases(file.Lines)
@@ -47,7 +47,7 @@ func (a Analyzer) excelAPIFailureContractFindingsContext(ctx context.Context, fi
 			}
 		}
 		line := diagnostic.Range.Start.Line + 1
-		proc := procedureForLine(procedures, line, len(file.Lines))
+		proc := procedureForLineView(procedures, line, len(file.Lines))
 		if isExceptionContractDiagnostic(diagnostic.Message) && exceptionContractHasErrorStrategy(file.Lines, proc, line) {
 			continue
 		}
@@ -67,7 +67,12 @@ func (a Analyzer) excelAPIFailureContractFindingsContext(ctx context.Context, fi
 }
 
 func procedureForLine(procedures []sourceProcedure, line, lineCount int) sourceProcedure {
-	for _, procedure := range procedures {
+	return procedureForLineView(newReadOnlySpan(procedures), line, lineCount)
+}
+
+func procedureForLineView(procedures readOnlySpan[sourceProcedure], line, lineCount int) sourceProcedure {
+	for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+		procedure := procedures.valueAt(procedureIndex)
 		if line >= procedure.StartLine && line <= procedure.EndLine {
 			return procedure
 		}
@@ -203,7 +208,7 @@ func (a Analyzer) errorValueWrapperFindingsContext(ctx context.Context, file par
 	if len(wrappers) == 0 {
 		return nil, nil
 	}
-	procedures := file.procedures()
+	procedures := file.procedureView()
 	aliases := a.errorGuardAliases
 	if aliases == nil {
 		aliases = isErrorGuardAliases(file.Lines)
@@ -215,7 +220,7 @@ func (a Analyzer) errorValueWrapperFindingsContext(ctx context.Context, file par
 				return nil, err
 			}
 		}
-		proc := procedureForLine(procedures, irProcedure.Symbol.DeclarationRange.StartLine+1, len(file.Lines))
+		proc := procedureForLineView(procedures, irProcedure.Symbol.DeclarationRange.StartLine+1, len(file.Lines))
 		for _, call := range irProcedure.Calls {
 			if !wrapperCallMatches(call, wrappers) {
 				continue

--- a/internal/analyze/excel_loop_access.go
+++ b/internal/analyze/excel_loop_access.go
@@ -160,8 +160,9 @@ func buildExcelLoopAccessIndex(files []parsedFile, db *vbadb.DB, rootDir string,
 		return index
 	}
 	for _, file := range files {
-		procedures := file.procedures()
-		for i, proc := range procedures {
+		procedures := file.procedureView()
+		for i := 0; i < procedures.Len(); i++ {
+			proc := procedures.valueAt(i)
 			if i >= len(file.IR.Procedures) {
 				continue
 			}
@@ -436,13 +437,17 @@ func buildRealtimeExcelLoopSummaries(file parsedFile, db *vbadb.DB, rootBindings
 	if rootBindings == nil {
 		rootBindings = buildExcelRootBindingIndex([]parsedFile{file})
 	}
-	procedures := file.procedures()
+	procedures := file.procedureView()
 	for i, candidate := range file.IR.Procedures {
-		if i >= len(procedures) {
+		if i >= procedures.Len() {
 			continue
 		}
 		key := excelProcedureKey(file.IR, candidate.Symbol)
-		summaries[key] = directExcelAccessSummary(file, procedures[i], db, rootBindings, rootDir, cfg)
+		procedure, ok := procedures.At(i)
+		if !ok {
+			continue
+		}
+		summaries[key] = directExcelAccessSummary(file, procedure, db, rootBindings, rootDir, cfg)
 	}
 	changed := true
 	for changed {
@@ -934,20 +939,20 @@ func classifyExcelStatement(file parsedFile, proc sourceProcedure, statement pro
 	text = sanitizeExcelStatementText(text)
 	lower := strings.ToLower(text)
 	var out []excelLoopAccess
-	for _, expression := range statementMemberExpressions(facts, statement) {
+	facts.forEachMemberExpressionForStatement(statement.ID, func(expression procedureir.Expression) {
 		receiver, member, memberEnd, ok := splitExcelMemberAccess(expression.Text)
 		if !ok {
-			continue
+			return
 		}
 		memberLower := strings.ToLower(member)
 		if strings.EqualFold(receiver, "Application") && memberLower == "worksheetfunction" {
 			out = append(out, excelLoopAccess{Category: excelAccessWorksheetCall, Member: member, Line: line, Read: true})
-			continue
+			return
 		}
 		typ, resolved := resolveExcelExpressionType(file, db, receiver, line-1, rootDir, cfg)
 		perCell := isPerCellExcelExpression(file, proc, db, receiver, rangeVars, line-1, rootDir, cfg)
 		if !resolved && !perCell {
-			continue
+			return
 		}
 		if rangeVars.Range[strings.ToLower(strings.TrimSpace(receiver))] {
 			typ = "Excel.Range"
@@ -966,23 +971,23 @@ func classifyExcelStatement(file parsedFile, proc sourceProcedure, statement pro
 			if perCell {
 				out = append(out, access)
 			}
-			continue
+			return
 		}
 		if formattingMembers[memberLower] && perCell {
 			out = append(out, excelLoopAccess{Category: excelAccessFormatting, Member: member, Line: line, Write: assignmentOperatorAfter(text, assignmentEnd)})
-			continue
+			return
 		}
 		if rangeLookupMembers[memberLower] && isExcelWorksheetOrRangeType(typ) {
 			if memberLower == "range" && !perCell && literalRangeCellCount(receiver) > 1 {
-				continue
+				return
 			}
 			out = append(out, excelLoopAccess{Category: excelAccessRangeLookup, Member: member, Line: line, Read: true})
-			continue
+			return
 		}
 		if mutatingRangeMembers[memberLower] && isExcelRangeType(typ) {
 			out = append(out, excelLoopAccess{Category: excelAccessWrite, Member: member, Line: line, Write: true})
 		}
-	}
+	})
 	if strings.Contains(lower, "worksheetfunction.") || strings.Contains(lower, ".evaluate(") {
 		out = append(out, excelLoopAccess{Category: excelAccessWorksheetCall, Line: line, Read: true})
 	}
@@ -1126,13 +1131,6 @@ func excelRootBindingHasValueType(kind string) bool {
 	default:
 		return false
 	}
-}
-
-func statementMemberExpressions(facts *procedureAnalysisFacts, statement procedureir.Statement) []procedureir.Expression {
-	if facts == nil {
-		return nil
-	}
-	return facts.MemberExpressionsForStatement(statement.ID)
 }
 
 func splitExcelMemberAccess(text string) (string, string, int, bool) {

--- a/internal/analyze/excel_loop_invariant.go
+++ b/internal/analyze/excel_loop_invariant.go
@@ -50,10 +50,6 @@ func (a Analyzer) excelLoopInvariantFindings(file parsedFile, proc sourceProcedu
 	if len(regions) == 0 {
 		return nil
 	}
-	statements := make(map[int]procedureir.Statement, proc.Statements.Len())
-	for statement := range proc.Statements.All() {
-		statements[statement.ID] = statement
-	}
 	facts := proc.Facts
 	if facts == nil {
 		// Standalone callers may omit the attached projection. Share one
@@ -61,21 +57,17 @@ func (a Analyzer) excelLoopInvariantFindings(file parsedFile, proc sourceProcedu
 		facts = proc.analysisFacts()
 	}
 	constants := loopInvariantStringConstants(file, proc)
-	expressionsByStatement := make(map[int][]procedureir.Expression)
-	for statement := range proc.Statements.All() {
-		expressionsByStatement[statement.ID] = statementMemberExpressions(facts, statement)
-	}
 	seen := map[string]loopInvariantCandidate{}
 	for statement := range proc.Statements.All() {
-		for _, expression := range expressionsByStatement[statement.ID] {
-			candidate, ok := a.loopInvariantCandidate(file, proc, statement, expression, constants, statements)
+		facts.forEachMemberExpressionForStatement(statement.ID, func(expression procedureir.Expression) {
+			candidate, ok := a.loopInvariantCandidate(file, proc, statement, expression, constants, facts)
 			if !ok {
-				continue
+				return
 			}
 			owners := containingExcelLoops(regions, statement.ID, expression.Range.StartLine)
-			owner, ok := loopInvariantOwner(proc, owners, statement, expression, statements)
+			owner, ok := loopInvariantOwner(proc, owners, statement, expression, facts)
 			if !ok {
-				continue
+				return
 			}
 			candidate.Owner = owner
 			candidate.Depth = owner.Depth
@@ -83,7 +75,7 @@ func (a Analyzer) excelLoopInvariantFindings(file parsedFile, proc sourceProcedu
 			if previous, exists := seen[key]; !exists || candidate.Expression.Range.StartByte < previous.Expression.Range.StartByte {
 				seen[key] = candidate
 			}
-		}
+		})
 	}
 	if len(seen) == 0 {
 		return nil
@@ -135,7 +127,7 @@ func (a Analyzer) excelLoopInvariantFindings(file parsedFile, proc sourceProcedu
 	return findings
 }
 
-func (a Analyzer) loopInvariantCandidate(file parsedFile, proc sourceProcedure, statement procedureir.Statement, expression procedureir.Expression, constants map[string]string, statements map[int]procedureir.Statement) (loopInvariantCandidate, bool) {
+func (a Analyzer) loopInvariantCandidate(file parsedFile, proc sourceProcedure, statement procedureir.Statement, expression procedureir.Expression, constants map[string]string, facts *procedureAnalysisFacts) (loopInvariantCandidate, bool) {
 	expression.Text = loopInvariantExpressionSource(file.Source, expression)
 	loopInvariantExpandRange(&expression, expression.Text)
 	segments := splitLoopInvariantChain(expression.Text)
@@ -149,7 +141,7 @@ func (a Analyzer) loopInvariantCandidate(file parsedFile, proc sourceProcedure, 
 	if !loopInvariantConstantSelector(normalizeLoopInvariantChain(last.Arguments), constants) {
 		return loopInvariantCandidate{}, false
 	}
-	withPrefix, _ := loopInvariantWithPrefix(statement.ID, statements)
+	withPrefix, _ := loopInvariantWithPrefix(statement.ID, facts)
 	chain := strings.TrimSpace(expression.Text)
 	if withPrefix != "" && (strings.HasPrefix(strings.TrimSpace(chain), ".") || !strings.Contains(chain, ".")) {
 		chain = strings.TrimSpace(withPrefix) + strings.TrimSpace(chain)
@@ -271,8 +263,8 @@ func loopInvariantCallEnd(source []byte, open int) int {
 	return 0
 }
 
-func loopInvariantOwner(proc sourceProcedure, owners []excelLoopRegion, statement procedureir.Statement, expression procedureir.Expression, statements map[int]procedureir.Statement) (excelLoopRegion, bool) {
-	withStatements := candidateWithStatements(statement.ID, statements)
+func loopInvariantOwner(proc sourceProcedure, owners []excelLoopRegion, statement procedureir.Statement, expression procedureir.Expression, facts *procedureAnalysisFacts) (excelLoopRegion, bool) {
+	withStatements := candidateWithStatements(statement.ID, facts)
 	for _, owner := range owners {
 		if owner.Small || owner.StatementID == statement.ID {
 			continue
@@ -371,12 +363,15 @@ func loopInvariantLoopVariables(owner excelLoopRegion, proc sourceProcedure) map
 	return variables
 }
 
-func loopInvariantWithPrefix(statementID int, statements map[int]procedureir.Statement) (string, []procedureir.Statement) {
+func loopInvariantWithPrefix(statementID int, facts *procedureAnalysisFacts) (string, []procedureir.Statement) {
+	if facts == nil {
+		return "", nil
+	}
 	var chain []string
 	var withStatements []procedureir.Statement
-	current, ok := statements[statementID]
+	current, ok := facts.Statement(statementID)
 	for ok && current.ParentID != 0 {
-		parent, found := statements[current.ParentID]
+		parent, found := facts.Statement(current.ParentID)
 		if !found {
 			break
 		}
@@ -430,8 +425,8 @@ func loopInvariantWithHeaderText(text string) string {
 	return strings.Join(parts, " ")
 }
 
-func candidateWithStatements(statementID int, statements map[int]procedureir.Statement) []procedureir.Statement {
-	_, withStatements := loopInvariantWithPrefix(statementID, statements)
+func candidateWithStatements(statementID int, facts *procedureAnalysisFacts) []procedureir.Statement {
+	_, withStatements := loopInvariantWithPrefix(statementID, facts)
 	return withStatements
 }
 

--- a/internal/analyze/object_use_before_set.go
+++ b/internal/analyze/object_use_before_set.go
@@ -113,9 +113,10 @@ func buildObjectAnalysisPlans(files []parsedFile) *objectAnalysisContext {
 		moduleProcedureKeys: map[string][]string{},
 	}
 	for _, file := range files {
-		procedures := file.procedureProjection()
+		procedures := file.procedureView()
 		moduleDecls := file.moduleDecls()
-		for _, proc := range procedures {
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			key := objectSummaryKey(file.IR.Path, objectProcedureQualifiedName(proc), string(proc.ProcedureKind), proc.StartLine)
 			plan := newObjectProcedurePlan(file, proc, moduleDecls, key)
 			analysis.plans[key] = plan

--- a/internal/analyze/procedure_cycles.go
+++ b/internal/analyze/procedure_cycles.go
@@ -152,9 +152,10 @@ func (a Analyzer) procedureCallCycleFindings(ctx context.Context, files []parsed
 		if !ok {
 			continue
 		}
-		procedures := file.procedures()
+		procedures := file.procedureView()
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
-		for _, candidate := range procedures {
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			candidate := procedures.valueAt(procedureIndex)
 			if strings.EqualFold(candidate.Name, cycleNodeName(cycle.Nodes[0].QualifiedName)) && candidate.StartLine == cycle.Nodes[0].Line {
 				proc = candidate
 				break

--- a/internal/analyze/procedure_facts.go
+++ b/internal/analyze/procedure_facts.go
@@ -381,6 +381,35 @@ func (facts *procedureAnalysisFacts) Accesses() readOnlySpan[procedureir.Variabl
 	return facts.accessesView()
 }
 
+// forEachMemberExpressionForStatement visits the non-recovered member
+// expressions associated with statementID in IR order. The authoritative IR
+// path walks the compact statement index directly and does not allocate a
+// result slice. Callback values are copies, but nested IR slices remain
+// immutable and share the facts lifetime.
+//
+// MemberExpressionsForStatement remains the compatibility API for callers
+// that need an owned result. Recovered or hand-built IR may need the fallback
+// tree traversal used by that API; that uncommon path is intentionally not a
+// hot-path allocation contract.
+func (facts *procedureAnalysisFacts) forEachMemberExpressionForStatement(statementID int, visit func(procedureir.Expression)) {
+	if facts == nil || visit == nil {
+		return
+	}
+	expressions := facts.expressionsView()
+	indexes := facts.memberExpressionsByStatement[statementID]
+	if !facts.memberExpressionFallback {
+		for _, index := range indexes {
+			if expression, ok := expressions.At(index); ok {
+				visit(expression)
+			}
+		}
+		return
+	}
+	for _, expression := range facts.MemberExpressionsForStatement(statementID) {
+		visit(expression)
+	}
+}
+
 // AccessesForStatement returns accesses associated with a statement,
 // preserving IR order. The returned slice is independent of the immutable
 // facts.

--- a/internal/analyze/procedure_facts_test.go
+++ b/internal/analyze/procedure_facts_test.go
@@ -201,6 +201,163 @@ func TestProcedureAnalysisFactsMemberExpressionsMixedStatementIDFallback(t *test
 	}
 }
 
+func TestProcedureAnalysisFactsMemberExpressionsReturnsOwnedCopy(t *testing.T) {
+	statements := []procedureir.Statement{{ID: 10}}
+	expressions := []procedureir.Expression{{ID: 1, StatementID: 10, Kind: procedureir.ExpressionMember, Text: "Range.Value"}}
+	facts := newProcedureAnalysisFacts(statements, expressions, nil, nil)
+	got := facts.MemberExpressionsForStatement(10)
+	if len(got) != 1 {
+		t.Fatalf("member expressions = %#v, want one expression", got)
+	}
+	got[0].ID = 99
+	got = facts.MemberExpressionsForStatement(10)
+	if len(got) != 1 || got[0].ID != 1 {
+		t.Fatalf("member expressions were not returned as an owned copy: %#v", got)
+	}
+}
+
+func TestProcedureAnalysisFactsMemberExpressionIteratorPreservesOrder(t *testing.T) {
+	statements := []procedureir.Statement{{ID: 10}, {ID: 20}}
+	expressions := []procedureir.Expression{
+		{ID: 1, StatementID: 10, Kind: procedureir.ExpressionMember, Text: "Application.Range", Range: vbaast.Range{StartByte: 30}},
+		{ID: 2, StatementID: 20, Kind: procedureir.ExpressionMember, Text: "Other.Range", Range: vbaast.Range{StartByte: 40}},
+		{ID: 3, StatementID: 10, Kind: procedureir.ExpressionMember, Text: "Range.Value", Range: vbaast.Range{StartByte: 50}},
+		{ID: 4, StatementID: 10, Kind: procedureir.ExpressionIdentifier, Text: "value", Range: vbaast.Range{StartByte: 60}},
+	}
+	facts := newProcedureAnalysisFacts(statements, expressions, nil, nil)
+	var got []int
+	facts.forEachMemberExpressionForStatement(10, func(expression procedureir.Expression) {
+		got = append(got, expression.ID)
+	})
+	if len(got) != 2 || got[0] != 1 || got[1] != 3 {
+		t.Fatalf("member expression iterator = %#v, want [1 3]", got)
+	}
+}
+
+func TestProcedureAnalysisFactsMemberExpressionIteratorMatchesFallbackOrder(t *testing.T) {
+	statements := []procedureir.Statement{{ID: 10, ExpressionIDs: []int{1}}}
+	expressions := []procedureir.Expression{
+		{ID: 1, StatementID: 10, Kind: procedureir.ExpressionMember, Text: "Application.Range", Children: []int{2}},
+		{ID: 2, Kind: procedureir.ExpressionMember, Text: "Range.Value2"},
+	}
+	facts := newProcedureAnalysisFacts(statements, expressions, nil, nil)
+	var got []int
+	facts.forEachMemberExpressionForStatement(10, func(expression procedureir.Expression) {
+		got = append(got, expression.ID)
+	})
+	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("fallback member expression iterator = %#v, want [1 2]", got)
+	}
+}
+
+func TestProcedureAnalysisFactsMemberExpressionIteratorIsAllocationFree(t *testing.T) {
+	statements := []procedureir.Statement{{ID: 10}}
+	expressions := []procedureir.Expression{
+		{ID: 1, StatementID: 10, Kind: procedureir.ExpressionMember, Text: "Application.Range"},
+		{ID: 2, StatementID: 10, Kind: procedureir.ExpressionMember, Text: "Range.Value"},
+	}
+	facts := newProcedureAnalysisFacts(statements, expressions, nil, nil)
+	allocs := testing.AllocsPerRun(100, func() {
+		facts.forEachMemberExpressionForStatement(10, consumeMemberExpression)
+	})
+	if allocs != 0 {
+		t.Fatalf("authoritative member expression iteration allocated %v times", allocs)
+	}
+}
+
+func BenchmarkProcedureAnalysisFactsMemberExpressionIterator(b *testing.B) {
+	statements := []procedureir.Statement{{ID: 10}}
+	expressions := make([]procedureir.Expression, 32)
+	for index := range expressions {
+		expressions[index] = procedureir.Expression{
+			ID: index + 1, StatementID: 10, Kind: procedureir.ExpressionMember,
+			Text: "Application.Range", Range: vbaast.Range{StartByte: index},
+		}
+	}
+	facts := newProcedureAnalysisFacts(statements, expressions, nil, nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		facts.forEachMemberExpressionForStatement(10, consumeMemberExpression)
+	}
+}
+
+func consumeMemberExpression(procedureir.Expression) {}
+
+var benchmarkProcedureFactReadSink int
+
+func BenchmarkProcedureAnalysisFactsReadOnlyViews(b *testing.B) {
+	const factCount = 4096
+	statements := make([]procedureir.Statement, factCount)
+	expressions := make([]procedureir.Expression, factCount)
+	calls := make([]procedureir.CallSite, factCount)
+	accesses := make([]procedureir.VariableAccess, factCount)
+	for index := 0; index < factCount; index++ {
+		id := index + 1
+		statements[index] = procedureir.Statement{ID: id}
+		expressions[index] = procedureir.Expression{ID: id, StatementID: 1, Kind: procedureir.ExpressionIdentifier}
+		calls[index] = procedureir.CallSite{ID: id, StatementID: 1}
+		accesses[index] = procedureir.VariableAccess{Name: "value", StatementID: 1, Mode: procedureir.AccessRead}
+	}
+	facts := newProcedureAnalysisFacts(statements, expressions, calls, accesses)
+
+	b.Run("statements", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			total := 0
+			for statement := range facts.Statements().All() {
+				total += statement.ID
+			}
+			benchmarkProcedureFactReadSink = total
+		}
+	})
+	b.Run("expressions", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			total := 0
+			for expression := range facts.Expressions().All() {
+				total += expression.ID
+			}
+			benchmarkProcedureFactReadSink = total
+		}
+	})
+	b.Run("calls", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			total := 0
+			for call := range facts.Calls().All() {
+				total += call.ID
+			}
+			benchmarkProcedureFactReadSink = total
+		}
+	})
+	b.Run("accesses", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			total := 0
+			for access := range facts.Accesses().All() {
+				total += access.StatementID
+			}
+			benchmarkProcedureFactReadSink = total
+		}
+	})
+	b.Run("grouped-calls", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			facts.forEachCallForStatement(1, consumeCallSite)
+		}
+	})
+	b.Run("grouped-accesses", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			facts.forEachAccessForStatement(1, consumeVariableAccess)
+		}
+	})
+}
+
+func consumeCallSite(procedureir.CallSite)             {}
+func consumeVariableAccess(procedureir.VariableAccess) {}
+
 func TestProcedureAnalysisFactsEmptyAuthoritativeMemberGroupDoesNotTraverseOtherStatements(t *testing.T) {
 	statements := []procedureir.Statement{
 		{ID: 10, ExpressionIDs: []int{1}},

--- a/internal/analyze/procedure_planner.go
+++ b/internal/analyze/procedure_planner.go
@@ -445,10 +445,11 @@ func materializeProcedureAnalysisPlans(file *parsedFile, projectEffects effects.
 
 func projectPlansDomain(cfg config.AnalyzeConfig, files []parsedFile, projectEffects effects.ProjectSummary, domain analysisstats.Domain) bool {
 	for _, file := range files {
-		procedures := file.procedureProjection()
+		procedures := file.procedureView()
 		materialized := file.Procedures != nil
 		if materialized {
-			for _, proc := range procedures {
+			for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+				proc := procedures.valueAt(procedureIndex)
 				if !proc.PlanReady {
 					materialized = false
 					break
@@ -456,9 +457,10 @@ func projectPlansDomain(cfg config.AnalyzeConfig, files []parsedFile, projectEff
 			}
 		}
 		if !materialized {
-			procedures = sourceProceduresWithEffects(file, projectEffects)
+			procedures = newReadOnlySpan(sourceProceduresWithEffects(file, projectEffects))
 		}
-		for _, proc := range procedures {
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			proc := procedures.valueAt(procedureIndex)
 			plan := proc.Plan
 			if !proc.PlanReady {
 				plan = proc.analysisPlan(cfg, file.moduleDecls())

--- a/internal/analyze/project_capabilities.go
+++ b/internal/analyze/project_capabilities.go
@@ -172,7 +172,9 @@ func dataFlowInputsEnabled(cfg config.AnalyzeConfig) bool {
 
 func projectHasFeature(files []parsedFile, feature procedureFeature) bool {
 	for _, file := range files {
-		for _, procedure := range file.procedureProjection() {
+		procedures := file.procedureView()
+		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
+			procedure := procedures.valueAt(procedureIndex)
 			if procedure.Features.mayHave(feature) {
 				return true
 			}

--- a/internal/analyze/public_api_types.go
+++ b/internal/analyze/public_api_types.go
@@ -86,13 +86,16 @@ func (a Analyzer) publicAPITypeFindings(file parsedFile, index *apiTypeIndex) []
 	if !publicAPIModule(file.IR) {
 		return nil
 	}
-	procedures := file.procedures()
+	procedures := file.procedureView()
 	var findings []Finding
 	for i, procedure := range file.IR.Procedures {
-		if i >= len(procedures) || !publicAPIProcedure(procedure.Symbol) || procedure.Symbol.IsEventHandler {
+		if i >= procedures.Len() || !publicAPIProcedure(procedure.Symbol) || procedure.Symbol.IsEventHandler {
 			continue
 		}
-		proc := procedures[i]
+		proc, ok := procedures.At(i)
+		if !ok {
+			continue
+		}
 		if procedure.Symbol.Kind == procedureir.ProcedureFunction ||
 			procedure.Symbol.Kind == procedureir.ProcedurePropertyGet {
 			findings = append(findings, a.checkPublicAPIType(file, proc, index, procedure.Symbol.ReturnType, proc.StartLine, "return type")...)
@@ -295,14 +298,14 @@ func isSafePublicAPIType(name string) bool {
 	}
 }
 
-func (a Analyzer) propertyVisibilityFindings(file parsedFile, index *apiTypeIndex, procedures []sourceProcedure) []Finding {
+func (a Analyzer) propertyVisibilityFindings(file parsedFile, index *apiTypeIndex, procedures readOnlySpan[sourceProcedure]) []Finding {
 	type propertyAccessors struct {
 		get   []int
 		write []int
 	}
 	groups := map[string]*propertyAccessors{}
 	for i, procedure := range file.IR.Procedures {
-		if i >= len(procedures) || procedure.Symbol.IsEventHandler || !publicAPIModule(file.IR) {
+		if i >= procedures.Len() || procedure.Symbol.IsEventHandler || !publicAPIModule(file.IR) {
 			continue
 		}
 		name := strings.ToLower(procedure.Symbol.Name)
@@ -334,9 +337,17 @@ func (a Analyzer) propertyVisibilityFindings(file parsedFile, index *apiTypeInde
 		if procedureVisibilityRank(getter.Visibility) == procedureVisibilityRank(writer.Visibility) {
 			continue
 		}
-		line := procedures[group.get[0]].StartLine
+		getterProcedure, ok := procedures.At(group.get[0])
+		if !ok {
+			continue
+		}
+		writerProcedure, ok := procedures.At(group.write[0])
+		if !ok {
+			continue
+		}
+		line := getterProcedure.StartLine
 		if procedureVisibilityRank(getter.Visibility) < procedureVisibilityRank(writer.Visibility) {
-			line = procedures[group.write[0]].StartLine
+			line = writerProcedure.StartLine
 		}
 		typeName := publicAPITypeName(getter.ReturnType)
 		if typeName == "" {
@@ -351,7 +362,7 @@ func (a Analyzer) propertyVisibilityFindings(file parsedFile, index *apiTypeInde
 		message := fmt.Sprintf("Property %s has mismatched getter/setter visibility for type %s (%s getter, %s setter).", getter.Name, typeName, effectiveVisibility(getter.Visibility), effectiveVisibility(writer.Visibility))
 		reason := fmt.Sprintf("The public property %s exposes type %s through accessors with different effective visibility, so callers cannot rely on one stable public contract.", getter.Name, typeName)
 		suggestion := fmt.Sprintf("Give both accessors the same visibility and keep type %s consistently exposed.", typeName)
-		finding := a.simpleFinding(file, procedures[group.get[0]], line, publicAPITypeRule, "warning", message, reason, suggestion)
+		finding := a.simpleFinding(file, getterProcedure, line, publicAPITypeRule, "warning", message, reason, suggestion)
 		findings = append(findings, finding)
 	}
 	return findings

--- a/internal/analyze/value2_performance.go
+++ b/internal/analyze/value2_performance.go
@@ -72,22 +72,22 @@ func (a Analyzer) value2PerformanceFindings(file parsedFile, proc sourceProcedur
 		if !ok {
 			continue
 		}
-		for _, expression := range statementMemberExpressions(factsForMembers, statement) {
+		factsForMembers.forEachMemberExpressionForStatement(statement.ID, func(expression procedureir.Expression) {
 			if seen[expression.ID] {
-				continue
+				return
 			}
 			receiver, ok := rangeValueMemberReceiver(&expression, facts, "value")
 			if !ok || !value2ReceiverIsExcelRange(a, file, proc, receiver) {
-				continue
+				return
 			}
 			memberRange, ok := value2MemberRange(expression, facts)
 			if !ok {
-				continue
+				return
 			}
 			shape, recognized := rangeValueRangeShapeExpression(&receiver, state, facts)
 			dynamic := value2DynamicRangeReceiver(receiver, shape, state, facts, proc, statement.ID)
 			if !recognized && !dynamic {
-				continue
+				return
 			}
 			write := value2IsAssignmentTarget(statement, expression)
 			owners := containingExcelLoops(regions, statement.ID, expression.Range.StartLine)
@@ -95,7 +95,7 @@ func (a Analyzer) value2PerformanceFindings(file parsedFile, proc sourceProcedur
 			large := shape.known && shape.rows > 0 && shape.cols > 0 && shape.rows*shape.cols >= value2PerformanceLargeCells
 			variantTransfer := !write && value2ImmediateVariantTransfer(statement, expression, shape, dynamic, declarations)
 			if !large && !dynamic && len(owners) == 0 && !variantTransfer {
-				continue
+				return
 			}
 			candidate := value2PerformanceCandidate{
 				Statement: statement, Expression: expression, MemberRange: memberRange,
@@ -103,7 +103,7 @@ func (a Analyzer) value2PerformanceFindings(file parsedFile, proc sourceProcedur
 				VariantTransfer: variantTransfer, ScalarProcessing: value2ScalarProcessing(proc, statement.ID, statement.Text), Loops: owners,
 			}
 			if value2IntentionalDateCurrency(proc, candidate, declarations) {
-				continue
+				return
 			}
 			seen[expression.ID] = true
 			key := strings.ToLower(strings.TrimSpace(receiver.Text))
@@ -111,11 +111,11 @@ func (a Analyzer) value2PerformanceFindings(file parsedFile, proc sourceProcedur
 				if len(candidates[existing].Loops) == 0 && len(candidate.Loops) > 0 {
 					candidates[existing] = candidate
 				}
-				continue
+				return
 			}
 			seenReceivers[key] = len(candidates)
 			candidates = append(candidates, candidate)
-		}
+		})
 	}
 	if len(candidates) == 0 {
 		return nil


### PR DESCRIPTION
## Summary

- Replace defensive procedure-list copies in hot analyzer readers with a package-private immutable span while retaining explicit owned-copy boundaries.
- Iterate statement-grouped member expressions through compact fact indexes without materializing temporary slices, preserving canonical ordering and recovery fallback behavior.
- Add ownership, ordering, fallback, race-safety, and allocation benchmarks; document the immutable-read contract and ROneCOne profile evidence.

Closes #700.

## Performance

- Focused procedure and analysis-fact read benchmarks report `0 B/op` and `0 allocs/op`.
- ROneCOne retained 510 findings and improved median elapsed time from 20.147 s to 19.975 s.
- Allocation profiles no longer attribute the prior 13.33 MB procedure-copy leaf or 1 MB member-expression-copy leaf to the migrated paths.

## Tests

- `rtk task test`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/analyze -count=1`
- `rtk task lint`
- `rtk task corpus:test`
- `rtk proxy task review:codex`
- Focused 2,000-procedure, 4,096-fact, synthetic-module, and ROneCOne benchmarks documented in `docs/specs/static-analysis-corpus.md`
