### PR TITLE
perf(analyze): precompute immutable module semantic facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Precomputed immutable module semantic facts once per module/revision,
+  including conservative `Option Private Module` state and the compact array
+  operation observations used by idempotent setup analysis. Procedure workers
+  now share the facts safely, avoiding repeated module-wide source scans and
+  normalization while preserving diagnostic, snapshot, CLI JSON, and LSP
+  contracts. Extended the opt-in fact-build telemetry with
+  `module_option_scans`; cross-revision caching and a complete normalized AST
+  remain out of scope.
+
 - Split procedure data-flow execution into lazy generic and HTTP lanes, so
   procedures with no applicable HTTP projections avoid HTTP CFG/state work
   while preserving diagnostic ownership, ordering, suppression, and output

--- a/docs/adr/ADR-0046-procedure-applicability-planning.md
+++ b/docs/adr/ADR-0046-procedure-applicability-planning.md
@@ -248,6 +248,49 @@ remain for compatibility and are not defined as the sum of the two lanes.
 These counters are additive, opt-in stderr telemetry only; no public CLI,
 configuration, JSON, or LSP schema is introduced.
 
+### Amendment: immutable module semantic facts (#711)
+
+`moduleAnalysisFacts` now owns a small immutable semantic projection for one
+module and analysis revision. The projection is built from the canonical
+`DocumentIR`/`ProcedureIR` and the existing source-line normalization path in
+one bounded module pass. It is not a second AST, a persistent cache, or a
+replacement for the canonical IR.
+
+The module projection records the option state needed by procedure planning,
+including `Option Private Module`, using the same conservative tri-state
+contract as other analyzer facts: `present` only for an exact declaration in
+complete canonical input, `absent` when complete input proves it is missing,
+and `unknown` for recovered, incomplete, or ambiguous module options. An
+unknown option fails open: private-procedure applicability must retain the
+possibility that the module is externally visible. Comments and string
+contents are excluded from the declaration check, and a procedure loop must
+not rescan the module source.
+
+The same pass may retain only the array-operation observations required by the
+idempotent array setup query: canonical lowercase identifier keys and compact
+facts for scalar assignment, direct `ReDim`, `Erase`, and whole-array
+assignment. Shared maps and slices remain private to the facts value. Accessors
+return scalar values, enums, or small owned copies and never expose mutable
+shared storage. The operation projection does not build an array participant
+graph or data-flow state.
+
+Facts are attached before batch, realtime, or LSP procedure workers start.
+They are immutable after construction and safe for concurrent procedure reads.
+Their lifetime is bounded by the owning parsed-file/IR revision; an edit, a
+new revision, or a complete/incomplete transition builds a new value. No
+cross-revision or cross-run persistence is introduced, and normal compatibility
+or synthetic callers must pass one explicitly owned facts value rather than
+silently rebuilding it in a procedure loop.
+
+The performance recorder adds `module_fact_builds` and
+`module_option_scans`. For a normal module revision each is at most one, and
+the option scan is independent of the number of public procedures. These
+counters are opt-in stderr-only telemetry and are absent from normal analysis
+JSON and LSP payloads. `BenchmarkModuleAnalysisFacts` and the existing
+`BenchmarkRealWorldCorpus/ronecone/analyze-only` profile comparison measure
+construction/reuse, source-normalization CPU and allocation cost, and the
+small-module regression guard.
+
 ## Rationale
 
 The IR and fact ownership boundaries already make procedure inputs immutable
@@ -360,6 +403,8 @@ produce a finding.
   `internal/analyze/procedure_planner.go`,
   `internal/analyze/procedure_profile.go`, and
   `internal/vba/analysisstats/recorder.go`.
+- Issue #711's module-fact construction, immutable accessors, option-scan
+  counter, and module-fact benchmark requirements.
 
 ## Related
 
@@ -368,6 +413,7 @@ produce a finding.
 - Issue #696
 - Issue #697
 - Issue #701
+- Issue #711
 - ADR-0021, ADR-0022, ADR-0023, ADR-0024, ADR-0043, ADR-0045
 - ADR-0040
 - `docs/specs/vba-analysis-ir.md`

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1575,6 +1575,86 @@ path-witness contracts. Snapshot review removed three pre-existing `VBA224`
 rows that arose only from transient, partially propagated FIFO states; all
 remaining diagnostics are stable across repeated verify-only runs.
 
+### Immutable module semantic facts verification record (#711)
+
+Issue #711 moves the `Option Private Module` decision and the profiler-backed
+module array-operation index into the immutable facts object attached to one
+parsed-file/IR revision. The public analyzer and corpus JSON contracts remain
+unchanged. The focused scan counter is emitted only through developer
+telemetry; a normal module revision reports one `module_fact_builds` and one
+`module_option_scans`, independent of public procedure count.
+
+The regression and focused benchmark commands were:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run 'TestModuleAnalysisFacts|TestArrayOptionPrivateModuleNormalization|TestModuleArrayOperationIndexMatchesLegacySourceScan|TestModuleIdempotentSetupPreservesNonCandidateExecutableTail|TestModuleOptionScanCountDoesNotScaleWithPublicProcedures' -count=1
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -run '^$' -bench '^BenchmarkModuleAnalysisFacts(OperationHeavy|OperationAccessors)?$' -benchmem -benchtime=1x -count=1
+```
+
+The module-facts benchmark recorded the following post-change observations on
+the Windows Go toolchain used for this record:
+
+| workload                         |     ns/op |      B/op | allocs/op |
+| -------------------------------- | --------: | --------: | --------: |
+| small                            |    53,900 |    60,608 |       295 |
+| hundreds                         | 1,120,000 | 1,256,360 |    16,626 |
+| thousands                        | 8,086,400 | 5,763,832 |    72,076 |
+| operation-heavy (500 procedures) | 4,044,100 | 2,302,192 |    41,166 |
+
+The accessor-only benchmark was added to verify that repeated operation and
+option reads reuse the frozen maps and slices without exposing mutable storage;
+its `B/op` and `allocs/op` must remain zero in normal runs. The small-module
+test also enforces the recorded pre-#711 baseline of 60,560 B/op and 295
+allocs/op with a +2% guard (61,771 B/op and 301 allocs/op).
+
+For the required ROneCOne leaf, five serial samples used the same explicit
+benchmark command as earlier records:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=5
+```
+
+The post-change samples were 19.701, 16.207, 16.428, 16.794, and 16.363 s;
+the median was 16.428 s, 18,418,130,784 B/op, and 99,679,756 allocs/op. The
+earlier same-worktree baseline was 20.958 s, 20,957,546,080 B/op, and
+153,741,582 allocs/op. This is an environment observation, not a CI threshold;
+all five samples reported 510 findings, `module_fact_builds=1`, and
+`module_option_scans=1`.
+
+The post-change profile was captured with:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -Command '$cpu = Join-Path $env:TEMP "xlflow-issue711-after2-ronecone.cpu.pprof"; $mem = Join-Path $env:TEMP "xlflow-issue711-after2-ronecone.mem.pprof"; $bin = Join-Path $env:TEMP "xlflow-issue711-after2-ronecone.test.exe"; $args = @("test", "./internal/staticanalysis/corpus", "-run", "^$", "-bench", "^BenchmarkRealWorldCorpus/ronecone/analyze-only$", "-benchtime=1x", "-count=1", "-cpuprofile=$cpu", "-memprofile=$mem", "-o=$bin"); & ".\scripts\dev\go.ps1" @args'
+rtk proxy go tool pprof -sample_index=alloc_space -focus 'strings\.Fields' -top C:\temp\xlflow-issue711-after2-ronecone.test.exe C:\temp\xlflow-issue711-after2-ronecone.mem.pprof
+```
+
+`strings.Fields` fell to 60.01 MB and 979,713 allocation objects in the
+focused allocation profile (from 1,108.09 MB and 18,315,928 objects). The
+`arrayOptionPrivateModule` focus had no samples after the procedure-loop scan
+was removed; `normalizedCodeLine` was 89.01 MB and 1,725,823 objects (from
+1,092.58 MB and 18,084,039 objects). The CPU focus likewise showed no
+`arrayOptionPrivateModule` samples.
+
+The small/medium synthetic guard used five serial samples of
+`BenchmarkSingleModuleSynthetic`; the post-change medians were:
+
+| workload            |        B/op | allocs/op |
+| ------------------- | ----------: | --------: |
+| independent/100     |  16,658,824 |   196,759 |
+| independent/500     |  99,605,592 |   803,748 |
+| chain/100           |  34,585,936 |   260,675 |
+| chain/500           | 200,302,824 | 1,241,100 |
+| declarations/100    |  31,056,344 |    92,556 |
+| declarations/500    | 272,754,864 |   277,278 |
+| cfg-independent/100 |  28,357,888 |   214,094 |
+| cfg-independent/500 | 522,708,336 |   928,796 |
+
+The repository's +2% small-module guard passed. No analyzer finding identity,
+range, severity, evidence, multiplicity, ordering, snapshot, or review-ledger
+change was accepted as part of this performance work. `rtk task corpus:metrics`
+and two verify-only `rtk task corpus:test` runs are required before merging;
+any snapshot delta remains a stop-and-investigate condition.
+
 ## Related
 
 - `docs/adr/ADR-0029-vendored-static-analysis-corpus.md`

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1605,7 +1605,7 @@ The accessor-only benchmark was added to verify that repeated operation and
 option reads reuse the frozen maps and slices without exposing mutable storage;
 its `B/op` and `allocs/op` must remain zero in normal runs. The small-module
 test also enforces the recorded pre-#711 baseline of 60,560 B/op and 295
-allocs/op with a +2% guard (61,771 B/op and 301 allocs/op).
+allocs/op with a +2% guard (61,771 B/op and 300 allocs/op).
 
 For the required ROneCOne leaf, five serial samples used the same explicit
 benchmark command as earlier records:

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -355,6 +355,50 @@ procedure IR. A consumer that needs an independently owned resolved snapshot
 continues to call `Resolve`/`Materialize`, which remains the compatibility
 boundary.
 
+### Module semantic facts
+
+`moduleAnalysisFacts` may also own the immutable module-wide semantic facts
+needed by analyzer kernels. They are derived from the canonical
+`DocumentIR`/`ProcedureIR` and existing source normalization in one bounded
+pass for one module/revision. They are an implementation-level projection,
+not a complete normalized AST and not a replacement for the IR or resolution
+overlay.
+
+The module option projection includes `Option Private Module` as a tri-state
+value: `present` for an exact declaration in complete canonical input,
+`absent` when complete input proves no declaration exists, and `unknown` for
+recovered, incomplete, or ambiguous option syntax. Comment and string content
+cannot establish the option. Consumers must fail open for `unknown`, retaining
+the existing possibility that a procedure is externally visible. A module-wide
+option check is performed at most once per module/revision; procedure loops
+must consume the stored value and must not scan all source lines.
+
+The same immutable pass may index only the operation facts required by
+idempotent array setup: canonical lowercase identifier keys and compact
+observations for scalar assignment, direct `ReDim`, `Erase`, and whole-array
+assignment. This is not an array participant graph or a data-flow state. Shared
+maps and slices are private implementation details. Read access uses scalar,
+enum, or small owned-copy accessors; no mutable slice or map is exposed to a
+kernel.
+
+Module facts are attached before procedure workers run in batch, realtime, and
+LSP analysis. They are safe for concurrent readers and immutable after
+construction. Their lifetime is the parsed-file/IR revision; edits and
+complete/incomplete transitions require rebuilding the facts, and no
+cross-revision persistent cache is defined. Compatibility and synthetic
+callers must share one caller-owned facts value rather than triggering an
+implicit rebuild.
+
+The opt-in performance recorder reports `module_fact_builds` and
+`module_option_scans` as stderr-only counters. A normal module revision
+contributes at most one of each, regardless of its public procedure count.
+These counters are not part of CLI JSON, LSP payloads, or diagnostic output.
+`BenchmarkModuleAnalysisFacts` covers small, many-procedure, and
+operation-heavy construction/reuse cases; the real-world corpus benchmark
+`BenchmarkRealWorldCorpus/ronecone/analyze-only` is used for before/after CPU,
+heap, and allocation measurements. Small-module benchmark medians are kept as
+a regression guard while giant-module profiles verify normalization reuse.
+
 ### Procedure features and applicability planning
 
 Each `procedureAnalysisFacts` value also owns one immutable applicability

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -499,6 +499,7 @@ func recordFactBuilds(ctx context.Context, procedureCount int) {
 		return
 	}
 	recorder.RecordModuleFactBuild()
+	recorder.RecordModuleOptionScan()
 	if procedureCount > 0 {
 		recorder.RecordProcedureFactBuilds(uint64(procedureCount))
 	}
@@ -677,8 +678,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	for i := range parsedFiles {
 		procedures := sourceProceduresFromIRRef(&parsedFiles[i].IR, parsedFiles[i].CFG)
 		parsedFiles[i].Procedures = procedures
-		parsedFiles[i].ModuleFacts = buildModuleAnalysisFacts(parsedFiles[i].Lines, parsedFiles[i].IR, procedures)
-		parsedFiles[i].ModuleDeclarations = parsedFiles[i].ModuleFacts.moduleDeclarations
+		parsedFiles[i].ensureModuleAnalysisFacts()
 		materializeProcedureAnalysisPlans(&parsedFiles[i], projectEffects, analysis.Config.Analyze)
 		recordFactBuilds(ctx, len(procedures))
 	}
@@ -1514,8 +1514,7 @@ func SourceNonShortCircuitObjectGuardFindingsParsedContext(ctx context.Context, 
 			IR:         ir,
 			Procedures: procedures,
 		}
-		file.ModuleFacts = buildModuleAnalysisFacts(file.Lines, file.IR, procedures)
-		file.ModuleDeclarations = file.ModuleFacts.moduleDeclarations
+		file.ensureModuleAnalysisFacts()
 		recordFactBuilds(ctx, len(procedures))
 		analyzer := Analyzer{RootDir: rootDir, Config: cfg}
 		projectEffects := effects.ProjectSummary{}
@@ -1675,8 +1674,7 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 			ConstantValues:            constantValues,
 			DataFlowModuleBindings:    dataFlowModuleBindings,
 		}
-		file.ModuleFacts = buildModuleAnalysisFacts(file.Lines, file.IR, procedures)
-		file.ModuleDeclarations = file.ModuleFacts.moduleDeclarations
+		file.ensureModuleAnalysisFacts()
 		materializeProcedureAnalysisPlans(&file, projectEffects, cfg.Analyze)
 		recordFactBuilds(ctx, len(procedures))
 		if cfg.Analyze.DetectArrayLifecycleSafety || cfg.Analyze.DetectRedimPreserveDimension || cfg.Analyze.DetectObjectArrayComparison || cfg.Analyze.DetectDeterministicRuntimeErrors {
@@ -2226,6 +2224,7 @@ func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analys
 	if err := cancelCtx.Err(); err != nil {
 		return nil, err
 	}
+	file.ensureModuleAnalysisFacts()
 	var findings []Finding
 	procedures := sourceProceduresWithEffects(file, projectEffects)
 	moduleDecls := file.moduleDecls()
@@ -2242,6 +2241,10 @@ func (a Analyzer) analyzeParsedFileContext(cancelCtx context.Context, ctx analys
 // shared analysis execution budget. Each result is stored by source index and
 // merged in that order, so worker completion order cannot affect findings.
 func (a Analyzer) analyzeProcedureContextsBounded(cancelCtx context.Context, file parsedFile, procedures []sourceProcedure, moduleDecls map[string]sourceDeclaration, ctx analysisContext, projectEffects effects.ProjectSummary, filePermitHeld bool) ([]Finding, error) {
+	file.ensureModuleAnalysisFacts()
+	if moduleDecls == nil {
+		moduleDecls = file.moduleDecls()
+	}
 	if len(procedures) == 0 {
 		proc := sourceProcedure{StartLine: 1, EndLine: len(file.Lines)}
 		profile := newProcedureDomainProfile(cancelCtx)

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -1894,13 +1894,17 @@ type arrayModuleEntryStates map[string]map[string]bool
 
 func arrayPrivateProcedureTargets(files []parsedFile) map[string]sourceProcedure {
 	targets := map[string]sourceProcedure{}
+	for index := range files {
+		files[index].ensureModuleAnalysisFacts()
+	}
 	for _, file := range files {
+		facts := file.ModuleFacts
 		procedures := file.procedureView()
 		for procedureIndex := 0; procedureIndex < procedures.Len(); procedureIndex++ {
 			proc := procedures.valueAt(procedureIndex)
 			visibility := strings.TrimSpace(proc.Visibility)
 			private := strings.EqualFold(visibility, "Private") || strings.EqualFold(visibility, "Friend")
-			modulePrivate := strings.EqualFold(visibility, "Public") && arrayOptionPrivateModule(file.Lines)
+			modulePrivate := strings.EqualFold(visibility, "Public") && facts.privateModulePresent()
 			if !private && !modulePrivate {
 				continue
 			}
@@ -2679,6 +2683,12 @@ func inferArrayModuleAllocationSummaries(files []parsedFile, ctx analysisContext
 		proc        sourceProcedure
 		moduleDecls map[string]sourceDeclaration
 	}, 0)
+	// Package-local synthetic callers may omit ModuleFacts. Attach one local
+	// immutable instance before expanding the procedure list so compatibility
+	// paths do not rebuild and rescan module source once per procedure.
+	for index := range files {
+		files[index].ensureModuleAnalysisFacts()
+	}
 	for _, file := range files {
 		procs := file.procedureView()
 		moduleDecls := file.moduleDecls()
@@ -2822,17 +2832,17 @@ func arrayModuleIdempotentSetupArrays(file parsedFile, proc sourceProcedure, mod
 	}
 	end := min(len(file.Lines), proc.EndLine)
 	start := max(0, proc.StartLine-1)
+	facts := file.moduleAnalysisFacts()
 	type setupGuard struct {
 		name    string
 		checkAt int
 	}
 	guards := make([]setupGuard, 0)
 	for index := start; index < end; index++ {
-		match := arraySetupGuardRe.FindStringSubmatch(normalizedCodeLine(file.Lines[index]))
-		if len(match) != 2 {
+		name, ok := facts.sourceLineSetupGuard(index)
+		if !ok {
 			continue
 		}
-		name := strings.ToLower(cleanIdentifier(match[1]))
 		declaration, ok := moduleDecls[name]
 		if !ok || declaration.Array || declaration.Parameter || !strings.EqualFold(strings.TrimSpace(declaration.Type), "Boolean") {
 			continue
@@ -2845,8 +2855,7 @@ func arrayModuleIdempotentSetupArrays(file parsedFile, proc sourceProcedure, mod
 
 	lastExecutable := -1
 	for index := start; index < end; index++ {
-		text := strings.ToLower(strings.TrimSpace(normalizedCodeLine(file.Lines[index])))
-		if text != "" && text != "end sub" && text != "end function" && text != "end property" {
+		if facts.sourceLineIsExecutable(index) {
 			lastExecutable = index
 		}
 	}
@@ -2858,20 +2867,16 @@ func arrayModuleIdempotentSetupArrays(file parsedFile, proc sourceProcedure, mod
 		line int
 		rhs  string
 	}{}
-	for index, line := range file.Lines {
-		lhs, rhs, indexed, assigned := arrayAssignment(normalizedCodeLine(line))
-		if !assigned || indexed {
-			continue
-		}
-		name := strings.ToLower(cleanIdentifier(lhs))
-		for _, guard := range guards {
-			if name == guard.name {
-				guardWrites[name] = append(guardWrites[name], struct {
-					line int
-					rhs  string
-				}{line: index, rhs: strings.TrimSpace(rhs)})
+	for _, guard := range guards {
+		facts.forEachArrayOperationFor(guard.name, func(operation moduleArrayOperationFact) {
+			if operation.Kind != moduleArrayWholeAssignment {
+				return
 			}
-		}
+			guardWrites[guard.name] = append(guardWrites[guard.name], struct {
+				line int
+				rhs  string
+			}{line: operation.Line, rhs: operation.RHS})
+		})
 	}
 
 	result := map[string]bool{}
@@ -2882,25 +2887,20 @@ func arrayModuleIdempotentSetupArrays(file parsedFile, proc sourceProcedure, mod
 		}
 		setAt := writes[0].line
 		for index := guard.checkAt + 1; index < setAt; index++ {
-			match := arrayRedimRe.FindStringSubmatch(normalizedCodeLine(file.Lines[index]))
-			if len(match) == 0 || strings.TrimSpace(match[1]) != "" {
-				continue
-			}
-			for _, clause := range splitArgs(match[2]) {
-				redim, direct := parseDirectArrayRedimClause(clause)
-				if !direct {
-					continue
+			facts.forEachArrayOperationAt(index, func(operation moduleArrayOperationFact) {
+				if operation.Kind != moduleArrayDirectRedim || operation.Preserve {
+					return
 				}
-				name := strings.ToLower(cleanIdentifier(redim.name))
+				name := operation.Name
 				declaration, declared := moduleDecls[name]
 				if !declared || !declaration.Array || declaration.Parameter {
-					continue
+					return
 				}
-				if arrayModuleIdempotentSetupArrayHasOtherWrite(file, name, index) {
-					continue
+				if moduleArrayOperationHasOtherWrite(facts, name, index) {
+					return
 				}
 				result[name] = true
-			}
+			})
 		}
 	}
 	if len(result) == 0 {
@@ -2909,31 +2909,19 @@ func arrayModuleIdempotentSetupArrays(file parsedFile, proc sourceProcedure, mod
 	return result
 }
 
-func arrayModuleIdempotentSetupArrayHasOtherWrite(file parsedFile, name string, setupLine int) bool {
+func moduleArrayOperationHasOtherWrite(facts *moduleAnalysisFacts, name string, setupLine int) bool {
 	name = strings.ToLower(cleanIdentifier(name))
-	for index, line := range file.Lines {
-		text := normalizedCodeLine(line)
-		if match := arrayEraseRe.FindStringSubmatch(text); len(match) == 2 {
-			for _, target := range splitArgs(match[1]) {
-				if strings.EqualFold(strings.TrimSpace(target), name) {
-					return true
-				}
-			}
+	otherWrite := false
+	facts.forEachArrayOperationFor(name, func(operation moduleArrayOperationFact) {
+		if otherWrite {
+			return
 		}
-		if match := arrayRedimRe.FindStringSubmatch(text); len(match) > 0 {
-			for _, clause := range splitArgs(match[2]) {
-				redim, direct := parseDirectArrayRedimClause(clause)
-				if direct && strings.EqualFold(cleanIdentifier(redim.name), name) && index != setupLine {
-					return true
-				}
-			}
+		if operation.Kind == moduleArrayDirectRedim && operation.Line == setupLine {
+			return
 		}
-		lhs, _, indexed, assigned := arrayAssignment(text)
-		if assigned && !indexed && strings.EqualFold(cleanIdentifier(lhs), name) {
-			return true
-		}
-	}
-	return false
+		otherWrite = true
+	})
+	return otherWrite
 }
 
 func arrayProcedureLineHasInlineConditional(file parsedFile, line int) bool {

--- a/internal/analyze/module_facts.go
+++ b/internal/analyze/module_facts.go
@@ -28,6 +28,47 @@ type moduleAnalysisFacts struct {
 	moduleConstantNames    map[string]struct{}
 	procedureConstantNames map[int]map[string]struct{}
 	procedureNames         map[string]struct{}
+	// privateModule records the module option once for this source revision.
+	// The zero value is unknown so incomplete/recovered syntax fails open.
+	privateModule moduleOptionState
+
+	// arrayOperationsByName and arrayOperationsByLine are immutable indexes over
+	// the small set of module-wide operations used by array interprocedural
+	// summaries. Values are only exposed through callback accessors below; in
+	// particular, callers cannot retain or mutate the backing slices.
+	arrayOperationsByName map[string][]moduleArrayOperationFact
+	arrayOperationsByLine map[int][]moduleArrayOperationFact
+	lineFacts             []moduleSourceLineFact
+}
+
+type moduleOptionState uint8
+
+const (
+	moduleOptionUnknown moduleOptionState = iota
+	moduleOptionAbsent
+	moduleOptionPresent
+)
+
+type moduleArrayOperationKind uint8
+
+const (
+	moduleArrayWholeAssignment moduleArrayOperationKind = iota + 1
+	moduleArrayDirectRedim
+	moduleArrayErase
+)
+
+type moduleArrayOperationFact struct {
+	Name       string
+	Line       int
+	RHS        string
+	Dimensions string
+	Preserve   bool
+	Kind       moduleArrayOperationKind
+}
+
+type moduleSourceLineFact struct {
+	executable     bool
+	setupGuardName string
 }
 
 type moduleConstantFact struct {
@@ -46,6 +87,7 @@ func buildModuleAnalysisFacts(lines []string, document procedureir.DocumentIR, p
 		procedureLineOwners: make([]int, len(lines)+1),
 		procedureDecls:      make(map[int]map[string]sourceDeclaration, len(procedures)),
 	}
+	facts.privateModule = buildModuleSourceFacts(lines, facts, document.Parse.HasError || document.Parse.HasMissing)
 	if len(procedures) > 0 {
 		facts.procedureFactsByStart = make(map[int]*procedureAnalysisFacts, len(procedures))
 	}
@@ -159,6 +201,166 @@ func buildModuleAnalysisFacts(lines []string, document procedureir.DocumentIR, p
 		facts.moduleDeclarations = moduleDeclarationsFromSource(lines, facts.procedureLineOwners)
 	}
 	return facts
+}
+
+// buildModuleSourceFacts performs the one source-line pass needed by the
+// module-wide array summaries. normalizedCodeLine is intentionally called only
+// here for these facts; procedure consumers read the resulting immutable
+// operation/index values through accessors instead of repeating the scan.
+func buildModuleSourceFacts(lines []string, facts *moduleAnalysisFacts, parseIncomplete bool) moduleOptionState {
+	if facts == nil {
+		return moduleOptionUnknown
+	}
+	privateModule := moduleOptionAbsent
+	privateModuleCandidate := false
+	for lineNo, rawLine := range lines {
+		candidate := moduleFactCandidateLine(rawLine)
+		// Before a setup guard is found, only lines that can contribute to the
+		// indexed facts need normalization. Once lineFacts is materialized, the
+		// remainder of the procedure must also be normalized so the final
+		// executable-line check preserves the legacy all-line behavior.
+		if !candidate && facts.lineFacts == nil {
+			continue
+		}
+		text := normalizedCodeLine(rawLine)
+		lower := strings.ToLower(strings.TrimSpace(text))
+		if strings.HasPrefix(lower, "if ") {
+			match := arraySetupGuardRe.FindStringSubmatch(text)
+			if len(match) == 2 {
+				facts.ensureLineFacts(lines, lineNo)
+				facts.lineFacts[lineNo].setupGuardName = strings.ToLower(cleanIdentifier(match[1]))
+			}
+		}
+		if facts.lineFacts != nil {
+			facts.lineFacts[lineNo].executable = lower != "" && lower != "end sub" && lower != "end function" && lower != "end property"
+		}
+		if !candidate {
+			continue
+		}
+		if strings.Contains(lower, "=") {
+			if lhs, rhs, indexed, assigned := arrayAssignment(text); assigned && !indexed {
+				facts.addModuleArrayOperation(moduleArrayOperationFact{
+					Name: strings.ToLower(cleanIdentifier(lhs)), Line: lineNo,
+					RHS: strings.TrimSpace(rhs), Kind: moduleArrayWholeAssignment,
+				})
+			}
+		}
+		if strings.HasPrefix(lower, "redim ") {
+			match := arrayRedimRe.FindStringSubmatch(text)
+			if len(match) > 0 {
+				preserve := strings.TrimSpace(match[1]) != ""
+				for _, clause := range splitArgs(match[2]) {
+					redim, direct := parseDirectArrayRedimClause(clause)
+					if !direct {
+						continue
+					}
+					facts.addModuleArrayOperation(moduleArrayOperationFact{
+						Name: strings.ToLower(cleanIdentifier(redim.name)), Line: lineNo,
+						Dimensions: redim.dimensions, Preserve: preserve,
+						Kind: moduleArrayDirectRedim,
+					})
+				}
+			}
+		}
+		if strings.HasPrefix(lower, "erase ") {
+			match := arrayEraseRe.FindStringSubmatch(text)
+			if len(match) == 2 {
+				for _, target := range splitArgs(match[1]) {
+					name := strings.ToLower(strings.TrimSpace(target))
+					if !arrayEraseNameRe.MatchString(name) {
+						continue
+					}
+					facts.addModuleArrayOperation(moduleArrayOperationFact{
+						Name: name, Line: lineNo, Kind: moduleArrayErase,
+					})
+				}
+			}
+		}
+		switch lower {
+		case "option private module":
+			privateModule = moduleOptionPresent
+		case "option private":
+			privateModuleCandidate = true
+		default:
+			if strings.HasPrefix(lower, "option private ") {
+				privateModuleCandidate = true
+			}
+		}
+	}
+	if privateModuleCandidate || parseIncomplete {
+		return moduleOptionUnknown
+	}
+	return privateModule
+}
+
+// moduleFactCandidateLine is a cheap lexical gate for the small subset of
+// source lines that can contribute module options or array operation facts.
+// Most lines in ordinary modules are declarations or procedure boundaries;
+// avoiding normalization for those lines keeps the shared-facts fast path
+// allocation-light without changing the conservative parser-backed matching
+// below. False positives are harmless because the full normalizer still runs.
+func moduleFactCandidateLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return false
+	}
+	if asciiFoldPrefix(trimmed, "option") ||
+		asciiFoldKeywordPrefix(trimmed, "if") ||
+		asciiFoldKeywordPrefix(trimmed, "redim") ||
+		asciiFoldKeywordPrefix(trimmed, "erase") {
+		return true
+	}
+	return strings.Contains(trimmed, "=")
+}
+
+func asciiFoldPrefix(value, prefix string) bool {
+	if len(value) < len(prefix) {
+		return false
+	}
+	for index := range prefix {
+		left, right := value[index], prefix[index]
+		if left >= 'A' && left <= 'Z' {
+			left += 'a' - 'A'
+		}
+		if right >= 'A' && right <= 'Z' {
+			right += 'a' - 'A'
+		}
+		if left != right {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiFoldKeywordPrefix(value, keyword string) bool {
+	return asciiFoldPrefix(value, keyword) && len(value) > len(keyword) &&
+		(value[len(keyword)] == ' ' || value[len(keyword)] == '\t')
+}
+
+func (facts *moduleAnalysisFacts) addModuleArrayOperation(operation moduleArrayOperationFact) {
+	if facts == nil || operation.Name == "" {
+		return
+	}
+	if facts.arrayOperationsByName == nil {
+		facts.arrayOperationsByName = make(map[string][]moduleArrayOperationFact)
+		facts.arrayOperationsByLine = make(map[int][]moduleArrayOperationFact)
+	}
+	facts.arrayOperationsByName[operation.Name] = append(facts.arrayOperationsByName[operation.Name], operation)
+	facts.arrayOperationsByLine[operation.Line] = append(facts.arrayOperationsByLine[operation.Line], operation)
+}
+
+func (facts *moduleAnalysisFacts) ensureLineFacts(lines []string, through int) {
+	if facts == nil || facts.lineFacts != nil {
+		return
+	}
+	facts.lineFacts = make([]moduleSourceLineFact, len(lines))
+	if through >= len(lines) {
+		through = len(lines) - 1
+	}
+	for lineNo := 0; lineNo <= through; lineNo++ {
+		lower := strings.ToLower(strings.TrimSpace(normalizedCodeLine(lines[lineNo])))
+		facts.lineFacts[lineNo].executable = lower != "" && lower != "end sub" && lower != "end function" && lower != "end property"
+	}
 }
 
 func isSourceModuleDeclaration(declaration procedureir.Declaration) bool {
@@ -353,6 +555,50 @@ func (facts *moduleAnalysisFacts) hasProcedure(name string) bool {
 	return ok
 }
 
+func (facts *moduleAnalysisFacts) privateModuleState() moduleOptionState {
+	if facts == nil {
+		return moduleOptionUnknown
+	}
+	return facts.privateModule
+}
+
+func (facts *moduleAnalysisFacts) privateModulePresent() bool {
+	return facts.privateModuleState() == moduleOptionPresent
+}
+
+// forEachArrayOperationFor visits a copy of each operation for one canonical
+// identifier. The callback API deliberately keeps the immutable backing slice
+// private to moduleAnalysisFacts.
+func (facts *moduleAnalysisFacts) forEachArrayOperationFor(name string, visit func(moduleArrayOperationFact)) {
+	if facts == nil || visit == nil {
+		return
+	}
+	for _, operation := range facts.arrayOperationsByName[strings.ToLower(cleanIdentifier(name))] {
+		visit(operation)
+	}
+}
+
+func (facts *moduleAnalysisFacts) forEachArrayOperationAt(line int, visit func(moduleArrayOperationFact)) {
+	if facts == nil || visit == nil {
+		return
+	}
+	for _, operation := range facts.arrayOperationsByLine[line] {
+		visit(operation)
+	}
+}
+
+func (facts *moduleAnalysisFacts) sourceLineIsExecutable(line int) bool {
+	return facts != nil && line >= 0 && line < len(facts.lineFacts) && facts.lineFacts[line].executable
+}
+
+func (facts *moduleAnalysisFacts) sourceLineSetupGuard(line int) (string, bool) {
+	if facts == nil || line < 0 || line >= len(facts.lineFacts) {
+		return "", false
+	}
+	name := facts.lineFacts[line].setupGuardName
+	return name, name != ""
+}
+
 func moduleDeclarationsFromSource(lines []string, procedureLineOwners []int) map[string]sourceDeclaration {
 	decls := make(map[string]sourceDeclaration)
 	for lineNo, rawLine := range lines {
@@ -383,11 +629,25 @@ func moduleDeclarationsFromSource(lines []string, procedureLineOwners []int) map
 	return decls
 }
 
-func (file parsedFile) moduleAnalysisFacts() *moduleAnalysisFacts {
-	if file.ModuleFacts != nil {
-		return file.ModuleFacts
+// ensureModuleAnalysisFacts attaches the immutable facts object to the
+// caller-owned parsed-file revision. Normal batch/realtime setup attaches it
+// before worker launch; this helper is the explicit compatibility boundary for
+// package-local synthetic callers.
+func (file *parsedFile) ensureModuleAnalysisFacts() *moduleAnalysisFacts {
+	if file == nil {
+		return nil
 	}
-	return buildModuleAnalysisFacts(file.Lines, file.IR, file.procedureProjection())
+	if file.ModuleFacts == nil {
+		file.ModuleFacts = buildModuleAnalysisFacts(file.Lines, file.IR, file.procedureProjection())
+		if file.ModuleDeclarations == nil && file.ModuleFacts != nil {
+			file.ModuleDeclarations = file.ModuleFacts.moduleDeclarations
+		}
+	}
+	return file.ModuleFacts
+}
+
+func (file *parsedFile) moduleAnalysisFacts() *moduleAnalysisFacts {
+	return file.ensureModuleAnalysisFacts()
 }
 
 func (file parsedFile) procedureDeclarationsFor(proc sourceProcedure) map[string]sourceDeclaration {

--- a/internal/analyze/module_facts_allocation_guard_norace_test.go
+++ b/internal/analyze/module_facts_allocation_guard_norace_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package analyze
+
+const moduleFactsAllocationGuardEnabled = true

--- a/internal/analyze/module_facts_allocation_guard_race_test.go
+++ b/internal/analyze/module_facts_allocation_guard_race_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package analyze
+
+const moduleFactsAllocationGuardEnabled = false

--- a/internal/analyze/module_facts_perf_test.go
+++ b/internal/analyze/module_facts_perf_test.go
@@ -1,0 +1,457 @@
+package analyze
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/typedb"
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+var benchmarkModuleFactsOperationCount int
+
+func TestArrayOptionPrivateModuleNormalization(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		lines          []string
+		document       procedureir.DocumentIR
+		want           moduleOptionState
+		wantLegacyBool bool
+	}{
+		{
+			name:           "present",
+			lines:          []string{"Option Private Module"},
+			want:           moduleOptionPresent,
+			wantLegacyBool: true,
+		},
+		{
+			name:           "case and whitespace insensitive",
+			lines:          []string{"\toption\tprivate\tmodule  "},
+			want:           moduleOptionPresent,
+			wantLegacyBool: true,
+		},
+		{
+			name:           "trailing comment",
+			lines:          []string{"Option Private Module ' module visibility"},
+			want:           moduleOptionPresent,
+			wantLegacyBool: true,
+		},
+		{
+			name:           "comment only",
+			lines:          []string{"' Option Private Module"},
+			want:           moduleOptionAbsent,
+			wantLegacyBool: false,
+		},
+		{
+			name:           "quoted text",
+			lines:          []string{"Debug.Print \"Option Private Module\""},
+			want:           moduleOptionAbsent,
+			wantLegacyBool: false,
+		},
+		{
+			name:           "incomplete option",
+			lines:          []string{"Option Private"},
+			want:           moduleOptionUnknown,
+			wantLegacyBool: false,
+		},
+		{
+			name:           "recovered declaration elsewhere",
+			lines:          []string{"Option Private Module"},
+			document:       procedureir.DocumentIR{Parse: procedureir.ParseSummary{HasMissing: true}},
+			want:           moduleOptionUnknown,
+			wantLegacyBool: true,
+		},
+		{
+			name:           "syntax error elsewhere",
+			lines:          []string{"Option Private Module"},
+			document:       procedureir.DocumentIR{Parse: procedureir.ParseSummary{HasError: true}},
+			want:           moduleOptionUnknown,
+			wantLegacyBool: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := buildModuleAnalysisFacts(test.lines, test.document, nil)
+			if got := facts.privateModuleState(); got != test.want {
+				t.Fatalf("privateModuleState(%q) = %v, want %v", test.lines, got, test.want)
+			}
+			if got := arrayOptionPrivateModule(test.lines); got != test.wantLegacyBool {
+				t.Fatalf("arrayOptionPrivateModule(%q) = %v, want %v", test.lines, got, test.wantLegacyBool)
+			}
+		})
+	}
+}
+
+func TestModuleAnalysisFactsConcurrentRead(t *testing.T) {
+	lines := []string{
+		"Option Private Module",
+		"Private Const ModuleValue As Long = 1",
+		"moduleArray = Array(1)",
+		"Public Sub First()",
+		"    Dim localValue As Long",
+		"End Sub",
+		"Public Sub Second()",
+		"    Dim otherValue As Long",
+		"End Sub",
+	}
+	procedures := []sourceProcedure{
+		{Name: "First", StartLine: 4, EndLine: 6, StartByte: 101},
+		{Name: "Second", StartLine: 7, EndLine: 9, StartByte: 201},
+	}
+	facts := buildModuleAnalysisFacts(lines, procedureir.DocumentIR{}, procedures)
+	if facts == nil {
+		t.Fatal("buildModuleAnalysisFacts returned nil")
+	}
+
+	const readers = 32
+	const iterations = 100
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for reader := 0; reader < readers; reader++ {
+		go func() {
+			defer wg.Done()
+			for iteration := 0; iteration < iterations; iteration++ {
+				if facts.privateModuleState() != moduleOptionPresent || !facts.privateModulePresent() {
+					t.Errorf("private module state is not stable")
+					return
+				}
+				if !facts.lineInProcedure(4) || facts.lineInProcedure(1) {
+					t.Errorf("unexpected procedure ownership")
+					return
+				}
+				declarations := facts.procedureDeclarations(procedures[0])
+				if got := declarations["localvalue"].Name; got != "localValue" {
+					t.Errorf("procedure declarations = %#v", declarations)
+					return
+				}
+				if facts.procedureFactsFor(procedures[0]) == nil || facts.procedureFactsFor(procedures[1]) == nil {
+					t.Errorf("procedure facts lookup returned nil")
+					return
+				}
+				if !facts.hasConstant("modulevalue") || facts.hasConstantForProcedure("LocalValue", procedures[0]) || facts.hasConstantForProcedure("OtherValue", procedures[0]) {
+					t.Errorf("constant lookup returned inconsistent result")
+					return
+				}
+				if !facts.hasProcedure("FIRST") || !facts.hasProcedure("second") {
+					t.Errorf("procedure lookup returned inconsistent result")
+					return
+				}
+				operationCount := 0
+				facts.forEachArrayOperationFor("MODULEARRAY", func(operation moduleArrayOperationFact) {
+					if operation.Kind == moduleArrayWholeAssignment && operation.RHS == "Array(1)" {
+						operationCount++
+					}
+				})
+				if operationCount != 1 {
+					t.Errorf("module operation lookup count = %d, want one", operationCount)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestModuleAnalysisFactsIndexesArrayOperations(t *testing.T) {
+	lines := []string{
+		"Private values() As Long",
+		"Private other() As Long",
+		"values = Array(1)",
+		"ReDim values(0 To 2)",
+		"ReDim Preserve values(0 To 4)",
+		"Erase values, other",
+	}
+	facts := buildModuleAnalysisFacts(lines, procedureir.DocumentIR{}, nil)
+
+	var values []moduleArrayOperationFact
+	facts.forEachArrayOperationFor("VALUES", func(operation moduleArrayOperationFact) {
+		values = append(values, operation)
+	})
+	if len(values) != 4 {
+		t.Fatalf("values operations = %#v, want whole assignment, two ReDim operations, and Erase", values)
+	}
+	if values[0].Kind != moduleArrayWholeAssignment || values[0].RHS != "Array(1)" {
+		t.Fatalf("whole-array operation = %#v", values[0])
+	}
+	if values[1].Kind != moduleArrayDirectRedim || values[1].Preserve || values[1].Dimensions != "0 To 2" {
+		t.Fatalf("direct ReDim operation = %#v", values[1])
+	}
+	if values[2].Kind != moduleArrayDirectRedim || !values[2].Preserve || values[2].Dimensions != "0 To 4" {
+		t.Fatalf("Preserve ReDim operation = %#v", values[2])
+	}
+	if values[3].Kind != moduleArrayErase {
+		t.Fatalf("Erase operation = %#v", values[3])
+	}
+
+	var other []moduleArrayOperationFact
+	facts.forEachArrayOperationFor("other", func(operation moduleArrayOperationFact) {
+		other = append(other, operation)
+	})
+	if len(other) != 1 || other[0].Kind != moduleArrayErase {
+		t.Fatalf("other operations = %#v, want one Erase", other)
+	}
+
+	var atLine []moduleArrayOperationFact
+	facts.forEachArrayOperationAt(values[1].Line, func(operation moduleArrayOperationFact) {
+		atLine = append(atLine, operation)
+	})
+	if len(atLine) != 1 || atLine[0].Name != "values" {
+		t.Fatalf("line operation index = %#v, want one values operation", atLine)
+	}
+}
+
+func TestModuleArrayOperationIndexMatchesLegacySourceScan(t *testing.T) {
+	lines := []string{
+		"ReDim first(0 To 1), second(0 To 2) ' multi-clause",
+		"ReDim Preserve first(0 To 3), second(0 To 4)",
+		"Erase first, second, indexed(1)",
+		"first(0) = 1",
+		"first = Array(1) ' whole-array assignment",
+		"first% = Array(2) ' type-suffix identifier",
+	}
+	facts := buildModuleAnalysisFacts(lines, procedureir.DocumentIR{}, nil)
+	got := make([]moduleArrayOperationFact, 0)
+	for _, name := range []string{"first", "second", "indexed"} {
+		facts.forEachArrayOperationFor(name, func(operation moduleArrayOperationFact) {
+			got = append(got, operation)
+		})
+	}
+	want := legacyModuleArrayOperationFacts(lines)
+	canonicalize := func(operations []moduleArrayOperationFact) {
+		sort.SliceStable(operations, func(i, j int) bool {
+			if operations[i].Line != operations[j].Line {
+				return operations[i].Line < operations[j].Line
+			}
+			if operations[i].Kind != operations[j].Kind {
+				return operations[i].Kind < operations[j].Kind
+			}
+			return operations[i].Name < operations[j].Name
+		})
+	}
+	canonicalize(got)
+	canonicalize(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("module operation index differs from legacy scan:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func legacyModuleArrayOperationFacts(lines []string) []moduleArrayOperationFact {
+	operations := make([]moduleArrayOperationFact, 0)
+	for lineNo, line := range lines {
+		text := normalizedCodeLine(line)
+		if lhs, rhs, indexed, assigned := arrayAssignment(text); assigned && !indexed {
+			operations = append(operations, moduleArrayOperationFact{
+				Name: strings.ToLower(cleanIdentifier(lhs)), Line: lineNo,
+				RHS: strings.TrimSpace(rhs), Kind: moduleArrayWholeAssignment,
+			})
+		}
+		if match := arrayRedimRe.FindStringSubmatch(text); len(match) > 0 {
+			preserve := strings.TrimSpace(match[1]) != ""
+			for _, clause := range splitArgs(match[2]) {
+				redim, direct := parseDirectArrayRedimClause(clause)
+				if !direct {
+					continue
+				}
+				operations = append(operations, moduleArrayOperationFact{
+					Name: strings.ToLower(cleanIdentifier(redim.name)), Line: lineNo,
+					Dimensions: redim.dimensions, Preserve: preserve,
+					Kind: moduleArrayDirectRedim,
+				})
+			}
+		}
+		if match := arrayEraseRe.FindStringSubmatch(text); len(match) == 2 {
+			for _, target := range splitArgs(match[1]) {
+				name := strings.ToLower(strings.TrimSpace(target))
+				if !arrayEraseNameRe.MatchString(name) {
+					continue
+				}
+				operations = append(operations, moduleArrayOperationFact{Name: name, Line: lineNo, Kind: moduleArrayErase})
+			}
+		}
+	}
+	return operations
+}
+
+func TestModuleIdempotentSetupPreservesNonCandidateExecutableTail(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		tail       string
+		wantValues bool
+	}{
+		{name: "assignment is final", tail: "", wantValues: true},
+		{name: "debug statement follows assignment", tail: "Debug.Print \"initialized\"", wantValues: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lines := []string{
+				"Private ready As Boolean",
+				"Private values() As Long",
+				"Private Sub EnsureValues()",
+				"    If ready Then Exit Sub",
+				"    ReDim values(0 To 1)",
+				"    ready = True",
+			}
+			if test.tail != "" {
+				lines = append(lines, "    "+test.tail)
+			}
+			lines = append(lines, "End Sub")
+			proc := sourceProcedure{Name: "EnsureValues", StartLine: 3, EndLine: len(lines), StartByte: 1}
+			facts := buildModuleAnalysisFacts(lines, procedureir.DocumentIR{}, []sourceProcedure{proc})
+			file := parsedFile{Lines: lines, ModuleFacts: facts}
+			moduleDecls := map[string]sourceDeclaration{
+				"ready":  {Name: "ready", Type: "Boolean"},
+				"values": {Name: "values", Array: true, Type: "Long"},
+			}
+			got := arrayModuleIdempotentSetupArrays(file, proc, moduleDecls)
+			if got["values"] != test.wantValues {
+				t.Fatalf("idempotent setup summary = %#v, values presence = %v, want %v", got, got["values"], test.wantValues)
+			}
+		})
+	}
+}
+
+func TestModuleAnalysisFactsSmallAllocationGuard(t *testing.T) {
+	if !moduleFactsAllocationGuardEnabled {
+		t.Skip("allocation guard is disabled under the race detector")
+	}
+	lines := make([]string, 8*3)
+	procedures := make([]sourceProcedure, 0, 8)
+	for index := 0; index < 8; index++ {
+		start := index*3 + 1
+		lines[start-1] = "Private Sub Run" + strconvItoa(index) + "()"
+		lines[start] = "    Dim localValue As Long"
+		lines[start+1] = "End Sub"
+		procedures = append(procedures, sourceProcedure{StartLine: start, EndLine: start + 2, StartByte: index + 1})
+	}
+	declarations := make([]procedureir.Declaration, 0, 4)
+	for index := 0; index < 4; index++ {
+		declarations = append(declarations, procedureir.Declaration{
+			Name: "ModuleValue" + strconvItoa(index), Type: "Long", Scope: procedureir.ScopeModule,
+			Kind: "variable", Range: vbaast.Range{StartLine: index + 1, EndLine: index + 1},
+		})
+	}
+	document := procedureir.DocumentIR{Declarations: declarations}
+	result := testing.Benchmark(func(b *testing.B) {
+		for index := 0; index < b.N; index++ {
+			benchmarkModuleFactsSink = buildModuleAnalysisFacts(lines, document, procedures)
+		}
+	})
+	// Baseline is the pre-#711 small workload measured on the repository's
+	// Windows Go toolchain. Keep the guard at +2% to catch accidental per-file
+	// normalization regressions while allowing normal benchmark jitter.
+	const baselineBytes = 60560
+	const baselineAllocs = 295
+	if got := result.AllocedBytesPerOp(); got > baselineBytes*102/100 {
+		t.Fatalf("small module allocation = %d B/op, baseline %d B/op (+2%% guard)", got, baselineBytes)
+	}
+	if got := result.AllocsPerOp(); got > baselineAllocs*102/100 {
+		t.Fatalf("small module allocations = %d allocs/op, baseline %d (+2%% guard)", got, baselineAllocs)
+	}
+}
+
+func TestModuleOptionScanCountDoesNotScaleWithPublicProcedures(t *testing.T) {
+	for _, procedureCount := range []int{1, 100, 1000} {
+		t.Run(fmt.Sprintf("procedures_%d", procedureCount), func(t *testing.T) {
+			values := runModuleOptionScanBenchmarkAnalysis(t, procedureCount)
+			if got := values[analysisstats.ModuleOptionScansCounter]; got != 1 {
+				t.Fatalf("module option scans = %d for %d procedures, want one", got, procedureCount)
+			}
+			if got := values[analysisstats.ModuleFactBuildsCounter]; got != 1 {
+				t.Fatalf("module fact builds = %d for %d procedures, want one", got, procedureCount)
+			}
+		})
+	}
+}
+
+func runModuleOptionScanBenchmarkAnalysis(t *testing.T, procedureCount int) map[string]uint64 {
+	t.Helper()
+	root := t.TempDir()
+	modules := filepath.Join(root, "src", "modules")
+	if err := os.MkdirAll(modules, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := "Option Explicit\nOption Private Module\n"
+	for index := 0; index < procedureCount; index++ {
+		source += fmt.Sprintf("Public Sub Run%d()\nEnd Sub\n", index)
+	}
+	if err := os.WriteFile(filepath.Join(modules, "Main.bas"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
+	recorder := analysisstats.NewRecorder()
+	_, err := (Analyzer{RootDir: root, Config: config.Default()}).RunResultContext(analysisstats.WithRecorder(context.Background(), recorder))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, counters := recorder.Totals()
+	values := make(map[string]uint64, len(counters))
+	for _, counter := range counters {
+		values[counter.Name] = counter.Value
+	}
+	return values
+}
+
+// BenchmarkModuleAnalysisFactsOperationHeavy exercises the profiler-driven
+// operation index with the same repeated setup idiom that procedure workers
+// query. The benchmark intentionally measures construction only; accessors
+// are allocation-free reads over the frozen facts object.
+func BenchmarkModuleAnalysisFactsOperationHeavy(b *testing.B) {
+	const procedureCount = 500
+	lines := []string{
+		"Option Private Module",
+		"Private ready As Boolean",
+		"Private values() As Long",
+		"Private other() As Long",
+	}
+	procedures := make([]sourceProcedure, 0, procedureCount)
+	for index := 0; index < procedureCount; index++ {
+		start := len(lines) + 1
+		lines = append(lines,
+			fmt.Sprintf("Public Sub Run%d()", index),
+			"    If ready Then Exit Sub",
+			fmt.Sprintf("    ReDim values(0 To %d)", index%8+1),
+			"    ready = True",
+			"    Erase values, other",
+			"End Sub",
+		)
+		procedures = append(procedures, sourceProcedure{
+			StartLine: start, EndLine: start + 5, StartByte: index + 1,
+		})
+	}
+	document := procedureir.DocumentIR{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		benchmarkModuleFactsSink = buildModuleAnalysisFacts(lines, document, procedures)
+	}
+	b.ReportMetric(float64(procedureCount), "procedures/op")
+}
+
+func BenchmarkModuleAnalysisFactsOperationAccessors(b *testing.B) {
+	lines := []string{
+		"Private ready As Boolean",
+		"Private values() As Long",
+		"If ready Then Exit Sub",
+		"ReDim values(0 To 1)",
+		"ready = True",
+		"Erase values",
+	}
+	facts := buildModuleAnalysisFacts(lines, procedureir.DocumentIR{}, nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		count := 0
+		facts.forEachArrayOperationFor("values", func(moduleArrayOperationFact) { count++ })
+		facts.forEachArrayOperationAt(3, func(moduleArrayOperationFact) { count++ })
+		benchmarkModuleFactsOperationCount += count
+		benchmarkModuleFactsSink = facts
+	}
+}

--- a/internal/analyze/profiling_test.go
+++ b/internal/analyze/profiling_test.go
@@ -158,7 +158,8 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 		"file_count", "procedure_count", "statement_count", "expression_count",
 		"call_site_count", "cfg_block_count", "cfg_edge_count", "project_symbol_count",
 		"byref_diagnostic_passes", "line_count", "module_declaration_count",
-		analysisstats.ModuleFactBuildsCounter, analysisstats.ProcedureFactBuildsCounter,
+		analysisstats.ModuleFactBuildsCounter, analysisstats.ModuleOptionScansCounter,
+		analysisstats.ProcedureFactBuildsCounter,
 		"max_lines_per_file", "max_procedures_per_file", "max_calls_per_file",
 		"max_statements_per_procedure", "max_cfg_blocks_per_procedure", "max_cfg_edges_per_procedure",
 	} {
@@ -193,6 +194,9 @@ func TestBatchAnalysisProfilingPreservesResultsAndReportsWorkload(t *testing.T) 
 	}
 	if counterByName[analysisstats.ModuleFactBuildsCounter] != 1 || counterByName[analysisstats.ProcedureFactBuildsCounter] != 1 {
 		t.Fatalf("shared fact builds = module %d, procedure %d; want one each for one file/procedure revision", counterByName[analysisstats.ModuleFactBuildsCounter], counterByName[analysisstats.ProcedureFactBuildsCounter])
+	}
+	if counterByName[analysisstats.ModuleOptionScansCounter] != 1 {
+		t.Fatalf("module option scans = %d, want one for the file revision", counterByName[analysisstats.ModuleOptionScansCounter])
 	}
 	wantLineCount := uint64(len(normalizedSourceLines(source)) - 1)
 	if counterByName["line_count"] != wantLineCount ||

--- a/internal/analyze/project_capabilities.go
+++ b/internal/analyze/project_capabilities.go
@@ -90,8 +90,7 @@ func PlanProjectCapabilities(cfg config.AnalyzeConfig, documents []ProjectCapabi
 			CFG:        document.CFG,
 			Procedures: procedures,
 		}
-		file.ModuleFacts = buildModuleAnalysisFacts(file.Lines, file.IR, procedures)
-		file.ModuleDeclarations = file.ModuleFacts.moduleDeclarations
+		file.ensureModuleAnalysisFacts()
 		materializeProcedureAnalysisPlans(&file, effects.ProjectSummary{}, cfg)
 		files = append(files, file)
 	}

--- a/internal/vba/analysisstats/recorder.go
+++ b/internal/vba/analysisstats/recorder.go
@@ -276,6 +276,11 @@ func (c WorkCounter) String() string {
 const (
 	ModuleFactBuildsCounter    = "module_fact_builds"
 	ProcedureFactBuildsCounter = "procedure_fact_builds"
+	// ModuleOptionScansCounter records the number of module-wide option scans
+	// performed while constructing immutable module facts. It is deliberately
+	// an additive counter: one module/revision contributes one observation even
+	// when the module has many procedures.
+	ModuleOptionScansCounter = "module_option_scans"
 
 	// Capability build counters are also used as stage names when a build is
 	// timed with MeasureCapabilityBuild. Keeping the two names identical makes
@@ -572,6 +577,19 @@ func (r *Recorder) AddMax(name string, value uint64) {
 // facts for an analysis revision. A nil recorder is intentionally a no-op.
 func (r *Recorder) RecordModuleFactBuild() {
 	r.AddSum(ModuleFactBuildsCounter, 1)
+}
+
+// RecordModuleOptionScan records one module-wide option scan. A nil recorder
+// is intentionally a no-op, matching the other typed telemetry helpers.
+func (r *Recorder) RecordModuleOptionScan() {
+	r.RecordModuleOptionScans(1)
+}
+
+// RecordModuleOptionScans records multiple module-wide option scans in one
+// counter update. The batch form avoids taking one recorder lock per module
+// when a caller publishes already-aggregated observations.
+func (r *Recorder) RecordModuleOptionScans(count uint64) {
+	r.AddSum(ModuleOptionScansCounter, count)
 }
 
 // RecordProcedureFactBuild records one construction of the immutable

--- a/internal/vba/analysisstats/recorder_test.go
+++ b/internal/vba/analysisstats/recorder_test.go
@@ -66,12 +66,15 @@ func TestTotalsAggregateStagesAndSortCounters(t *testing.T) {
 func TestRecordFactBuildCounters(t *testing.T) {
 	recorder := NewRecorder()
 	recorder.RecordModuleFactBuild()
+	recorder.RecordModuleOptionScan()
+	recorder.RecordModuleOptionScans(2)
 	recorder.RecordProcedureFactBuild()
 	recorder.RecordProcedureFactBuilds(1)
 
 	_, counters := recorder.Totals()
 	want := []Counter{
 		{Name: ModuleFactBuildsCounter, Value: 1},
+		{Name: ModuleOptionScansCounter, Value: 3},
 		{Name: ProcedureFactBuildsCounter, Value: 2},
 	}
 	if !reflect.DeepEqual(counters, want) {
@@ -82,6 +85,8 @@ func TestRecordFactBuildCounters(t *testing.T) {
 func TestRecordFactBuildCountersNilSafe(t *testing.T) {
 	var recorder *Recorder
 	recorder.RecordModuleFactBuild()
+	recorder.RecordModuleOptionScan()
+	recorder.RecordModuleOptionScans(2)
 	recorder.RecordProcedureFactBuild()
 }
 

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -689,6 +689,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `module_new_failed`
 - `module_not_found`
 - `module_only_declaration_in_procedure`
+- `module_option_scans`
 - `module_path`
 - `module_score_threshold`
 - `module_state`


### PR DESCRIPTION
## Summary

- Implements #711 by building immutable module semantic facts once per parsed-file/IR revision.
- Precomputes tri-state `Option Private Module` semantics and the profiler-backed array operation index, removing procedure-loop module scans while preserving conservative recovered-syntax handling.
- Shares facts across batch, realtime/LSP, and compatibility analysis paths through accessor-only APIs; no public analyzer, diagnostic, source-range, or JSON/LSP schema changes.
- Adds scan-count, operation-parity, concurrency, allocation-guard, and focused benchmark coverage.
- Updates ADR-0046, IR/corpus specifications, the changelog, and generated reference inventory.

Closes #711

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/analyze ./internal/vba/analysisstats ./internal/lspserver`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/analyze`
- `rtk task corpus:metrics`
- `rtk task corpus:test` (verify-only, repeated twice; no snapshot or review-ledger changes)
- `rtk pnpm docs:check`
- Pre-commit Go, PowerShell, documentation, and formatting checks

## Performance

- ROneCOne `analyze-only` five-run median: 16.428 s, 18,418,130,784 B/op, 99,679,756 allocs/op; all runs reported 510 findings, `module_fact_builds=1`, and `module_option_scans=1`.
- Allocation profile: focused `strings.Fields` fell from 1,108.09 MB to 60.01 MB; `arrayOptionPrivateModule` no longer appears in the post-change profile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved analysis efficiency by reusing immutable module-level facts across batch, real-time, and LSP workflows.
  * Reduced repeated scans and normalization while preserving behavior for private modules and array-operation checks.
* **Telemetry**
  * Added `module_option_scans` measurements to help track analysis performance.
* **Documentation**
  * Added architecture, specification, verification, benchmark, and changelog documentation for the analysis improvements.
* **Quality**
  * Expanded regression, concurrency, allocation, and performance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->