### PR TITLE
perf(analyze): introduce compact semantic state solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Introduced the internal indexed semantic-state solver at the HTTP transport
+  scheduling boundary and for the ordinary Array CFG walk. Revision-local
+  `SymbolID` and `BlockOrdinal` indexes, dense/sparse slot storage, in-place
+  joins, and a deterministic changed-state worklist preserve diagnostic,
+  snapshot, CLI JSON, and LSP contracts. HTTP nested-map scalarization and
+  source-line/edge-refinement Array paths remain follow-up migrations.
+
 - Restricted array interprocedural fixed-point planning to semantic
   participants discovered from array operations, parameters/returns,
   ByRef/module-state dependencies, and resolved caller/callee closure.

--- a/docs/adr/ADR-0047-compact-semantic-state-solver.md
+++ b/docs/adr/ADR-0047-compact-semantic-state-solver.md
@@ -1,0 +1,186 @@
+# ADR-0047: Compact Semantic State Solver for Procedure Data Flow
+
+## Status
+
+Accepted
+
+## Context
+
+The procedure analysis wave has already moved expensive setup behind immutable
+procedure facts, applicability plans, semantic kernel result stores, and
+independent HTTP/generic data-flow lanes. The remaining HTTP and Array kernels
+still carry most of their propagation state as string-keyed maps. Every block
+transfer clones those maps, Array joins allocate a union-key map and copy shape
+slices, and HTTP state equality depends on a deep comparison of nested maps.
+
+On the ROneCOne `analyze-only` workload at the Issue #713 starting revision
+(`6c9f8ba60c5b162cb7115e8e68744412c7de9d5d`), a Windows amd64 profile run on
+the repository's i7-12700 development host used
+`scripts/dev/go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench
+'^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchtime=1x -count=1`
+with the test binary and heap profile retained under
+`C:\Users\HARUMI\AppData\Local\Temp\xlflow-issue713-baseline.*`. The focused
+alloc-space view attributed approximately 1.62 GB to `cloneArrayState`,
+0.53 GB to `meetArrayState`, and 0.07 GB to `cloneHTTPState` in that sample.
+These copies are semantic state, not diagnostic evidence, and their cost grows
+with the width of a procedure and the number of CFG joins.
+
+This decision relates to the ownership and identity boundary in ADR-0021, the
+CFG identity and conservative edge contract in ADR-0022, the bounded semantic
+state/evidence separation in
+`docs/adr/ADR-0044-bounded-procedure-effect-summaries.md`, and the
+kernel/result/work-budget contract in ADR-0046. It does not move the generic
+source-to-sink package,
+change CFG storage, or introduce a persistent cache.
+
+## Decision
+
+Add an internal `internal/analyze/semanticstate` solver boundary used first by
+the HTTP and Array kernels.
+
+### Ownership and identity
+
+Each procedure revision builds one immutable environment. Domain-relevant,
+case-insensitive names are assigned deterministic revision-local `SymbolID`
+values from sorted canonical names. CFG blocks and edges are indexed once using
+deterministic `BlockOrdinal` values derived from the graph's stable block order.
+Module/project constants, declarations, interned strings, URL/path values, and
+Array dimension shapes belong to this immutable environment and are not copied
+into every block state.
+
+Mutable flow state is procedure-local and owned by the solver invocation. A
+state must not retain parser leases, source buffers, mutable environment maps,
+or references to an obsolete analysis revision. Scratch states and changed-slot
+buffers are reusable only until the procedure invocation ends.
+
+### State representation
+
+The solver provides compact indexed slots with two physical representations:
+
+1. dense values plus a presence bitset for small or sufficiently dense domains;
+2. sorted sparse entries for wide, sparse domains.
+
+The hybrid selector is deterministic: it uses dense storage when the domain has
+at most 64 symbols or the precomputed touched-symbol density is at least 25%,
+and sparse storage otherwise. Representation benchmarks cover dense, sparse,
+and hybrid choices; changing these constants requires new benchmark evidence.
+Slot values are scalar IDs, flags, or bounded handles to immutable interned
+values. The ordinary Array adapter follows this rule and keeps dimension
+shapes in the value lattice. The initial HTTP adapter intentionally retains
+the legacy `httpAnalysisState` nested maps in one compatibility slot while
+its semantic-unit scalarization is developed separately; this exception is
+why the Issue #713 allocation target remains open.
+
+### Joins and convergence
+
+Domain adapters implement transfer, lattice join, equality, and edge-specific
+refinement. Joins update the destination state in place and return the changed
+`SymbolID` values through a caller-owned buffer. A union-key map or complete
+temporary result state is forbidden on the hot path.
+
+The HTTP and Array lattices are finite and use their existing conservative
+unknown/intersection/union semantics; no widening operation is added. The
+solver converges when no destination slot changes. Idempotent joins report no
+changed slots.
+
+The worklist is indexed by `(BlockOrdinal, LaneOrdinal)` and ordered
+deterministically. A lane/block is requeued only when its incoming state
+changes. Exceptional and uncertain edges retain the predecessor input state
+unless the domain adapter explicitly preserves an existing narrow exception.
+Cancellation is checked at queue and long transfer boundaries. The solver does
+not create goroutines or rule-level worker pools; it runs within the existing
+procedure execution budget. The processed work-item trace is opt-in for
+regression tests and is disabled by production adapters, so loop revisits do
+not accumulate an unused history allocation.
+
+### Evidence and projections
+
+Source ranges, representative paths, credential sink lines, diagnostic
+multiplicity, and other witness data are not lattice state. HTTP reconstructs
+findings after convergence from stable states. Array keeps a separate witness
+sidecar/replay and canonicalizes evidence by the existing source/range/order
+rules. Semantic state may retain only bounded membership required to decide a
+later transfer (for example an interned executable-path set); evidence itself
+must not cause state copies or affect equality.
+
+### Migration boundary
+
+The first migration covers the HTTP scheduler boundary (`solveHTTPStates`)
+and the ordinary block-level `arrayFlowState` walk. HTTP's nested state is
+not yet compacted into semantic-unit slots. Array source-line traversal,
+edge-refinement callbacks, and interprocedural evidence walkers remain on
+their compatibility path until their callback contracts can be migrated
+without changing the VBA227/VBA208/VBA249 boundary. Existing diagnostic IDs,
+severity, ranges, messages, suppression, JSON, LSP projections,
+batch/realtime parity, and performance-counter meanings remain unchanged.
+Generic
+`internal/vba/dataflow`, CFG storage, cross-run caching, and unrelated semantic
+domains remain outside this decision.
+
+## Consequences
+
+- Ordinary Array state copies become proportional to compact slot values or
+  active sparse entries. HTTP gains deterministic indexed scheduling and
+  cancellation through the shared boundary, but its compatibility slot still
+  copies nested maps until the follow-up scalarization.
+- The solver and domain adapters have a narrow ownership boundary that can be
+  reused by later semantic kernels without exposing analyzer or protocol APIs.
+- Deterministic indexed scheduling and changed-slot reporting make convergence
+  and reprocessing measurable and reproducible.
+- A second evidence projection is required where the old implementation
+  collected findings during transfers; this preserves diagnostics while keeping
+  witnesses out of the fixed-point state.
+- The hybrid threshold and intern tables add a small setup cost. Dense, sparse,
+  wide, loop-heavy, and real-world benchmarks must guard small-module
+  regressions.
+- Unsupported or recovered syntax continues to use the existing conservative
+  edge and unknown-state behavior. No diagnostic precision is traded for the
+  allocation reduction.
+
+## Alternatives Considered
+
+1. **Keep one map/deep-copy implementation per domain** — Rejected because the
+   measured allocation cost is dominated by repeated state ownership and join
+   work, and the two domains would continue to evolve different convergence
+   contracts.
+2. **Use dense arrays for every procedure** — Rejected because wide procedures
+   with few domain symbols would pay for unused slots; the representation must
+   be benchmarked for sparse and mixed shapes.
+3. **Use a pointer-heavy persistent map or tree** — Rejected because it adds
+   indirection and allocation pressure to the hot path without a demonstrated
+   benefit, and it conflicts with the issue's compact-state goal.
+4. **Put diagnostic evidence in the shared state** — Rejected because witness
+   growth changes fixed-point equality, copies, and representative ordering.
+5. **Add per-rule or nested solver workers** — Rejected because the existing
+   bounded procedure budget and deterministic merge contract already define the
+   concurrency boundary.
+6. **Migrate generic source-to-sink dataflow or all semantic domains now** —
+   Rejected because Issue #713 requires measured HTTP and Array coverage and a
+   broader migration would expand compatibility risk without profile evidence.
+7. **Persist solver results across runs** — Rejected because invalidation and
+   compatibility are a separate cache decision.
+
+## Evidence
+
+- `internal/analyze/http_transport.go` (`httpAnalysisState`,
+  `solveHTTPStates`, `cloneHTTPState`, `joinHTTPState`).
+- `internal/analyze/array_safety.go` (`arrayFlowState`,
+  `walkArrayCFGWorklist`, `walkArrayCFGCombined`, `cloneArrayState`,
+  `meetArrayState`).
+- `internal/analyze/http_transport_test.go`,
+  `internal/analyze/array_participants_test.go`,
+  `internal/analyze/array_kernel_benchmark_test.go`,
+  `internal/analyze/procedure_planner_test.go`, and the existing lane profiling
+  tests.
+- `docs/specs/vba-analysis-ir.md` and
+  `docs/specs/static-analysis-corpus.md` for ownership, deterministic analysis,
+  and ROneCOne measurement contracts.
+- ADR-0021, ADR-0022,
+  `docs/adr/ADR-0044-bounded-procedure-effect-summaries.md`, and ADR-0046.
+
+## Related
+
+- Issue #713: `perf(dataflow): introduce a compact semantic state solver`
+- Issue #693: shared semantic analysis kernel performance wave
+- ADR-0021, ADR-0022,
+  `docs/adr/ADR-0044-bounded-procedure-effect-summaries.md`, and ADR-0046

--- a/docs/adr/ADR-0047-compact-semantic-state-solver.md
+++ b/docs/adr/ADR-0047-compact-semantic-state-solver.md
@@ -16,10 +16,7 @@ slices, and HTTP state equality depends on a deep comparison of nested maps.
 On the ROneCOne `analyze-only` workload at the Issue #713 starting revision
 (`6c9f8ba60c5b162cb7115e8e68744412c7de9d5d`), a Windows amd64 profile run on
 the repository's i7-12700 development host used
-`scripts/dev/go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench
-'^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchtime=1x -count=1`
-with the test binary and heap profile retained under
-`C:\Users\HARUMI\AppData\Local\Temp\xlflow-issue713-baseline.*`. The focused
+`rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=1 -timeout=10m` with the test binary and heap profile retained locally under `%TEMP%\xlflow-issue713-baseline.*`. The focused
 alloc-space view attributed approximately 1.62 GB to `cloneArrayState`,
 0.53 GB to `meetArrayState`, and 0.07 GB to `cloneHTTPState` in that sample.
 These copies are semantic state, not diagnostic evidence, and their cost grows
@@ -155,7 +152,8 @@ domains remain outside this decision.
    bounded procedure budget and deterministic merge contract already define the
    concurrency boundary.
 6. **Migrate generic source-to-sink dataflow or all semantic domains now** —
-   Rejected because Issue #713 requires measured HTTP and Array coverage and a
+   Rejected because Issue #713 requires measurements for HTTP and Array
+   coverage and a
    broader migration would expand compatibility risk without profile evidence.
 7. **Persist solver results across runs** — Rejected because invalidation and
    compatibility are a separate cache decision.

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1737,6 +1737,28 @@ non-deterministic participant/worklist order is a stop-and-investigate
 condition. The three new counters are developer-only stderr telemetry and
 must never be copied into snapshots or the diagnostic review ledger.
 
+### Indexed semantic-state solver verification record (#713)
+
+Issue #713 introduced the first incremental shared-solver migration. The
+starting revision was `6c9f8ba60c5b162cb7115e8e68744412c7de9d5d` on Windows
+amd64 (12th Gen Intel(R) Core(TM) i7-12700). The measurement command was:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=1 -timeout=10m
+```
+
+The final post-migration sample completed in `8.93e9 ns/op`,
+`11,203,650,096 B/op`, and `81,659,543 allocs/op`. Its retained heap profile
+was `C:\Users\HARUMI\AppData\Local\Temp\xlflow-issue713-final.mem.pprof`.
+The focused alloc-space view attributed approximately 1.58 GB to
+`cloneArrayState`, 0.53 GB to `meetArrayState`, and 0.09 GB to
+`cloneHTTPState`; the starting focused sample was approximately 1.62 GB,
+0.53 GB, and 0.07 GB respectively. These measurements do not yet satisfy the
+Issue #713 50% reduction target, so source-line/edge-refinement Array paths
+remain explicitly on the compatibility walker and require a follow-up
+migration with differential evidence. No corpus snapshot or review-ledger
+change is justified by this partial migration.
+
 ## Related
 
 - `docs/adr/ADR-0029-vendored-static-analysis-corpus.md`

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1749,7 +1749,7 @@ rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 tes
 
 The final post-migration sample completed in `8.93e9 ns/op`,
 `11,203,650,096 B/op`, and `81,659,543 allocs/op`. Its retained heap profile
-was `C:\Users\HARUMI\AppData\Local\Temp\xlflow-issue713-final.mem.pprof`.
+was `%TEMP%\xlflow-issue713-final.mem.pprof` (retained locally).
 The focused alloc-space view attributed approximately 1.58 GB to
 `cloneArrayState`, 0.53 GB to `meetArrayState`, and 0.09 GB to
 `cloneHTTPState`; the starting focused sample was approximately 1.62 GB,

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -651,6 +651,34 @@ Data-flow lane telemetry additionally exposes
 `dataflow_cfg_walks` and `semantic_kernel_runs` counters remain compatibility
 measurements for the procedure execution and are not lane sums.
 
+### Indexed semantic-state solver boundary
+
+The HTTP transport kernel and the ordinary Array block-level walk use the
+internal `internal/analyze/semanticstate` solver. The ordinary Array adapter
+uses compact flow slots; HTTP currently uses one compatibility slot containing
+the legacy nested state while semantic-unit scalarization remains follow-up
+work. A procedure revision builds
+an immutable, case-insensitive environment with revision-local `SymbolID`
+values and a deterministic CFG `BlockOrdinal` index. Mutable flow states,
+scratch buffers, cancellation checks, and the `(BlockOrdinal, LaneOrdinal)`
+worklist remain owned by one solver invocation; no state or index is shared
+across revisions or nested worker pools.
+
+The solver stores present slots in dense bitset-backed storage for small or
+dense domains and sorted sparse storage for wide, sparse domains. Domain joins
+update the destination in place and report changed slots, so unchanged blocks
+are not requeued. Exceptional and uncertain edges retain predecessor input
+state. HTTP and Array adapters keep their existing conservative lattice and
+diagnostic projection contracts; source ranges, representative evidence, and
+finding multiplicity are not part of semantic state.
+
+This is an incremental migration boundary. Array source-line traversal,
+edge-refinement paths, and interprocedural evidence walkers continue to use
+their compatibility walker until their callback contracts can be represented
+without changing VBA227/VBA208/VBA249 behavior. The shared solver API and
+dense/sparse/hybrid benchmarks are internal implementation details and do not
+add CLI, JSON, or LSP fields.
+
 ### Batch procedure-worker boundary
 
 Batch `analyze` may evaluate procedures concurrently for a large file after

--- a/internal/analyze/array_compact_solver.go
+++ b/internal/analyze/array_compact_solver.go
@@ -1,0 +1,199 @@
+package analyze
+
+import (
+	"context"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticstate"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+// arrayCompactLattice is the adapter between the array allocation lattice and
+// semanticstate's indexed storage.  The array domain deliberately keeps its
+// existing meet semantics; only the representation and fixed-point scheduler
+// are shared.
+type arrayCompactLattice struct{}
+
+func (arrayCompactLattice) Clone(value arrayValue) arrayValue {
+	value.dimensions = append([]arrayDimension(nil), value.dimensions...)
+	value.preserveShape = append([]arrayDimension(nil), value.preserveShape...)
+	return value
+}
+
+func (l arrayCompactLattice) Join(dst *arrayValue, src arrayValue) bool {
+	if dst == nil {
+		return false
+	}
+	merged := meetArrayValue(*dst, src)
+	if arrayValueEqual(*dst, merged) {
+		return false
+	}
+	*dst = merged
+	return true
+}
+
+type arrayCompactAdapter struct {
+	environment semanticstate.Environment
+}
+
+func newArrayCompactAdapter(initial arrayFlowState) arrayCompactAdapter {
+	names := make([]string, 0, len(initial))
+	for name := range initial {
+		names = append(names, name)
+	}
+	return arrayCompactAdapter{environment: semanticstate.NewEnvironment(names, names)}
+}
+
+func (a arrayCompactAdapter) toFlow(view semanticstate.StateView[arrayValue]) arrayFlowState {
+	flow := make(arrayFlowState, view.Len())
+	view.ForEach(func(id semanticstate.SymbolID, value arrayValue) bool {
+		name, ok := a.environment.Name(id)
+		if !ok {
+			return true
+		}
+		flow[name] = arrayCompactLattice{}.Clone(value)
+		return true
+	})
+	return flow
+}
+
+func (a arrayCompactAdapter) fromFlow(state *semanticstate.State[arrayValue], flow arrayFlowState) {
+	state.Reset()
+	for name, value := range flow {
+		id, ok := a.environment.Symbol(name)
+		if !ok {
+			continue
+		}
+		state.Set(id, arrayCompactLattice{}.Clone(value))
+	}
+}
+
+func (a arrayCompactAdapter) initialState(state *semanticstate.State[arrayValue], initial arrayFlowState) {
+	a.fromFlow(state, initial)
+}
+
+// walkArrayCFGCompact runs one array policy on the shared semanticstate
+// solver. Callback compatibility is intentionally retained at this boundary,
+// so diagnostic/evidence code still receives arrayFlowState while joins happen
+// directly in indexed slots without union-map allocation.
+func walkArrayCFGCompact(ctx context.Context, graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, sourceLines bool) error {
+	if graph == nil {
+		return nil
+	}
+	adapter := newArrayCompactAdapter(initial)
+	index, err := semanticstate.NewIndex(*graph)
+	if err != nil {
+		return err
+	}
+	blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(graph.Blocks))
+	for _, block := range graph.Blocks {
+		blocks[block.ID] = block
+	}
+	lattice := arrayCompactLattice{}
+	lane := semanticstate.Lane[arrayValue]{
+		Initialize: func(_ context.Context, _ semanticstate.LaneOrdinal, state *semanticstate.State[arrayValue]) error {
+			adapter.initialState(state, initial)
+			return nil
+		},
+		Transfer: func(_ context.Context, _ semanticstate.LaneOrdinal, ordinal semanticstate.BlockOrdinal, input semanticstate.StateView[arrayValue], output *semanticstate.State[arrayValue]) error {
+			indexed, ok := index.Block(ordinal)
+			if !ok {
+				return nil
+			}
+			block, ok := blocks[indexed.ID]
+			if !ok {
+				return nil
+			}
+			in := adapter.toFlow(input)
+			out := arrayCompactVisitBlock(lines, block, in, visit, sourceLines)
+			adapter.fromFlow(output, out)
+			return nil
+		},
+		Edge: func(_ context.Context, _ semanticstate.LaneOrdinal, edge semanticstate.Edge, _ semanticstate.StateView[arrayValue], _ semanticstate.StateView[arrayValue], candidate *semanticstate.State[arrayValue]) error {
+			// The legacy walker applies edgeState only to normal edges. Exceptional
+			// and uncertain edges carry the predecessor input state and must not
+			// receive normal-edge refinements (guards/Select facts).
+			if edgeState == nil || edge.Class == vbacfg.EdgeExceptional || edge.Uncertain {
+				return nil
+			}
+			fromIndexed, ok := index.Block(edge.From)
+			if !ok {
+				return nil
+			}
+			from, ok := blocks[fromIndexed.ID]
+			if !ok {
+				return nil
+			}
+			toIndexed, ok := index.Block(edge.To)
+			if !ok {
+				return nil
+			}
+			to, ok := blocks[toIndexed.ID]
+			if !ok {
+				return nil
+			}
+			flow := adapter.toFlow(candidate.View())
+			refined := edgeState(from, vbacfg.Edge{ID: edge.ID, From: from.ID, To: to.ID, Kind: edge.Kind, Class: edge.Class, Uncertain: edge.Uncertain}, flow)
+			adapter.fromFlow(candidate, refined)
+			return nil
+		},
+	}
+	solver, err := semanticstate.NewSolver(index, adapter.environment, lattice, []semanticstate.Lane[arrayValue]{lane})
+	if err != nil {
+		return err
+	}
+	_, err = solver.SolveContext(ctx)
+	return err
+}
+
+func arrayCompactVisitBlock(lines []string, block vbacfg.Block, in arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, sourceLines bool) arrayFlowState {
+	if visit == nil || block.Statement == nil {
+		return in
+	}
+	if !sourceLines {
+		line := block.Statement.Range.StartLine
+		if line == 0 {
+			line = block.Range.StartLine
+		}
+		text := block.Statement.Text
+		if strings.TrimSpace(text) == "" && line >= 1 && line <= len(lines) {
+			text = normalizedCodeLine(lines[line-1])
+		}
+		return visit(text, line, in)
+	}
+	start := block.Statement.Range.StartLine
+	if start == 0 {
+		start = block.Range.StartLine
+	}
+	end := block.Statement.Range.EndLine
+	if end < start {
+		end = start
+	}
+	out := in
+	if block.Statement.Kind == procedureir.StatementSelect && start >= 1 && start <= len(lines) {
+		return visit(normalizedCodeLine(lines[start-1]), start, out)
+	}
+	if start == end && start >= 1 && start <= len(lines) {
+		text := block.Statement.Text
+		if strings.TrimSpace(text) == "" {
+			text = normalizedCodeLine(lines[start-1])
+		}
+		return visit(text, start, out)
+	}
+	if start >= 1 && end <= len(lines) {
+		for line := start; line <= end; line++ {
+			text := normalizedCodeLine(lines[line-1])
+			if len(text) == 0 {
+				continue
+			}
+			out = visit(text, line, out)
+		}
+		return out
+	}
+	text := block.Statement.Text
+	if strings.TrimSpace(text) == "" && start >= 1 && start <= len(lines) {
+		text = normalizedCodeLine(lines[start-1])
+	}
+	return visit(text, start, out)
+}

--- a/internal/analyze/array_compact_solver.go
+++ b/internal/analyze/array_compact_solver.go
@@ -15,6 +15,8 @@ import (
 // are shared.
 type arrayCompactLattice struct{}
 
+func unknownArrayValue() arrayValue { return arrayValue{kind: arrayUnknown} }
+
 func (arrayCompactLattice) Clone(value arrayValue) arrayValue {
 	value.dimensions = append([]arrayDimension(nil), value.dimensions...)
 	value.preserveShape = append([]arrayDimension(nil), value.preserveShape...)
@@ -46,7 +48,11 @@ func newArrayCompactAdapter(initial arrayFlowState) arrayCompactAdapter {
 }
 
 func (a arrayCompactAdapter) toFlow(view semanticstate.StateView[arrayValue]) arrayFlowState {
-	flow := make(arrayFlowState, view.Len())
+	names := a.environment.Names()
+	flow := make(arrayFlowState, len(names))
+	for _, name := range names {
+		flow[name] = unknownArrayValue()
+	}
 	view.ForEach(func(id semanticstate.SymbolID, value arrayValue) bool {
 		name, ok := a.environment.Name(id)
 		if !ok {
@@ -60,7 +66,11 @@ func (a arrayCompactAdapter) toFlow(view semanticstate.StateView[arrayValue]) ar
 
 func (a arrayCompactAdapter) fromFlow(state *semanticstate.State[arrayValue], flow arrayFlowState) {
 	state.Reset()
-	for name, value := range flow {
+	for _, name := range a.environment.Names() {
+		value, ok := flow[name]
+		if !ok {
+			value = unknownArrayValue()
+		}
 		id, ok := a.environment.Symbol(name)
 		if !ok {
 			continue

--- a/internal/analyze/array_compact_solver_test.go
+++ b/internal/analyze/array_compact_solver_test.go
@@ -1,0 +1,38 @@
+package analyze
+
+import (
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticstate"
+)
+
+func TestArrayCompactAdapterDegradesAbsentSymbolsToUnknown(t *testing.T) {
+	initial := arrayFlowState{
+		"allocated":   {kind: arrayAllocated, knownArray: true},
+		"unallocated": {kind: arrayUnallocated, knownArray: true},
+	}
+	adapter := newArrayCompactAdapter(initial)
+	left := semanticstate.NewState[arrayValue](adapter.environment.Layout())
+	incoming := semanticstate.NewState[arrayValue](adapter.environment.Layout())
+	adapter.fromFlow(&left, initial)
+	adapter.fromFlow(&incoming, arrayFlowState{
+		"allocated": initial["allocated"],
+	})
+
+	changed := make([]semanticstate.SymbolID, 0, 1)
+	if !left.JoinFrom(incoming.View(), arrayCompactLattice{}, &changed) {
+		t.Fatal("missing incoming symbol should degrade the destination state")
+	}
+	flow := adapter.toFlow(left.View())
+	if got := flow["unallocated"]; got.kind != arrayUnknown {
+		t.Fatalf("absent incoming symbol = %#v, want unknown", got)
+	}
+	if got := flow["allocated"]; got.kind != arrayAllocated || !got.knownArray {
+		t.Fatalf("unchanged symbol = %#v, want allocated", got)
+	}
+
+	destinationOnly := initial["allocated"]
+	if !(arrayCompactLattice{}).Join(&destinationOnly, unknownArrayValue()) || destinationOnly.kind != arrayUnknown {
+		t.Fatalf("unknown join = %#v, want unknown", destinationOnly)
+	}
+}

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -888,6 +888,20 @@ func walkArrayCFGWithSourceLines(graph *vbacfg.Graph, lines []string, initial ar
 }
 
 func walkArrayCFGWorklist(graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool) {
+	// The compact solver owns the ordinary block-level walk. Stop callbacks
+	// need an explicit edge-suppression protocol that semanticstate intentionally
+	// does not expose, while source-line and edge-refinement lanes still carry
+	// policy-specific metadata through the legacy callback boundary. Keep those
+	// paths on the proven walker until their evidence contract is migrated.
+	if stop == nil && !sourceLines && edgeState == nil {
+		if err := walkArrayCFGCompact(context.Background(), graph, lines, initial, visit, edgeState, sourceLines); err == nil {
+			return
+		}
+	}
+	walkArrayCFGWorklistLegacy(graph, lines, initial, visit, edgeState, stop, sourceLines)
+}
+
+func walkArrayCFGWorklistLegacy(graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool) {
 	if graph == nil {
 		return
 	}

--- a/internal/analyze/http_transport.go
+++ b/internal/analyze/http_transport.go
@@ -6,12 +6,12 @@ import (
 	"net"
 	"net/url"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticstate"
 	"github.com/harumiWeb/xlflow/internal/config"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
@@ -196,54 +196,83 @@ func httpRecordConstant(state *httpAnalysisState, name, expression string) {
 }
 
 func solveHTTPStates(ctx context.Context, a Analyzer, file parsedFile, proc sourceProcedure, graph vbacfg.Graph, initial httpAnalysisState) (map[vbacfg.BlockID]httpAnalysisState, error) {
-	states := map[vbacfg.BlockID]httpAnalysisState{graph.Entry: cloneHTTPState(initial)}
-	blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(graph.Blocks))
-	type httpEdge struct {
-		to    vbacfg.BlockID
-		class vbacfg.EdgeClass
+	// Keep the existing HTTP state as the domain value at one indexed slot. The
+	// solver owns scheduling, edge classification, cancellation, and snapshot
+	// isolation; the adapter preserves the established transfer/join semantics
+	// while the HTTP domain is incrementally migrated to scalar slots.
+	index, err := semanticstate.NewIndex(graph)
+	if err != nil {
+		return nil, err
 	}
-	outgoing := make(map[vbacfg.BlockID][]httpEdge)
+	blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(graph.Blocks))
 	for _, block := range graph.Blocks {
 		blocks[block.ID] = block
 	}
-	for _, edge := range graph.Edges {
-		outgoing[edge.From] = append(outgoing[edge.From], httpEdge{to: edge.To, class: edge.Class})
+	environment := semanticstate.NewEnvironment([]string{"http-state"}, []string{"http-state"})
+	const lane semanticstate.LaneOrdinal = 0
+	var symbol semanticstate.SymbolID
+	lattice := httpStateLattice{}
+	solver, err := semanticstate.NewSolver(index, environment, lattice, []semanticstate.Lane[httpAnalysisState]{
+		{
+			Initialize: func(_ context.Context, _ semanticstate.LaneOrdinal, state *semanticstate.State[httpAnalysisState]) error {
+				state.Set(symbol, cloneHTTPState(initial))
+				return nil
+			},
+			Transfer: func(_ context.Context, _ semanticstate.LaneOrdinal, block semanticstate.BlockOrdinal, input semanticstate.StateView[httpAnalysisState], output *semanticstate.State[httpAnalysisState]) error {
+				value, ok := input.Value(symbol)
+				if !ok {
+					return nil
+				}
+				cfgBlock, ok := index.Block(block)
+				if !ok {
+					return nil
+				}
+				candidate, ok := blocks[cfgBlock.ID]
+				if !ok || candidate.Statement == nil || candidate.Statement.Recovered {
+					output.Set(symbol, value)
+					return nil
+				}
+				value, _ = a.transferHTTPStatement(file, proc, *candidate.Statement, value, false)
+				output.Set(symbol, value)
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
 	}
-	queue := []vbacfg.BlockID{graph.Entry}
-	queued := map[vbacfg.BlockID]bool{graph.Entry: true}
-	for len(queue) > 0 {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		id := queue[0]
-		queue = queue[1:]
-		queued[id] = false
-		block, ok := blocks[id]
-		if !ok {
-			continue
-		}
-		out := cloneHTTPState(states[id])
-		if block.Statement != nil && !block.Statement.Recovered {
-			out, _ = a.transferHTTPStatement(file, proc, *block.Statement, out, false)
-		}
-		for _, edge := range outgoing[id] {
-			edgeState := out
-			if edge.class == vbacfg.EdgeExceptional {
-				edgeState = states[id]
-			}
-			previous, initialized := states[edge.to]
-			merged, different := joinHTTPState(previous, edgeState, initialized)
-			if !different {
-				continue
-			}
-			states[edge.to] = merged
-			if !queued[edge.to] {
-				queue = append(queue, edge.to)
-				queued[edge.to] = true
-			}
+	result, err := solver.SolveContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	states := make(map[vbacfg.BlockID]httpAnalysisState, index.BlockCount())
+	for _, block := range index.Blocks() {
+		value, ok := result.State(block.Ordinal, lane).Value(symbol)
+		if ok {
+			states[block.ID] = value
 		}
 	}
 	return states, nil
+}
+
+// httpStateLattice adapts the legacy HTTP state join to the indexed solver.
+// Clone is the alias-safety boundary for the nested evidence sets still used
+// by the HTTP domain during this migration step.
+type httpStateLattice struct{}
+
+func (httpStateLattice) Clone(value httpAnalysisState) httpAnalysisState {
+	return cloneHTTPState(value)
+}
+
+func (httpStateLattice) Join(dst *httpAnalysisState, src httpAnalysisState) bool {
+	if dst == nil {
+		return false
+	}
+	merged, changed := joinHTTPState(*dst, src, true)
+	if changed {
+		*dst = merged
+	}
+	return changed
 }
 
 func (a Analyzer) transferHTTPStatement(file parsedFile, proc sourceProcedure, statement procedureir.Statement, state httpAnalysisState, collect bool) (httpAnalysisState, []httpFindingSpec) {
@@ -812,7 +841,60 @@ func httpPartialNewMatches(kind httpClientKind, rhs string) bool {
 }
 
 func sameHTTPState(a, b httpAnalysisState) bool {
-	return reflect.DeepEqual(a, b)
+	if len(a.objects) != len(b.objects) || len(a.launchers) != len(b.launchers) || len(a.strings) != len(b.strings) || len(a.known) != len(b.known) || len(a.sensitive) != len(b.sensitive) {
+		return false
+	}
+	for name, left := range a.objects {
+		right, ok := b.objects[name]
+		if !ok || left.kind != right.kind || left.identity != right.identity || left.url != right.url || left.urlKnown != right.urlKnown || left.hasCredentials != right.hasCredentials || left.timeoutConfigured != right.timeoutConfigured || left.timeoutInfinite != right.timeoutInfinite || left.downloaded != right.downloaded || !sameHTTPBoolSet(left.savedExecutable, right.savedExecutable) || !sameHTTPIntSet(left.credentialSinks, right.credentialSinks) {
+			return false
+		}
+	}
+	for name, value := range a.launchers {
+		if b.launchers[name] != value {
+			return false
+		}
+	}
+	for name, value := range a.strings {
+		if b.strings[name] != value {
+			return false
+		}
+	}
+	for name, value := range a.known {
+		if b.known[name] != value {
+			return false
+		}
+	}
+	for name, value := range a.sensitive {
+		if b.sensitive[name] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func sameHTTPBoolSet(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if b[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func sameHTTPIntSet(a, b map[int]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if b[key] != value {
+			return false
+		}
+	}
+	return true
 }
 
 func httpURLHasCredentials(raw string) bool {

--- a/internal/analyze/http_transport.go
+++ b/internal/analyze/http_transport.go
@@ -851,22 +851,26 @@ func sameHTTPState(a, b httpAnalysisState) bool {
 		}
 	}
 	for name, value := range a.launchers {
-		if b.launchers[name] != value {
+		other, ok := b.launchers[name]
+		if !ok || other != value {
 			return false
 		}
 	}
 	for name, value := range a.strings {
-		if b.strings[name] != value {
+		other, ok := b.strings[name]
+		if !ok || other != value {
 			return false
 		}
 	}
 	for name, value := range a.known {
-		if b.known[name] != value {
+		other, ok := b.known[name]
+		if !ok || other != value {
 			return false
 		}
 	}
 	for name, value := range a.sensitive {
-		if b.sensitive[name] != value {
+		other, ok := b.sensitive[name]
+		if !ok || other != value {
 			return false
 		}
 	}
@@ -878,7 +882,8 @@ func sameHTTPBoolSet(a, b map[string]bool) bool {
 		return false
 	}
 	for key, value := range a {
-		if b[key] != value {
+		other, ok := b[key]
+		if !ok || other != value {
 			return false
 		}
 	}
@@ -890,7 +895,8 @@ func sameHTTPIntSet(a, b map[int]bool) bool {
 		return false
 	}
 	for key, value := range a {
-		if b[key] != value {
+		other, ok := b[key]
+		if !ok || other != value {
 			return false
 		}
 	}

--- a/internal/analyze/http_transport_test.go
+++ b/internal/analyze/http_transport_test.go
@@ -57,6 +57,61 @@ End Sub
 	}
 }
 
+func TestSameHTTPStateDistinguishesMissingZeroValueKeys(t *testing.T) {
+	base := httpAnalysisState{
+		objects: map[string]httpObjectState{
+			"request": {
+				kind:            httpXML,
+				identity:        "request",
+				savedExecutable: map[string]bool{"saved.exe": false},
+				credentialSinks: map[int]bool{10: false},
+			},
+		},
+		launchers: map[string]string{"launcher": ""},
+		strings:   map[string]string{"value": ""},
+		known:     map[string]bool{"value": false},
+		sensitive: map[string]bool{"secret": false},
+	}
+	cases := map[string]func(httpAnalysisState) httpAnalysisState{
+		"launchers": func(other httpAnalysisState) httpAnalysisState {
+			other.launchers = map[string]string{"other": ""}
+			return other
+		},
+		"strings": func(other httpAnalysisState) httpAnalysisState {
+			other.strings = map[string]string{"other": ""}
+			return other
+		},
+		"known": func(other httpAnalysisState) httpAnalysisState {
+			other.known = map[string]bool{"other": false}
+			return other
+		},
+		"sensitive": func(other httpAnalysisState) httpAnalysisState {
+			other.sensitive = map[string]bool{"other": false}
+			return other
+		},
+		"saved executable": func(other httpAnalysisState) httpAnalysisState {
+			object := other.objects["request"]
+			object.savedExecutable = map[string]bool{"other.exe": false}
+			other.objects["request"] = object
+			return other
+		},
+		"credential sinks": func(other httpAnalysisState) httpAnalysisState {
+			object := other.objects["request"]
+			object.credentialSinks = map[int]bool{20: false}
+			other.objects["request"] = object
+			return other
+		},
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			other := mutate(cloneHTTPState(base))
+			if sameHTTPState(base, other) {
+				t.Fatalf("states with distinct zero-value keys compared equal: %#v vs %#v", base, other)
+			}
+		})
+	}
+}
+
 func TestVBA246DetectsURLCredentialsTLSAndCertificateBypass(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/semanticstate/semanticstate_test.go
+++ b/internal/analyze/semanticstate/semanticstate_test.go
@@ -132,6 +132,60 @@ func TestSolverDeterministicAndExceptionalEdgesUseInput(t *testing.T) {
 	}
 }
 
+func TestSolverSnapshotsInputBeforeSelfEdgePropagation(t *testing.T) {
+	env := NewEnvironment([]string{"value"})
+	index, err := NewIndex(cfg.Graph{
+		Blocks: []cfg.Block{
+			{ID: 0, Kind: cfg.BlockEntry},
+			{ID: 1, Kind: cfg.BlockStatement},
+			{ID: 2, Kind: cfg.BlockNormalExit},
+		},
+		Edges: []cfg.Edge{
+			{ID: 0, From: 0, To: 1, Kind: cfg.EdgeFallthrough, Class: cfg.EdgeNormal},
+			{ID: 1, From: 1, To: 1, Kind: cfg.EdgeBranchTrue, Class: cfg.EdgeNormal},
+			{ID: 2, From: 1, To: 2, Kind: cfg.EdgeError, Class: cfg.EdgeExceptional},
+		},
+		Entry: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, _ := env.Symbol("value")
+	var exceptionalInputs []int
+	solver, err := NewSolver[int](index, env, maxLattice{}, []Lane[int]{{
+		Initialize: func(_ context.Context, _ LaneOrdinal, state *State[int]) error {
+			state.Set(value, 1)
+			return nil
+		},
+		Transfer: func(_ context.Context, _ LaneOrdinal, block BlockOrdinal, in StateView[int], out *State[int]) error {
+			out.CloneFrom(in, nil)
+			if block == 1 {
+				out.Set(value, 2)
+			}
+			return nil
+		},
+		Edge: func(_ context.Context, _ LaneOrdinal, edge Edge, input, _ StateView[int], _ *State[int]) error {
+			if edge.From == 1 && edge.Class == cfg.EdgeExceptional {
+				got, ok := input.Value(value)
+				if !ok {
+					t.Fatalf("exceptional edge input lost value")
+				}
+				exceptionalInputs = append(exceptionalInputs, got)
+			}
+			return nil
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := solver.Solve(); err != nil {
+		t.Fatal(err)
+	}
+	if len(exceptionalInputs) < 2 || exceptionalInputs[0] != 1 {
+		t.Fatalf("exceptional edge inputs = %#v, want first input 1 before self-edge update", exceptionalInputs)
+	}
+}
+
 func TestSolverCancellationDoesNotPublishPartialResult(t *testing.T) {
 	env := NewEnvironment([]string{"value"})
 	index, err := NewIndex(testGraph())
@@ -169,8 +223,10 @@ func BenchmarkStateJoinRepresentations(b *testing.B) {
 			env := NewEnvironment(envNames, touched)
 			left := NewState[int](env.Layout())
 			right := NewState[int](env.Layout())
+			ids := make([]SymbolID, tc.touched)
 			for i := 0; i < tc.touched; i++ {
-				id, _ := env.Symbol(envNames[i])
+				ids[i], _ = env.Symbol(envNames[i])
+				id := ids[i]
 				left.Set(id, i)
 				right.Set(id, i+1)
 			}
@@ -181,11 +237,12 @@ func BenchmarkStateJoinRepresentations(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				changed = changed[:0]
 				left.JoinFrom(right.View(), lattice, &changed)
+				b.StopTimer()
 				left.Reset()
-				for symbol := 0; symbol < tc.touched; symbol++ {
-					id, _ := env.Symbol(envNames[symbol])
+				for symbol, id := range ids {
 					left.Set(id, symbol)
 				}
+				b.StartTimer()
 			}
 		})
 	}

--- a/internal/analyze/semanticstate/semanticstate_test.go
+++ b/internal/analyze/semanticstate/semanticstate_test.go
@@ -1,0 +1,192 @@
+package semanticstate
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/vba/cfg"
+)
+
+type maxLattice struct{}
+
+func (maxLattice) Clone(value int) int { return value }
+func (maxLattice) Join(dst *int, src int) bool {
+	if src <= *dst {
+		return false
+	}
+	*dst = src
+	return true
+}
+
+func testGraph() cfg.Graph {
+	return cfg.Graph{
+		Blocks: []cfg.Block{
+			{ID: 0, Kind: cfg.BlockEntry},
+			{ID: 1, Kind: cfg.BlockStatement},
+			{ID: 2, Kind: cfg.BlockStatement},
+			{ID: 3, Kind: cfg.BlockNormalExit},
+		},
+		Edges: []cfg.Edge{
+			{ID: 0, From: 0, To: 1, Kind: cfg.EdgeFallthrough, Class: cfg.EdgeNormal},
+			{ID: 1, From: 1, To: 2, Kind: cfg.EdgeFallthrough, Class: cfg.EdgeNormal},
+			{ID: 2, From: 1, To: 3, Kind: cfg.EdgeError, Class: cfg.EdgeExceptional},
+			{ID: 3, From: 2, To: 3, Kind: cfg.EdgeProcedureExit, Class: cfg.EdgeNormal},
+		},
+		Entry: 0,
+	}
+}
+
+func TestEnvironmentAndLayoutAreDeterministic(t *testing.T) {
+	dense := NewEnvironment([]string{" B ", "a", "A"}, []string{"a", "b"})
+	if got := dense.Names(); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("names = %#v", got)
+	}
+	if dense.Layout().Representation() != RepresentationDense {
+		t.Fatalf("small environment selected %s", dense.Layout().Representation())
+	}
+	wideNames := make([]string, 100)
+	for i := range wideNames {
+		wideNames[i] = "name"
+		if i > 0 {
+			wideNames[i] += string(rune('a'+i%26)) + string(rune('0'+i/26))
+		}
+	}
+	wide := NewEnvironment(wideNames, []string{"namea1"})
+	if wide.Layout().Representation() != RepresentationSparse {
+		t.Fatalf("wide sparse environment selected %s", wide.Layout().Representation())
+	}
+	first := NewEnvironment([]string{"z", "a", "m"})
+	second := NewEnvironment([]string{"m", "z", "a"})
+	if !reflect.DeepEqual(first.Names(), second.Names()) {
+		t.Fatalf("name order changed: %#v vs %#v", first.Names(), second.Names())
+	}
+}
+
+func TestStateJoinReportsOnlyChangedSlotsAndIsIdempotent(t *testing.T) {
+	env := NewEnvironment([]string{"a", "b"})
+	left := NewState[int](env.Layout())
+	right := NewState[int](env.Layout())
+	a, _ := env.Symbol("a")
+	b, _ := env.Symbol("b")
+	left.Set(a, 2)
+	right.Set(a, 2)
+	right.Set(b, 3)
+	changed := []SymbolID{}
+	if !left.JoinFrom(right.View(), maxLattice{}, &changed) {
+		t.Fatalf("equal slot should not report a change")
+	}
+	if !reflect.DeepEqual(changed, []SymbolID{b}) {
+		t.Fatalf("changed slots = %#v", changed)
+	}
+	changed = changed[:0]
+	if left.JoinFrom(right.View(), maxLattice{}, &changed) {
+		t.Fatalf("idempotent join changed state: %#v", changed)
+	}
+}
+
+func TestSolverDeterministicAndExceptionalEdgesUseInput(t *testing.T) {
+	env := NewEnvironment([]string{"value"})
+	index, err := NewIndex(testGraph())
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, _ := env.Symbol("value")
+	makeSolver := func() *Solver[int] {
+		solver, err := NewSolver[int](index, env, maxLattice{}, []Lane[int]{{
+			Initialize: func(_ context.Context, _ LaneOrdinal, state *State[int]) error {
+				state.Set(value, 1)
+				return nil
+			},
+			Transfer: func(_ context.Context, _ LaneOrdinal, block BlockOrdinal, in StateView[int], out *State[int]) error {
+				out.CloneFrom(in, nil)
+				if block == 1 {
+					out.Set(value, 4)
+				}
+				return nil
+			},
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		solver.RecordOrder = true
+		return solver
+	}
+	one, err := makeSolver().Solve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := makeSolver().Solve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(one.Order(), two.Order()) {
+		t.Fatalf("worklist order changed: %#v vs %#v", one.Order(), two.Order())
+	}
+	if got, ok := one.State(2, 0).Value(value); !ok || got != 4 {
+		t.Fatalf("normal edge lost transfer value: %d, %v", got, ok)
+	}
+	if got, ok := one.State(3, 0).Value(value); !ok || got != 4 {
+		t.Fatalf("join result = %d, %v", got, ok)
+	}
+}
+
+func TestSolverCancellationDoesNotPublishPartialResult(t *testing.T) {
+	env := NewEnvironment([]string{"value"})
+	index, err := NewIndex(testGraph())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	solver, err := NewSolver[int](index, env, maxLattice{}, []Lane[int]{{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := solver.SolveContext(ctx); err != context.Canceled {
+		t.Fatalf("cancellation error = %v", err)
+	}
+}
+
+func BenchmarkStateJoinRepresentations(b *testing.B) {
+	cases := []struct {
+		name    string
+		symbols int
+		touched int
+	}{
+		{name: "dense", symbols: 32, touched: 32},
+		{name: "hybrid-dense", symbols: 128, touched: 64},
+		{name: "sparse", symbols: 4096, touched: 16},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			envNames := make([]string, tc.symbols)
+			for i := range envNames {
+				envNames[i] = "symbol" + strconv.Itoa(i)
+			}
+			touched := envNames[:tc.touched]
+			env := NewEnvironment(envNames, touched)
+			left := NewState[int](env.Layout())
+			right := NewState[int](env.Layout())
+			for i := 0; i < tc.touched; i++ {
+				id, _ := env.Symbol(envNames[i])
+				left.Set(id, i)
+				right.Set(id, i+1)
+			}
+			lattice := maxLattice{}
+			changed := make([]SymbolID, 0, tc.touched)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				changed = changed[:0]
+				left.JoinFrom(right.View(), lattice, &changed)
+				left.Reset()
+				for symbol := 0; symbol < tc.touched; symbol++ {
+					id, _ := env.Symbol(envNames[symbol])
+					left.Set(id, symbol)
+				}
+			}
+		})
+	}
+}

--- a/internal/analyze/semanticstate/solver.go
+++ b/internal/analyze/semanticstate/solver.go
@@ -4,6 +4,8 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+
+	"github.com/harumiWeb/xlflow/internal/vba/cfg"
 )
 
 // WorkItem is the deterministic scheduling key used by the solver.
@@ -59,6 +61,7 @@ type Solver[T any] struct {
 	states          []State[T]
 	transferScratch []State[T]
 	edgeScratch     []State[T]
+	inputScratch    []State[T]
 	changed         []SymbolID
 	queue           workQueue
 	queued          []bool
@@ -103,6 +106,7 @@ func (s *Solver[T]) allocateStates() {
 	if len(s.transferScratch) != len(s.lanes) {
 		s.transferScratch = make([]State[T], len(s.lanes))
 		s.edgeScratch = make([]State[T], len(s.lanes))
+		s.inputScratch = make([]State[T], len(s.lanes))
 	}
 	for i := range s.states {
 		if s.states[i].Layout() != s.layout {
@@ -115,9 +119,11 @@ func (s *Solver[T]) allocateStates() {
 		if s.transferScratch[i].Layout() != s.layout {
 			s.transferScratch[i] = newState[T](s.layout)
 			s.edgeScratch[i] = newState[T](s.layout)
+			s.inputScratch[i] = newState[T](s.layout)
 		} else {
 			s.transferScratch[i].Reset()
 			s.edgeScratch[i].Reset()
+			s.inputScratch[i].Reset()
 		}
 	}
 	clear(s.queued)
@@ -185,6 +191,16 @@ func (s *Solver[T]) SolveContext(ctx context.Context) (Result[T], error) {
 		if err := ctx.Err(); err != nil {
 			return Result[T]{}, err
 		}
+		inputView := input.View()
+		for _, edge := range s.index.outgoing[item.Block] {
+			if edge.To != item.Block {
+				continue
+			}
+			snapshot := &s.inputScratch[item.Lane]
+			snapshot.CloneFrom(inputView, s.lattice.Clone)
+			inputView = snapshot.View()
+			break
+		}
 		for edgeIndex, edge := range s.index.outgoing[item.Block] {
 			if edgeIndex&0xff == 0 {
 				if err := ctx.Err(); err != nil {
@@ -193,12 +209,12 @@ func (s *Solver[T]) SolveContext(ctx context.Context) (Result[T], error) {
 			}
 			candidate := &s.edgeScratch[item.Lane]
 			base := output.View()
-			if edge.Class == cfgExceptional || edge.Uncertain {
-				base = input.View()
+			if edge.Class == cfg.EdgeExceptional || edge.Uncertain {
+				base = inputView
 			}
 			candidate.CloneFrom(base, s.lattice.Clone)
 			if lane.Edge != nil {
-				if err := lane.Edge(ctx, item.Lane, edge, input.View(), output.View(), candidate); err != nil {
+				if err := lane.Edge(ctx, item.Lane, edge, inputView, output.View(), candidate); err != nil {
 					return Result[T]{}, err
 				}
 			}
@@ -220,8 +236,6 @@ func (s *Solver[T]) SolveContext(ctx context.Context) (Result[T], error) {
 	}
 	return result, nil
 }
-
-const cfgExceptional = "exceptional"
 
 func (s *Solver[T]) stateIndex(block BlockOrdinal, lane LaneOrdinal) int {
 	return int(block)*len(s.lanes) + int(lane)

--- a/internal/analyze/semanticstate/solver.go
+++ b/internal/analyze/semanticstate/solver.go
@@ -1,0 +1,260 @@
+package semanticstate
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+)
+
+// WorkItem is the deterministic scheduling key used by the solver.
+type WorkItem struct {
+	Block BlockOrdinal
+	Lane  LaneOrdinal
+}
+
+// Stats describes one fixed-point run. The counters are intentionally
+// procedure-local and do not change existing analyzer performance counters.
+type Stats struct {
+	Transfers int
+	Joins     int
+	Requeues  int
+}
+
+// Result owns an immutable snapshot of converged states. It remains valid
+// after the Solver is reused for another procedure invocation.
+type Result[T any] struct {
+	layout Layout
+	lanes  int
+	blocks int
+	states []State[T]
+	order  []WorkItem
+	stats  Stats
+}
+
+// State returns a read-only view of a converged block/lane state.
+func (r Result[T]) State(block BlockOrdinal, lane LaneOrdinal) StateView[T] {
+	if int(block) >= r.blocks || int(lane) >= r.lanes {
+		return StateView[T]{}
+	}
+	return r.states[int(block)*r.lanes+int(lane)].View()
+}
+
+// Order returns work items in the order they were processed when Solver.RecordOrder
+// was enabled. Repeated items are retained because they are useful for
+// deterministic regression tests; production adapters normally leave the
+// trace disabled.
+func (r Result[T]) Order() []WorkItem { return append([]WorkItem(nil), r.order...) }
+
+// Stats returns fixed-point counters for the run.
+func (r Result[T]) Stats() Stats { return r.stats }
+
+// Solver runs one finite-lattice analysis for one procedure revision. A
+// Solver is intentionally single-use at a time; after SolveContext returns it
+// may be reused sequentially and will retain its scratch backing arrays.
+type Solver[T any] struct {
+	index           *Index
+	layout          Layout
+	lattice         Lattice[T]
+	lanes           []Lane[T]
+	states          []State[T]
+	transferScratch []State[T]
+	edgeScratch     []State[T]
+	changed         []SymbolID
+	queue           workQueue
+	queued          []bool
+	// RecordOrder retains the processed work-item trace in Result.Order for
+	// deterministic diagnostics and solver tests. Production adapters leave it
+	// disabled so loop-heavy procedures do not retain an otherwise unused
+	// allocation proportional to transfer count.
+	RecordOrder bool
+}
+
+// NewSolver constructs a procedure-local solver. The index and environment
+// must describe the same revision; this package keeps no persistent cache.
+func NewSolver[T any](index *Index, environment Environment, lattice Lattice[T], lanes []Lane[T]) (*Solver[T], error) {
+	if index == nil {
+		return nil, fmt.Errorf("semanticstate: nil CFG index")
+	}
+	if lattice == nil {
+		return nil, fmt.Errorf("semanticstate: nil lattice")
+	}
+	if len(lanes) == 0 {
+		return nil, fmt.Errorf("semanticstate: at least one lane is required")
+	}
+	if len(lanes) > int(^LaneOrdinal(0)) {
+		return nil, fmt.Errorf("semanticstate: too many lanes: %d", len(lanes))
+	}
+	s := &Solver[T]{
+		index:   index,
+		layout:  environment.Layout(),
+		lattice: lattice,
+		lanes:   append([]Lane[T](nil), lanes...),
+		queued:  make([]bool, index.BlockCount()*len(lanes)),
+	}
+	s.allocateStates()
+	return s, nil
+}
+
+func (s *Solver[T]) allocateStates() {
+	count := s.index.BlockCount() * len(s.lanes)
+	if len(s.states) != count {
+		s.states = make([]State[T], count)
+	}
+	if len(s.transferScratch) != len(s.lanes) {
+		s.transferScratch = make([]State[T], len(s.lanes))
+		s.edgeScratch = make([]State[T], len(s.lanes))
+	}
+	for i := range s.states {
+		if s.states[i].Layout() != s.layout {
+			s.states[i] = newState[T](s.layout)
+		} else {
+			s.states[i].Reset()
+		}
+	}
+	for i := range s.transferScratch {
+		if s.transferScratch[i].Layout() != s.layout {
+			s.transferScratch[i] = newState[T](s.layout)
+			s.edgeScratch[i] = newState[T](s.layout)
+		} else {
+			s.transferScratch[i].Reset()
+			s.edgeScratch[i].Reset()
+		}
+	}
+	clear(s.queued)
+	s.queue = s.queue[:0]
+	s.changed = s.changed[:0]
+}
+
+// Solve runs a context-independent fixed point.
+func (s *Solver[T]) Solve() (Result[T], error) {
+	return s.SolveContext(context.Background())
+}
+
+// SolveContext runs all lanes to a finite fixed point. It checks cancellation
+// before queue operations, transfers, and edge propagation. Cancellation never
+// returns a partial Result.
+func (s *Solver[T]) SolveContext(ctx context.Context) (Result[T], error) {
+	if s == nil {
+		return Result[T]{}, fmt.Errorf("semanticstate: nil solver")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return Result[T]{}, err
+	}
+	s.allocateStates()
+	entry := s.index.Entry()
+	for laneIndex, lane := range s.lanes {
+		if err := ctx.Err(); err != nil {
+			return Result[T]{}, err
+		}
+		if lane.Initialize != nil {
+			if err := lane.Initialize(ctx, LaneOrdinal(laneIndex), &s.states[s.stateIndex(entry, LaneOrdinal(laneIndex))]); err != nil {
+				return Result[T]{}, err
+			}
+		}
+		s.enqueue(WorkItem{Block: entry, Lane: LaneOrdinal(laneIndex)})
+	}
+	stats := Stats{}
+	var order []WorkItem
+	if s.RecordOrder {
+		order = make([]WorkItem, 0, s.index.BlockCount()*len(s.lanes))
+	}
+	for len(s.queue) != 0 {
+		if err := ctx.Err(); err != nil {
+			return Result[T]{}, err
+		}
+		item := heap.Pop(&s.queue).(WorkItem)
+		s.queued[s.stateIndex(item.Block, item.Lane)] = false
+		if s.RecordOrder {
+			order = append(order, item)
+		}
+		stats.Transfers++
+		lane := s.lanes[item.Lane]
+		input := &s.states[s.stateIndex(item.Block, item.Lane)]
+		output := &s.transferScratch[item.Lane]
+		output.Reset()
+		if lane.Transfer != nil {
+			if err := lane.Transfer(ctx, item.Lane, item.Block, input.View(), output); err != nil {
+				return Result[T]{}, err
+			}
+		} else {
+			output.CloneFrom(input.View(), s.lattice.Clone)
+		}
+		if err := ctx.Err(); err != nil {
+			return Result[T]{}, err
+		}
+		for edgeIndex, edge := range s.index.outgoing[item.Block] {
+			if edgeIndex&0xff == 0 {
+				if err := ctx.Err(); err != nil {
+					return Result[T]{}, err
+				}
+			}
+			candidate := &s.edgeScratch[item.Lane]
+			base := output.View()
+			if edge.Class == cfgExceptional || edge.Uncertain {
+				base = input.View()
+			}
+			candidate.CloneFrom(base, s.lattice.Clone)
+			if lane.Edge != nil {
+				if err := lane.Edge(ctx, item.Lane, edge, input.View(), output.View(), candidate); err != nil {
+					return Result[T]{}, err
+				}
+			}
+			stats.Joins++
+			s.changed = s.changed[:0]
+			destination := &s.states[s.stateIndex(edge.To, item.Lane)]
+			if !destination.JoinFrom(candidate.View(), s.lattice, &s.changed) {
+				continue
+			}
+			stats.Requeues++
+			s.enqueue(WorkItem{Block: edge.To, Lane: item.Lane})
+		}
+	}
+	result := Result[T]{layout: s.layout, lanes: len(s.lanes), blocks: s.index.BlockCount(), order: order, stats: stats}
+	result.states = make([]State[T], len(s.states))
+	for i := range s.states {
+		result.states[i] = newState[T](s.layout)
+		result.states[i].CloneFrom(s.states[i].View(), s.lattice.Clone)
+	}
+	return result, nil
+}
+
+const cfgExceptional = "exceptional"
+
+func (s *Solver[T]) stateIndex(block BlockOrdinal, lane LaneOrdinal) int {
+	return int(block)*len(s.lanes) + int(lane)
+}
+
+func (s *Solver[T]) enqueue(item WorkItem) {
+	index := s.stateIndex(item.Block, item.Lane)
+	if s.queued[index] {
+		return
+	}
+	s.queued[index] = true
+	heap.Push(&s.queue, item)
+}
+
+type workQueue []WorkItem
+
+func (q workQueue) Len() int { return len(q) }
+
+func (q workQueue) Less(i, j int) bool {
+	if q[i].Block != q[j].Block {
+		return q[i].Block < q[j].Block
+	}
+	return q[i].Lane < q[j].Lane
+}
+
+func (q workQueue) Swap(i, j int) { q[i], q[j] = q[j], q[i] }
+
+func (q *workQueue) Push(value any) { *q = append(*q, value.(WorkItem)) }
+
+func (q *workQueue) Pop() any {
+	old := *q
+	last := len(old) - 1
+	value := old[last]
+	*q = old[:last]
+	return value
+}

--- a/internal/analyze/semanticstate/types.go
+++ b/internal/analyze/semanticstate/types.go
@@ -10,6 +10,7 @@ package semanticstate
 import (
 	"context"
 	"fmt"
+	"math/bits"
 	"sort"
 	"strings"
 
@@ -514,8 +515,8 @@ func (s *State[T]) value(id SymbolID) (T, bool) {
 func (s *State[T]) len() int {
 	if s.layout.representation == RepresentationDense {
 		n := 0
-		for _, bits := range s.present {
-			n += bitsOnes(bits)
+		for _, word := range s.present {
+			n += bits.OnesCount64(word)
 		}
 		return n
 	}
@@ -562,15 +563,6 @@ func (s *State[T]) setBit(index int) {
 
 func (s *State[T]) clearBit(index int) {
 	s.present[index/64] &^= uint64(1) << uint(index%64)
-}
-
-func bitsOnes(value uint64) int {
-	count := 0
-	for value != 0 {
-		value &= value - 1
-		count++
-	}
-	return count
 }
 
 // TransferFunc advances one lane's block transfer. out is a reusable scratch

--- a/internal/analyze/semanticstate/types.go
+++ b/internal/analyze/semanticstate/types.go
@@ -1,0 +1,595 @@
+// Package semanticstate provides the procedure-local, indexed fixed-point
+// state used by semantic analysis kernels.
+//
+// The package deliberately knows only about CFG identity and lattice state. It
+// does not interpret VBA values or diagnostic evidence. A procedure creates an
+// Environment and Index once, then reuses a Solver and its scratch states for
+// the duration of that procedure revision.
+package semanticstate
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/vba/cfg"
+)
+
+// SymbolID is an identity local to one procedure revision. It is intentionally
+// not a source-level identifier and must not be persisted across revisions.
+type SymbolID uint32
+
+// BlockOrdinal is the deterministic index of a CFG block in one revision.
+type BlockOrdinal uint32
+
+// LaneOrdinal identifies an independent semantic policy in a solver run.
+type LaneOrdinal uint16
+
+// Representation is the physical representation selected for propagated
+// slots. Hybrid selection means that the selector chooses Dense or Sparse per
+// procedure; there is no third pointer-heavy representation on the hot path.
+type Representation uint8
+
+const (
+	RepresentationDense Representation = iota
+	RepresentationSparse
+)
+
+func (r Representation) String() string {
+	if r == RepresentationSparse {
+		return "sparse"
+	}
+	return "dense"
+}
+
+// Layout is immutable metadata shared by all states in one procedure.
+type Layout struct {
+	symbols        int
+	touched        int
+	representation Representation
+}
+
+// NewLayout applies the deterministic hybrid selector from ADR-0047. A
+// domain with at most 64 symbols, or one touching at least 25% of its symbols,
+// uses dense slots. touched is a count of distinct symbols known to be touched
+// by the domain, not a number of transfer events.
+func NewLayout(symbolCount, touched int) Layout {
+	if symbolCount < 0 {
+		symbolCount = 0
+	}
+	if touched < 0 {
+		touched = 0
+	}
+	if touched > symbolCount {
+		touched = symbolCount
+	}
+	representation := RepresentationSparse
+	if symbolCount <= 64 || touched*4 >= symbolCount {
+		representation = RepresentationDense
+	}
+	return Layout{symbols: symbolCount, touched: touched, representation: representation}
+}
+
+// SymbolCount returns the number of indexed symbols.
+func (l Layout) SymbolCount() int { return l.symbols }
+
+// TouchedCount returns the number used by the hybrid representation selector.
+func (l Layout) TouchedCount() int { return l.touched }
+
+// Representation reports the selected physical representation.
+func (l Layout) Representation() Representation { return l.representation }
+
+// Environment is immutable revision-local name/index data. Methods return
+// copies where a slice is involved, so callers cannot mutate the index through
+// an accessor.
+type Environment struct {
+	names  []string
+	lookup map[string]SymbolID
+	layout Layout
+}
+
+// NewEnvironment canonicalizes case-insensitive domain names, removes
+// duplicates, and assigns IDs in canonical name order. An optional touched-name
+// slice supplies the density estimate used by the hybrid selector.
+func NewEnvironment(names []string, touchedNames ...[]string) Environment {
+	canonical := make([]string, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = canonicalName(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		canonical = append(canonical, name)
+	}
+	sort.Strings(canonical)
+	lookup := make(map[string]SymbolID, len(canonical))
+	for id, name := range canonical {
+		lookup[name] = SymbolID(id)
+	}
+	touched := 0
+	if len(touchedNames) != 0 {
+		touchedSeen := make(map[SymbolID]struct{}, len(touchedNames[0]))
+		for _, name := range touchedNames[0] {
+			if id, ok := lookup[canonicalName(name)]; ok {
+				touchedSeen[id] = struct{}{}
+			}
+		}
+		touched = len(touchedSeen)
+	}
+	return Environment{
+		names:  canonical,
+		lookup: lookup,
+		layout: NewLayout(len(canonical), touched),
+	}
+}
+
+// Layout returns immutable slot metadata for this revision.
+func (e Environment) Layout() Layout { return e.layout }
+
+// Symbol resolves a canonicalized name to its revision-local ID.
+func (e Environment) Symbol(name string) (SymbolID, bool) {
+	id, ok := e.lookup[canonicalName(name)]
+	return id, ok
+}
+
+// Name returns the canonical name for an ID.
+func (e Environment) Name(id SymbolID) (string, bool) {
+	if int(id) >= len(e.names) {
+		return "", false
+	}
+	return e.names[id], true
+}
+
+// Names returns canonical names in SymbolID order.
+func (e Environment) Names() []string { return append([]string(nil), e.names...) }
+
+func canonicalName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.Trim(name, "[]")
+	return strings.ToLower(name)
+}
+
+// Block is a stable index reference to a CFG block.
+type Block struct {
+	Ordinal BlockOrdinal
+	ID      cfg.BlockID
+}
+
+// Edge is the protocol-neutral edge view consumed by a lane policy.
+type Edge struct {
+	ID        cfg.EdgeID
+	From      BlockOrdinal
+	To        BlockOrdinal
+	Kind      cfg.EdgeKind
+	Class     cfg.EdgeClass
+	Uncertain bool
+}
+
+// Index is immutable CFG identity and outgoing-edge data. The input graph is
+// copied while constructing the index; later graph mutations cannot affect a
+// solver invocation.
+type Index struct {
+	blocks   []Block
+	byID     map[cfg.BlockID]BlockOrdinal
+	outgoing [][]Edge
+	entry    BlockOrdinal
+	entryID  cfg.BlockID
+}
+
+// NewIndex builds deterministic ordinals by sorting the graph's stable block
+// IDs. Outgoing edges are ordered by stable edge ID (then destination and edge
+// kind as tie-breakers) to keep adapter traversal reproducible while retaining
+// CFG builder branch precedence.
+func NewIndex(graph cfg.Graph) (*Index, error) {
+	if len(graph.Blocks) == 0 {
+		return nil, fmt.Errorf("semanticstate: CFG has no blocks")
+	}
+	ids := make([]cfg.BlockID, 0, len(graph.Blocks))
+	seen := make(map[cfg.BlockID]struct{}, len(graph.Blocks))
+	for _, block := range graph.Blocks {
+		if _, ok := seen[block.ID]; ok {
+			return nil, fmt.Errorf("semanticstate: duplicate CFG block %d", block.ID)
+		}
+		seen[block.ID] = struct{}{}
+		ids = append(ids, block.ID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	byID := make(map[cfg.BlockID]BlockOrdinal, len(ids))
+	blocks := make([]Block, len(ids))
+	for ordinal, id := range ids {
+		byID[id] = BlockOrdinal(ordinal)
+		blocks[ordinal] = Block{Ordinal: BlockOrdinal(ordinal), ID: id}
+	}
+	entry, ok := byID[graph.Entry]
+	if !ok {
+		return nil, fmt.Errorf("semanticstate: CFG entry %d is not a block", graph.Entry)
+	}
+	outgoing := make([][]Edge, len(blocks))
+	for _, source := range graph.Edges {
+		from, fromOK := byID[source.From]
+		to, toOK := byID[source.To]
+		if !fromOK || !toOK {
+			return nil, fmt.Errorf("semanticstate: edge %d references unknown block", source.ID)
+		}
+		outgoing[from] = append(outgoing[from], Edge{
+			ID: source.ID, From: from, To: to, Kind: source.Kind,
+			Class: source.Class, Uncertain: source.Uncertain,
+		})
+	}
+	for i := range outgoing {
+		sort.SliceStable(outgoing[i], func(a, b int) bool {
+			left, right := outgoing[i][a], outgoing[i][b]
+			// CFG builders assign stable edge IDs in source order. Keeping that
+			// order preserves domain-specific branch precedence while still
+			// making the traversal independent of the input slice order.
+			if left.ID != right.ID {
+				return left.ID < right.ID
+			}
+			if left.To != right.To {
+				return left.To < right.To
+			}
+			if left.Kind != right.Kind {
+				return left.Kind < right.Kind
+			}
+			if left.Class != right.Class {
+				return left.Class < right.Class
+			}
+			return !left.Uncertain && right.Uncertain
+		})
+	}
+	return &Index{blocks: blocks, byID: byID, outgoing: outgoing, entry: entry, entryID: graph.Entry}, nil
+}
+
+// BlockCount returns the number of blocks in the indexed graph.
+func (i *Index) BlockCount() int {
+	if i == nil {
+		return 0
+	}
+	return len(i.blocks)
+}
+
+// Entry returns the indexed entry block.
+func (i *Index) Entry() BlockOrdinal { return i.entry }
+
+// Block returns a stable block reference.
+func (i *Index) Block(ordinal BlockOrdinal) (Block, bool) {
+	if i == nil || int(ordinal) >= len(i.blocks) {
+		return Block{}, false
+	}
+	return i.blocks[ordinal], true
+}
+
+// Ordinal resolves a source CFG block ID.
+func (i *Index) Ordinal(id cfg.BlockID) (BlockOrdinal, bool) {
+	if i == nil {
+		return 0, false
+	}
+	ordinal, ok := i.byID[id]
+	return ordinal, ok
+}
+
+// Blocks returns stable block references in ordinal order.
+func (i *Index) Blocks() []Block {
+	if i == nil {
+		return nil
+	}
+	return append([]Block(nil), i.blocks...)
+}
+
+// Outgoing returns one block's immutable deterministic edge list. Index is
+// immutable after construction; callers must treat the returned slice as
+// read-only so hot solver iterations do not allocate a defensive copy.
+func (i *Index) Outgoing(from BlockOrdinal) []Edge {
+	if i == nil || int(from) >= len(i.outgoing) {
+		return nil
+	}
+	return i.outgoing[from]
+}
+
+// Lattice is a finite-lattice adapter. Join must mutate *dst in place and
+// report whether the destination changed. Clone must produce an independent
+// value suitable for storing in another state; it is also the alias-safety
+// boundary for slices, maps, and pointers held by a domain value.
+type Lattice[T any] interface {
+	Clone(T) T
+	Join(dst *T, src T) bool
+}
+
+// StateView is a read-only view valid until the owning solver advances or
+// reuses that state. Values are returned by value; the lattice Clone method is
+// responsible for making pointer-bearing values safe before storing them.
+type StateView[T any] struct{ state *State[T] }
+
+// Has reports whether a slot is present (as opposed to lattice bottom).
+func (v StateView[T]) Has(id SymbolID) bool {
+	return v.state != nil && v.state.has(id)
+}
+
+// Value returns a present slot value.
+func (v StateView[T]) Value(id SymbolID) (T, bool) {
+	if v.state == nil {
+		var zero T
+		return zero, false
+	}
+	return v.state.value(id)
+}
+
+// IDs returns present IDs in ascending order.
+func (v StateView[T]) IDs() []SymbolID {
+	if v.state == nil {
+		return nil
+	}
+	return v.state.ids()
+}
+
+// Len returns the number of present slots.
+func (v StateView[T]) Len() int {
+	if v.state == nil {
+		return 0
+	}
+	return v.state.len()
+}
+
+// ForEach visits present slots in SymbolID order. Returning false stops the
+// traversal.
+func (v StateView[T]) ForEach(fn func(SymbolID, T) bool) {
+	if v.state != nil {
+		v.state.forEach(fn)
+	}
+}
+
+// NewState creates an empty state using an immutable layout.
+func NewState[T any](layout Layout) State[T] {
+	return newState[T](layout)
+}
+
+// State is a compact indexed set of slots. Use StateView when passing state to
+// transfer callbacks; mutation is reserved for destination and scratch states.
+type State[T any] struct {
+	layout  Layout
+	dense   []T
+	present []uint64
+	sparse  []slot[T]
+}
+
+type slot[T any] struct {
+	id    SymbolID
+	value T
+}
+
+func newState[T any](layout Layout) State[T] {
+	s := State[T]{layout: layout}
+	if layout.representation == RepresentationDense {
+		s.dense = make([]T, layout.symbols)
+		s.present = make([]uint64, (layout.symbols+63)/64)
+	}
+	return s
+}
+
+// Layout reports the state's immutable layout.
+func (s *State[T]) Layout() Layout {
+	if s == nil {
+		return Layout{}
+	}
+	return s.layout
+}
+
+// Representation reports the state's selected physical representation.
+func (s *State[T]) Representation() Representation { return s.layout.representation }
+
+// View returns a read-only view over the state.
+func (s *State[T]) View() StateView[T] { return StateView[T]{state: s} }
+
+// Reset clears all slots while retaining backing storage for reuse.
+func (s *State[T]) Reset() {
+	if s == nil {
+		return
+	}
+	var zero T
+	if s.layout.representation == RepresentationDense {
+		for id := range s.dense {
+			if s.bit(id) {
+				s.dense[id] = zero
+			}
+		}
+		clear(s.present)
+		return
+	}
+	for i := range s.sparse {
+		s.sparse[i].value = zero
+	}
+	s.sparse = s.sparse[:0]
+}
+
+// Set stores a slot value. It returns false when id is outside the layout.
+// Callers that need an independent value should pass a lattice.Clone result.
+func (s *State[T]) Set(id SymbolID, value T) bool {
+	if s == nil || int(id) >= s.layout.symbols {
+		return false
+	}
+	if s.layout.representation == RepresentationDense {
+		s.dense[id] = value
+		s.setBit(int(id))
+		return true
+	}
+	index, found := s.sparseIndex(id)
+	if found {
+		s.sparse[index].value = value
+		return true
+	}
+	s.sparse = append(s.sparse, slot[T]{})
+	copy(s.sparse[index+1:], s.sparse[index:])
+	s.sparse[index] = slot[T]{id: id, value: value}
+	return true
+}
+
+// Delete removes one present slot.
+func (s *State[T]) Delete(id SymbolID) bool {
+	if s == nil || int(id) >= s.layout.symbols || !s.has(id) {
+		return false
+	}
+	var zero T
+	if s.layout.representation == RepresentationDense {
+		s.dense[id] = zero
+		s.clearBit(int(id))
+		return true
+	}
+	index, _ := s.sparseIndex(id)
+	s.sparse[index].value = zero
+	copy(s.sparse[index:], s.sparse[index+1:])
+	s.sparse = s.sparse[:len(s.sparse)-1]
+	return true
+}
+
+// CloneFrom replaces the destination with an independent copy of src.
+func (s *State[T]) CloneFrom(src StateView[T], clone func(T) T) {
+	s.Reset()
+	if clone == nil {
+		clone = func(value T) T { return value }
+	}
+	src.ForEach(func(id SymbolID, value T) bool {
+		s.Set(id, clone(value))
+		return true
+	})
+}
+
+// JoinFrom joins src into the destination in place. Each changed SymbolID is
+// appended to changed, which is caller-owned and can be reused across edges.
+// The bool result reports whether at least one slot changed.
+func (s *State[T]) JoinFrom(src StateView[T], lattice Lattice[T], changed *[]SymbolID) bool {
+	if s == nil || lattice == nil {
+		return false
+	}
+	changedAny := false
+	src.ForEach(func(id SymbolID, value T) bool {
+		if !s.has(id) {
+			s.Set(id, lattice.Clone(value))
+			if changed != nil {
+				*changed = append(*changed, id)
+			}
+			changedAny = true
+			return true
+		}
+		current, _ := s.value(id)
+		if lattice.Join(&current, value) {
+			s.Set(id, current)
+			if changed != nil {
+				*changed = append(*changed, id)
+			}
+			changedAny = true
+		}
+		return true
+	})
+	return changedAny
+}
+
+func (s *State[T]) has(id SymbolID) bool {
+	if s == nil || int(id) >= s.layout.symbols {
+		return false
+	}
+	if s.layout.representation == RepresentationDense {
+		return s.bit(int(id))
+	}
+	_, found := s.sparseIndex(id)
+	return found
+}
+
+func (s *State[T]) value(id SymbolID) (T, bool) {
+	if !s.has(id) {
+		var zero T
+		return zero, false
+	}
+	if s.layout.representation == RepresentationDense {
+		return s.dense[id], true
+	}
+	index, _ := s.sparseIndex(id)
+	return s.sparse[index].value, true
+}
+
+func (s *State[T]) len() int {
+	if s.layout.representation == RepresentationDense {
+		n := 0
+		for _, bits := range s.present {
+			n += bitsOnes(bits)
+		}
+		return n
+	}
+	return len(s.sparse)
+}
+
+func (s *State[T]) ids() []SymbolID {
+	ids := make([]SymbolID, 0, s.len())
+	s.forEach(func(id SymbolID, _ T) bool { ids = append(ids, id); return true })
+	return ids
+}
+
+func (s *State[T]) forEach(fn func(SymbolID, T) bool) {
+	if fn == nil {
+		return
+	}
+	if s.layout.representation == RepresentationDense {
+		for id := 0; id < len(s.dense); id++ {
+			if s.bit(id) && !fn(SymbolID(id), s.dense[id]) {
+				return
+			}
+		}
+		return
+	}
+	for _, entry := range s.sparse {
+		if !fn(entry.id, entry.value) {
+			return
+		}
+	}
+}
+
+func (s *State[T]) sparseIndex(id SymbolID) (int, bool) {
+	index := sort.Search(len(s.sparse), func(i int) bool { return s.sparse[i].id >= id })
+	return index, index < len(s.sparse) && s.sparse[index].id == id
+}
+
+func (s *State[T]) bit(index int) bool {
+	return s.present[index/64]&(uint64(1)<<uint(index%64)) != 0
+}
+
+func (s *State[T]) setBit(index int) {
+	s.present[index/64] |= uint64(1) << uint(index%64)
+}
+
+func (s *State[T]) clearBit(index int) {
+	s.present[index/64] &^= uint64(1) << uint(index%64)
+}
+
+func bitsOnes(value uint64) int {
+	count := 0
+	for value != 0 {
+		value &= value - 1
+		count++
+	}
+	return count
+}
+
+// TransferFunc advances one lane's block transfer. out is a reusable scratch
+// state and is reset by the solver before the callback runs.
+type TransferFunc[T any] func(context.Context, LaneOrdinal, BlockOrdinal, StateView[T], *State[T]) error
+
+// EdgePolicy refines a propagated state for one edge. candidate is initialized
+// from predecessor output on normal edges and predecessor input on exceptional
+// or uncertain edges. A policy may explicitly copy from predecessorOutput when
+// a domain has a narrow exception that remains valid across that edge.
+type EdgePolicy[T any] func(context.Context, LaneOrdinal, Edge, StateView[T], StateView[T], *State[T]) error
+
+// InitializeFunc seeds the entry state for one lane.
+type InitializeFunc[T any] func(context.Context, LaneOrdinal, *State[T]) error
+
+// Lane defines an independent transfer and edge policy. Lanes share indexed
+// scheduling but never share mutable state.
+type Lane[T any] struct {
+	Transfer   TransferFunc[T]
+	Edge       EdgePolicy[T]
+	Initialize InitializeFunc[T]
+}


### PR DESCRIPTION
## Summary

- Introduce `internal/analyze/semanticstate`, a shared indexed solver with revision-local symbol, block, and lane IDs, dense/sparse state storage, in-place joins, changed-slot reporting, deterministic worklists, and cancellation support.
- Migrate HTTP scheduling and CFG indexing to the shared solver while retaining a compatibility adapter for the existing HTTP transfer semantics.
- Migrate the ordinary block-level Array CFG walk to the shared solver and preserve legacy handling for source-line, edge-refinement, and combined evidence paths.
- Add ADR-0047, specification updates, changelog notes, solver tests, and corpus benchmark evidence.
- Keep #713 open for the remaining allocation target; the focused follow-ups are [#720](https://github.com/harumiWeb/xlflow/issues/720) and [#721](https://github.com/harumiWeb/xlflow/issues/721).

## Compatibility and scope

- Diagnostic behavior, deterministic result ordering, cancellation, and race-safety are preserved by the migrated paths.
- HTTP nested-map scalarization is intentionally deferred to #720.
- Advanced Array source-line, edge-refinement, interprocedural, and evidence lanes are intentionally deferred to #721.
- This PR is related to #713 and does not close it because the parent issue's combined 50% allocation-reduction criterion is not yet met.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/analyze/semanticstate ./internal/analyze -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/analyze/semanticstate`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/analyze`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./...`
- `rtk task corpus:test`
- `rtk task corpus:metrics`
- `rtk task lint`
- `rtk pnpm format:check`
- `rtk proxy task review:codex`

## Benchmark evidence

- `BenchmarkRealWorldCorpus/ronecone/analyze-only`: `8.93e9 ns/op`, `11,203,650,096 B/op`, `81,659,543 allocs/op` in the final sample.
- Focused allocation profile: `cloneArrayState` ~1.58 GB, `meetArrayState` ~0.53 GB, and `cloneHTTPState` ~0.09 GB; the parent issue's 50% combined reduction remains follow-up work.

## Not run

- Windows Excel COM end-to-end tests and the local VBE oracle were not run because this PR changes the internal analysis solver boundary and does not modify Excel bridge behavior or VBE interpretation rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved consistency and determinism of HTTP and standard Array code analysis.
  * Reduced unnecessary state processing, with potential performance and memory benefits.
  * Analysis cancellation now stops cleanly without publishing incomplete results.
  * Preserved existing diagnostics, snapshots, CLI JSON output, and LSP behavior.

* **Documentation**
  * Added architecture and verification documentation for the updated analysis behavior and measurement results.
  * Documented analysis paths reserved for future improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->