### PR TITLE
perf(cfg): replace copied derived graphs with immutable CFG views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Replaced copied derived CFGs with immutable, revision-scoped `CFGView`
+  values. Stable block ordinals, canonical filter identities, shared
+  adjacency/query indexes, reachability, and dominators are reused across
+  equivalent views with bounded procedure/revision lifetime and safe
+  concurrent reads. Existing Graph compatibility and defensive ownership
+  boundaries remain available; Array, Object, Error, and return-path
+  diagnostics, CLI JSON, and LSP contracts are unchanged.
+
 - Introduced the internal indexed semantic-state solver at the HTTP transport
   scheduling boundary and for the ordinary Array CFG walk. Revision-local
   `SymbolID` and `BlockOrdinal` indexes, dense/sparse slot storage, in-place

--- a/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
+++ b/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
@@ -108,6 +108,53 @@ converts byte ranges to UTF-16 only at the protocol boundary. This keeps
 `VB055`--`VB058` parity and prevents a second control-flow parser from being
 introduced in an adapter.
 
+### Amendment: immutable CFG views and bounded derived-query ownership (Issue #714)
+
+The graph storage for a procedure is an immutable base revision. The revision
+owns its blocks, edges, stable dense block ordinals, block-ID lookup, and base
+normal/incoming/outgoing adjacency in deterministic order. Block ordinals are
+internal positions within that revision; they do not replace the public
+meaning of sparse or non-contiguous `BlockID` values, and the defensive
+handling of duplicate IDs, zero IDs, and directly constructed graph values
+remains part of the compatibility contract. A graph transformation or
+defensive clone creates a new revision; indexed graph storage is never changed
+in place.
+
+`CFGView` is a read-only, borrowed view over that base revision. It carries a
+canonical edge-filter identity and an optional edge mask, such as the mask
+that excludes the normal continuation after `Err.Raise`. Constructing a view
+does not copy blocks, edges, procedure IR, or adjacency. View iteration uses
+the base adjacency (or an allocation-free filtered traversal), preserves base
+edge ordering, and never removes the exceptional edge or changes `On Error`,
+`Resume Next`, or `Error` semantics. A view cannot expose mutable slices or
+outlive the immutable procedure/revision that owns it.
+
+Derived query state is keyed by the immutable graph revision and canonical
+filter identity. Query indexes, filtered adjacency, reachability sets,
+dominators, and other derived results are built lazily, reused by equivalent
+views in that revision, and published for concurrent readers with deterministic
+results and traversal order. Caches are bounded by the procedure/revision
+lifetime; no derived result is reused across an incompatible revision and no
+persistent cross-revision cache is introduced. A failed or canceled build is
+not published as a reusable result.
+
+Existing `Graph` construction, query, clone, and materialization APIs remain
+compatibility boundaries. The legacy
+`WithoutNormalErrRaiseContinuation` entry point remains available with its
+existing owned-Graph return and defensive-value behavior; internal consumers
+use the equivalent read-only view directly. A caller that needs independent
+mutable storage must request an explicit defensive clone/materialization. This
+preserves ownership for existing Graph callers while allowing Array, Object,
+Error, and return-path consumers to share one base revision and its derived
+queries.
+
+This amendment is an implementation and ownership change only. It does not
+change CFG construction semantics, diagnostic meaning or ordering, diagnostic
+IDs, CLI configuration or JSON, LSP capabilities or ranges, or the public
+behavior of `VBA204`, `VBA210`, and related consumers. Exceptional flow and
+uncertainty remain conservative, and performance telemetry remains
+observability rather than a new user-facing contract.
+
 ## Consequences
 
 - Positive: batch and LSP reliability checks share one deterministic
@@ -118,14 +165,16 @@ introduced in an adapter.
   false confidence on malformed or dynamically targeted control flow.
 - Positive: the graph remains protocol-neutral and safe after parser retirement
   because it contains only Go-owned IR values and ranges.
-- Positive: repeated analyzer queries reuse immutable lookup, adjacency, and
-  reachability data instead of rebuilding maps or scanning all edges.
+- Positive: repeated analyzer queries and equivalent filtered views reuse
+  immutable ordinal, adjacency, reachability, and dominator data instead of
+  copying graphs or rebuilding maps and scans.
 - Negative: treating every executable statement as a potential fault site adds
   edges and can reduce precision; ADR-0023 does not narrow this fallback.
 - Negative: path-sensitive error modes and conservative unknown flow make graph
   construction and query testing more complex than a structured-only CFG.
-- Negative: each built graph retains additional index memory, and transformed
-  graphs must rebuild the index when their edge set changes.
+- Negative: each procedure/revision retains bounded derived-query state, and
+  transformed graphs must rebuild revision-local indexes when their edge set
+  changes.
 - Negative: callers must choose a flow view deliberately; using a normal-only
   view for a general guarantee would be unsound.
 - Limitation: graph IDs are stable only for the same document revision and are

--- a/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
+++ b/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
@@ -130,8 +130,10 @@ edge ordering, and never removes the exceptional edge or changes `On Error`,
 outlive the immutable procedure/revision that owns it.
 
 Derived query state is keyed by the immutable graph revision and canonical
-filter identity. Query indexes, filtered adjacency, reachability sets,
-dominators, and other derived results are built lazily, reused by equivalent
+filter identity. This supersedes the earlier Decision statement that the
+query index eagerly retains reachability sets for the supported edge-filter
+views. Query indexes, filtered adjacency, reachability sets, dominators, and
+other derived results are built lazily, reused by equivalent
 views in that revision, and published for concurrent readers with deterministic
 results and traversal order. Caches are bounded by the procedure/revision
 lifetime; no derived result is reused across an incompatible revision and no

--- a/docs/specs/vba-control-flow-graph.md
+++ b/docs/specs/vba-control-flow-graph.md
@@ -17,6 +17,38 @@ support defensive cloning: callers may mutate returned slices without changing
 the builder result or a snapshot's cached copy. Graph construction is
 deterministic for the same IR.
 
+### Immutable base revisions and `CFGView`
+
+The built graph is an immutable base revision for its procedure. The base
+revision owns the block and edge storage, stable dense `BlockOrdinal` values,
+the `BlockID` lookup, and canonical base-order incoming/outgoing adjacency.
+Ordinals are internal positions and are stable only within that graph revision;
+they do not change the existing `BlockID` contract. Sparse or non-contiguous
+block IDs, ID `0`, duplicate defensive values, and directly constructed Graph
+values retain their existing lookup, validation, and deterministic-order
+behavior. Callers must use `Clone` or an explicit graph transformation before
+changing graph contents; indexed storage is not mutated in place.
+
+`CFGView` is a read-only view that borrows one immutable base revision. A view
+contains a canonical filter identity and, when needed, a compact edge mask.
+For example, the view equivalent to
+`WithoutNormalErrRaiseContinuation` excludes only the normal continuation
+after `Err.Raise`; it preserves exceptional edges and all existing `On Error`,
+`Resume Next`, and `Error` semantics. Creating or passing a view does not copy
+blocks, edges, procedure IR, or complete adjacency. Iteration uses shared
+base-order adjacency or an allocation-free filtered traversal, and view APIs
+must not expose mutable slices or outlive their procedure/revision owner.
+
+The existing Graph APIs remain compatibility boundaries. Graph construction,
+ordinary queries, `Clone`, and callers that explicitly need independent owned
+storage retain their defensive-value behavior. The legacy
+`WithoutNormalErrRaiseContinuation` entry point remains available with its
+existing owned-Graph return and defensive-value behavior; internal consumers
+should pass the equivalent read-only view directly. An independent Graph must
+be requested through explicit materialization or cloning. Internal Array,
+Object, Error, and return-path consumers should pass views so equivalent
+filters share the same base revision and derived query state.
+
 ### Validation facts
 
 ProcedureIR retains the source ranges and normalized operands needed by CFG
@@ -171,22 +203,26 @@ cleanup use the same conservative reachability. A path through unknown flow or
 established before that path diverges.
 
 Built graphs retain immutable per-revision query indexes. Statement-to-block
-lookups and incoming/outgoing edge traversal use these indexes, and the default
-and `NormalOnly` reachability sets are computed once when the graph is built.
-`IsReachable` reads membership directly from the matching cached set for these
-canonical views without materializing a defensive copy. APIs that materialize
-reachability data continue to receive independently owned copies, and a future
-filter view without a cached set must use the general reachability path.
-Graph value copies may share the index because it is read-only. `Clone`, graph
-rebasing, and edge-changing transformations rebuild the index with their
-independent graph storage. A Graph literal without an index builds a temporary
-fallback index, preserving the same query semantics for internal callers. The
-`Blocks`, `Edges`, `Entry`, `UnknownExit`, and `UnknownFlowSources` values are
-immutable for an indexed graph revision. If a caller replaces either slice or
-changes any reachability input on a copied graph, the index validity check
-discards the old index and rebuilds it before querying. In-place mutation of
-indexed slice elements is not a supported graph revision; callers should use
-`Clone` or a graph transformation before changing graph contents.
+lookups and incoming/outgoing edge traversal use stable ordinals and shared
+base adjacency. Derived query state is keyed by `(graph revision, canonical
+filter identity)`. Reachability, filtered adjacency, dominators, and other
+derived indexes are initialized lazily and reused by equivalent `CFGView`
+values; `IsReachable` and equivalent hot queries do not materialize a copied
+filtered graph. APIs that intentionally materialize reachability data continue
+to receive independently owned copies.
+
+The derived-query cache is scoped to one procedure/revision lifetime and is
+bounded to the supported filter identities. A result from one graph revision
+or filter identity must never be reused for another. Cache initialization and
+publication are safe for concurrent readers, and every reader observes the
+same deterministic traversal and result ordering. Canceled or failed query
+construction is not published as reusable state. A Graph value copy may share
+read-only base and derived state; `Clone`, graph rebasing, and edge-changing
+transformations create independent storage and a new revision. A Graph literal
+without indexes uses a correctness-preserving fallback index. Replacing graph
+slices or changing reachability inputs invalidates the old revision-local state
+and rebuilds it before querying; in-place mutation of indexed slice elements is
+not a supported revision.
 
 The default guarantee view includes normal and exceptional flow. A consumer may
 explicitly request a narrower view when its rule defines one. Narrowing by flow
@@ -268,6 +304,12 @@ may seed it with a CFG built from the same revision's IR. The cache:
 - returns defensive copies; and
 - retires with the snapshot without retaining parser state.
 
+The snapshot owns the immutable base revision and its revision-local
+`CFGView`/derived-query cache. Views are read-only borrows and do not create a
+second document CFG or escape the snapshot lifetime. Equivalent filters share
+the base ordinals, adjacency, reachability, and dominator state; a new snapshot
+or changed procedure receives a new revision and cannot reuse those results.
+
 `NewAnalysisSnapshotWithArtifacts` deep-copies a supplied CFG at the snapshot
 boundary and keeps the existing cancellation and defensive-copy behavior.
 
@@ -293,4 +335,7 @@ flow or infer legality from diagnostic text.
 
 The CFG does not define interprocedural call propagation, public visualization,
 new CLI output, configuration, or LSP capabilities. Adapters remain responsible
-for converting `ast.Range` byte columns to LSP UTF-16 positions.
+for converting `ast.Range` byte columns to LSP UTF-16 positions. Introducing
+`CFGView` changes only internal storage ownership and derived-query reuse; it
+does not change diagnostic IDs, finding meaning or order, CLI behavior/JSON, or
+LSP ranges and capabilities.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -3621,50 +3621,47 @@ func (w applicationStateExitWitness) description() string {
 // restoration is the cleanup boundary itself, so it clears state on its own
 // exceptional transition as well.
 func applicationStateExitWitnesses(proc sourceProcedure, property string, facts *procedureAnalysisFacts) map[int]applicationStateExitWitness {
-	flowGraph := proc.Graph.WithoutNormalErrRaiseContinuation()
-	graph := &flowGraph
-	in := map[vbacfg.BlockID]applicationStateFlow{graph.Entry: newApplicationStateFlow()}
-	queued := map[vbacfg.BlockID]bool{graph.Entry: true}
-	queue := []vbacfg.BlockID{graph.Entry}
+	graph := proc.Graph.WithoutNormalErrRaiseContinuationView()
+	in := map[vbacfg.BlockID]applicationStateFlow{graph.Entry(): newApplicationStateFlow()}
+	queued := map[vbacfg.BlockID]bool{graph.Entry(): true}
+	queue := []vbacfg.BlockID{graph.Entry()}
 
 	for len(queue) > 0 {
 		blockID := queue[0]
 		queue = queue[1:]
 		queued[blockID] = false
 		state := in[blockID]
-		block, ok := applicationStateBlock(*graph, blockID)
+		block, ok := applicationStateBlock(graph, blockID)
 		if !ok {
 			continue
 		}
-		for _, edge := range graph.Edges {
-			if edge.From != blockID {
-				continue
-			}
+		graph.ForEachOutgoing(blockID, func(edge vbacfg.Edge) bool {
 			out := applicationStateFlowAcrossEdge(proc, state, block, edge, property, facts)
 			merged, changed := mergeApplicationStateFlow(in[edge.To], out)
 			if !changed {
-				continue
+				return true
 			}
 			in[edge.To] = merged
 			if !queued[edge.To] {
 				queue = append(queue, edge.To)
 				queued[edge.To] = true
 			}
-		}
+			return true
+		})
 	}
 	witnesses := map[int]applicationStateExitWitness{}
-	for _, edge := range graph.Edges {
-		kind := applicationStateExitKind(*graph, edge.To)
+	graph.ForEachEdge(func(edge vbacfg.Edge) bool {
+		kind := applicationStateViewExitKind(graph, edge.To)
 		if kind == "" {
-			continue
+			return true
 		}
 		state, reachable := in[edge.From]
 		if !reachable || state.Dirty == nil {
-			continue
+			return true
 		}
-		block, ok := applicationStateBlock(*graph, edge.From)
+		block, ok := applicationStateBlock(graph, edge.From)
 		if !ok {
-			continue
+			return true
 		}
 		out := applicationStateFlowAcrossEdge(proc, state, block, edge, property, facts)
 		if out.ViaExceptional && kind == "normal exit" {
@@ -3675,7 +3672,8 @@ func applicationStateExitWitnesses(proc sourceProcedure, property string, facts 
 				witnesses[origin] = applicationStateExitWitness{Kind: kind, Line: edge.Range.StartLine}
 			}
 		}
-	}
+		return true
+	})
 	return witnesses
 }
 
@@ -3710,11 +3708,23 @@ func applicationStateWitnessRank(kind string) int {
 	}
 }
 
-func applicationStateBlock(graph vbacfg.Graph, id vbacfg.BlockID) (vbacfg.Block, bool) {
-	if id <= 0 || int(id) > len(graph.Blocks) {
-		return vbacfg.Block{}, false
+func applicationStateBlock(graph vbacfg.CFGView, id vbacfg.BlockID) (vbacfg.Block, bool) {
+	return graph.BlockByID(id)
+}
+
+func applicationStateViewExitKind(graph vbacfg.CFGView, id vbacfg.BlockID) string {
+	switch id {
+	case graph.NormalExit():
+		return "normal exit"
+	case graph.ExceptionalExit():
+		return "error exit"
+	case graph.TerminationExit():
+		return "termination exit"
+	case graph.UnknownExit():
+		return "unknown exit"
+	default:
+		return ""
 	}
-	return graph.Blocks[int(id)-1], true
 }
 
 func applicationStateExitKind(graph vbacfg.Graph, id vbacfg.BlockID) string {
@@ -4287,7 +4297,7 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 	}
 	var findings []Finding
 	if proc.Graph != nil {
-		flowGraph := proc.Graph.WithoutNormalErrRaiseContinuation()
+		flowGraph := proc.Graph.WithoutNormalErrRaiseContinuationView()
 		reachable := map[vbacfg.BlockID]bool{}
 		for _, blockID := range proc.Graph.Reachable(vbacfg.EdgeFilter{NormalOnly: true}) {
 			reachable[blockID] = true
@@ -4306,8 +4316,8 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 			}
 			implicitEntry := false
 			loopExitVariables := map[string]bool{}
-			for _, edge := range flowGraph.Edges {
-				if edge.To == block.ID && edge.Class == vbacfg.EdgeNormal && reachable[edge.From] &&
+			flowGraph.ForEachIncoming(block.ID, func(edge vbacfg.Edge) bool {
+				if edge.Class == vbacfg.EdgeNormal && reachable[edge.From] &&
 					edge.Kind != vbacfg.EdgeGoto && edge.Kind != vbacfg.EdgeUnknown {
 					implicitEntry = true
 					if edge.Kind == vbacfg.EdgeLoopExit {
@@ -4318,7 +4328,8 @@ func (a Analyzer) errorHandlerFallthroughFindings(file parsedFile, proc sourcePr
 						}
 					}
 				}
-			}
+				return true
+			})
 			if !implicitEntry {
 				continue
 			}
@@ -4970,11 +4981,7 @@ func isCleanupFallthroughLabel(label string) bool {
 // qualified or project-specific labels whose body is demonstrably limited to
 // resource cleanup or loop finalization. Arbitrary handler code is rejected so
 // a normal fallthrough into logging or error reporting remains VBA204.
-func isSemanticCleanupFallthrough(proc sourceProcedure, labelBlock vbacfg.Block, graph vbacfg.Graph, loopExitVariables map[string]bool) bool {
-	blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(graph.Blocks))
-	for _, block := range graph.Blocks {
-		blocks[block.ID] = block
-	}
+func isSemanticCleanupFallthrough(proc sourceProcedure, labelBlock vbacfg.Block, graph vbacfg.CFGView, loopExitVariables map[string]bool) bool {
 
 	queue := []vbacfg.BlockID{labelBlock.ID}
 	seen := map[vbacfg.BlockID]bool{}
@@ -4987,14 +4994,14 @@ func isSemanticCleanupFallthrough(proc sourceProcedure, labelBlock vbacfg.Block,
 			continue
 		}
 		seen[blockID] = true
-		if blockID == graph.NormalExit {
+		if blockID == graph.NormalExit() {
 			reachedNormalExit = true
 			continue
 		}
-		if blockID == graph.ExceptionalExit || blockID == graph.TerminationExit || blockID == graph.UnknownExit {
+		if blockID == graph.ExceptionalExit() || blockID == graph.TerminationExit() || blockID == graph.UnknownExit() {
 			return false
 		}
-		block, ok := blocks[blockID]
+		block, ok := graph.BlockByID(blockID)
 		if !ok {
 			return false
 		}
@@ -5006,14 +5013,20 @@ func isSemanticCleanupFallthrough(proc sourceProcedure, labelBlock vbacfg.Block,
 				foundCleanup = true
 			}
 		}
-		for _, edge := range graph.Edges {
-			if edge.From != blockID || edge.Class != vbacfg.EdgeNormal {
-				continue
+		invalidEdge := false
+		graph.ForEachOutgoing(blockID, func(edge vbacfg.Edge) bool {
+			if edge.Class != vbacfg.EdgeNormal {
+				return true
 			}
 			if edge.Kind == vbacfg.EdgeUnknown || edge.Uncertain {
+				invalidEdge = true
 				return false
 			}
 			queue = append(queue, edge.To)
+			return true
+		})
+		if invalidEdge {
+			return false
 		}
 	}
 	return reachedNormalExit && foundCleanup

--- a/internal/analyze/array_compact_solver.go
+++ b/internal/analyze/array_compact_solver.go
@@ -87,18 +87,14 @@ func (a arrayCompactAdapter) initialState(state *semanticstate.State[arrayValue]
 // solver. Callback compatibility is intentionally retained at this boundary,
 // so diagnostic/evidence code still receives arrayFlowState while joins happen
 // directly in indexed slots without union-map allocation.
-func walkArrayCFGCompact(ctx context.Context, graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, sourceLines bool) error {
+func walkArrayCFGCompact(ctx context.Context, graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, sourceLines bool) error {
 	if graph == nil {
 		return nil
 	}
 	adapter := newArrayCompactAdapter(initial)
-	index, err := semanticstate.NewIndex(*graph)
+	index, err := semanticstate.NewIndexView(*graph)
 	if err != nil {
 		return err
-	}
-	blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(graph.Blocks))
-	for _, block := range graph.Blocks {
-		blocks[block.ID] = block
 	}
 	lattice := arrayCompactLattice{}
 	lane := semanticstate.Lane[arrayValue]{
@@ -107,11 +103,11 @@ func walkArrayCFGCompact(ctx context.Context, graph *vbacfg.Graph, lines []strin
 			return nil
 		},
 		Transfer: func(_ context.Context, _ semanticstate.LaneOrdinal, ordinal semanticstate.BlockOrdinal, input semanticstate.StateView[arrayValue], output *semanticstate.State[arrayValue]) error {
-			indexed, ok := index.Block(ordinal)
+			_, ok := index.Block(ordinal)
 			if !ok {
 				return nil
 			}
-			block, ok := blocks[indexed.ID]
+			block, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(ordinal))
 			if !ok {
 				return nil
 			}
@@ -127,19 +123,19 @@ func walkArrayCFGCompact(ctx context.Context, graph *vbacfg.Graph, lines []strin
 			if edgeState == nil || edge.Class == vbacfg.EdgeExceptional || edge.Uncertain {
 				return nil
 			}
-			fromIndexed, ok := index.Block(edge.From)
+			_, ok := index.Block(edge.From)
 			if !ok {
 				return nil
 			}
-			from, ok := blocks[fromIndexed.ID]
+			from, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(edge.From))
 			if !ok {
 				return nil
 			}
-			toIndexed, ok := index.Block(edge.To)
+			_, ok = index.Block(edge.To)
 			if !ok {
 				return nil
 			}
-			to, ok := blocks[toIndexed.ID]
+			to, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(edge.To))
 			if !ok {
 				return nil
 			}

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -268,10 +268,11 @@ func (a Analyzer) arrayLifecycleFindingsPreparedWithRuntimeEntryContext(cancelCt
 	for _, finding := range findings {
 		seen[arrayFindingKey(finding)] = true
 	}
+	baseView := proc.Graph.View(vbacfg.EdgeFilter{})
 	lanes := make([]arrayCFGWorklistLane, 0, 3)
 	if baseLaneRequested {
 		lanes = append(lanes, arrayCFGWorklistLane{
-			Graph: proc.Graph, Initial: initial,
+			Graph: &baseView, Initial: initial,
 			Visit: func(text string, line int, in arrayFlowState) arrayFlowState {
 				out, issues := a.arrayTransfer(file, proc, ctx, variables, in, text, line, constants, capacityGuards)
 				for _, call := range arrayCallsAtLine(proc.Calls, line) {
@@ -290,7 +291,7 @@ func (a Analyzer) arrayLifecycleFindingsPreparedWithRuntimeEntryContext(cancelCt
 				return out
 			},
 			EdgeState: func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
-				out = applyArrayConditionalAllocationBranch(out, proc.Graph, block, edge)
+				out = applyArrayConditionalAllocationBranch(out, &baseView, block, edge)
 				out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, variables)
 				return applyArrayModuleConfigurationBranch(out, block.Statement, edge, ctx.arrayModuleConfigurations[file.Path], variables, file, proc, moduleDecls)
 			},
@@ -334,7 +335,7 @@ func (a Analyzer) arrayLifecycleFindingsPreparedWithRuntimeEntryContext(cancelCt
 		runtimeSeen := map[string]bool{}
 		runtimeState := arrayInitialState(variables)
 		lanes = append(lanes, arrayCFGWorklistLane{
-			Graph: proc.Graph, Initial: runtimeState,
+			Graph: &baseView, Initial: runtimeState,
 			Visit: func(text string, line int, in arrayFlowState) arrayFlowState {
 				for _, issue := range deterministicArrayRuntimeIssues(text, line, in, variables, constants) {
 					key := strconv.Itoa(issue.line) + ":" + issue.kind + ":" + issue.operationKey
@@ -866,15 +867,15 @@ func arrayResumeNextCapacityProofApplies(guards []arrayResumeNextCapacityGuard, 
 // procedure findings pass and the array-return summary pass. Exceptional and
 // uncertain edges retain the predecessor's input state because the statement
 // may not have completed before control leaves the block.
-func walkArrayCFG(graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState) {
+func walkArrayCFG(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState) {
 	walkArrayCFGWithEdges(graph, lines, initial, visit, nil)
 }
 
-func walkArrayCFGWithEdges(graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState) {
+func walkArrayCFGWithEdges(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState) {
 	walkArrayCFGWithStop(graph, lines, initial, visit, edgeState, nil)
 }
 
-func walkArrayCFGWithStop(graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool) {
+func walkArrayCFGWithStop(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool) {
 	walkArrayCFGWorklist(graph, lines, initial, visit, edgeState, stop, false)
 }
 
@@ -883,11 +884,11 @@ func walkArrayCFGWithStop(graph *vbacfg.Graph, lines []string, initial arrayFlow
 // VBA208 and VBA249; this variant additionally exposes source-line order
 // inside a CFG block so an allocation and a later access on the same loop body
 // can be analyzed in sequence.
-func walkArrayCFGWithSourceLines(graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState) {
+func walkArrayCFGWithSourceLines(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState) {
 	walkArrayCFGWorklist(graph, lines, initial, visit, edgeState, nil, true)
 }
 
-func walkArrayCFGWorklist(graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool) {
+func walkArrayCFGWorklist(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool) {
 	// The compact solver owns the ordinary block-level walk. Stop callbacks
 	// need an explicit edge-suppression protocol that semanticstate intentionally
 	// does not expose, while source-line and edge-refinement lanes still carry
@@ -901,20 +902,12 @@ func walkArrayCFGWorklist(graph *vbacfg.Graph, lines []string, initial arrayFlow
 	walkArrayCFGWorklistLegacy(graph, lines, initial, visit, edgeState, stop, sourceLines)
 }
 
-func walkArrayCFGWorklistLegacy(graph *vbacfg.Graph, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool) {
+func walkArrayCFGWorklistLegacy(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool) {
 	if graph == nil {
 		return
 	}
-	blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(graph.Blocks))
-	outgoing := make(map[vbacfg.BlockID][]vbacfg.Edge)
-	for _, block := range graph.Blocks {
-		blocks[block.ID] = block
-	}
-	for _, edge := range graph.Edges {
-		outgoing[edge.From] = append(outgoing[edge.From], edge)
-	}
-	inStates := map[vbacfg.BlockID]arrayFlowState{graph.Entry: initial}
-	queued := map[vbacfg.BlockID]bool{graph.Entry: true}
+	inStates := map[vbacfg.BlockID]arrayFlowState{graph.Entry(): initial}
+	queued := map[vbacfg.BlockID]bool{graph.Entry(): true}
 	for len(queued) > 0 {
 		// Block IDs are ordered so the worklist cannot inherit Go map iteration
 		// order and change the fixed-point path through the array state lattice.
@@ -928,7 +921,7 @@ func walkArrayCFGWorklistLegacy(graph *vbacfg.Graph, lines []string, initial arr
 		}
 		delete(queued, id)
 		in := cloneArrayState(inStates[id])
-		block, ok := blocks[id]
+		block, ok := graph.BlockByID(id)
 		if !ok {
 			continue
 		}
@@ -1010,7 +1003,7 @@ func walkArrayCFGWorklistLegacy(graph *vbacfg.Graph, lines []string, initial arr
 				}
 			}
 		}
-		for _, edge := range outgoing[id] {
+		graph.ForEachOutgoing(id, func(edge vbacfg.Edge) bool {
 			next := out
 			if edge.Class == vbacfg.EdgeExceptional || edge.Uncertain {
 				next = in
@@ -1030,7 +1023,8 @@ func walkArrayCFGWorklistLegacy(graph *vbacfg.Graph, lines []string, initial arr
 			if mergeArrayState(inStates, edge.To, next) {
 				queued[edge.To] = true
 			}
-		}
+			return true
+		})
 	}
 }
 
@@ -1044,7 +1038,7 @@ func walkArrayCFGWorklistLegacy(graph *vbacfg.Graph, lines []string, initial arr
 // impossible normal continuations).  Block IDs are stable across those copies
 // and the worklist remains shared even when an edge is absent from one lane.
 type arrayCFGWorklistLane struct {
-	Graph   *vbacfg.Graph
+	Graph   *vbacfg.CFGView
 	Initial arrayFlowState
 
 	// Visit receives a private copy of the lane's block input state and returns
@@ -1087,15 +1081,14 @@ func walkArrayCFGCombined(ctx context.Context, lines []string, lanes []arrayCFGW
 	}
 
 	type graphIndex struct {
-		blocks   map[vbacfg.BlockID]vbacfg.Block
-		outgoing map[vbacfg.BlockID][]vbacfg.Edge
+		graph *vbacfg.CFGView
 	}
 	type laneIndex struct {
 		graphIndex
 		inStates map[vbacfg.BlockID]arrayFlowState
 	}
 	indexes := make([]laneIndex, len(lanes))
-	graphIndexes := make(map[*vbacfg.Graph]graphIndex, len(lanes))
+	graphIndexes := make(map[*vbacfg.CFGView]graphIndex, len(lanes))
 	queued := map[vbacfg.BlockID]bool{}
 	for index, lane := range lanes {
 		if lane.Graph == nil {
@@ -1103,22 +1096,14 @@ func walkArrayCFGCombined(ctx context.Context, lines []string, lanes []arrayCFGW
 		}
 		shared, ok := graphIndexes[lane.Graph]
 		if !ok {
-			blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(lane.Graph.Blocks))
-			for _, block := range lane.Graph.Blocks {
-				blocks[block.ID] = block
-			}
-			outgoing := make(map[vbacfg.BlockID][]vbacfg.Edge)
-			for _, edge := range lane.Graph.Edges {
-				outgoing[edge.From] = append(outgoing[edge.From], edge)
-			}
-			shared = graphIndex{blocks: blocks, outgoing: outgoing}
+			shared = graphIndex{graph: lane.Graph}
 			graphIndexes[lane.Graph] = shared
 		}
 		inStates := map[vbacfg.BlockID]arrayFlowState{
-			lane.Graph.Entry: cloneArrayState(lane.Initial),
+			lane.Graph.Entry(): cloneArrayState(lane.Initial),
 		}
 		indexes[index] = laneIndex{graphIndex: shared, inStates: inStates}
-		queued[lane.Graph.Entry] = true
+		queued[lane.Graph.Entry()] = true
 	}
 
 	for len(queued) > 0 {
@@ -1147,7 +1132,7 @@ func walkArrayCFGCombined(ctx context.Context, lines []string, lanes []arrayCFGW
 			if !ok {
 				continue
 			}
-			block, ok := stateIndex.blocks[id]
+			block, ok := stateIndex.graph.BlockByID(id)
 			if !ok {
 				continue
 			}
@@ -1220,7 +1205,7 @@ func walkArrayCFGCombined(ctx context.Context, lines []string, lanes []arrayCFGW
 				continue
 			}
 
-			for _, edge := range stateIndex.outgoing[id] {
+			stateIndex.graph.ForEachOutgoing(id, func(edge vbacfg.Edge) bool {
 				next := out
 				if edge.Class == vbacfg.EdgeExceptional || edge.Uncertain {
 					next = in
@@ -1233,7 +1218,8 @@ func walkArrayCFGCombined(ctx context.Context, lines []string, lanes []arrayCFGW
 				if mergeArrayState(stateIndex.inStates, edge.To, next) {
 					queued[edge.To] = true
 				}
-			}
+				return true
+			})
 		}
 	}
 	return nil
@@ -1279,13 +1265,13 @@ func arrayCountExpressionMatches(expression, source string) bool {
 	return expression == source || expression == source+".count"
 }
 
-func applyArrayConditionalAllocationBranch(state arrayFlowState, graph *vbacfg.Graph, block vbacfg.Block, edge vbacfg.Edge) arrayFlowState {
+func applyArrayConditionalAllocationBranch(state arrayFlowState, graph *vbacfg.CFGView, block vbacfg.Block, edge vbacfg.Edge) arrayFlowState {
 	if block.Statement == nil {
 		return state
 	}
 	if block.Statement.Kind == procedureir.StatementSelect && edge.Kind == vbacfg.EdgeCase && graph != nil {
 		selectExpression := selectCaseExpression(block.Statement.Text)
-		caseBlock, ok := graphBlockByID(*graph, edge.To)
+		caseBlock, ok := graph.BlockByID(edge.To)
 		if !ok {
 			return state
 		}
@@ -1335,15 +1321,6 @@ func applyArrayConditionalAllocationBranch(state arrayFlowState, graph *vbacfg.G
 		}
 	}
 	return state
-}
-
-func graphBlockByID(graph vbacfg.Graph, id vbacfg.BlockID) (vbacfg.Block, bool) {
-	for _, block := range graph.Blocks {
-		if block.ID == id {
-			return block, true
-		}
-	}
-	return vbacfg.Block{}, false
 }
 
 func selectCaseExpression(text string) string {
@@ -1506,11 +1483,11 @@ func arrayIsArrayGuardCondition(text string) (string, vbacfg.EdgeKind, bool) {
 // latter covers project-local error wrappers such as RaiseContractError:
 // their call sites must not poison the normal allocation state with an
 // impossible fall-through branch.
-func arrayVBA227Graph(proc sourceProcedure, ctx analysisContext) vbacfg.Graph {
+func arrayVBA227Graph(proc sourceProcedure, ctx analysisContext) vbacfg.CFGView {
 	if proc.Graph == nil {
-		return vbacfg.Graph{}
+		return vbacfg.CFGView{}
 	}
-	graph := proc.Graph.WithoutNormalErrRaiseContinuation()
+	graph := proc.Graph.WithoutNormalErrRaiseContinuationView()
 	removed := map[vbacfg.BlockID]bool{}
 	for call := range proc.Calls.All() {
 		_, target, ok := arrayPrivateTargetForCall(ctx, ctx.arrayPrivateTargets, call)
@@ -1525,23 +1502,15 @@ func arrayVBA227Graph(proc sourceProcedure, ctx analysisContext) vbacfg.Graph {
 	if len(removed) == 0 {
 		return graph
 	}
-	edges := make([]vbacfg.Edge, 0, len(graph.Edges))
-	for _, edge := range graph.Edges {
-		if edge.Class == vbacfg.EdgeNormal && removed[edge.From] {
-			continue
-		}
-		edges = append(edges, edge)
-	}
-	graph.Edges = edges
-	return graph
+	return graph.WithoutNormalContinuationsFrom(removed)
 }
 
 func arrayProcedureAlwaysRaises(proc sourceProcedure) bool {
 	if proc.Graph == nil {
 		return false
 	}
-	graph := proc.Graph.WithoutNormalErrRaiseContinuation()
-	return !graph.IsReachable(graph.NormalExit, vbacfg.EdgeFilter{NormalOnly: true})
+	graph := proc.Graph.View(vbacfg.EdgeFilter{NormalOnly: true, WithoutNormalErrRaiseContinuation: true})
+	return !graph.IsReachable(graph.NormalExit())
 }
 
 func arrayAllocationGuardCondition(text string, guards map[string]bool, state arrayFlowState) (string, vbacfg.EdgeKind, bool) {
@@ -2901,7 +2870,7 @@ func arrayByRefFlowAllocations(file parsedFile, proc sourceProcedure, ctx analys
 	edgeState := func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
 		out = applyArrayConditionalAllocationBranch(out, &graph, block, edge)
 		out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, variables)
-		if edge.To == graph.NormalExit {
+		if edge.To == graph.NormalExit() {
 			if !hasNormalExit {
 				normalExit = cloneArrayState(out)
 				hasNormalExit = true
@@ -4361,8 +4330,9 @@ func inferArrayByRefEntryStates(a Analyzer, files []parsedFile, ctx analysisCont
 		if ctx.arrayStats != nil {
 			ctx.arrayStats.cfgWalks++
 		}
-		walkArrayCFGWithEdges(proc.Graph, file.Lines, initial, visit, func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
-			out = applyArrayConditionalAllocationBranch(out, proc.Graph, block, edge)
+		baseView := proc.Graph.View(vbacfg.EdgeFilter{})
+		walkArrayCFGWithEdges(&baseView, file.Lines, initial, visit, func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
+			out = applyArrayConditionalAllocationBranch(out, &baseView, block, edge)
 			out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, variables)
 			return applyArrayModuleConfigurationBranch(out, block.Statement, edge, ctx.arrayModuleConfigurations[file.Path], variables, file, proc, moduleDecls)
 		})
@@ -6202,7 +6172,8 @@ func inferArrayReturnSummaries(files []parsedFile, arrayAllocationGuards map[str
 		if participantCtx.arrayStats != nil {
 			participantCtx.arrayStats.cfgWalks++
 		}
-		walkArrayCFGWithStop(proc.Graph, procedure.file.Lines, arrayInitialState(procedure.variables), func(text string, line int, in arrayFlowState) arrayFlowState {
+		baseView := proc.Graph.View(vbacfg.EdgeFilter{})
+		walkArrayCFGWithStop(&baseView, procedure.file.Lines, arrayInitialState(procedure.variables), func(text string, line int, in arrayFlowState) arrayFlowState {
 			if lhs, rhs, indexed, ok := arrayAssignment(text); ok && !indexed && strings.EqualFold(lhs, proc.Name) {
 				value, known := arrayExpressionState(rhs, in, ctx)
 				returnCandidates[line] = candidate{value: value, ok: known && value.kind == arrayAllocated && value.knownArray && value.origin != arrayOriginRangeValue}

--- a/internal/analyze/function_return_paths.go
+++ b/internal/analyze/function_return_paths.go
@@ -40,16 +40,19 @@ func (a Analyzer) functionReturnPathFindings(file parsedFile, proc sourceProcedu
 		return nil
 	}
 
-	filter := vbacfg.EdgeFilter{}
-	graph := proc.Graph.WithoutNormalErrRaiseContinuation()
-	if !graph.IsReachable(graph.NormalExit, filter) {
+	graph := proc.Graph.WithoutNormalErrRaiseContinuationView()
+	if !graph.IsReachable(graph.NormalExit()) {
 		return nil
 	}
 
 	variable := returnSlotVariable(proc.Name)
-	filtered := graphWithValidReturnAssignments(graph, proc, variable)
-	definite := filtered.DefiniteAssignments(filter)
-	if hasReturnVariable(definite[filtered.NormalExit], variable) {
+	definite := graph.DefiniteAssignmentsWith(func(block vbacfg.Block, assigned vbacfg.Variable) bool {
+		if block.Statement == nil || returnAssignmentKindForStatement(proc, *block.Statement) != returnAssignmentInvalid {
+			return true
+		}
+		return assigned.Scope != variable.Scope || !strings.EqualFold(assigned.Name, variable.Name)
+	})
+	if hasReturnVariable(definite[graph.NormalExit()], variable) {
 		return nil
 	}
 
@@ -92,30 +95,6 @@ func (a Analyzer) functionReturnPathFindings(file parsedFile, proc sourceProcedu
 
 func returnSlotVariable(name string) vbacfg.Variable {
 	return vbacfg.Variable{Scope: procedureir.ScopeLocal, Name: strings.ToLower(name)}
-}
-
-func graphWithValidReturnAssignments(graph vbacfg.Graph, proc sourceProcedure, variable vbacfg.Variable) vbacfg.Graph {
-	graph.Blocks = append([]vbacfg.Block(nil), graph.Blocks...)
-	for i, block := range graph.Blocks {
-		if block.Statement == nil || returnAssignmentKindForStatement(proc, *block.Statement) != returnAssignmentInvalid {
-			continue
-		}
-		copyBlock := block
-		copyBlock.Assignments = removeReturnVariable(copyBlock.Assignments, variable)
-		graph.Blocks[i] = copyBlock
-	}
-	return graph
-}
-
-func removeReturnVariable(assignments []vbacfg.Variable, variable vbacfg.Variable) []vbacfg.Variable {
-	filtered := make([]vbacfg.Variable, 0, len(assignments))
-	for _, assigned := range assignments {
-		if assigned.Scope == variable.Scope && strings.EqualFold(assigned.Name, variable.Name) {
-			continue
-		}
-		filtered = append(filtered, assigned)
-	}
-	return filtered
 }
 
 func returnAssignmentKindForStatement(proc sourceProcedure, statement procedureir.Statement) returnAssignmentKind {
@@ -175,13 +154,13 @@ func hasReturnVariable(assignments []vbacfg.Variable, variable vbacfg.Variable) 
 	return false
 }
 
-func returnPathWitnesses(graph vbacfg.Graph, proc sourceProcedure) []returnPathWitness {
+func returnPathWitnesses(graph vbacfg.CFGView, proc sourceProcedure) []returnPathWitness {
 	type pathKey struct {
 		block    vbacfg.BlockID
 		state    returnPathState
 		viaError bool
 	}
-	queue := []pathKey{{block: graph.Entry, state: returnPathUnassigned}}
+	queue := []pathKey{{block: graph.Entry(), state: returnPathUnassigned}}
 	seen := map[pathKey]bool{queue[0]: true}
 	var witnesses []returnPathWitness
 
@@ -192,10 +171,7 @@ func returnPathWitnesses(graph vbacfg.Graph, proc sourceProcedure) []returnPathW
 		if !ok {
 			continue
 		}
-		for _, edge := range graph.Edges {
-			if edge.From != current.block {
-				continue
-			}
+		graph.ForEachOutgoing(current.block, func(edge vbacfg.Edge) bool {
 			nextState := current.state
 			if edge.Class == vbacfg.EdgeNormal && block.Statement != nil {
 				switch returnAssignmentKindForStatement(proc, *block.Statement) {
@@ -206,7 +182,7 @@ func returnPathWitnesses(graph vbacfg.Graph, proc sourceProcedure) []returnPathW
 				}
 			}
 			viaError := current.viaError || edge.Class == vbacfg.EdgeExceptional
-			if edge.To == graph.NormalExit && nextState != returnPathAssigned {
+			if edge.To == graph.NormalExit() && nextState != returnPathAssigned {
 				witnesses = append(witnesses, returnPathWitness{
 					Kind:     returnExitKind(graph, edge, viaError),
 					Line:     returnExitLine(graph, edge, proc),
@@ -216,23 +192,21 @@ func returnPathWitnesses(graph vbacfg.Graph, proc sourceProcedure) []returnPathW
 			}
 			next := pathKey{block: edge.To, state: nextState, viaError: viaError}
 			if seen[next] {
-				continue
+				return true
 			}
 			seen[next] = true
 			queue = append(queue, next)
-		}
+			return true
+		})
 	}
 	return witnesses
 }
 
-func returnPathBlock(graph vbacfg.Graph, id vbacfg.BlockID) (vbacfg.Block, bool) {
-	if id <= 0 || int(id) > len(graph.Blocks) {
-		return vbacfg.Block{}, false
-	}
-	return graph.Blocks[int(id)-1], true
+func returnPathBlock(graph vbacfg.CFGView, id vbacfg.BlockID) (vbacfg.Block, bool) {
+	return graph.BlockByID(id)
 }
 
-func returnExitKind(graph vbacfg.Graph, edge vbacfg.Edge, viaError bool) string {
+func returnExitKind(graph vbacfg.CFGView, edge vbacfg.Edge, viaError bool) string {
 	if viaError {
 		return "error-handler path to normal exit"
 	}
@@ -253,7 +227,7 @@ func returnExitKind(graph vbacfg.Graph, edge vbacfg.Edge, viaError bool) string 
 	return "normal exit"
 }
 
-func returnExitLine(graph vbacfg.Graph, edge vbacfg.Edge, proc sourceProcedure) int {
+func returnExitLine(graph vbacfg.CFGView, edge vbacfg.Edge, proc sourceProcedure) int {
 	if edge.Range.StartLine > 0 {
 		return edge.Range.StartLine
 	}

--- a/internal/analyze/function_return_paths.go
+++ b/internal/analyze/function_return_paths.go
@@ -46,8 +46,17 @@ func (a Analyzer) functionReturnPathFindings(file parsedFile, proc sourceProcedu
 	}
 
 	variable := returnSlotVariable(proc.Name)
+	returnKinds := map[int]returnAssignmentKind{}
 	definite := graph.DefiniteAssignmentsWith(func(block vbacfg.Block, assigned vbacfg.Variable) bool {
-		if block.Statement == nil || returnAssignmentKindForStatement(proc, *block.Statement) != returnAssignmentInvalid {
+		if block.Statement == nil {
+			return true
+		}
+		kind, cached := returnKinds[block.Statement.ID]
+		if !cached {
+			kind = returnAssignmentKindForStatement(proc, *block.Statement)
+			returnKinds[block.Statement.ID] = kind
+		}
+		if kind != returnAssignmentInvalid {
 			return true
 		}
 		return assigned.Scope != variable.Scope || !strings.EqualFold(assigned.Name, variable.Name)

--- a/internal/analyze/http_transport.go
+++ b/internal/analyze/http_transport.go
@@ -200,13 +200,10 @@ func solveHTTPStates(ctx context.Context, a Analyzer, file parsedFile, proc sour
 	// solver owns scheduling, edge classification, cancellation, and snapshot
 	// isolation; the adapter preserves the established transfer/join semantics
 	// while the HTTP domain is incrementally migrated to scalar slots.
-	index, err := semanticstate.NewIndex(graph)
+	view := graph.View(vbacfg.EdgeFilter{})
+	index, err := semanticstate.NewIndexView(view)
 	if err != nil {
 		return nil, err
-	}
-	blocks := make(map[vbacfg.BlockID]vbacfg.Block, len(graph.Blocks))
-	for _, block := range graph.Blocks {
-		blocks[block.ID] = block
 	}
 	environment := semanticstate.NewEnvironment([]string{"http-state"}, []string{"http-state"})
 	const lane semanticstate.LaneOrdinal = 0
@@ -223,11 +220,11 @@ func solveHTTPStates(ctx context.Context, a Analyzer, file parsedFile, proc sour
 				if !ok {
 					return nil
 				}
-				cfgBlock, ok := index.Block(block)
+				_, ok = index.Block(block)
 				if !ok {
 					return nil
 				}
-				candidate, ok := blocks[cfgBlock.ID]
+				candidate, ok := view.BlockAtOrdinal(vbacfg.BlockOrdinal(block))
 				if !ok || candidate.Statement == nil || candidate.Statement.Recovered {
 					output.Set(symbol, value)
 					return nil

--- a/internal/analyze/object_use_before_set.go
+++ b/internal/analyze/object_use_before_set.go
@@ -59,7 +59,7 @@ type objectProcedurePlan struct {
 	procedureDecls map[string]sourceDeclaration
 
 	flowProc    sourceProcedure
-	flowGraph   vbacfg.Graph
+	flowGraph   vbacfg.CFGView
 	flowContext objectFlowContext
 	reachable   map[vbacfg.BlockID]bool
 	vars        map[string]objectVariable
@@ -184,13 +184,12 @@ func newObjectProcedurePlan(file parsedFile, proc sourceProcedure, moduleDecls m
 		vars:           map[string]objectVariable{},
 	}
 	plan.flowProc = proc
-	if proc.Graph != nil {
-		plan.flowGraph = proc.Graph.WithoutNormalErrRaiseContinuation()
-		plan.flowProc.Graph = &plan.flowGraph
-		for _, id := range plan.flowGraph.Reachable(vbacfg.EdgeFilter{}) {
+	if plan.proc.Graph != nil {
+		plan.flowGraph = proc.Graph.WithoutNormalErrRaiseContinuationView()
+		for _, id := range plan.flowGraph.Reachable() {
 			plan.reachable[id] = true
 		}
-		plan.flowContext = newObjectFlowContext(plan.flowProc)
+		plan.flowContext = newObjectFlowContext(plan.flowProc, plan.flowGraph)
 	}
 	addObjectVariables := func(scope procedureir.SymbolScope, declarations map[string]sourceDeclaration) {
 		for _, declaration := range declarations {
@@ -934,7 +933,8 @@ func objectErrorResumeNextAt(proc sourceProcedure, statementID int) bool {
 }
 
 type objectFlowGuardCache struct {
-	graph      *vbacfg.Graph
+	graph      vbacfg.CFGView
+	graphReady bool
 	dominators map[vbacfg.BlockID][]vbacfg.BlockID
 	successors map[vbacfg.BlockID][]vbacfg.BlockID
 }
@@ -943,14 +943,13 @@ func objectFlowGuardedByOpenFlag(proc sourceProcedure, statementID int, objectNa
 	if proc.Graph == nil {
 		return false
 	}
-	if cache.graph == nil {
-		flowGraph := proc.Graph.WithoutNormalErrRaiseContinuation()
-		cache.graph = &flowGraph
-		cache.dominators = flowGraph.Dominators(vbacfg.EdgeFilter{})
+	if !cache.graphReady {
+		cache.graph = proc.Graph.WithoutNormalErrRaiseContinuationView()
+		cache.graphReady = true
+		cache.dominators = cache.graph.Dominators()
 	}
 	flowProc := proc
-	flowProc.Graph = cache.graph
-	accessBlock, ok := flowProc.Graph.BlockForStatement(statementID)
+	accessBlock, ok := cache.graph.BlockForStatement(statementID)
 	if !ok {
 		return false
 	}
@@ -960,7 +959,7 @@ func objectFlowGuardedByOpenFlag(proc sourceProcedure, statementID int, objectNa
 		if !ok || !objectOpenFlagForObject(flag, objectName) {
 			continue
 		}
-		conditionBlock, ok := flowProc.Graph.BlockForStatement(statement.ID)
+		conditionBlock, ok := cache.graph.BlockForStatement(statement.ID)
 		if !ok || !objectBlockSetContains(dominators[accessBlock.ID], conditionBlock.ID) {
 			continue
 		}
@@ -974,9 +973,9 @@ func objectFlowGuardedByOpenFlag(proc sourceProcedure, statementID int, objectNa
 		safeReachable := false
 		unsafeReachable := false
 		cache.buildSuccessors()
-		for _, edge := range flowProc.Graph.Edges {
-			if edge.From != conditionBlock.ID || (edge.Kind != vbacfg.EdgeBranchTrue && edge.Kind != vbacfg.EdgeBranchFalse) {
-				continue
+		cache.graph.ForEachOutgoing(conditionBlock.ID, func(edge vbacfg.Edge) bool {
+			if edge.Kind != vbacfg.EdgeBranchTrue && edge.Kind != vbacfg.EdgeBranchFalse {
+				return true
 			}
 			reachesAccess := objectFlowCanReach(cache.successors, edge.To, accessBlock.ID)
 			if edge.Kind == safeBranch {
@@ -984,7 +983,8 @@ func objectFlowGuardedByOpenFlag(proc sourceProcedure, statementID int, objectNa
 			} else {
 				unsafeReachable = unsafeReachable || reachesAccess
 			}
-		}
+			return true
+		})
 		if safeReachable && !unsafeReachable {
 			return true
 		}
@@ -996,13 +996,13 @@ func (cache *objectFlowGuardCache) buildSuccessors() {
 	if cache.successors != nil {
 		return
 	}
-	cache.successors = make(map[vbacfg.BlockID][]vbacfg.BlockID, len(cache.graph.Blocks))
-	for _, edge := range cache.graph.Edges {
-		if edge.Class == vbacfg.EdgeExceptional {
-			continue
+	cache.successors = make(map[vbacfg.BlockID][]vbacfg.BlockID)
+	cache.graph.ForEachEdge(func(edge vbacfg.Edge) bool {
+		if edge.Class != vbacfg.EdgeExceptional {
+			cache.successors[edge.From] = append(cache.successors[edge.From], edge.To)
 		}
-		cache.successors[edge.From] = append(cache.successors[edge.From], edge.To)
-	}
+		return true
+	})
 }
 
 func objectBooleanGuard(statement procedureir.Statement) (string, bool, bool) {
@@ -1110,16 +1110,17 @@ type objectFlowContext struct {
 	receiverSummaryKeys map[string][]string
 }
 
-func newObjectFlowContext(proc sourceProcedure) objectFlowContext {
+func newObjectFlowContext(proc sourceProcedure, graph vbacfg.CFGView) objectFlowContext {
 	context := objectFlowContext{
 		facts:        proc.analysisFacts(),
 		predecessors: make(map[vbacfg.BlockID][]vbacfg.Edge),
 		vars:         map[string]objectVariable{},
 	}
 	if proc.Graph != nil {
-		for _, edge := range proc.Graph.Edges {
+		graph.ForEachEdge(func(edge vbacfg.Edge) bool {
 			context.predecessors[edge.To] = append(context.predecessors[edge.To], edge)
-		}
+			return true
+		})
 	}
 	return context
 }
@@ -1171,6 +1172,7 @@ func objectStateFlowPlan(plan *objectProcedurePlan, summaries map[string]objectP
 	}
 	result.vars = plan.vars
 	flowProc := plan.flowProc
+	flowGraph := plan.flowGraph
 	flowContext := plan.flowContext
 	flowContext.receiverSummaryKeys = plan.receiverSummaryKeys
 	initial := map[string]bool{}
@@ -1185,23 +1187,24 @@ func objectStateFlowPlan(plan *objectProcedurePlan, summaries map[string]objectP
 		// initializer establishes a safe value.
 	}
 	reachable := plan.reachable
-	for _, block := range flowProc.Graph.Blocks {
+	flowGraph.ForEachBlock(func(block vbacfg.Block) bool {
 		if !reachable[block.ID] {
-			continue
+			return true
 		}
-		if block.ID == flowProc.Graph.Entry {
+		if block.ID == flowGraph.Entry() {
 			result.in[block.ID] = cloneObjectState(initial)
 		} else {
 			result.in[block.ID] = objectStateAllTrue(plan.vars)
 		}
 		result.out[block.ID] = objectFlowTransfer(plan.file, flowProc, block, result.in[block.ID], plan.vars, plan.declarations, summaries, flowContext)
-	}
+		return true
+	})
 	changed := true
 	for changed {
 		changed = false
-		for _, block := range flowProc.Graph.Blocks {
-			if !reachable[block.ID] || block.ID == flowProc.Graph.Entry {
-				continue
+		flowGraph.ForEachBlock(func(block vbacfg.Block) bool {
+			if !reachable[block.ID] || block.ID == flowGraph.Entry() {
+				return true
 			}
 			incoming := make([]map[string]bool, 0)
 			for _, edge := range flowContext.predecessors[block.ID] {
@@ -1216,7 +1219,7 @@ func objectStateFlowPlan(plan *objectProcedurePlan, summaries map[string]objectP
 				incoming = append(incoming, state)
 			}
 			if len(incoming) == 0 {
-				continue
+				return true
 			}
 			next := objectFlowIntersection(incoming, plan.vars)
 			if !objectStateEqual(result.in[block.ID], next) {
@@ -1228,10 +1231,11 @@ func objectStateFlowPlan(plan *objectProcedurePlan, summaries map[string]objectP
 				result.out[block.ID] = updated
 				changed = true
 			}
-		}
+			return true
+		})
 	}
-	if flowProc.Graph != nil {
-		result.normalExit = cloneObjectState(result.in[flowProc.Graph.NormalExit])
+	if plan.proc.Graph != nil {
+		result.normalExit = cloneObjectState(result.in[flowGraph.NormalExit()])
 	}
 	return result
 }

--- a/internal/analyze/runtime_error.go
+++ b/internal/analyze/runtime_error.go
@@ -162,7 +162,8 @@ func (a Analyzer) deterministicArrayRuntimeFindings(file parsedFile, proc source
 		return out
 	}
 	if proc.Graph != nil {
-		walkArrayCFG(proc.Graph, file.Lines, state, visit)
+		view := proc.Graph.View(vbacfg.EdgeFilter{})
+		walkArrayCFG(&view, file.Lines, state, visit)
 	} else {
 		for line := proc.StartLine; line <= proc.EndLine && line <= len(file.Lines); line++ {
 			state = visit(normalizedCodeLine(file.Lines[line-1]), line, state)

--- a/internal/analyze/semanticstate/types.go
+++ b/internal/analyze/semanticstate/types.go
@@ -182,45 +182,58 @@ type Index struct {
 	entryID  cfg.BlockID
 }
 
-// NewIndex builds deterministic ordinals by sorting the graph's stable block
-// IDs. Outgoing edges are ordered by stable edge ID (then destination and edge
-// kind as tie-breakers) to keep adapter traversal reproducible while retaining
-// CFG builder branch precedence.
+// NewIndex builds deterministic ordinals from the CFG view's stable base
+// storage positions. Outgoing edges are ordered by stable edge ID (then
+// destination and edge kind as tie-breakers) to keep adapter traversal
+// reproducible while retaining CFG builder branch precedence.
 func NewIndex(graph cfg.Graph) (*Index, error) {
-	if len(graph.Blocks) == 0 {
+	return NewIndexView(graph.View(cfg.EdgeFilter{}))
+}
+
+// NewIndexView builds the solver index from a read-only CFGView. The view
+// owns the graph revision and filter; this adapter keeps the solver's compact
+// lane representation while avoiding a materialized filtered Graph copy.
+func NewIndexView(view cfg.CFGView) (*Index, error) {
+	if view.BlockCount() == 0 {
 		return nil, fmt.Errorf("semanticstate: CFG has no blocks")
 	}
-	ids := make([]cfg.BlockID, 0, len(graph.Blocks))
-	seen := make(map[cfg.BlockID]struct{}, len(graph.Blocks))
-	for _, block := range graph.Blocks {
+	blocks := make([]Block, view.BlockCount())
+	byID := make(map[cfg.BlockID]BlockOrdinal, view.BlockCount())
+	seen := make(map[cfg.BlockID]struct{}, view.BlockCount())
+	viewErr := error(nil)
+	view.ForEachBlockOrdinal(func(ordinal cfg.BlockOrdinal, block cfg.Block) bool {
 		if _, ok := seen[block.ID]; ok {
-			return nil, fmt.Errorf("semanticstate: duplicate CFG block %d", block.ID)
+			viewErr = fmt.Errorf("semanticstate: duplicate CFG block %d", block.ID)
+			return false
 		}
 		seen[block.ID] = struct{}{}
-		ids = append(ids, block.ID)
+		byID[block.ID] = BlockOrdinal(ordinal)
+		blocks[ordinal] = Block{Ordinal: BlockOrdinal(ordinal), ID: block.ID}
+		return true
+	})
+	if viewErr != nil {
+		return nil, viewErr
 	}
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	byID := make(map[cfg.BlockID]BlockOrdinal, len(ids))
-	blocks := make([]Block, len(ids))
-	for ordinal, id := range ids {
-		byID[id] = BlockOrdinal(ordinal)
-		blocks[ordinal] = Block{Ordinal: BlockOrdinal(ordinal), ID: id}
-	}
-	entry, ok := byID[graph.Entry]
+	entry, ok := byID[view.Entry()]
 	if !ok {
-		return nil, fmt.Errorf("semanticstate: CFG entry %d is not a block", graph.Entry)
+		return nil, fmt.Errorf("semanticstate: CFG entry %d is not a block", view.Entry())
 	}
 	outgoing := make([][]Edge, len(blocks))
-	for _, source := range graph.Edges {
+	view.ForEachEdge(func(source cfg.Edge) bool {
 		from, fromOK := byID[source.From]
 		to, toOK := byID[source.To]
 		if !fromOK || !toOK {
-			return nil, fmt.Errorf("semanticstate: edge %d references unknown block", source.ID)
+			viewErr = fmt.Errorf("semanticstate: edge %d references unknown block", source.ID)
+			return false
 		}
 		outgoing[from] = append(outgoing[from], Edge{
 			ID: source.ID, From: from, To: to, Kind: source.Kind,
 			Class: source.Class, Uncertain: source.Uncertain,
 		})
+		return true
+	})
+	if viewErr != nil {
+		return nil, viewErr
 	}
 	for i := range outgoing {
 		sort.SliceStable(outgoing[i], func(a, b int) bool {
@@ -243,7 +256,7 @@ func NewIndex(graph cfg.Graph) (*Index, error) {
 			return !left.Uncertain && right.Uncertain
 		})
 	}
-	return &Index{blocks: blocks, byID: byID, outgoing: outgoing, entry: entry, entryID: graph.Entry}, nil
+	return &Index{blocks: blocks, byID: byID, outgoing: outgoing, entry: entry, entryID: view.Entry()}, nil
 }
 
 // BlockCount returns the number of blocks in the indexed graph.

--- a/internal/vba/cfg/cfg_test.go
+++ b/internal/vba/cfg/cfg_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
@@ -328,6 +329,159 @@ func TestIsReachableCanonicalQueriesDoNotAllocate(t *testing.T) {
 				t.Fatalf("IsReachable(%d, %+v) = %v, want %v", test.target, test.filter, got, test.want)
 			}
 		})
+	}
+}
+
+func TestCFGViewSharesRevisionStorageAndPreservesFilteredSemantics(t *testing.T) {
+	t.Parallel()
+	doc := buildIR(t, `Public Sub Work()
+    On Error GoTo Handler
+    Err.Raise 5
+    Debug.Print "unreachable"
+    Exit Sub
+Handler:
+    Resume Next
+End Sub
+`)
+	graph := BuildDocument(doc).Graphs[0]
+	view := graph.WithoutNormalErrRaiseContinuationView()
+	if len(view.graph.Blocks) == 0 || &view.graph.Blocks[0] != &graph.Blocks[0] {
+		t.Fatal("CFGView copied block storage")
+	}
+	if len(view.graph.Edges) == 0 || &view.graph.Edges[0] != &graph.Edges[0] {
+		t.Fatal("CFGView copied edge storage")
+	}
+	materialized := view.Materialize()
+	if len(materialized.Edges) >= len(graph.Edges) {
+		t.Fatalf("materialized view edges = %d, base edges = %d; raise continuation was not filtered", len(materialized.Edges), len(graph.Edges))
+	}
+	raiseStatement := 0
+	for _, statement := range doc.Procedures[0].Statements {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(statement.Text)), "err.raise") {
+			raiseStatement = statement.ID
+			break
+		}
+	}
+	raiseBlock, ok := graph.BlockForStatement(raiseStatement)
+	if !ok {
+		t.Fatal("Err.Raise block not found")
+	}
+	var filteredNormal bool
+	var exceptional bool
+	view.ForEachEdge(func(edge Edge) bool {
+		if edge.From != raiseBlock.ID {
+			return true
+		}
+		if edge.Class == EdgeNormal {
+			filteredNormal = true
+		}
+		if edge.Class == EdgeExceptional {
+			exceptional = true
+		}
+		return true
+	})
+	if filteredNormal || !exceptional {
+		t.Fatalf("filtered view flow: normal=%v exceptional=%v", filteredNormal, exceptional)
+	}
+}
+
+func TestCFGViewCachesCanonicalQueriesAndCustomMasks(t *testing.T) {
+	t.Parallel()
+	graph := benchmarkQueryGraph(100)
+	first := graph.WithoutNormalErrRaiseContinuationView()
+	second := graph.View(EdgeFilter{WithoutNormalErrRaiseContinuation: true})
+	if first.cache != second.cache {
+		t.Fatal("canonical views did not share the revision cache")
+	}
+	if first.IsReachable(graph.Entry) != second.IsReachable(graph.Entry) {
+		t.Fatal("canonical views returned different reachability")
+	}
+	if !reflect.DeepEqual(first.Dominators(), second.Dominators()) {
+		t.Fatal("canonical views returned different dominators")
+	}
+	dominators := first.DominatorsOf(graph.Blocks[len(graph.Blocks)-1].ID)
+	if len(dominators) > 0 {
+		dominators[0] = -1
+		if first.DominatorsOf(graph.Blocks[len(graph.Blocks)-1].ID)[0] == -1 {
+			t.Fatal("DominatorsOf exposed mutable cache storage")
+		}
+	}
+	custom := first.WithoutNormalContinuationsFrom(map[BlockID]bool{graph.Entry: true})
+	if custom.cache == first.cache {
+		t.Fatal("custom mask reused the canonical cache")
+	}
+	if custom.IsReachable(graph.Blocks[1].ID) {
+		t.Fatal("custom mask retained the entry normal continuation")
+	}
+	revision := graph
+	revision.Entry = graph.Blocks[len(graph.Blocks)-1].ID
+	if revised := revision.View(EdgeFilter{WithoutNormalErrRaiseContinuation: true}); revised.index == first.index {
+		t.Fatal("revised graph reused an incompatible query index")
+	}
+	chainGraph := Graph{
+		Blocks: []Block{{ID: 1, Kind: BlockEntry}, {ID: 2, Kind: BlockStatement}, {ID: 3, Kind: BlockStatement}, {ID: 4, Kind: BlockNormalExit}},
+		Edges: []Edge{
+			{ID: 1, From: 1, To: 2, Class: EdgeNormal},
+			{ID: 2, From: 1, To: 3, Class: EdgeNormal},
+			{ID: 3, From: 2, To: 4, Class: EdgeNormal},
+			{ID: 4, From: 3, To: 4, Class: EdgeNormal},
+		},
+		Entry: 1,
+	}
+	chained := chainGraph.View(EdgeFilter{}).
+		WithoutNormalContinuationsFrom(map[BlockID]bool{2: true}).
+		WithoutNormalContinuationsFrom(map[BlockID]bool{3: true})
+	if chained.IsReachable(4) {
+		t.Fatal("chained custom mask restored the first excluded continuation")
+	}
+}
+
+func TestCFGViewConcurrentReadsAreDeterministic(t *testing.T) {
+	graph := benchmarkQueryGraph(500)
+	view := graph.View(EdgeFilter{})
+	wantReachable := view.Reachable()
+	wantDominators := view.Dominators()
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if got := view.Reachable(); !reflect.DeepEqual(got, wantReachable) {
+					t.Errorf("Reachable() = %v, want %v", got, wantReachable)
+					return
+				}
+				if got := view.Dominators(); !reflect.DeepEqual(got, wantDominators) {
+					t.Errorf("Dominators() changed under concurrent reads")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestCFGViewPreservesDenseOrdinalsForDefensiveZeroIDs(t *testing.T) {
+	t.Parallel()
+	graph := Graph{
+		Blocks: []Block{{ID: 0, Kind: BlockEntry}, {ID: 40, Kind: BlockNormalExit}},
+		Edges:  []Edge{{ID: 1, From: 0, To: 40, Class: EdgeNormal}},
+		Entry:  0,
+	}
+	view := graph.View(EdgeFilter{})
+	if !view.IsReachable(40) {
+		t.Fatal("view did not follow an ID-zero entry")
+	}
+	ordinal, ok := view.Ordinal(0)
+	if !ok || ordinal != 0 {
+		t.Fatalf("Ordinal(0) = (%d, %v), want (0, true)", ordinal, ok)
+	}
+	block, ok := view.BlockAtOrdinal(ordinal)
+	if !ok || block.ID != 0 {
+		t.Fatalf("BlockAtOrdinal(0) = (%+v, %v)", block, ok)
+	}
+	if block, ok := view.BlockByID(0); !ok || block.ID != 0 {
+		t.Fatalf("BlockByID(0) = (%+v, %v)", block, ok)
 	}
 }
 

--- a/internal/vba/cfg/query.go
+++ b/internal/vba/cfg/query.go
@@ -1,36 +1,13 @@
 package cfg
 
-import (
-	"sort"
-	"strings"
-
-	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
-)
+import "strings"
 
 // WithoutNormalErrRaiseContinuation returns a graph where normal-flow edges
 // leaving an Err.Raise or Error statement are removed. These statements never
 // complete through normal VBA flow; exceptional edges remain available so
 // active On Error modes, including Resume Next, are still represented.
 func (g Graph) WithoutNormalErrRaiseContinuation() Graph {
-	g.Blocks = append([]Block(nil), g.Blocks...)
-	blocksByID := make(map[BlockID]Block, len(g.Blocks))
-	for _, block := range g.Blocks {
-		// Match BlockByID's first-match behavior for defensive graph values
-		// that contain duplicate block IDs.
-		if _, exists := blocksByID[block.ID]; !exists {
-			blocksByID[block.ID] = block
-		}
-	}
-	edges := g.Edges
-	g.Edges = make([]Edge, 0, len(edges))
-	for _, edge := range edges {
-		if edge.Class == EdgeNormal && isNonReturningRaiseBlock(blocksByID[edge.From]) {
-			continue
-		}
-		g.Edges = append(g.Edges, edge)
-	}
-	g.query = buildQueryIndex(g)
-	return g
+	return g.View(EdgeFilter{WithoutNormalErrRaiseContinuation: true}).Materialize()
 }
 
 func isNonReturningRaiseBlock(block Block) bool {
@@ -107,23 +84,12 @@ func (g Graph) OutgoingEdges(from BlockID) []Edge {
 
 // Reachable returns reachable block IDs in stable ID order.
 func (g Graph) Reachable(filter EdgeFilter) []BlockID {
-	seen := g.reachableWithout(filter, nil)
-	out := make([]BlockID, 0, len(seen))
-	for _, block := range g.Blocks {
-		if seen[block.ID] {
-			out = append(out, block.ID)
-		}
-	}
-	return out
+	return g.View(filter).Reachable()
 }
 
 // IsReachable reports whether target is reachable from Entry.
 func (g Graph) IsReachable(target BlockID, filter EdgeFilter) bool {
-	index := g.queryIndexes()
-	if reachable, ok := index.cachedReachable(filter); ok {
-		return reachable[target]
-	}
-	return g.reachableWithout(filter, nil)[target]
+	return g.View(filter).IsReachable(target)
 }
 
 // Unreachable returns statement blocks that cannot be reached from Entry.
@@ -140,225 +106,29 @@ func (g Graph) Unreachable(filter EdgeFilter) []Block {
 
 // ExitTransitions returns reachable edges into selected synthetic exits.
 func (g Graph) ExitTransitions(selection ExitSelection, filter EdgeFilter) []Edge {
-	reachable := g.reachableWithout(filter, nil)
+	view := g.View(filter)
+	reachable := view.reachableSet()
 	selected := idSet(selection.ids(g))
 	var out []Edge
-	for _, edge := range g.Edges {
-		if filter.accepts(edge) && reachable[edge.From] && selected[edge.To] {
+	view.ForEachEdge(func(edge Edge) bool {
+		if reachable[edge.From] && selected[edge.To] {
 			out = append(out, edge)
 		}
-	}
+		return true
+	})
 	return out
 }
 
 // Dominators computes conservative dominators. Uncertain edges are always
 // included; NormalOnly may be used for explicitly normal-flow consumers.
 func (g Graph) Dominators(filter EdgeFilter) map[BlockID][]BlockID {
-	reachable := g.reachableWithout(filter, nil)
-	all := map[BlockID]bool{}
-	for id := range reachable {
-		all[id] = true
-	}
-	dom := map[BlockID]map[BlockID]bool{}
-	for id := range reachable {
-		if id == g.Entry {
-			dom[id] = map[BlockID]bool{id: true}
-		} else {
-			dom[id] = copySet(all)
-		}
-	}
-	changed := true
-	for changed {
-		changed = false
-		unknownDominators, hasUnknown := g.unknownDominatorInput(reachable, dom)
-		for id := range reachable {
-			if id == g.Entry {
-				continue
-			}
-			preds := g.predecessors(id, filter, reachable)
-			next := map[BlockID]bool{id: true}
-			var intersection map[BlockID]bool
-			if len(preds) > 0 {
-				intersection = copySet(dom[preds[0]])
-				for _, pred := range preds[1:] {
-					for candidate := range intersection {
-						if !dom[pred][candidate] {
-							delete(intersection, candidate)
-						}
-					}
-				}
-			}
-			if hasUnknown && g.block(id).Kind == BlockStatement {
-				if intersection == nil {
-					intersection = copySet(unknownDominators)
-				} else {
-					for candidate := range intersection {
-						if !unknownDominators[candidate] {
-							delete(intersection, candidate)
-						}
-					}
-				}
-			}
-			for candidate := range intersection {
-				next[candidate] = true
-			}
-			if !sameSet(dom[id], next) {
-				dom[id] = next
-				changed = true
-			}
-		}
-	}
-	out := map[BlockID][]BlockID{}
-	for id, set := range dom {
-		for candidate := range set {
-			out[id] = append(out[id], candidate)
-		}
-		sort.Slice(out[id], func(i, j int) bool { return out[id][i] < out[id][j] })
-	}
-	return out
-}
-
-func (g Graph) unknownDominatorInput(
-	reachable map[BlockID]bool,
-	dominators map[BlockID]map[BlockID]bool,
-) (map[BlockID]bool, bool) {
-	var intersection map[BlockID]bool
-	for _, source := range g.UnknownFlowSources {
-		if !reachable[source] {
-			continue
-		}
-		if intersection == nil {
-			intersection = copySet(dominators[source])
-			continue
-		}
-		for candidate := range intersection {
-			if !dominators[source][candidate] {
-				delete(intersection, candidate)
-			}
-		}
-	}
-	return intersection, intersection != nil
+	return g.View(filter).Dominators()
 }
 
 // DefiniteAssignments returns variables definitely assigned on entry to every
 // reachable block. It is a must-analysis and always includes uncertain edges.
 func (g Graph) DefiniteAssignments(filter EdgeFilter) map[BlockID][]Variable {
-	reachable := g.reachableWithout(filter, nil)
-	universe := map[Variable]bool{}
-	parameters := map[Variable]bool{}
-	for _, parameter := range g.Procedure.Parameters {
-		variable := Variable{Scope: procedureir.ScopeParameter, Name: parameter.Name}.canonical()
-		universe[variable] = true
-		parameters[variable] = true
-	}
-	for _, block := range g.Blocks {
-		for _, variable := range block.Assignments {
-			universe[variable.canonical()] = true
-		}
-	}
-	in := map[BlockID]map[Variable]bool{}
-	outSet := map[BlockID]map[Variable]bool{}
-	for id := range reachable {
-		if id == g.Entry {
-			in[id] = copyVariableSet(parameters)
-		} else {
-			in[id] = copyVariableSet(universe)
-		}
-		outSet[id] = withBlockAssignments(in[id], g.block(id))
-	}
-	changed := true
-	for changed {
-		changed = false
-		unknownInput, hasUnknown := g.unknownAssignmentInput(reachable, in)
-		for id := range reachable {
-			if id == g.Entry {
-				continue
-			}
-			incoming := g.assignmentInputs(id, filter, reachable, in, outSet)
-			if hasUnknown && g.block(id).Kind == BlockStatement {
-				incoming = append(incoming, unknownInput)
-			}
-			next := map[Variable]bool{}
-			if len(incoming) > 0 {
-				next = copyVariableSet(incoming[0])
-				for _, predecessor := range incoming[1:] {
-					for variable := range next {
-						if !predecessor[variable] {
-							delete(next, variable)
-						}
-					}
-				}
-			}
-			if !sameVariableSet(in[id], next) {
-				in[id] = next
-				outSet[id] = withBlockAssignments(next, g.block(id))
-				changed = true
-			}
-		}
-	}
-	result := map[BlockID][]Variable{}
-	for id, set := range in {
-		for variable := range set {
-			result[id] = append(result[id], variable)
-		}
-		sort.Slice(result[id], func(i, j int) bool {
-			if result[id][i].Scope != result[id][j].Scope {
-				return result[id][i].Scope < result[id][j].Scope
-			}
-			return result[id][i].Name < result[id][j].Name
-		})
-	}
-	return result
-}
-
-func (g Graph) unknownAssignmentInput(
-	reachable map[BlockID]bool,
-	in map[BlockID]map[Variable]bool,
-) (map[Variable]bool, bool) {
-	var intersection map[Variable]bool
-	for _, source := range g.UnknownFlowSources {
-		if !reachable[source] {
-			continue
-		}
-		if intersection == nil {
-			intersection = copyVariableSet(in[source])
-			continue
-		}
-		for variable := range intersection {
-			if !in[source][variable] {
-				delete(intersection, variable)
-			}
-		}
-	}
-	return intersection, intersection != nil
-}
-
-func (g Graph) assignmentInputs(
-	id BlockID,
-	filter EdgeFilter,
-	reachable map[BlockID]bool,
-	in, out map[BlockID]map[Variable]bool,
-) []map[Variable]bool {
-	var inputs []map[Variable]bool
-	for _, edge := range g.Edges {
-		if edge.To != id || !filter.accepts(edge) || !reachable[edge.From] {
-			continue
-		}
-		source := g.block(edge.From)
-		forEachZeroIteration := source.Statement != nil &&
-			source.Statement.Kind == procedureir.StatementForEach && edge.Kind == EdgeLoopExit
-		unknownBeforeCompletion := edge.Kind == EdgeUnknown && edge.Uncertain
-		if edge.Class == EdgeExceptional || forEachZeroIteration || unknownBeforeCompletion {
-			// A fault can occur before the source statement's writes complete.
-			// For Each may also take its zero-iteration exit before assigning
-			// the iterator variable. Unknown control may diverge before a
-			// recovered statement's writes complete.
-			inputs = append(inputs, in[edge.From])
-		} else {
-			inputs = append(inputs, out[edge.From])
-		}
-	}
-	return inputs
+	return g.View(filter).DefiniteAssignments()
 }
 
 // IsDefinitelyAssigned is the case-insensitive convenience query.
@@ -395,47 +165,14 @@ func (g Graph) CleanupGuaranteed(cleanupStatementIDs []int, selection ExitSelect
 }
 
 func (g Graph) reachableWithout(filter EdgeFilter, removed map[BlockID]bool) map[BlockID]bool {
-	index := g.queryIndexes()
 	if removed == nil {
-		if reachable, ok := index.cachedReachable(filter); ok {
-			return cloneBlockSet(reachable)
-		}
+		return cloneBlockSet(g.View(filter).reachableSet())
 	}
-	seen := physicalReachableWithIndex(g, index, filter, removed)
-	if g.unknownFlowReached(seen) {
-		for _, block := range g.Blocks {
-			if block.Kind == BlockStatement && !removed[block.ID] {
-				seen[block.ID] = true
-			}
-		}
-		if !removed[g.UnknownExit] {
-			seen[g.UnknownExit] = true
-		}
-		seen = expandReachableWithIndex(index, filter, removed, seen)
-	}
-	return seen
-}
-
-func (g Graph) unknownFlowReached(reachable map[BlockID]bool) bool {
-	for _, source := range g.UnknownFlowSources {
-		if reachable[source] {
-			return true
-		}
-	}
-	return false
+	return g.View(filter).reachableSetWithoutTargets(removed)
 }
 
 func (g Graph) predecessors(id BlockID, filter EdgeFilter, reachable map[BlockID]bool) []BlockID {
-	var out []BlockID
-	seen := map[BlockID]bool{}
-	for _, edge := range g.queryIndexes().incoming[id] {
-		if filter.accepts(edge) && reachable[edge.From] && !seen[edge.From] {
-			seen[edge.From] = true
-			out = append(out, edge.From)
-		}
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
-	return out
+	return g.View(filter).predecessors(id, reachable)
 }
 
 func (g Graph) block(id BlockID) Block {
@@ -489,12 +226,4 @@ func sameVariableSet(a, b map[Variable]bool) bool {
 		}
 	}
 	return true
-}
-
-func withBlockAssignments(in map[Variable]bool, block Block) map[Variable]bool {
-	out := copyVariableSet(in)
-	for _, variable := range block.Assignments {
-		out[variable.canonical()] = true
-	}
-	return out
 }

--- a/internal/vba/cfg/query_benchmark_test.go
+++ b/internal/vba/cfg/query_benchmark_test.go
@@ -3,6 +3,8 @@ package cfg
 import (
 	"strconv"
 	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 var (
@@ -12,6 +14,7 @@ var (
 	benchmarkReachableSink   []BlockID
 	benchmarkPredecessorSink []BlockID
 	benchmarkOutgoingSink    []Edge
+	benchmarkViewSink        CFGView
 )
 
 func BenchmarkCFGQuery(b *testing.B) {
@@ -107,6 +110,33 @@ func BenchmarkCFGIndexedLookup(b *testing.B) {
 	})
 }
 
+// BenchmarkCFGViewReuse contrasts the compatibility materialization boundary
+// with the immutable view used by migrated analyzers. The view path performs
+// one lazy reachability/dominator build and reuses it for every query; the
+// materialized path copies graph storage and rebuilds its revision on every
+// iteration.
+func BenchmarkCFGViewReuse(b *testing.B) {
+	graph := benchmarkRaiseQueryGraph(5000)
+	b.Run("materialized", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			filtered := graph.WithoutNormalErrRaiseContinuation()
+			benchmarkIsReachableSink = filtered.IsReachable(filtered.NormalExit, EdgeFilter{})
+			benchmarkViewSink = filtered.View(EdgeFilter{})
+		}
+	})
+	b.Run("shared-view", func(b *testing.B) {
+		view := graph.WithoutNormalErrRaiseContinuationView()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			benchmarkIsReachableSink = view.IsReachable(view.NormalExit())
+			benchmarkViewSink = view
+		}
+	})
+}
+
 func benchmarkSizeName(size int) string {
 	return strconv.Itoa(size)
 }
@@ -138,6 +168,15 @@ func benchmarkQueryGraph(size int) Graph {
 	}
 	edges = append(edges, Edge{From: BlockID(size + 5), To: 2, Class: EdgeNormal})
 	graph := Graph{Blocks: blocks, Edges: edges, Entry: 1, NormalExit: 2, ExceptionalExit: 3, TerminationExit: 4, UnknownExit: 5}
+	graph.query = buildQueryIndex(graph)
+	return graph
+}
+
+func benchmarkRaiseQueryGraph(size int) Graph {
+	graph := benchmarkQueryGraph(size)
+	if len(graph.Blocks) > 5 {
+		graph.Blocks[5].Statement = &procedureir.Statement{Text: "Err.Raise 5"}
+	}
 	graph.query = buildQueryIndex(graph)
 	return graph
 }

--- a/internal/vba/cfg/query_index.go
+++ b/internal/vba/cfg/query_index.go
@@ -8,8 +8,8 @@ type queryIndex struct {
 	blocksByID         map[BlockID]int
 	outgoing           map[BlockID][]Edge
 	incoming           map[BlockID][]Edge
-	reachableAll       map[BlockID]bool
-	reachableNormal    map[BlockID]bool
+	nonReturningRaise  map[BlockID]bool
+	viewCaches         [4]viewCache
 	blocksBase         *Block
 	blocksLen          int
 	edgesBase          *Edge
@@ -25,6 +25,7 @@ func buildQueryIndex(g Graph) *queryIndex {
 		blocksByID:         make(map[BlockID]int, len(g.Blocks)),
 		outgoing:           make(map[BlockID][]Edge),
 		incoming:           make(map[BlockID][]Edge),
+		nonReturningRaise:  make(map[BlockID]bool),
 		blocksLen:          len(g.Blocks),
 		edgesLen:           len(g.Edges),
 		entry:              g.Entry,
@@ -40,6 +41,7 @@ func buildQueryIndex(g Graph) *queryIndex {
 	for blockIndex, block := range g.Blocks {
 		if _, exists := index.blocksByID[block.ID]; !exists {
 			index.blocksByID[block.ID] = blockIndex
+			index.nonReturningRaise[block.ID] = isNonReturningRaiseBlock(block)
 		}
 		if block.Kind == BlockStatement && block.StatementID > 0 {
 			if _, exists := index.blocksByStatement[block.StatementID]; !exists {
@@ -51,8 +53,6 @@ func buildQueryIndex(g Graph) *queryIndex {
 		index.outgoing[edge.From] = append(index.outgoing[edge.From], edge)
 		index.incoming[edge.To] = append(index.incoming[edge.To], edge)
 	}
-	index.reachableAll = computeReachable(g, index, EdgeFilter{})
-	index.reachableNormal = computeReachable(g, index, EdgeFilter{NormalOnly: true})
 	return index
 }
 
@@ -65,20 +65,6 @@ func (g Graph) queryIndexes() *queryIndex {
 	// slice storage changes so the fallback remains correct without penalizing
 	// stable graph revisions.
 	return buildQueryIndex(g)
-}
-
-// cachedReachable returns the immutable reachability set for a canonical
-// filter view. Keep the filter cases explicit so a future filter variant does
-// not accidentally reuse the conservative default set.
-func (index *queryIndex) cachedReachable(filter EdgeFilter) (map[BlockID]bool, bool) {
-	switch filter {
-	case EdgeFilter{}:
-		return index.reachableAll, true
-	case EdgeFilter{NormalOnly: true}:
-		return index.reachableNormal, true
-	default:
-		return nil, false
-	}
 }
 
 func (index *queryIndex) matches(g Graph) bool {
@@ -105,60 +91,6 @@ func sameBlockIDs(a, b []BlockID) bool {
 		}
 	}
 	return true
-}
-
-func computeReachable(g Graph, index *queryIndex, filter EdgeFilter) map[BlockID]bool {
-	seen := physicalReachableWithIndex(g, index, filter, nil)
-	if unknownFlowReachedFor(g, seen) {
-		for _, block := range g.Blocks {
-			if block.Kind == BlockStatement {
-				seen[block.ID] = true
-			}
-		}
-		seen[g.UnknownExit] = true
-		seen = expandReachableWithIndex(index, filter, nil, seen)
-	}
-	return seen
-}
-
-func unknownFlowReachedFor(g Graph, reachable map[BlockID]bool) bool {
-	for _, source := range g.UnknownFlowSources {
-		if reachable[source] {
-			return true
-		}
-	}
-	return false
-}
-
-func physicalReachableWithIndex(g Graph, index *queryIndex, filter EdgeFilter, removed map[BlockID]bool) map[BlockID]bool {
-	seen := map[BlockID]bool{}
-	if removed != nil && removed[g.Entry] {
-		return seen
-	}
-	seen[g.Entry] = true
-	return expandReachableWithIndex(index, filter, removed, seen)
-}
-
-func expandReachableWithIndex(index *queryIndex, filter EdgeFilter, removed map[BlockID]bool, seen map[BlockID]bool) map[BlockID]bool {
-	queue := make([]BlockID, 0, len(seen))
-	for id := range seen {
-		queue = append(queue, id)
-	}
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-		for _, edge := range index.outgoing[current] {
-			if !filter.accepts(edge) || removed != nil && removed[edge.To] {
-				continue
-			}
-			if seen[edge.To] {
-				continue
-			}
-			seen[edge.To] = true
-			queue = append(queue, edge.To)
-		}
-	}
-	return seen
 }
 
 func cloneBlockSet(in map[BlockID]bool) map[BlockID]bool {

--- a/internal/vba/cfg/types.go
+++ b/internal/vba/cfg/types.go
@@ -10,6 +10,12 @@ import (
 )
 
 type BlockID int
+
+// BlockOrdinal is the dense, revision-local position of a block in the
+// immutable base storage. It is an implementation identity for indexed
+// consumers and must not be persisted or compared across graph revisions.
+type BlockOrdinal int
+
 type EdgeID int
 
 type BlockKind string
@@ -130,6 +136,11 @@ type Document struct {
 // view: every normal and exceptional edge, including uncertain edges.
 type EdgeFilter struct {
 	NormalOnly bool
+	// WithoutNormalErrRaiseContinuation excludes normal-flow edges leaving
+	// Err.Raise and Error statements. Exceptional edges remain part of the
+	// selected view. The flag is interpreted by CFGView, which has access to
+	// the immutable graph's statement index.
+	WithoutNormalErrRaiseContinuation bool
 }
 
 func (f EdgeFilter) accepts(edge Edge) bool {

--- a/internal/vba/cfg/view.go
+++ b/internal/vba/cfg/view.go
@@ -1,0 +1,633 @@
+package cfg
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+// CFGView is a read-only flow view over one immutable graph revision. It
+// shares the graph's block/edge storage and query index; filtering never
+// materializes a second graph. The callbacks exposed by this type must not
+// retain or mutate the values they receive.
+type CFGView struct {
+	graph              Graph
+	index              *queryIndex
+	filter             EdgeFilter
+	excludedNormalFrom map[BlockID]bool
+	cache              *viewCache
+}
+
+// viewCache is owned by one graph revision/filter identity. sync.Once keeps
+// lazy derived queries deterministic when analyzer readers arrive together.
+type viewCache struct {
+	reachableOnce  sync.Once
+	reachable      map[BlockID]bool
+	dominatorsOnce sync.Once
+	dominators     map[BlockID][]BlockID
+}
+
+// View returns a read-only view for filter. Canonical filters share a bounded
+// cache owned by the graph revision. A graph literal without a retained index
+// still gets a stable cache for the lifetime of this view.
+func (g Graph) View(filter EdgeFilter) CFGView {
+	index := g.queryIndexes()
+	return CFGView{
+		graph:  g,
+		index:  index,
+		filter: filter,
+		cache:  &index.viewCaches[filterCacheKey(filter)],
+	}
+}
+
+// WithoutNormalErrRaiseContinuationView returns the allocation-free canonical
+// view used by error-outcome consumers. Use Materialize only at compatibility
+// boundaries that still require mutable Graph fields.
+func (g Graph) WithoutNormalErrRaiseContinuationView() CFGView {
+	return g.View(EdgeFilter{WithoutNormalErrRaiseContinuation: true})
+}
+
+// WithoutNormalContinuationsFrom returns a view that additionally removes
+// normal edges leaving the supplied block IDs. The input is copied because a
+// caller may reuse its temporary map after constructing the view. The custom
+// mask has a view-local cache and therefore cannot grow the revision cache.
+func (v CFGView) WithoutNormalContinuationsFrom(blocks map[BlockID]bool) CFGView {
+	if len(blocks) == 0 {
+		return v
+	}
+	removed := make(map[BlockID]bool, len(v.excludedNormalFrom)+len(blocks))
+	for id, present := range v.excludedNormalFrom {
+		if present {
+			removed[id] = true
+		}
+	}
+	for id, present := range blocks {
+		if present {
+			removed[id] = true
+		}
+	}
+	if len(removed) == 0 {
+		return v
+	}
+	return CFGView{
+		graph:              v.graph,
+		index:              v.index,
+		filter:             v.filter,
+		excludedNormalFrom: removed,
+		cache:              &viewCache{},
+	}
+}
+
+func filterCacheKey(filter EdgeFilter) int {
+	key := 0
+	if filter.NormalOnly {
+		key |= 1
+	}
+	if filter.WithoutNormalErrRaiseContinuation {
+		key |= 2
+	}
+	return key
+}
+
+// Materialize retains the legacy defensive-copy behavior for callers that
+// still need mutable Graph fields. New analyzer code should stay on CFGView.
+func (v CFGView) Materialize() Graph {
+	out := v.graph
+	out.Blocks = append([]Block(nil), v.graph.Blocks...)
+	out.Edges = make([]Edge, 0, len(v.graph.Edges))
+	v.ForEachEdge(func(edge Edge) bool {
+		out.Edges = append(out.Edges, edge)
+		return true
+	})
+	out.query = buildQueryIndex(out)
+	return out
+}
+
+// ForEachBlock visits blocks in their stable source/storage order.
+func (v CFGView) ForEachBlock(fn func(Block) bool) {
+	if fn == nil {
+		return
+	}
+	for _, block := range v.graph.Blocks {
+		if !fn(block) {
+			return
+		}
+	}
+}
+
+// BlockCount returns the number of blocks in this revision. The count is
+// independent of the edge filter because views never remove block storage.
+func (v CFGView) BlockCount() int { return len(v.graph.Blocks) }
+
+// ForEachBlockOrdinal visits blocks with their stable dense revision-local
+// ordinals. The ordinal is the base block-storage position, not the public
+// sparse BlockID.
+func (v CFGView) ForEachBlockOrdinal(fn func(BlockOrdinal, Block) bool) {
+	if fn == nil {
+		return
+	}
+	for ordinal, block := range v.graph.Blocks {
+		if !fn(BlockOrdinal(ordinal), block) {
+			return
+		}
+	}
+}
+
+// BlockAtOrdinal resolves one dense revision-local ordinal without exposing
+// the underlying block slice.
+func (v CFGView) BlockAtOrdinal(ordinal BlockOrdinal) (Block, bool) {
+	if ordinal < 0 || int(ordinal) >= len(v.graph.Blocks) {
+		return Block{}, false
+	}
+	return v.graph.Blocks[int(ordinal)], true
+}
+
+// Ordinal resolves a sparse public BlockID to its stable dense ordinal. It
+// follows the first-match rule used by the base revision, including defensive
+// directly-constructed block ID zero values.
+func (v CFGView) Ordinal(id BlockID) (BlockOrdinal, bool) {
+	if id < 0 {
+		return 0, false
+	}
+	blockIndex, ok := v.index.blocksByID[id]
+	if !ok || blockIndex < 0 || blockIndex >= len(v.graph.Blocks) || v.graph.Blocks[blockIndex].ID != id {
+		return 0, false
+	}
+	return BlockOrdinal(blockIndex), true
+}
+
+// ForEachEdge visits accepted edges in base graph order.
+func (v CFGView) ForEachEdge(fn func(Edge) bool) {
+	if fn == nil {
+		return
+	}
+	for _, edge := range v.graph.Edges {
+		if !v.accepts(edge) {
+			continue
+		}
+		if !fn(edge) {
+			return
+		}
+	}
+}
+
+// ForEachOutgoing visits accepted outgoing edges in query-index order.
+func (v CFGView) ForEachOutgoing(from BlockID, fn func(Edge) bool) {
+	if fn == nil {
+		return
+	}
+	for _, edge := range v.index.outgoing[from] {
+		if !v.accepts(edge) {
+			continue
+		}
+		if !fn(edge) {
+			return
+		}
+	}
+}
+
+// ForEachIncoming visits accepted incoming edges in query-index order.
+func (v CFGView) ForEachIncoming(to BlockID, fn func(Edge) bool) {
+	if fn == nil {
+		return
+	}
+	for _, edge := range v.index.incoming[to] {
+		if !v.accepts(edge) {
+			continue
+		}
+		if !fn(edge) {
+			return
+		}
+	}
+}
+
+func (v CFGView) accepts(edge Edge) bool {
+	if !v.filter.accepts(edge) {
+		return false
+	}
+	if edge.Class != EdgeNormal {
+		return true
+	}
+	if v.excludedNormalFrom[edge.From] {
+		return false
+	}
+	return !v.filter.WithoutNormalErrRaiseContinuation || !v.index.nonReturningRaise[edge.From]
+}
+
+// BlockByID resolves a graph-local block through the revision index. Unlike
+// the legacy Graph lookup, a view also addresses defensive directly-constructed
+// ID zero values; Graph remains the compatibility boundary for its historical
+// positive-ID behavior.
+func (v CFGView) BlockByID(id BlockID) (Block, bool) { return v.blockByID(id) }
+
+func (v CFGView) blockByID(id BlockID) (Block, bool) {
+	if id < 0 {
+		return Block{}, false
+	}
+	blockIndex, ok := v.index.blocksByID[id]
+	if !ok || blockIndex < 0 || blockIndex >= len(v.graph.Blocks) || v.graph.Blocks[blockIndex].ID != id {
+		return Block{}, false
+	}
+	return v.graph.Blocks[blockIndex], true
+}
+
+// BlockForStatement resolves a statement block using the base query index.
+func (v CFGView) BlockForStatement(statementID int) (Block, bool) {
+	return v.graph.BlockForStatement(statementID)
+}
+
+func (v CFGView) Entry() BlockID           { return v.graph.Entry }
+func (v CFGView) NormalExit() BlockID      { return v.graph.NormalExit }
+func (v CFGView) ExceptionalExit() BlockID { return v.graph.ExceptionalExit }
+func (v CFGView) TerminationExit() BlockID { return v.graph.TerminationExit }
+func (v CFGView) UnknownExit() BlockID     { return v.graph.UnknownExit }
+
+// Reachable returns accepted reachable block IDs in stable graph order. The
+// cached set is copied because the legacy materialized API is mutable.
+func (v CFGView) Reachable() []BlockID {
+	seen := v.reachableSet()
+	out := make([]BlockID, 0, len(seen))
+	for _, block := range v.graph.Blocks {
+		if seen[block.ID] {
+			out = append(out, block.ID)
+		}
+	}
+	return out
+}
+
+// IsReachable reads cached membership without materializing a result slice.
+func (v CFGView) IsReachable(target BlockID) bool { return v.reachableSet()[target] }
+
+func (v CFGView) reachableSet() map[BlockID]bool {
+	v.cache.reachableOnce.Do(func() { v.cache.reachable = v.computeReachable() })
+	return v.cache.reachable
+}
+
+// reachableSetWithoutTargets computes a one-off reachability result while
+// treating removed block IDs as cut targets. Cleanup guarantees use this
+// overlay to ask whether an exit remains reachable after bypassing selected
+// cleanup statements; it intentionally does not participate in the bounded
+// canonical view cache.
+func (v CFGView) reachableSetWithoutTargets(removed map[BlockID]bool) map[BlockID]bool {
+	seen := map[BlockID]bool{}
+	if removed[v.graph.Entry] {
+		return seen
+	}
+	seen[v.graph.Entry] = true
+	queue := []BlockID{v.graph.Entry}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		v.ForEachOutgoing(current, func(edge Edge) bool {
+			if removed[edge.To] || seen[edge.To] {
+				return true
+			}
+			seen[edge.To] = true
+			queue = append(queue, edge.To)
+			return true
+		})
+	}
+	unknownReached := false
+	for _, source := range v.graph.UnknownFlowSources {
+		if seen[source] {
+			unknownReached = true
+			break
+		}
+	}
+	if unknownReached {
+		for _, block := range v.graph.Blocks {
+			if block.Kind == BlockStatement && !removed[block.ID] {
+				seen[block.ID] = true
+			}
+		}
+		if !removed[v.graph.UnknownExit] {
+			seen[v.graph.UnknownExit] = true
+		}
+		queue = queue[:0]
+		for id := range seen {
+			queue = append(queue, id)
+		}
+		for len(queue) > 0 {
+			current := queue[0]
+			queue = queue[1:]
+			v.ForEachOutgoing(current, func(edge Edge) bool {
+				if removed[edge.To] || seen[edge.To] {
+					return true
+				}
+				seen[edge.To] = true
+				queue = append(queue, edge.To)
+				return true
+			})
+		}
+	}
+	return seen
+}
+
+func (v CFGView) computeReachable() map[BlockID]bool {
+	seen := map[BlockID]bool{}
+	seen[v.graph.Entry] = true
+	queue := []BlockID{v.graph.Entry}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		v.ForEachOutgoing(current, func(edge Edge) bool {
+			if !seen[edge.To] {
+				seen[edge.To] = true
+				queue = append(queue, edge.To)
+			}
+			return true
+		})
+	}
+	unknownReached := false
+	for _, source := range v.graph.UnknownFlowSources {
+		if seen[source] {
+			unknownReached = true
+			break
+		}
+	}
+	if unknownReached {
+		for _, block := range v.graph.Blocks {
+			if block.Kind == BlockStatement {
+				seen[block.ID] = true
+			}
+		}
+		seen[v.graph.UnknownExit] = true
+		queue = queue[:0]
+		for id := range seen {
+			queue = append(queue, id)
+		}
+		for len(queue) > 0 {
+			current := queue[0]
+			queue = queue[1:]
+			v.ForEachOutgoing(current, func(edge Edge) bool {
+				if !seen[edge.To] {
+					seen[edge.To] = true
+					queue = append(queue, edge.To)
+				}
+				return true
+			})
+		}
+	}
+	return seen
+}
+
+// Dominators returns a defensive map copy of the cached conservative result.
+// DominatorsOf is available to read a single cached entry without copying the
+// complete result.
+func (v CFGView) Dominators() map[BlockID][]BlockID {
+	result := v.dominatorSet()
+	out := make(map[BlockID][]BlockID, len(result))
+	for id, values := range result {
+		out[id] = append([]BlockID(nil), values...)
+	}
+	return out
+}
+
+// DominatorsOf returns an owned copy of one cached dominator list. Copying one
+// entry keeps the view read-only without materializing the complete result.
+func (v CFGView) DominatorsOf(block BlockID) []BlockID {
+	return append([]BlockID(nil), v.dominatorSet()[block]...)
+}
+
+func (v CFGView) dominatorSet() map[BlockID][]BlockID {
+	v.cache.dominatorsOnce.Do(func() { v.cache.dominators = v.computeDominators() })
+	return v.cache.dominators
+}
+
+func (v CFGView) computeDominators() map[BlockID][]BlockID {
+	reachable := v.reachableSet()
+	all := map[BlockID]bool{}
+	for id := range reachable {
+		all[id] = true
+	}
+	dom := map[BlockID]map[BlockID]bool{}
+	for id := range reachable {
+		if id == v.graph.Entry {
+			dom[id] = map[BlockID]bool{id: true}
+		} else {
+			dom[id] = copySet(all)
+		}
+	}
+	changed := true
+	for changed {
+		changed = false
+		unknownDominators, hasUnknown := v.unknownDominatorInput(reachable, dom)
+		for id := range reachable {
+			if id == v.graph.Entry {
+				continue
+			}
+			preds := v.predecessors(id, reachable)
+			next := map[BlockID]bool{id: true}
+			var intersection map[BlockID]bool
+			if len(preds) > 0 {
+				intersection = copySet(dom[preds[0]])
+				for _, pred := range preds[1:] {
+					for candidate := range intersection {
+						if !dom[pred][candidate] {
+							delete(intersection, candidate)
+						}
+					}
+				}
+			}
+			if hasUnknown {
+				block, ok := v.blockByID(id)
+				if ok && block.Kind == BlockStatement {
+					if intersection == nil {
+						intersection = copySet(unknownDominators)
+					} else {
+						for candidate := range intersection {
+							if !unknownDominators[candidate] {
+								delete(intersection, candidate)
+							}
+						}
+					}
+				}
+			}
+			for candidate := range intersection {
+				next[candidate] = true
+			}
+			if !sameSet(dom[id], next) {
+				dom[id] = next
+				changed = true
+			}
+		}
+	}
+	out := map[BlockID][]BlockID{}
+	for id, set := range dom {
+		for candidate := range set {
+			out[id] = append(out[id], candidate)
+		}
+		sort.Slice(out[id], func(i, j int) bool { return out[id][i] < out[id][j] })
+	}
+	return out
+}
+
+func (v CFGView) unknownDominatorInput(
+	reachable map[BlockID]bool,
+	dominators map[BlockID]map[BlockID]bool,
+) (map[BlockID]bool, bool) {
+	var intersection map[BlockID]bool
+	for _, source := range v.graph.UnknownFlowSources {
+		if !reachable[source] {
+			continue
+		}
+		if intersection == nil {
+			intersection = copySet(dominators[source])
+			continue
+		}
+		for candidate := range intersection {
+			if !dominators[source][candidate] {
+				delete(intersection, candidate)
+			}
+		}
+	}
+	return intersection, intersection != nil
+}
+
+func (v CFGView) predecessors(id BlockID, reachable map[BlockID]bool) []BlockID {
+	seen := map[BlockID]bool{}
+	var out []BlockID
+	v.ForEachIncoming(id, func(edge Edge) bool {
+		if reachable[edge.From] && !seen[edge.From] {
+			seen[edge.From] = true
+			out = append(out, edge.From)
+		}
+		return true
+	})
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// DefiniteAssignments returns variables definitely assigned at every reachable
+// block boundary. It shares the view's filtered reachability and adjacency.
+func (v CFGView) DefiniteAssignments() map[BlockID][]Variable {
+	return v.DefiniteAssignmentsWith(nil)
+}
+
+// DefiniteAssignmentsWith is the compatibility-preserving assignment overlay
+// hook used by return-path analysis. Returning false for one block/variable
+// suppresses that assignment without copying the block or edge slices.
+func (v CFGView) DefiniteAssignmentsWith(allow func(Block, Variable) bool) map[BlockID][]Variable {
+	reachable := v.reachableSet()
+	universe := map[Variable]bool{}
+	parameters := map[Variable]bool{}
+	for _, parameter := range v.graph.Procedure.Parameters {
+		variable := (Variable{Scope: procedureir.ScopeParameter, Name: parameter.Name}).canonical()
+		universe[variable] = true
+		parameters[variable] = true
+	}
+	for _, block := range v.graph.Blocks {
+		for _, variable := range block.Assignments {
+			variable = variable.canonical()
+			if allow == nil || allow(block, variable) {
+				universe[variable] = true
+			}
+		}
+	}
+	in := map[BlockID]map[Variable]bool{}
+	outSet := map[BlockID]map[Variable]bool{}
+	for id := range reachable {
+		if id == v.graph.Entry {
+			in[id] = copyVariableSet(parameters)
+		} else {
+			in[id] = copyVariableSet(universe)
+		}
+		block, _ := v.blockByID(id)
+		outSet[id] = v.withBlockAssignments(in[id], block, allow)
+	}
+	changed := true
+	for changed {
+		changed = false
+		unknownInput, hasUnknown := v.unknownAssignmentInput(reachable, in)
+		for id := range reachable {
+			if id == v.graph.Entry {
+				continue
+			}
+			incoming := v.assignmentInputs(id, reachable, in, outSet)
+			block, _ := v.blockByID(id)
+			if hasUnknown && block.Kind == BlockStatement {
+				incoming = append(incoming, unknownInput)
+			}
+			next := map[Variable]bool{}
+			if len(incoming) > 0 {
+				next = copyVariableSet(incoming[0])
+				for _, predecessor := range incoming[1:] {
+					for variable := range next {
+						if !predecessor[variable] {
+							delete(next, variable)
+						}
+					}
+				}
+			}
+			if !sameVariableSet(in[id], next) {
+				in[id] = next
+				outSet[id] = v.withBlockAssignments(next, block, allow)
+				changed = true
+			}
+		}
+	}
+	result := map[BlockID][]Variable{}
+	for id, set := range in {
+		for variable := range set {
+			result[id] = append(result[id], variable)
+		}
+		sort.Slice(result[id], func(i, j int) bool {
+			if result[id][i].Scope != result[id][j].Scope {
+				return result[id][i].Scope < result[id][j].Scope
+			}
+			return result[id][i].Name < result[id][j].Name
+		})
+	}
+	return result
+}
+
+func (v CFGView) withBlockAssignments(in map[Variable]bool, block Block, allow func(Block, Variable) bool) map[Variable]bool {
+	out := copyVariableSet(in)
+	for _, variable := range block.Assignments {
+		variable = variable.canonical()
+		if allow == nil || allow(block, variable) {
+			out[variable] = true
+		}
+	}
+	return out
+}
+
+func (v CFGView) unknownAssignmentInput(reachable map[BlockID]bool, in map[BlockID]map[Variable]bool) (map[Variable]bool, bool) {
+	var intersection map[Variable]bool
+	for _, source := range v.graph.UnknownFlowSources {
+		if !reachable[source] {
+			continue
+		}
+		if intersection == nil {
+			intersection = copyVariableSet(in[source])
+			continue
+		}
+		for variable := range intersection {
+			if !in[source][variable] {
+				delete(intersection, variable)
+			}
+		}
+	}
+	return intersection, intersection != nil
+}
+
+func (v CFGView) assignmentInputs(id BlockID, reachable map[BlockID]bool, in, out map[BlockID]map[Variable]bool) []map[Variable]bool {
+	var inputs []map[Variable]bool
+	v.ForEachIncoming(id, func(edge Edge) bool {
+		if !reachable[edge.From] {
+			return true
+		}
+		source, _ := v.blockByID(edge.From)
+		forEachZeroIteration := source.Statement != nil &&
+			source.Statement.Kind == procedureir.StatementForEach && edge.Kind == EdgeLoopExit
+		unknownBeforeCompletion := edge.Kind == EdgeUnknown && edge.Uncertain
+		if edge.Class == EdgeExceptional || forEachZeroIteration || unknownBeforeCompletion {
+			inputs = append(inputs, in[edge.From])
+		} else {
+			inputs = append(inputs, out[edge.From])
+		}
+		return true
+	})
+	return inputs
+}

--- a/internal/vba/effects/errors.go
+++ b/internal/vba/effects/errors.go
@@ -63,7 +63,7 @@ func extractErrorSummary(summary *ProcedureSummary, proc procedureir.ProcedureIR
 				continue
 			}
 			addErrorEvidence(summary, statement.Range, statement.ID, 0, ErrorHasHandler, errorTargetHandler, target)
-			outcome := inspectHandler(proc, graph, label.ID, candidateKeys, loggerTargets, rethrowTargets, terminalTargets)
+			outcome := inspectHandler(proc, graph.WithoutNormalErrRaiseContinuationView(), label.ID, candidateKeys, loggerTargets, rethrowTargets, terminalTargets)
 			if outcome.swallows {
 				fallback, ok := dominatingResultFallback(proc, graph, statement.ID)
 				if !ok {
@@ -209,8 +209,7 @@ type handlerOutcome struct {
 // inspectHandler walks the actual exceptional target subgraph. A path is
 // intentionally handled when it explicitly raises, resumes, or returns a
 // fallback value. Any remaining path to normal exit loses the original error.
-func inspectHandler(proc procedureir.ProcedureIR, graph cfg.Graph, labelStatementID int, candidateKeys map[string]string, loggerTargets map[string]loggerContract, rethrowTargets, terminalTargets map[string]bool) handlerOutcome {
-	graph = graph.WithoutNormalErrRaiseContinuation()
+func inspectHandler(proc procedureir.ProcedureIR, graph cfg.CFGView, labelStatementID int, candidateKeys map[string]string, loggerTargets map[string]loggerContract, rethrowTargets, terminalTargets map[string]bool) handlerOutcome {
 	start, ok := graph.BlockForStatement(labelStatementID)
 	if !ok {
 		return handlerOutcome{swallows: true}
@@ -234,13 +233,13 @@ func inspectHandler(proc procedureir.ProcedureIR, graph cfg.Graph, labelStatemen
 			continue
 		}
 		seen[current] = true
-		if current.block == graph.NormalExit {
+		if current.block == graph.NormalExit() {
 			if !current.returned && !current.recovered {
 				out.swallows = true
 			}
 			continue
 		}
-		if current.block == graph.ExceptionalExit || current.block == graph.TerminationExit || current.block == graph.UnknownExit {
+		if current.block == graph.ExceptionalExit() || current.block == graph.TerminationExit() || current.block == graph.UnknownExit() {
 			continue
 		}
 		block, _ := graph.BlockByID(current.block)
@@ -283,17 +282,17 @@ func inspectHandler(proc procedureir.ProcedureIR, graph cfg.Graph, labelStatemen
 			}
 			errorGuard = errorPresentCondition(statement)
 		}
-		for _, edge := range graph.OutgoingEdges(current.block) {
+		graph.ForEachOutgoing(current.block, func(edge cfg.Edge) bool {
 			// Fault transitions from statements in the handler describe a new
 			// error, not an outcome of the original exceptional path.
 			if edge.Kind == cfg.EdgeError && edge.Class == cfg.EdgeExceptional {
-				continue
+				return true
 			}
 			if errorGuard == errorGuardTrue && edge.Kind == cfg.EdgeBranchFalse {
-				continue
+				return true
 			}
 			if errorGuard == errorGuardFalse && edge.Kind == cfg.EdgeBranchTrue {
-				continue
+				return true
 			}
 			recovered := current.recovered
 			if hasGuardedRethrow {
@@ -302,7 +301,8 @@ func inspectHandler(proc procedureir.ProcedureIR, graph cfg.Graph, labelStatemen
 				}
 			}
 			queue = append(queue, state{block: edge.To, returned: current.returned, recovered: recovered, errorValues: current.errorValues, errorNumber: current.errorNumber})
-		}
+			return true
+		})
 	}
 	return out
 }
@@ -365,7 +365,7 @@ func procedureAlwaysTerminates(proc procedureir.ProcedureIR, graph cfg.Graph, ca
 			sawTerminal = true
 			continue
 		}
-		block := graphBlock(graph, current)
+		block, _ := graph.BlockByID(current)
 		if block.Statement != nil {
 			statement := byID[block.StatementID]
 			if isRaiseStatement(proc, statement) || callsKnownTarget(proc, statement, candidateKeys, known) {
@@ -429,7 +429,7 @@ func callsKnownTarget(proc procedureir.ProcedureIR, statement procedureir.Statem
 	return false
 }
 
-func handlerSubgraphHasRaise(proc procedureir.ProcedureIR, graph cfg.Graph, start cfg.BlockID) bool {
+func handlerSubgraphHasRaise(proc procedureir.ProcedureIR, graph cfg.CFGView, start cfg.BlockID) bool {
 	byID := statementIndex(proc)
 	queue := []cfg.BlockID{start}
 	seen := map[cfg.BlockID]bool{}
@@ -440,15 +440,16 @@ func handlerSubgraphHasRaise(proc procedureir.ProcedureIR, graph cfg.Graph, star
 			continue
 		}
 		seen[current] = true
-		block := graphBlock(graph, current)
+		block, _ := graph.BlockByID(current)
 		if block.Statement != nil && isRaiseStatement(proc, byID[block.StatementID]) {
 			return true
 		}
-		for _, edge := range graph.OutgoingEdges(current) {
+		graph.ForEachOutgoing(current, func(edge cfg.Edge) bool {
 			if edge.Kind != cfg.EdgeError {
 				queue = append(queue, edge.To)
 			}
-		}
+			return true
+		})
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

- Replace copied derived CFG graphs with immutable `CFGView` values that share the base graph's block and edge storage.
- Reuse query indexes, reachability, dominators, and related derived queries within a graph revision through bounded caches.
- Migrate Array, Object, Error, return-path, semantic-state, runtime, and HTTP consumers while keeping the materializing compatibility API.
- Add sparse-ID, filter-chain, cache, concurrency, and defensive-copy regression tests, plus a CFG reuse benchmark.
- Update ADR-0022, the CFG specification, and the changelog.

## Performance

- Warm `BenchmarkCFGViewReuse/shared-view`: approximately 0.2–0.4 µs/op, 0 B/op, and 0 allocs/op, compared with approximately 1.9–3.0 ms/op, 7.49 MB/op, and 20.2k allocs/op for materialized filtered graphs.
- `BenchmarkRealWorldCorpus/ronecone/analyze-only`: approximately 8.5–8.85 s/op, 10.3 GB/op, and 78.1M allocs/op after the change, compared with the recorded baseline of 8.93 s/op, 11.20 GB/op, and 81.66M allocs/op.

## Tests

- `task test`
- `task lint`
- `task corpus:test`
- `go test -race ./internal/vba/cfg ./internal/vba/effects ./internal/analyze/...`
- `go test -race ./internal/vba/cfg ./internal/analyze/semanticstate`

Closes #714


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable, filtered control-flow graph views for efficient analysis and reuse.
  * Added shared caching for reachability, dominator, and data-flow queries.
  * Preserved compatibility with existing graph access and diagnostic, CLI, and LSP behavior.
* **Bug Fixes**
  * Improved consistency and determinism for concurrent control-flow analysis.
  * Preserved correct handling of exceptional flow, continuations, filtering, and zero-valued blocks.
* **Documentation**
  * Updated the changelog, architecture decision record, and control-flow graph specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->