### PR TITLE
perf(analyze): add revision-scoped semantic query DAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Added process-local, revision-scoped semantic query reuse for unchanged
+  analyzer work. Dependency-aware invalidation, cancellation safety, and
+  stderr-only query telemetry preserve existing batch/LSP diagnostics; disk
+  and cross-process caching remain out of scope.
+
 - Replaced copied derived CFGs with immutable, revision-scoped `CFGView`
   values. Stable block ordinals, canonical filter identities, shared
   adjacency/query indexes, reachability, and dominators are reused across

--- a/docs/adr/ADR-0021-procedure-analysis-ir.md
+++ b/docs/adr/ADR-0021-procedure-analysis-ir.md
@@ -209,5 +209,6 @@ contracts.
 - `docs/adr/ADR-0014-reusable-vba-lsp-server.md`
 - `docs/adr/ADR-0022-conservative-vba-control-flow-graph.md`
 - `docs/adr/ADR-0023-procedure-effect-summaries.md`
+- `docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md`
 - `docs/specs/vba-analysis-ir.md`
 - xlflow issues #425, #426, #427, #428, and #699

--- a/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
+++ b/docs/adr/ADR-0022-conservative-vba-control-flow-graph.md
@@ -222,5 +222,6 @@ observability rather than a new user-facing contract.
 - `docs/adr/ADR-0014-reusable-vba-lsp-server.md`
 - `docs/adr/ADR-0021-procedure-analysis-ir.md`
 - `docs/adr/ADR-0023-procedure-effect-summaries.md`
+- `docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md`
 - `docs/specs/vba-control-flow-graph.md`
 - xlflow issues #425, #426, #427, and #428

--- a/docs/adr/ADR-0046-procedure-applicability-planning.md
+++ b/docs/adr/ADR-0046-procedure-applicability-planning.md
@@ -470,5 +470,7 @@ produce a finding.
 - Issue #711
 - ADR-0021, ADR-0022, ADR-0023, ADR-0024, ADR-0043, ADR-0045
 - ADR-0040
+- ADR-0048
 - `docs/specs/vba-analysis-ir.md`
+- `docs/specs/vba-semantic-query-dag.md`
 - `docs/specs/static-analysis-corpus.md`

--- a/docs/adr/ADR-0047-compact-semantic-state-solver.md
+++ b/docs/adr/ADR-0047-compact-semantic-state-solver.md
@@ -181,4 +181,5 @@ domains remain outside this decision.
 - Issue #713: `perf(dataflow): introduce a compact semantic state solver`
 - Issue #693: shared semantic analysis kernel performance wave
 - ADR-0021, ADR-0022,
-  `docs/adr/ADR-0044-bounded-procedure-effect-summaries.md`, and ADR-0046
+  `docs/adr/ADR-0044-bounded-procedure-effect-summaries.md`, ADR-0046, and
+  ADR-0048

--- a/docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md
+++ b/docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md
@@ -1,0 +1,168 @@
+# ADR-0048: Revision-Scoped Semantic Query DAG
+
+## Status
+
+Accepted
+
+## Context
+
+The analyzer now has immutable procedure IR and CFG views, project capability
+planning, semantic execution plans, and compact solver state. Those boundaries
+share work within one analysis revision, but a subsequent edit still rebuilds
+every affected kernel even when its semantic inputs are unchanged. Batch and
+LSP also have separate entry-point lifecycles, so they need one explicit
+ownership and invalidation contract before they can safely reuse results.
+
+Issue #715 introduces reuse across immutable revisions in one process. The
+reuse must follow semantic dependencies rather than file-level guesses. A body
+edit should not invalidate unrelated procedures; a signature, resolution,
+call/effect, module, or configuration change must invalidate every dependent
+query whose input can change. Reuse must not weaken the conservative treatment
+of recovered, ambiguous, dynamic, or incomplete VBA.
+
+## Decision
+
+Add a process-local semantic query store represented as a directed acyclic
+dependency graph. The store is an internal execution facility that may be
+shared by batch and LSP analysis in the same process. It does not become a
+public CLI, JSON, or LSP interface and it does not define a disk cache format.
+
+### Ownership and identity
+
+The store owns only immutable, Go-managed query values and the dependency
+metadata that led to those values. It must not retain tree-sitter nodes,
+parser leases, source buffers, mutable solver scratch, finding builders, or
+revision-local objects whose owner has retired. A revision handle identifies
+the immutable IR/CFG, module facts, project capabilities, configuration, and
+resolution view used for one query evaluation; callers retain ownership of
+those inputs.
+
+Query entries are scoped to a canonical procedure identity and a semantic
+query. The identity includes the normalized document/module identity,
+qualified procedure name and kind, and the procedure's deterministic
+declaration identity. A query key includes, at minimum:
+
+- the procedure fingerprint, with body, signature, and module/conditional
+  context components kept distinguishable;
+- the semantic kernel or diagnostic projection identity;
+- a hash of configuration that can affect that query; and
+- the relevant project capability/resolution revision.
+
+Dependency edges record the exact source, module, capability, procedure, call,
+effect-summary, kernel, and projection inputs read by a query. Procedure
+fingerprints and revision-local IR/CFG IDs are not workspace-global identities;
+the canonical identity and current dependency fingerprints are required before
+an entry can be reused.
+
+### Query graph and invalidation
+
+The graph contains immutable source/module and capability inputs, procedure
+semantic kernels, and diagnostic projections. A kernel result is materialized
+once for a matching key; projections consume the matching immutable result and
+must not rebuild the kernel privately. Same-revision concurrent readers share
+one in-flight evaluation for a key.
+
+On a new revision, changed leaves and their reverse dependents are marked red
+using both the previous and current dependency edges. This covers deleted or
+redirected calls as well as newly added edges. Red entries are reevaluated in
+deterministic dependency order. If an entry's output fingerprint is unchanged,
+it becomes green and invalidity does not continue downstream; otherwise its
+reverse dependents remain candidates for recomputation.
+
+Invalidation is dependency-scoped: a body edit starts at that procedure and
+its projections; a changed signature, resolution result, call edge, effect
+summary, module context, capability, or relevant configuration reaches the
+callers, callees, module summaries, and project summaries that actually depend
+on it. Recovered syntax, ambiguous or dynamic binding, incomplete resolution,
+and unknown ownership fail open at the smallest reliable module, SCC, or
+project boundary. The DAG may therefore recompute more work when precision is
+not proven, but it must never reuse a result across an unproven semantic
+boundary.
+
+### Cancellation, concurrency, and lifetime
+
+Every evaluation observes its revision context. A canceled, failed, or
+panicked evaluation publishes no query value and commits no new dependency
+edges; waiters may retry the key. A result from an older revision cannot replace
+or publish over a newer revision, even when its worker completes later. Values
+inherited by a successor revision remain immutable and are released when no
+revision or in-flight reader can reach them. Eviction is bounded to current and
+actively referenced revision state; close/reopen starts a new lifecycle.
+
+The store does not add nested rule workers or change the existing bounded
+execution budget. Finding assembly, suppression, ordering, and protocol
+publication remain outside the reusable semantic value and retain their
+existing cancellation and defensive-copy boundaries.
+
+### Compatibility and observability
+
+Reuse is an execution optimization. A cache-enabled run must produce the same
+diagnostic code, severity, range, message, reason, suggestion, evidence,
+multiplicity, ordering, suppression result, exit status, and JSON/LSP projection
+as a fresh full recomputation. No partial or stale finding may be published.
+
+The performance recorder adds the developer-only counters
+`semantic_query_hits`, `semantic_query_misses`,
+`semantic_query_invalidated_procedures`, and
+`semantic_query_recomputed_kernels`. They are emitted only through the
+existing stderr/performance-log channel and never appear in normal CLI JSON,
+LSP payloads, corpus snapshots, or the diagnostic review ledger.
+
+The store is process-local and revision-scoped. Persistent disk caching,
+cross-process reuse, cache files, serialization, and compatibility guarantees
+for stored query values are explicitly out of scope.
+
+## Consequences
+
+- Unchanged procedures can reuse semantic kernels and projections after an
+  edit, while dependency changes still propagate to the necessary callers and
+  summaries.
+- The store and reverse-edge bookkeeping add memory and graph-maintenance
+  work, and conservative uncertainty may intentionally reduce reuse.
+- Query keys and dependency recording become internal compatibility contracts;
+  any new kernel or projection must declare its relevant inputs.
+- Batch and LSP can share the same process-local policy, but independent
+  processes and close/reopen lifecycles do not share values.
+- Diagnostic evidence remains a projection concern, so reuse cannot alter
+  finding identity or representative ordering.
+
+## Alternatives Considered
+
+1. **Rebuild every query for every revision** - Rejected because unchanged
+   procedures pay the same kernel cost after local edits.
+2. **Invalidate an entire file or project for every edit** - Rejected because
+   it cannot meet the issue's local-edit acceptance criterion and hides real
+   dependency boundaries.
+3. **Keep one cache per diagnostic rule** - Rejected because kernels and
+   capabilities are shared semantic inputs; per-rule caches duplicate work and
+   can diverge in invalidation behavior.
+4. **Persist or share query values across processes** - Rejected because it
+   would require a disk schema, compatibility, corruption, and migration
+   policy outside this issue.
+5. **Reuse red entries without output comparison** - Rejected because a
+   dependency may be invalidated conservatively even when its resulting value
+   remains identical; red/green comparison preserves both safety and reuse.
+
+## Evidence
+
+- Issue #715: `perf(analyze): add a revision-scoped semantic query DAG`.
+- Procedure ownership and revision-local identity:
+  `docs/adr/ADR-0021-procedure-analysis-ir.md` and
+  `docs/specs/vba-analysis-ir.md`.
+- Conservative graph identity and immutable views:
+  `docs/adr/ADR-0022-conservative-vba-control-flow-graph.md`.
+- Capability, kernel, projection, and bounded execution contracts:
+  `docs/adr/ADR-0046-procedure-applicability-planning.md` and
+  `docs/adr/ADR-0047-compact-semantic-state-solver.md`.
+- CLI telemetry and corpus verification contracts:
+  `docs/specs/cli-contract.md` and
+  `docs/specs/static-analysis-corpus.md`.
+
+## Related
+
+- Issue #715
+- Issue #701 (semantic execution plans)
+- Issue #713 (compact semantic state solver)
+- Issue #714 (immutable CFG views)
+- ADR-0021, ADR-0022, ADR-0046, and ADR-0047
+- `docs/specs/vba-semantic-query-dag.md`

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -147,6 +147,12 @@ For GitHub Copilot, use `agents` because Copilot reads repository instructions f
 
 TypeDB is loaded once during LSP server construction, outside the revision-scoped diagnostics recorder; `capability_typedb_builds` is therefore not emitted by LSP performance telemetry.
 
+Revision-scoped semantic query reuse in Full diagnostics follows the
+process-local ownership, key, invalidation, and cancellation contract in
+`docs/specs/vba-semantic-query-dag.md`. Its hit, miss, invalidation, and kernel
+recomputation counters remain stderr-only developer telemetry and never become
+LSP diagnostic fields.
+
 `didOpen` synchronously registers the snapshot, reserves its analysis generation, and schedules workspace-overlay and Full diagnostics work, but does not wait for either result. `didChange` publishes the incremental snapshot, schedules procedure-scoped Fast diagnostics after a 300 ms debounce, builds the matching overlay after Fast publication, and schedules Full diagnostics after two seconds of editor idle; each open document has at most one active worker. A Full publication completely replaces Fast and a lower phase cannot overwrite a higher phase for the same generation. Fast results recalculate changed procedures, rebase safe unchanged procedure diagnostics, reapply current suppressions, and omit stale interprocedural findings until Full validation. Overlay and diagnostics results are therefore eventually published rather than being available before the lifecycle handler returns. While the newest overlay is pending, workspace-wide symbol and Call Hierarchy queries mask that document's saved and previously published entries, so they may be temporarily incomplete but never return stale information for the open buffer. Diagnostic call resolution constructs one immutable indexed workspace view and merges current open-document declarations once per request. Document-local completion, hover, and signature help read the current snapshot directly and do not wait for overlay analysis. Only work whose generation, lifecycle, snapshot, and publication phase still match the newest open document may publish. Superseding edits, `didClose`, reopen, and shutdown cancel obsolete work; internal analysis loops observe cancellation, publish no partial diagnostics, and do not retain canceled IR or control-flow builds as completed cache entries. Different documents may be analyzed concurrently. `didClose` invalidates the generation, stops both timers, drops lifecycle-local diagnostic/artifact reuse, restores the saved workspace entry, and publishes an empty diagnostic result that cannot be followed by results from an older lifecycle. Diagnostics use `source="xlflow"` and xlflow rule IDs such as `VB001`, `VB005`, `VB014`, and `VB020`. LSP diagnostics reuse the file-local lint rules used by `xlflow lint` against the current in-memory buffer; CLI `lint` and `analyze` always run Full analysis, and project-wide/filesystem-only lint checks such as unused private procedure detection remain CLI-only.
 
 The VBA LSP recognizes xlflow documentation comments written as consecutive `'''` lines directly before a declaration, with optional blank lines and Rubberduck annotation lines between the comment block and the declaration. The first paragraph is the summary; `Args:` entries of the form `name: description` are matched to procedure parameters; `Returns:` describes function and `Property Get` results; `Errors:`, `Remarks:`, `Examples:`, `See Also:`, `Deprecated:`, and unknown sections are preserved as markdown body content. Rubberduck `@ModuleDescription`, `@Description`, and `@VariableDescription` annotations are accepted as fallback descriptions, with `'''` documentation taking precedence. Hover, Signature Help, and Completion documentation use the same parsed model. Completion is triggered by `.`, `"`, `'`, and `@`; when a line contains only `'''` immediately before a supported procedure declaration, completion offers a `Generate documentation comment for <name>` snippet, and when `@` is typed inside an apostrophe comment, completion offers Rubberduck description annotation snippets. Code actions offer the same documentation comment generation for supported declarations without existing documentation.
@@ -415,6 +421,24 @@ analysis revision; these counters do not imply persistent or cross-run
 caching. They use the existing `operation="analyze/counter"` stderr shape and
 are developer telemetry only. They never appear in normal analysis JSON or LSP
 diagnostic payloads.
+
+Revision-scoped semantic query reuse adds the developer-only counters
+`semantic_query_hits`, `semantic_query_misses`,
+`semantic_query_invalidated_procedures`, and
+`semantic_query_recomputed_kernels`. They use the same stderr counter shape
+and are scoped to the process-local query store and its immutable revision
+dependencies. A query result may be reused only when its procedure fingerprint,
+kernel or projection identity, relevant configuration hash, capability or
+resolution revision, and recorded dependency edges still match. Body,
+signature, resolution, call/effect, module, capability, and relevant
+configuration changes invalidate the affected reverse dependency closure;
+recovered, ambiguous, dynamic, incomplete, or unknown ownership fails open at
+the smallest reliable boundary. Canceled or superseded work publishes no
+partial result, and a late older revision cannot overwrite a newer one. These
+counters never appear in normal CLI JSON, LSP payloads, corpus snapshots, or
+the diagnostic review ledger. The store has no disk, serialization,
+cross-process, or cache-file compatibility contract; see
+`docs/specs/vba-semantic-query-dag.md` and ADR-0048.
 
 Data-flow planning also reports independent lane decisions and work:
 `planned_generic_dataflow_runs` / `skipped_generic_dataflow_runs` for

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1759,6 +1759,44 @@ remain explicitly on the compatibility walker and require a follow-up
 migration with differential evidence. No corpus snapshot or review-ledger
 change is justified by this partial migration.
 
+### Revision-scoped semantic query DAG verification requirements (#715)
+
+Issue #715 adds process-local, revision-scoped reuse for immutable semantic
+kernel and diagnostic-projection values. The query key and dependency graph
+must include procedure fingerprints, kernel/projection identity, relevant
+configuration, capability/resolution revisions, and the source, module, call,
+effect, and project-summary edges actually read. Body, signature, resolution,
+call/effect, module, capability, and relevant configuration changes must
+invalidate the affected reverse dependency closure; recovered, ambiguous,
+dynamic, incomplete, or unknown ownership must fail open at the smallest
+reliable boundary.
+
+The focused verification matrix must cover query-key stability and dependency
+recording; body, signature, configuration, resolution, callee/effect summary,
+call add/remove/redirect, and module/project invalidation; red/green output
+comparison; same-revision single-flight; cancellation and retry; revision
+replacement; and bounded eviction. Differential tests compare warm batch and
+LSP results with a fresh full recomputation and must match findings, ranges,
+severity, evidence, multiplicity, ordering, suppression, exit status, and
+normal JSON/protocol output. `go test -race` and concurrent-revision tests
+must report no new races or stale publication.
+
+The required ROneCOne and many-file benchmarks record cold/full, warm,
+same-revision, body, signature, resolution, configuration, and local-edit
+work. Record `semantic_query_hits`, `semantic_query_misses`,
+`semantic_query_invalidated_procedures`, and
+`semantic_query_recomputed_kernels` with the benchmark revision. These are
+stderr/developer telemetry only and must never be copied into snapshots or
+`reviews/diagnostics.jsonl`; wall-clock observations are not CI thresholds.
+Run corpus verification in read-only mode twice. Any unexplained snapshot,
+diagnostic identity, range, severity, evidence, multiplicity, ordering, or
+review-ledger delta is a stop-and-investigate condition; no snapshot update is
+justified merely because a query cache was added. Persistent disk caching,
+cross-process reuse, and cache-file compatibility are out of scope. The full
+ownership and invalidation contract is in
+`docs/specs/vba-semantic-query-dag.md` and
+`docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md`.
+
 ## Related
 
 - `docs/adr/ADR-0029-vendored-static-analysis-corpus.md`
@@ -1767,6 +1805,8 @@ change is justified by this partial migration.
 - `docs/adr/ADR-0032-reviewed-static-analysis-corpus-evidence.md`
 - `docs/adr/ADR-0024-shared-static-analysis-rule-registry.md`
 - `docs/adr/ADR-0026-local-vbe-oracle-evidence.md`
+- `docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md`
+- `docs/specs/vba-semantic-query-dag.md`
 - Issue #530
 - Issue #531
 - Issue #537

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -597,10 +597,10 @@ Semantic results are immutable and scoped to one procedure and analysis
 revision. A result is materialized at most once for that plan and can be read
 by multiple projections through a procedure-local result store. The store is
 released with the procedure analysis or revision; canceled, failed, and
-obsolete results are not published or retained. This boundary does not add a
-persistent or cross-run cache. Result identity and dependencies may be useful
-to a future incremental analyzer, but no incremental or cross-process cache
-contract is defined here.
+obsolete results are not published or retained. The procedure-local store
+does not itself add a persistent or cross-run cache. Cross-revision reuse, when
+available, is owned by the separate process-local query DAG specified below;
+that DAG may retain only immutable values whose dependencies remain valid.
 
 Data-flow execution is split into independent lazy lanes inside that same
 procedure-local boundary. The generic lane serves `VBA224`, `VBA236`, and
@@ -650,6 +650,52 @@ Data-flow lane telemetry additionally exposes
 `generic_dataflow_cfg_walks`, and `http_dataflow_cfg_walks`. Existing aggregate
 `dataflow_cfg_walks` and `semantic_kernel_runs` counters remain compatibility
 measurements for the procedure execution and are not lane sums.
+
+### Revision-scoped semantic query DAG
+
+Issue #715 adds a process-local query store above the procedure/revision result
+store. Batch and LSP may use the same store in one process, but the store does
+not own parser state, source buffers, mutable solver scratch, findings, or
+revision-local IR/CFG IDs. Query values are immutable Go-owned projections and
+are released when no current or actively referenced revision can reach them.
+Close/reopen starts a new lifecycle.
+
+Each query key combines canonical procedure identity, distinguishable body,
+signature, and module-context fingerprints, semantic kernel or projection
+identity, the relevant configuration hash, and the relevant project
+capability/resolution revision. Dependency edges record the source/module,
+capability, procedure, call/effect-summary, kernel, and projection inputs that
+were actually read. Revision-local IR and CFG IDs are lookup metadata, not
+persistent workspace identities.
+
+When a new revision is built, changed leaves and reverse dependents are found
+from both the old and new edge sets so call removal and redirection invalidate
+former consumers. Red entries are reevaluated deterministically. An unchanged
+output fingerprint turns an entry green and stops propagation; a changed
+output continues invalidation through its reverse dependents. Body, signature,
+resolution, call/effect, module, capability, and relevant configuration
+changes therefore invalidate only their recorded semantic closure. Recovered,
+ambiguous, dynamic, incomplete, or unknown ownership fails open at the
+smallest reliable module, SCC, or project boundary.
+
+Same-revision readers share one in-flight key evaluation. Cancellation,
+failure, and panic commit neither a value nor dependency edges; waiters may
+retry. A late result from an older revision cannot publish over a newer one,
+and no partial diagnostic projection is retained. Existing bounded worker,
+canonical ordering, suppression, and defensive-copy boundaries remain in
+force.
+
+The performance recorder adds `semantic_query_hits`,
+`semantic_query_misses`, `semantic_query_invalidated_procedures`, and
+`semantic_query_recomputed_kernels`. They are stderr-only developer telemetry
+and never appear in normal CLI JSON, LSP payloads, corpus snapshots, or the
+diagnostic review ledger. The query store is process-local and has no disk
+cache, serialization, cross-process, or cache-file compatibility contract.
+
+The full ownership, key, invalidation, cancellation, and no-disk-cache
+rationale is recorded in
+`docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md` and the detailed
+verification matrix is in `docs/specs/vba-semantic-query-dag.md`.
 
 ### Indexed semantic-state solver boundary
 

--- a/docs/specs/vba-semantic-query-dag.md
+++ b/docs/specs/vba-semantic-query-dag.md
@@ -1,0 +1,154 @@
+# VBA Semantic Query DAG
+
+This specification defines the internal revision-scoped semantic query store
+for Issue #715. ADR-0048 records the rationale. The store reuses immutable
+semantic kernel and diagnostic-projection results within one process while
+preserving the ownership, conservative uncertainty, cancellation, and public
+output contracts of the existing analyzer.
+
+## Scope and boundaries
+
+The query store may be shared by batch and LSP analysis when they refer to the
+same immutable project/revision inputs. It is an execution optimization, not a
+new analyzer API. It does not change diagnostic IDs, severity, ranges, messages,
+evidence, multiplicity, suppression, ordering, exit status, CLI options,
+configuration keys, JSON envelopes, or LSP schemas.
+
+The store is process-local. It does not persist values to disk, define a cache
+file or serialization format, or share entries across processes. Parser and
+tree-sitter reuse, cold parsing optimization, and distributed caching remain
+outside this specification.
+
+## Ownership and revision lifetime
+
+The store owns immutable Go values and dependency metadata. Query values may
+refer to immutable IR/CFG and capability data only through an owner that keeps
+that revision alive; they must not retain parser leases, tree-sitter nodes,
+source buffers, mutable maps or slices, solver scratch, finding builders, or
+obsolete revision objects. Mutable worklists and evidence reconstruction stay
+inside one evaluation and are never placed in a reusable value.
+
+Each evaluation receives an immutable revision handle covering the document or
+project inputs, module facts, resolution state, capabilities, relevant
+configuration, and cancellation context. A successor revision may inherit a
+completed value only when its key and every recorded dependency fingerprint
+match. Close/reopen begins a new lifecycle and cannot inherit lifecycle-local
+artifacts. Eviction must retain values reachable by the current or actively
+referenced revisions and may release unreachable older entries.
+
+## Query keys and dependency graph
+
+A query key contains these components:
+
+1. canonical procedure identity: normalized document/module identity,
+   qualified name, procedure kind, and deterministic declaration identity;
+2. procedure fingerprint: body, signature, and module/conditional context
+   components, plus any resolution/call-edge fingerprint used by the query;
+3. semantic query identity: kernel or diagnostic projection, including its
+   versioned internal meaning;
+4. relevant configuration hash; and
+5. relevant project capability/resolution revision.
+
+The exact internal encoding is not public, but omitting a semantic input from
+the key or dependency list is a correctness defect. Dependency edges identify
+the immutable source/module facts, capabilities, procedures, call edges,
+effect summaries, kernels, and projections read during evaluation. Revision-
+local IR/CFG IDs aid lookup only; they are not persistent workspace identities.
+
+The graph has source/module and project-capability leaves, procedure semantic
+kernels, and diagnostic projections. A projection reads the immutable result
+of its required kernel and does not silently construct a duplicate semantic
+result. One key has at most one in-flight build; concurrent readers share that
+build and receive the same immutable value.
+
+## Invalidation and red/green reuse
+
+When a new revision is opened, changed leaves and reverse dependents are
+identified from the union of the previous and current dependency edges. The
+union is required so removal, redirection, or resolution of a call invalidates
+the former caller as well as a new target. Candidates are marked red and
+reevaluated in deterministic dependency order.
+
+After reevaluation, an unchanged output fingerprint turns a red entry green
+and stops invalidity propagation through that entry. A changed output keeps
+its reverse dependents invalid and schedules them for recomputation. A hit is
+valid only after key, dependency, ownership, and revision-lifetime checks.
+
+The minimum invalidation matrix is:
+
+| change                                                   | required invalidation boundary                                  |
+| -------------------------------------------------------- | --------------------------------------------------------------- |
+| procedure body or local source range                     | that procedure's affected kernels and projections               |
+| signature or declaration identity                        | the procedure and callers/callees that consume the signature    |
+| resolution, ambiguity, or call addition/removal/redirect | affected procedures, reverse callers, and dependent summaries   |
+| effect or project-summary output                         | consumers recorded on the changed summary edge                  |
+| module declarations or conditional context               | affected module and dependent resolution/CFG/capability queries |
+| relevant configuration                                   | queries whose key includes that configuration input             |
+| recovered, dynamic, incomplete, or unknown ownership     | smallest reliable module, SCC, or project boundary, fail-open   |
+
+The table describes dependency boundaries, not a promise that every uncertain
+case can be reduced to a procedure. A safe implementation may invalidate a
+larger boundary when it cannot prove a narrower one; it must not reuse across
+an unproven boundary.
+
+## Cancellation and concurrent revisions
+
+Evaluations check cancellation at query scheduling and long-running semantic
+work boundaries. A canceled, failed, or panicked build commits neither its
+value nor its dependency edges. Waiters may retry the key, and no partial
+diagnostic projection is publishable.
+
+Revision publication is generation-safe: a late result from revision N cannot
+replace, publish over, or become the completed value for newer revision N+1.
+Same-revision readers may run concurrently against immutable values; mutable
+solver state, findings, telemetry deltas, and projection buffers remain local
+to the evaluation. The query store does not add nested rule-level workers or
+expand the existing bounded execution budget.
+
+## Diagnostics and telemetry
+
+The cache-enabled result must be structurally equivalent to a fresh full
+recomputation, including diagnostic ordering, evidence, suppression, and
+batch/LSP projection. Finding evidence is rebuilt or defensively copied at
+the existing publication boundary; it is not shared as mutable query state.
+
+The following additive counters use the existing stderr/performance-log
+channel:
+
+- `semantic_query_hits`;
+- `semantic_query_misses`;
+- `semantic_query_invalidated_procedures`; and
+- `semantic_query_recomputed_kernels`.
+
+They are developer-only telemetry. They never appear in normal CLI JSON, LSP
+diagnostic payloads, corpus snapshots, or `reviews/diagnostics.jsonl`, and they
+must not affect findings or snapshot identity. Repeated runs should report
+deterministically ordered records for a fixed revision and input.
+
+## Verification requirements
+
+Focused tests must cover key stability, dependency recording, reverse-edge
+traversal, output-fingerprint green recovery, single-flight evaluation,
+retryable cancellation, revision eviction, and late-result rejection. The
+invalidation matrix must cover body, signature, configuration, resolution,
+callee/effect summary, call add/remove/redirect, and module/project changes.
+
+Differential tests compare warm incremental and LSP/batch results with a fresh
+full recomputation, including findings, ranges, evidence, multiplicity,
+ordering, suppression, exit status, and normal JSON/protocol projection.
+Concurrent-revision tests and `go test -race` must cover cancellation and
+replacement. Benchmarks record cold/full, warm/same-revision, local body,
+signature, resolution, configuration, and many-file edits; wall-clock values
+are observations rather than CI thresholds. Corpus verification is read-only:
+any unexplained snapshot or review-ledger delta is a stop-and-investigate
+condition, and query counters are never copied into corpus artifacts.
+
+## Related
+
+- `docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md`
+- `docs/specs/vba-analysis-ir.md`
+- `docs/specs/vba-control-flow-graph.md`
+- `docs/specs/cli-contract.md`
+- `docs/specs/static-analysis-corpus.md`
+- ADR-0021, ADR-0022, ADR-0046, and ADR-0047
+- Issue #715

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"unicode"
 
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/gui"
 	"github.com/harumiWeb/xlflow/internal/lint"
@@ -361,6 +362,7 @@ type analysisContext struct {
 	objectAnalysis            *objectAnalysisContext
 	worksheetCodenames        map[string]string
 	projectEffects            effects.ProjectSummary
+	queryRevision             *semanticquery.Revision
 }
 
 type arrayInterproceduralStats struct {
@@ -400,6 +402,7 @@ type parsedFile struct {
 	// ModuleFacts owns the immutable module declaration and procedure ownership
 	// indexes shared by all rule stages for this file revision.
 	ModuleFacts                 *moduleAnalysisFacts
+	moduleFactsFingerprint      string
 	Parsed                      *vbaast.ParsedDocument
 	IntelDocument               intel.Document
 	RangeValueModuleConstants   map[string]int
@@ -545,6 +548,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	ctx, queryContext := withSemanticQueryContext(ctx)
 	finishTotal := analysisstats.Measure(ctx, "analyze_total")
 	defer func() { finishTotal(len(result.Findings), err) }()
 	if err := ctx.Err(); err != nil {
@@ -660,6 +664,15 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		parsedFiles = append(parsedFiles, parsedFile)
 	}
 	defer closeParsedFiles(parsedFiles)
+	var queryRevision *semanticquery.Revision
+	if queryContext.Store != nil {
+		revisionID := queryContext.Revision
+		if revisionID == "" {
+			revisionID = semanticQueryRevisionID(a.RootDir, a.Config, parsedFiles)
+		}
+		queryRevision = queryContext.Store.Begin(revisionID)
+		defer queryRevision.Close()
+	}
 	recordBatchWorkload(ctx, parsedFiles)
 	initializeProjectCapabilityTelemetry(ctx)
 	analysis := a
@@ -703,6 +716,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		procedures := sourceProceduresFromIRRef(&parsedFiles[i].IR, parsedFiles[i].CFG)
 		parsedFiles[i].Procedures = procedures
 		parsedFiles[i].ensureModuleAnalysisFacts()
+		parsedFiles[i].moduleFactsFingerprint = semanticModuleFactsFingerprint(parsedFiles[i])
 		materializeProcedureAnalysisPlans(&parsedFiles[i], projectEffects, analysis.Config.Analyze)
 		recordFactBuilds(ctx, len(procedures))
 	}
@@ -791,6 +805,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		finishArrayCapability = beginProjectCapabilityBuild(ctx, projectCapabilityArrayInterprocedural)
 	}
 	analysisCtx := analysis.buildContextWithObjectAnalysisPlan(parsedFiles, objectAnalysis, capabilityPlan, procedureir.ProcedureOnlyResolver(resolutionResolver))
+	analysisCtx.queryRevision = queryRevision
 	recordArrayInterproceduralTelemetry(ctx, analysisCtx)
 	finishArrayCapability(nil)
 	finishStage(len(analysisCtx.procedures), nil)
@@ -1652,6 +1667,7 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	ctx, queryContext := withSemanticQueryContext(ctx)
 	if !sourceRealtimeAnalysisEnabled(cfg.Analyze) {
 		return nil, nil
 	}
@@ -1663,6 +1679,12 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 		}
 	}
 	var findings []Finding
+	var queryRevision *semanticquery.Revision
+	defer func() {
+		if queryRevision != nil {
+			queryRevision.Close()
+		}
+	}()
 	err := doc.ReadContext(ctx, func(view vbaast.ParsedView) error {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -1700,6 +1722,7 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 			DataFlowModuleBindings:    dataFlowModuleBindings,
 		}
 		file.ensureModuleAnalysisFacts()
+		file.moduleFactsFingerprint = semanticModuleFactsFingerprint(file)
 		materializeProcedureAnalysisPlans(&file, projectEffects, cfg.Analyze)
 		recordFactBuilds(ctx, len(procedures))
 		if cfg.Analyze.DetectArrayLifecycleSafety || cfg.Analyze.DetectRedimPreserveDimension || cfg.Analyze.DetectObjectArrayComparison || cfg.Analyze.DetectDeterministicRuntimeErrors {
@@ -1729,7 +1752,15 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 			procedures = []sourceProcedure{{StartLine: 1, EndLine: len(file.Lines), StartByte: 0, EndByte: len(file.Source)}}
 		}
 		contextFiles := []parsedFile{file}
+		if queryContext.Store != nil && queryRevision == nil {
+			revisionID := queryContext.Revision
+			if revisionID == "" {
+				revisionID = semanticQueryRevisionID(rootDir, cfg, contextFiles)
+			}
+			queryRevision = queryContext.Store.Begin(revisionID)
+		}
 		analysisCtx := analyzer.buildContext(contextFiles)
+		analysisCtx.queryRevision = queryRevision
 		// buildContext materializes the participant-restricted plan after the
 		// initial procedure projection above was copied. Rebind the realtime
 		// projection to that materialized revision so batch and realtime execute
@@ -1847,6 +1878,7 @@ func (a Analyzer) sourceRealtimeProcedureFindingsContext(ctx context.Context, fi
 	profile.realtimePlanSummary(plan)
 	defer profile.flush()
 	var resultStore procedureSemanticResultStore
+	resultStore.queryRevision = analysisCtx.queryRevision
 	var arrayResult *ArrayAnalysisResult
 	if plan.runsKernel(procedureKernelArray) {
 		var err error
@@ -1854,7 +1886,7 @@ func (a Analyzer) sourceRealtimeProcedureFindingsContext(ctx context.Context, fi
 		if err != nil {
 			return nil, err
 		}
-		if arrayResult != nil {
+		if arrayResult != nil && !resultStore.arrayHit {
 			profile.kernel()
 			profile.add(analysisstats.CounterArrayKernelRuns, 1)
 			profile.add(analysisstats.CounterArrayCFGWalks, arrayResult.cfgWalks)
@@ -2454,6 +2486,7 @@ func (a Analyzer) executeProcedureAnalysisPlan(cancelCtx context.Context, file p
 	profile.dataflowLaneDecisions(plan)
 	profile.planSummary(plan)
 	var resultStore procedureSemanticResultStore
+	resultStore.queryRevision = ctx.queryRevision
 	var arrayResult *ArrayAnalysisResult
 	if plan.runsKernel(procedureKernelArray) {
 		var err error
@@ -2461,7 +2494,7 @@ func (a Analyzer) executeProcedureAnalysisPlan(cancelCtx context.Context, file p
 		if err != nil {
 			return nil, err
 		}
-		if arrayResult != nil {
+		if arrayResult != nil && !resultStore.arrayHit {
 			profile.kernel()
 			profile.add(analysisstats.CounterArrayKernelRuns, 1)
 			profile.add(analysisstats.CounterArrayCFGWalks, arrayResult.cfgWalks)

--- a/internal/analyze/array_analysis.go
+++ b/internal/analyze/array_analysis.go
@@ -9,9 +9,9 @@ import (
 )
 
 // ArrayAnalysisResult is the immutable, procedure-local semantic result used
-// by array diagnostic projections.  It intentionally has no public fields:
-// the result is an implementation detail of one analysis revision and must
-// not become a cross-revision cache or a mutable rule API.
+// by array diagnostic projections. It intentionally has no public fields and
+// is safe for the process-local semantic query store to retain while the key's
+// revision inputs remain valid.
 //
 // The slices and maps are populated before the result is handed to any
 // projector.  Projectors only read them and create Finding values, which makes
@@ -52,14 +52,7 @@ func (r *ArrayAnalysisResult) findings(kind string) []Finding {
 	}
 	findings := make([]Finding, len(source))
 	for index, finding := range source {
-		findings[index] = finding
-		if finding.NearbyCode != nil {
-			findings[index].NearbyCode = append([]string(nil), finding.NearbyCode...)
-		}
-		if finding.RuntimeError != nil {
-			runtimeError := *finding.RuntimeError
-			findings[index].RuntimeError = &runtimeError
-		}
+		findings[index] = cloneFinding(finding)
 	}
 	return findings
 }

--- a/internal/analyze/dataflow.go
+++ b/internal/analyze/dataflow.go
@@ -107,34 +107,41 @@ func (a Analyzer) executeDataflowLanes(ctx context.Context, file parsedFile, pro
 	var genericFindings []Finding
 	var httpFindings []Finding
 	executed := false
+	executedWork := false
 
 	if plan.runsDataflowLane(procedureDataflowLaneHTTP) {
 		executed = true
-		findings, err := store.materializeHTTPDataflow(ctx, a, file, proc)
+		findings, err := store.materializeHTTPDataflow(ctx, a, file, proc, plan)
 		if err != nil {
 			measurement.finishOutcome(ctx, 0, err)
 			return nil, nil, err
 		}
 		httpFindings = findings
-		if proc.Graph != nil {
+		if !store.httpDataflowHit {
+			executedWork = true
+		}
+		if proc.Graph != nil && !store.httpDataflowHit {
 			profile.add(analysisstats.CounterHTTPDataflowKernelRuns, 1)
 			profile.add(analysisstats.CounterHTTPDataflowCFGWalks, 1)
 		}
 	}
 	if plan.runsDataflowLane(procedureDataflowLaneGeneric) {
 		executed = true
-		findings, err := store.materializeGenericDataflow(ctx, a, file, proc)
+		findings, err := store.materializeGenericDataflow(ctx, a, file, proc, plan)
 		if err != nil {
 			measurement.finishOutcome(ctx, len(httpFindings), err)
 			return nil, nil, err
 		}
 		genericFindings = findings
-		if proc.Graph != nil {
+		if !store.genericDataflowHit {
+			executedWork = true
+		}
+		if proc.Graph != nil && !store.genericDataflowHit {
 			profile.add(analysisstats.CounterGenericDataflowKernelRuns, 1)
 			profile.add(analysisstats.CounterGenericDataflowCFGWalks, 1)
 		}
 	}
-	if executed && proc.Graph != nil {
+	if executed && executedWork && proc.Graph != nil {
 		// Keep the aggregate counters as compatibility telemetry for existing
 		// consumers. A procedure with both lanes still contributes one
 		// aggregate dataflow candidate and CFG walk, while the lane counters

--- a/internal/analyze/procedure_results.go
+++ b/internal/analyze/procedure_results.go
@@ -3,26 +3,31 @@ package analyze
 import (
 	"context"
 
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 )
 
-// procedureSemanticResultStore owns semantic values for exactly one
-// procedure analysis revision. It deliberately has no package-level cache:
-// project summaries, configuration, and source revisions are all inputs to a
-// result and must not leak between workers or requests.
+// procedureSemanticResultStore owns semantic values for one procedure's
+// projections. Its optional revision handle delegates cross-revision reuse to
+// the process-local semantic query store; without a handle it retains the
+// historical revision-local behavior used by focused callers.
 //
 // ArrayAnalysisResult and the two dataflow lane results are procedure-local
 // values with bounded lifetimes. Keeping the store explicit makes the
 // at-most-once materialization contract visible without introducing a
-// cross-procedure cache.
+// cross-procedure finding builder.
 type procedureSemanticResultStore struct {
+	queryRevision        *semanticquery.Revision
 	array                *ArrayAnalysisResult
 	arrayBuilt           bool
+	arrayHit             bool
 	arrayReads           uint8
 	genericDataflow      []Finding
 	genericDataflowBuilt bool
+	genericDataflowHit   bool
 	httpDataflow         []Finding
 	httpDataflowBuilt    bool
+	httpDataflowHit      bool
 }
 
 func (s *procedureSemanticResultStore) materializeArray(cancelCtx context.Context, a Analyzer, file parsedFile, proc sourceProcedure, ctx analysisContext, moduleDecls map[string]sourceDeclaration, plan procedureAnalysisPlan) (*ArrayAnalysisResult, error) {
@@ -30,7 +35,16 @@ func (s *procedureSemanticResultStore) materializeArray(cancelCtx context.Contex
 		return a.buildArrayAnalysisResultContext(cancelCtx, file, proc, ctx, moduleDecls, plan)
 	}
 	if !s.arrayBuilt {
-		array, err := a.buildArrayAnalysisResultContext(cancelCtx, file, proc, ctx, moduleDecls, plan)
+		var array *ArrayAnalysisResult
+		var err error
+		if s.queryRevision != nil {
+			key := semanticProcedureQueryKey(a, file, proc, "array", plan, semanticAnalysisCapability(ctx, file, proc, "array"))
+			array, s.arrayHit, err = semanticquery.Evaluate[*ArrayAnalysisResult](cancelCtx, s.queryRevision, key, semanticQueryDependencies(key, file, proc), func(buildCtx context.Context) (*ArrayAnalysisResult, error) {
+				return a.buildArrayAnalysisResultContext(buildCtx, file, proc, ctx, moduleDecls, plan)
+			})
+		} else {
+			array, err = a.buildArrayAnalysisResultContext(cancelCtx, file, proc, ctx, moduleDecls, plan)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -56,30 +70,50 @@ func (s *procedureSemanticResultStore) arrayProjection(profile *procedureDomainP
 	return s.array
 }
 
-func (s *procedureSemanticResultStore) materializeGenericDataflow(ctx context.Context, a Analyzer, file parsedFile, proc sourceProcedure) ([]Finding, error) {
+func (s *procedureSemanticResultStore) materializeGenericDataflow(ctx context.Context, a Analyzer, file parsedFile, proc sourceProcedure, plan procedureAnalysisPlan) ([]Finding, error) {
 	if s == nil {
 		return a.dataFlowFindingsContext(ctx, file, proc)
 	}
 	if !s.genericDataflowBuilt {
-		findings, err := a.dataFlowFindingsContext(ctx, file, proc)
+		var findings []Finding
+		var err error
+		if s.queryRevision != nil {
+			key := semanticProcedureQueryKey(a, file, proc, "dataflow", plan, semanticAnalysisCapability(analysisContext{}, file, proc, "dataflow"))
+			findings, s.genericDataflowHit, err = semanticquery.Evaluate[[]Finding](ctx, s.queryRevision, key, semanticQueryDependencies(key, file, proc), func(buildCtx context.Context) ([]Finding, error) {
+				return a.dataFlowFindingsContext(buildCtx, file, proc)
+			})
+		} else {
+			findings, err = a.dataFlowFindingsContext(ctx, file, proc)
+		}
 		if err != nil {
 			return nil, err
 		}
+		findings = cloneFindings(findings)
 		s.genericDataflow = findings
 		s.genericDataflowBuilt = true
 	}
 	return s.genericDataflow, nil
 }
 
-func (s *procedureSemanticResultStore) materializeHTTPDataflow(ctx context.Context, a Analyzer, file parsedFile, proc sourceProcedure) ([]Finding, error) {
+func (s *procedureSemanticResultStore) materializeHTTPDataflow(ctx context.Context, a Analyzer, file parsedFile, proc sourceProcedure, plan procedureAnalysisPlan) ([]Finding, error) {
 	if s == nil {
 		return a.httpTransportFindingsContext(ctx, file, proc)
 	}
 	if !s.httpDataflowBuilt {
-		findings, err := a.httpTransportFindingsContext(ctx, file, proc)
+		var findings []Finding
+		var err error
+		if s.queryRevision != nil {
+			key := semanticProcedureQueryKey(a, file, proc, "http", plan, semanticAnalysisCapability(analysisContext{}, file, proc, "http"))
+			findings, s.httpDataflowHit, err = semanticquery.Evaluate[[]Finding](ctx, s.queryRevision, key, semanticQueryDependencies(key, file, proc), func(buildCtx context.Context) ([]Finding, error) {
+				return a.httpTransportFindingsContext(buildCtx, file, proc)
+			})
+		} else {
+			findings, err = a.httpTransportFindingsContext(ctx, file, proc)
+		}
 		if err != nil {
 			return nil, err
 		}
+		findings = cloneFindings(findings)
 		s.httpDataflow = findings
 		s.httpDataflowBuilt = true
 	}
@@ -89,3 +123,77 @@ func (s *procedureSemanticResultStore) materializeHTTPDataflow(ctx context.Conte
 // Keep the store's telemetry dependency explicit at compile time. This also
 // prevents an accidental replacement with an unscoped cross-procedure cache.
 var _ analysisstats.WorkCounter = analysisstats.CounterSemanticResultsReused
+
+func cloneFindings(findings []Finding) []Finding {
+	if findings == nil {
+		return nil
+	}
+	out := make([]Finding, len(findings))
+	for index, finding := range findings {
+		out[index] = cloneFinding(finding)
+	}
+	return out
+}
+
+func cloneFinding(in Finding) Finding {
+	out := in
+	out.NearbyCode = append([]string(nil), in.NearbyCode...)
+	if in.CallCycle != nil {
+		cycle := *in.CallCycle
+		cycle.Path = append([]CallCycleNode(nil), in.CallCycle.Path...)
+		cycle.Edges = append([]CallCycleEdge(nil), in.CallCycle.Edges...)
+		cycle.EventHandlers = append([]string(nil), in.CallCycle.EventHandlers...)
+		cycle.DangerousEffects = append([]CallCycleEffect(nil), in.CallCycle.DangerousEffects...)
+		cycle.Uncertainty = append([]CallCycleUncertainty(nil), in.CallCycle.Uncertainty...)
+		out.CallCycle = &cycle
+	}
+	if in.DataFlow != nil {
+		dataFlow := *in.DataFlow
+		dataFlow.Path = append([]DataFlowStep(nil), in.DataFlow.Path...)
+		out.DataFlow = &dataFlow
+	}
+	if in.CommandExecution != nil {
+		command := *in.CommandExecution
+		out.CommandExecution = &command
+	}
+	if in.SQLExecution != nil {
+		sql := *in.SQLExecution
+		out.SQLExecution = &sql
+	}
+	if in.FileOperation != nil {
+		fileOperation := *in.FileOperation
+		if in.FileOperation.Overwrite != nil {
+			overwrite := *in.FileOperation.Overwrite
+			fileOperation.Overwrite = &overwrite
+		}
+		out.FileOperation = &fileOperation
+	}
+	if in.HTTPSecurity != nil {
+		httpSecurity := *in.HTTPSecurity
+		out.HTTPSecurity = &httpSecurity
+	}
+	if in.HTTPReliability != nil {
+		httpReliability := *in.HTTPReliability
+		out.HTTPReliability = &httpReliability
+	}
+	if in.OpaqueBoolean != nil {
+		opaque := *in.OpaqueBoolean
+		opaque.ParameterNames = append([]string(nil), in.OpaqueBoolean.ParameterNames...)
+		if in.OpaqueBoolean.OptionalBooleanParameterCount != nil {
+			count := *in.OpaqueBoolean.OptionalBooleanParameterCount
+			opaque.OptionalBooleanParameterCount = &count
+		}
+		out.OpaqueBoolean = &opaque
+	}
+	if in.RuntimeError != nil {
+		runtimeError := *in.RuntimeError
+		out.RuntimeError = &runtimeError
+	}
+	if in.httpOwnedSinks != nil {
+		out.httpOwnedSinks = make(map[int]bool, len(in.httpOwnedSinks))
+		for key, value := range in.httpOwnedSinks {
+			out.httpOwnedSinks[key] = value
+		}
+	}
+	return out
+}

--- a/internal/analyze/semantic_query_integration.go
+++ b/internal/analyze/semantic_query_integration.go
@@ -1,0 +1,247 @@
+package analyze
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+)
+
+// withSemanticQueryContext makes the process-local store and the request's
+// recorder available to every kernel evaluation without changing the public
+// analyzer method signatures. A caller-owned store (for example, an LSP
+// workspace) wins; ordinary batch calls use the process store.
+func withSemanticQueryContext(ctx context.Context) (context.Context, semanticquery.Context) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	value := semanticquery.FromContext(ctx)
+	if value.Store == nil {
+		value.Store = semanticquery.DefaultStore()
+	}
+	if value.Metrics == nil {
+		value.Metrics = analysisstats.FromContext(ctx)
+	}
+	return semanticquery.WithContext(ctx, value), value
+}
+
+func semanticQueryRevisionID(rootDir string, cfg config.Config, files []parsedFile) string {
+	configBytes, err := json.Marshal(cfg.Analyze)
+	if err != nil {
+		configBytes = []byte(fmt.Sprintf("%#v", cfg.Analyze))
+	}
+	ordered := append([]parsedFile(nil), files...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Path < ordered[j].Path })
+	parts := []string{"workspace", rootDir, string(configBytes)}
+	for _, file := range ordered {
+		parts = append(parts, file.Path, file.Module, file.ModuleKind, semanticquery.Hash(string(file.Source)))
+	}
+	return semanticquery.Hash(parts...)
+}
+
+func semanticProcedureIdentity(file parsedFile, proc sourceProcedure) string {
+	return fmt.Sprintf("%s::%s::%s::%d", file.Path, file.Module, proc.Name, proc.Index)
+}
+
+func semanticProcedureQueryKey(a Analyzer, file parsedFile, proc sourceProcedure, kernel string, plan procedureAnalysisPlan, capability string) semanticquery.Key {
+	start, end := proc.StartByte, proc.EndByte
+	if start < 0 {
+		start = 0
+	}
+	if end < start {
+		end = start
+	}
+	if start > len(file.Source) {
+		start = len(file.Source)
+	}
+	if end > len(file.Source) {
+		end = len(file.Source)
+	}
+	body := file.Source[start:end]
+	configBytes, err := json.Marshal(a.Config.Analyze)
+	if err != nil {
+		configBytes = []byte(fmt.Sprintf("%#v", a.Config.Analyze))
+	}
+	fingerprint := semanticquery.Hash(
+		a.RootDir,
+		file.Path,
+		file.Module,
+		file.ModuleKind,
+		semanticModuleFactsFingerprint(file),
+		proc.Name,
+		proc.Kind,
+		string(proc.ProcedureKind),
+		proc.ReturnType,
+		fmt.Sprintf("%d", proc.Index),
+		fmt.Sprintf("%d:%d:%d:%d", proc.StartLine, proc.EndLine, proc.StartByte, proc.EndByte),
+		fmt.Sprintf("option-base:%d:%t", file.ArrayOptionBase, file.ArrayOptionBaseSet),
+		fmt.Sprintf("%#v", file.ArrayIntegerModuleConstants),
+		fmt.Sprintf("%#v", file.RangeValueModuleConstants),
+		fmt.Sprintf("%#v", file.ConstantValues),
+		fmt.Sprintf("%#v", file.DataFlowModuleBindings),
+		string(body),
+		fmt.Sprintf("%#v", proc.Features),
+		semanticStableJSON(proc.Effects),
+	)
+	return semanticquery.Key{
+		Procedure:   semanticProcedureIdentity(file, proc),
+		Fingerprint: fingerprint,
+		Kernel:      kernel + ":" + fmt.Sprintf("%#v", plan),
+		Config:      semanticquery.Hash(string(configBytes)),
+		Capability:  semanticquery.Hash(capability, semanticAnalyzerCapability(a), semanticTypeDBFingerprint(a)),
+	}
+}
+
+func semanticQueryDependencies(key semanticquery.Key, file parsedFile, proc sourceProcedure) []semanticquery.Key {
+	dependencies := []semanticquery.Key{
+		{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "source"},
+		{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "config", Config: key.Config},
+		{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "capability", Capability: key.Capability},
+		{Procedure: file.Path, Fingerprint: semanticquery.Hash(semanticModuleFactsFingerprint(file)), Kernel: "module"},
+		{Procedure: key.Procedure, Fingerprint: semanticStableJSON(proc.Effects), Kernel: "effect-summary"},
+	}
+	for index := 0; index < proc.Calls.Len(); index++ {
+		call, ok := proc.Calls.At(index)
+		if !ok {
+			continue
+		}
+		resolutionFingerprint := semanticStableJSON(call.Resolution)
+		if len(call.Resolution.Candidates) == 0 {
+			dependencies = append(dependencies, semanticquery.Key{
+				Procedure:   file.Path,
+				Fingerprint: semanticquery.Hash(fmt.Sprintf("call:%d", call.ID), resolutionFingerprint),
+				Kernel:      "call-resolution",
+			})
+			continue
+		}
+		for _, candidate := range call.Resolution.Candidates {
+			dependencies = append(dependencies, semanticquery.Key{
+				Procedure:   fmt.Sprintf("%s::%s::%s::%d", candidate.File, candidate.QualifiedName, candidate.Kind, candidate.Line),
+				Fingerprint: semanticquery.Hash(resolutionFingerprint),
+				Kernel:      "call-resolution",
+			})
+		}
+	}
+	return dependencies
+}
+
+func semanticAnalyzerCapability(a Analyzer) string {
+	return semanticquery.Hash(fmt.Sprintf("%#v", a.visibleConstants), fmt.Sprintf("%#v", a.visibleConstantValues))
+}
+
+func semanticTypeDBFingerprint(a Analyzer) string {
+	if a.typeDB == nil {
+		return ""
+	}
+	if value, ok := semanticTypeDBFingerprints.Load(a.typeDB); ok {
+		return value.(string)
+	}
+	fingerprint := semanticStableJSON(a.typeDB.AllConstantsList())
+	actual, _ := semanticTypeDBFingerprints.LoadOrStore(a.typeDB, fingerprint)
+	return actual.(string)
+}
+
+var semanticTypeDBFingerprints sync.Map // map[*vbadb.DB]string
+
+func semanticModuleFactsFingerprint(file parsedFile) string {
+	if file.moduleFactsFingerprint != "" {
+		return file.moduleFactsFingerprint
+	}
+	facts := file.ModuleFacts
+	if facts == nil {
+		return ""
+	}
+	return semanticquery.Hash(
+		fmt.Sprintf("%#v", facts.moduleDeclarations),
+		fmt.Sprintf("%#v", facts.constants),
+		fmt.Sprintf("%#v", facts.moduleConstantNames),
+		fmt.Sprintf("%#v", facts.procedureNames),
+		fmt.Sprintf("%#v", facts.privateModule),
+		fmt.Sprintf("%#v", facts.arrayOperationsByName),
+		fmt.Sprintf("%#v", facts.arrayOperationsByLine),
+		fmt.Sprintf("%#v", facts.lineFacts),
+	)
+}
+
+func semanticAnalysisCapability(ctx analysisContext, file parsedFile, proc sourceProcedure, kernel string) string {
+	// These maps are immutable for one analysis context. Including the relevant
+	// capability projection in the key prevents a stale value when resolution,
+	// effect summaries, or array participant closure changes.
+	switch kernel {
+	case "array":
+		parts := []string{
+			fmt.Sprintf("%t", proc.ArrayParticipant),
+			fmt.Sprintf("%t", proc.ArrayParticipantReady),
+			semanticStableJSON(proc.Effects),
+			fmt.Sprintf("%#v", ctx.arrayModuleConfigurations[file.Path]),
+		}
+		keys := []string{arrayProcedureKey(proc), strings.ToLower(proc.Name)}
+		if participantKey := ctx.arrayParticipantKeys[arrayProcedureKey(proc)]; participantKey != "" {
+			keys = append(keys, participantKey)
+		}
+		for index := 0; index < proc.Calls.Len(); index++ {
+			if call, ok := proc.Calls.At(index); ok {
+				keys = append(keys, strings.ToLower(call.Callee.BaseName))
+				for _, candidate := range call.Resolution.Candidates {
+					keys = append(keys, strings.ToLower(candidate.QualifiedName))
+				}
+			}
+		}
+		parts = append(parts,
+			semanticMapSubset(ctx.arrayReturns, keys),
+			semanticMapSubset(ctx.arrayAllocationGuards, keys),
+			semanticMapSubset(ctx.arrayByRefAllocations, keys),
+			semanticMapSubset(ctx.arrayByRefConditionalAllocations, keys),
+			semanticMapSubset(ctx.arrayByRefLengthAllocations, keys),
+			semanticMapSubset(ctx.arrayModuleAllocations, keys),
+			semanticMapSubset(ctx.arrayModuleEntryStates, keys),
+			semanticMapSubset(ctx.arrayByRefEntryStates, keys),
+			semanticMapSubset(ctx.arrayByRefEntryConditions, keys),
+			semanticMapSubset(ctx.arrayParticipants, keys),
+		)
+		return semanticquery.Hash(parts...)
+	case "dataflow", "http":
+		return semanticquery.Hash(fmt.Sprintf("%#v", file.DataFlowModuleBindings), semanticStableJSON(proc.Effects))
+	default:
+		return semanticquery.Hash(semanticStableJSON(proc.Effects))
+	}
+}
+
+func semanticStableJSON(value any) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%#v", value)
+	}
+	return string(encoded)
+}
+
+func semanticMapSubset[T any, M ~map[string]T](values M, wanted []string) string {
+	if len(values) == 0 || len(wanted) == 0 {
+		return ""
+	}
+	lookup := make(map[string]struct{}, len(wanted))
+	for _, key := range wanted {
+		key = strings.ToLower(strings.TrimSpace(key))
+		if key != "" {
+			lookup[key] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if _, ok := lookup[strings.ToLower(key)]; ok {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%#v", key, values[key]))
+	}
+	return strings.Join(parts, ";")
+}

--- a/internal/analyze/semantic_query_integration_test.go
+++ b/internal/analyze/semantic_query_integration_test.go
@@ -1,0 +1,95 @@
+package analyze
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+)
+
+func TestSemanticQueryReusesProcedureKernelsAcrossBatchRevisions(t *testing.T) {
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Const ModuleConstant As Long = 1
+Public Sub Run()
+    Dim values() As Long
+    ReDim values(1 To 2)
+    values(1) = 1
+End Sub
+
+Public Sub Untouched()
+    Dim other() As Long
+    ReDim other(1 To 2)
+    other(1) = 1
+End Sub
+`)
+	store := semanticquery.New(semanticquery.Options{})
+	run := func() (Result, map[string]uint64, error) {
+		recorder := analysisstats.NewRecorder()
+		ctx := analysisstats.WithRecorder(context.Background(), recorder)
+		ctx = semanticquery.WithContext(ctx, semanticquery.Context{Store: store})
+		result, err := (Analyzer{RootDir: dir, Config: config.Default()}).RunResultContext(ctx)
+		_, counters := recorder.Snapshot()
+		return result, counters, err
+	}
+	first, firstCounters, err := run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, secondCounters, err := run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first.Findings, second.Findings) {
+		t.Fatalf("warm analysis changed findings: first=%#v second=%#v", first.Findings, second.Findings)
+	}
+	if secondCounters[analysisstats.SemanticQueryHitsCounter] == 0 {
+		t.Fatalf("warm analysis recorded no semantic query hits: first=%v second=%v", firstCounters, secondCounters)
+	}
+	if secondCounters[analysisstats.SemanticQueryRecomputedKernelsCounter] >= firstCounters[analysisstats.SemanticQueryRecomputedKernelsCounter] {
+		t.Fatalf("warm analysis recomputed at least as many kernels: first=%v second=%v", firstCounters, secondCounters)
+	}
+	sourcePath := filepath.Join(dir, "src", "modules", "Main.bas")
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	moduleUpdated := strings.Replace(string(source), "ModuleConstant As Long = 1", "ModuleConstant As Long = 2", 1)
+	if moduleUpdated == string(source) {
+		t.Fatal("module constant replacement did not change source")
+	}
+	if err := os.WriteFile(sourcePath, []byte(moduleUpdated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, moduleCounters, err := run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moduleCounters[analysisstats.SemanticQueryMissesCounter] == 0 {
+		t.Fatalf("module input edit reused all old kernels: counters=%v", moduleCounters)
+	}
+	source, err = os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(source), "other(1) = 1", "other(1) = 2", 1)
+	if err := os.WriteFile(sourcePath, []byte(updated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, changedCounters, err := run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changedCounters[analysisstats.SemanticQueryHitsCounter] == 0 {
+		t.Fatalf("local edit did not reuse the unchanged procedure: counters=%v", changedCounters)
+	}
+	if changedCounters[analysisstats.SemanticQueryRecomputedKernelsCounter] >= firstCounters[analysisstats.SemanticQueryRecomputedKernelsCounter] {
+		t.Fatalf("local edit recomputed every kernel: first=%v changed=%v", firstCounters, changedCounters)
+	}
+}

--- a/internal/analyze/semanticquery/query.go
+++ b/internal/analyze/semanticquery/query.go
@@ -100,6 +100,11 @@ type cacheValue struct {
 	value any
 }
 
+// dependencyRecord is an eviction-tracked placeholder for a query whose
+// value was published outside Evaluate. It keeps RecordDependencies metadata
+// bounded without making a metadata-only record look like a cache hit.
+type dependencyRecord struct{}
+
 type pendingValue struct {
 	done chan struct{}
 }
@@ -241,6 +246,11 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 		}
 		s.mu.Lock()
 		if cached, ok := s.entries[stable]; ok {
+			if _, metadataOnly := cached.value.(dependencyRecord); metadataOnly {
+				s.removeNodeLocked(stable)
+				s.mu.Unlock()
+				continue
+			}
 			if !s.dependenciesMatchLocked(stable, dependencies) {
 				s.invalidateIDsLocked([]string{stable}, metrics)
 				s.mu.Unlock()
@@ -382,13 +392,21 @@ func (s *Store) recordDependenciesLocked(parent string, parentKey Key, dependenc
 
 // RecordDependencies records a dependency for an already-computed query. It
 // is useful for capability builders that publish an immutable value outside
-// Evaluate but still need reverse invalidation edges.
+// Evaluate but still need reverse invalidation edges. Metadata-only records
+// are represented by an eviction-tracked placeholder so repeated external
+// registrations cannot bypass MaxEntries.
 func (s *Store) RecordDependencies(parent Key, dependencies ...Key) {
 	if s == nil {
 		return
 	}
 	s.mu.Lock()
-	s.recordDependenciesLocked(parent.String(), parent, dependencies)
+	stable := parent.String()
+	if _, ok := s.entries[stable]; !ok {
+		s.entries[stable] = cacheValue{key: parent, value: dependencyRecord{}}
+		s.order = append(s.order, stable)
+	}
+	s.recordDependenciesLocked(stable, parent, dependencies)
+	s.pruneEntriesLocked()
 	s.mu.Unlock()
 }
 

--- a/internal/analyze/semanticquery/query.go
+++ b/internal/analyze/semanticquery/query.go
@@ -1,0 +1,571 @@
+// Package semanticquery provides the process-local ownership boundary for
+// revision-scoped semantic query results.  It deliberately stores opaque
+// values: the analyzer owns the value's immutability and the query package
+// owns only publication, single-flight, and dependency lifetime.
+package semanticquery
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+var ErrRevisionClosed = errors.New("semantic query revision is closed")
+
+// Metrics is implemented by the analyzer performance recorder.  Keeping this
+// interface small prevents the query package from depending on analyzer or
+// protocol types while preserving the existing stderr-only telemetry path.
+type Metrics interface {
+	RecordSemanticQueryHit()
+	RecordSemanticQueryMiss()
+	RecordSemanticQueryInvalidatedProcedures(uint64)
+	RecordSemanticQueryRecomputedKernel()
+}
+
+// Key identifies one semantic query.  Procedure and Fingerprint are kept
+// separate so callers can report invalidated procedures without parsing an
+// opaque cache key.  Config and Capability are content revisions, not a
+// monotonically increasing workspace number; unchanged values can therefore
+// be shared by adjacent revisions.
+type Key struct {
+	Procedure   string
+	Fingerprint string
+	Kernel      string
+	Config      string
+	Capability  string
+}
+
+func (k Key) String() string {
+	return strings.Join([]string{k.Procedure, k.Fingerprint, k.Kernel, k.Config, k.Capability}, "\x00")
+}
+
+// Hash returns a deterministic lowercase SHA-256 digest of length-prefixed
+// parts.  Length-prefixing keeps the digest stable even when a part contains
+// the separator used by Key.String.
+func Hash(parts ...string) string {
+	h := sha256.New()
+	for _, part := range parts {
+		_, _ = fmt.Fprintf(h, "%d:", len(part))
+		h.Write([]byte(part))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+type Options struct {
+	MaxEntries   int
+	MaxRevisions int
+	Metrics      Metrics
+}
+
+var processStore = New(Options{})
+
+// DefaultStore is the process-lifetime cache used by analyzer entrypoints
+// that are not owned by an LSP server. Callers that own a workspace lifecycle
+// may provide a bounded Store through Context instead.
+func DefaultStore() *Store { return processStore }
+
+type contextKey struct{}
+
+// Context carries an optional process-local store through batch and LSP
+// adapters without adding a protocol parameter to every analyzer entrypoint.
+// The revision string is supplied by a coherent workspace snapshot when one
+// exists; an empty string asks the batch entrypoint to derive one after parse.
+type Context struct {
+	Store    *Store
+	Revision string
+	Metrics  Metrics
+}
+
+func WithContext(ctx context.Context, value Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, contextKey{}, value)
+}
+
+func FromContext(ctx context.Context) Context {
+	if ctx == nil {
+		return Context{}
+	}
+	value, _ := ctx.Value(contextKey{}).(Context)
+	return value
+}
+
+type cacheValue struct {
+	key   Key
+	value any
+}
+
+type pendingValue struct {
+	done chan struct{}
+}
+
+type revisionState struct {
+	id   string
+	refs int
+}
+
+// Store owns values shared by revisions in one process.  Values are retained
+// only as completed opaque objects.  The FIFO bound is intentionally an
+// implementation detail; no disk or cross-process cache format is implied.
+type Store struct {
+	mu sync.Mutex
+
+	entries map[string]cacheValue
+	order   []string
+	pending map[string]*pendingValue
+	reverse map[string]map[string]Key
+	keys    map[string]Key
+	epochs  map[string]uint64
+	deps    map[string][]string
+
+	revisions    map[string]*revisionState
+	sequence     uint64
+	maxEntries   int
+	maxRevisions int
+	latest       string
+	metrics      Metrics
+}
+
+func New(opts Options) *Store {
+	maxEntries := opts.MaxEntries
+	if maxEntries <= 0 {
+		maxEntries = 8192
+	}
+	maxRevisions := opts.MaxRevisions
+	if maxRevisions <= 0 {
+		maxRevisions = 4
+	}
+	return &Store{
+		entries:      make(map[string]cacheValue),
+		pending:      make(map[string]*pendingValue),
+		reverse:      make(map[string]map[string]Key),
+		keys:         make(map[string]Key),
+		epochs:       make(map[string]uint64),
+		deps:         make(map[string][]string),
+		revisions:    make(map[string]*revisionState),
+		maxEntries:   maxEntries,
+		maxRevisions: maxRevisions,
+		metrics:      opts.Metrics,
+	}
+}
+
+// Revision is a lightweight handle.  Several concurrent requests may hold
+// the same revision; closing one handle does not retire values used by the
+// others.
+type Revision struct {
+	store  *Store
+	id     string
+	mu     sync.Mutex
+	closed bool
+}
+
+func (s *Store) Begin(id string) *Revision {
+	if s == nil {
+		return &Revision{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id == "" {
+		s.sequence++
+		id = fmt.Sprintf("anonymous-%d", s.sequence)
+	}
+	state := s.revisions[id]
+	if state == nil {
+		state = &revisionState{id: id}
+		s.revisions[id] = state
+	}
+	state.refs++
+	s.latest = id
+	s.pruneRevisionsLocked()
+	return &Revision{store: s, id: id}
+}
+
+func (r *Revision) ID() string {
+	if r == nil {
+		return ""
+	}
+	return r.id
+}
+
+func (r *Revision) Close() {
+	if r == nil || r.store == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.closed = true
+	r.mu.Unlock()
+	r.store.mu.Lock()
+	if state := r.store.revisions[r.id]; state != nil && state.refs > 0 {
+		state.refs--
+	}
+	r.store.pruneRevisionsLocked()
+	r.store.mu.Unlock()
+}
+
+func (r *Revision) isClosed() bool {
+	if r == nil || r.store == nil {
+		return true
+	}
+	r.mu.Lock()
+	closed := r.closed
+	r.mu.Unlock()
+	return closed
+}
+
+// Evaluate returns a completed value, a hit flag, and an error.  A build is
+// published only after it returns successfully and its context is still live.
+// Waiters retry after a canceled or failed producer instead of receiving a
+// partial value.
+func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, build func(context.Context) (any, error)) (any, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if r == nil || r.store == nil || r.isClosed() {
+		return nil, false, ErrRevisionClosed
+	}
+	s := r.store
+	metrics := s.metricsFor(ctx)
+	stable := key.String()
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		s.mu.Lock()
+		if cached, ok := s.entries[stable]; ok {
+			if !s.dependenciesMatchLocked(stable, dependencies) {
+				s.invalidateIDsLocked([]string{stable}, metrics)
+				s.mu.Unlock()
+				continue
+			}
+			s.mu.Unlock()
+			if metrics != nil {
+				metrics.RecordSemanticQueryHit()
+			}
+			return cached.value, true, nil
+		}
+		if pending := s.pending[stable]; pending != nil {
+			done := pending.done
+			s.mu.Unlock()
+			select {
+			case <-done:
+				continue
+			case <-ctx.Done():
+				return nil, false, ctx.Err()
+			}
+		}
+		pending := &pendingValue{done: make(chan struct{})}
+		epoch := s.epochs[stable]
+		s.pending[stable] = pending
+		if metrics != nil {
+			metrics.RecordSemanticQueryMiss()
+		}
+		s.mu.Unlock()
+
+		var value any
+		var err error
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					s.mu.Lock()
+					delete(s.pending, stable)
+					close(pending.done)
+					s.mu.Unlock()
+					panic(recovered)
+				}
+			}()
+			value, err = build(ctx)
+		}()
+		if err == nil {
+			err = ctx.Err()
+		}
+		s.mu.Lock()
+		delete(s.pending, stable)
+		if err == nil && s.epochs[stable] == epoch {
+			s.entries[stable] = cacheValue{key: key, value: value}
+			s.keys[stable] = key
+			s.order = append(s.order, stable)
+			s.recordDependenciesLocked(stable, key, dependencies)
+			s.pruneEntriesLocked()
+			if metrics != nil {
+				metrics.RecordSemanticQueryRecomputedKernel()
+			}
+		}
+		close(pending.done)
+		s.mu.Unlock()
+		if err != nil {
+			return nil, false, err
+		}
+		return value, false, nil
+	}
+}
+
+func (s *Store) dependenciesMatchLocked(parent string, dependencies []Key) bool {
+	stored := s.deps[parent]
+	if len(stored) != len(dependencies) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(dependencies))
+	for _, dependency := range dependencies {
+		seen[dependency.String()] = struct{}{}
+	}
+	for _, dependencyID := range stored {
+		if _, ok := seen[dependencyID]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Store) metricsFor(ctx context.Context) Metrics {
+	if value := FromContext(ctx).Metrics; value != nil {
+		return value
+	}
+	if s == nil {
+		return nil
+	}
+	return s.metrics
+}
+
+func Evaluate[T any](ctx context.Context, r *Revision, key Key, dependencies []Key, build func(context.Context) (T, error)) (T, bool, error) {
+	var zero T
+	value, hit, err := r.Evaluate(ctx, key, dependencies, func(ctx context.Context) (any, error) {
+		return build(ctx)
+	})
+	if err != nil {
+		return zero, hit, err
+	}
+	result, ok := value.(T)
+	if !ok {
+		return zero, hit, fmt.Errorf("semantic query %s returned %T, want %T", key.Kernel, value, zero)
+	}
+	return result, hit, nil
+}
+
+func (s *Store) recordDependenciesLocked(parent string, parentKey Key, dependencies []Key) {
+	for _, dependencyID := range s.deps[parent] {
+		if parents := s.reverse[dependencyID]; parents != nil {
+			delete(parents, parent)
+			if len(parents) == 0 {
+				delete(s.reverse, dependencyID)
+			}
+		}
+	}
+	s.keys[parent] = parentKey
+	ids := make([]string, 0, len(dependencies))
+	seen := make(map[string]struct{}, len(dependencies))
+	for _, dependency := range dependencies {
+		dependencyID := dependency.String()
+		if _, ok := seen[dependencyID]; ok {
+			continue
+		}
+		seen[dependencyID] = struct{}{}
+		ids = append(ids, dependencyID)
+		s.keys[dependencyID] = dependency
+		parents := s.reverse[dependencyID]
+		if parents == nil {
+			parents = make(map[string]Key)
+			s.reverse[dependencyID] = parents
+		}
+		parents[parent] = parentKey
+	}
+	s.deps[parent] = ids
+}
+
+// RecordDependencies records a dependency for an already-computed query. It
+// is useful for capability builders that publish an immutable value outside
+// Evaluate but still need reverse invalidation edges.
+func (s *Store) RecordDependencies(parent Key, dependencies ...Key) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.recordDependenciesLocked(parent.String(), parent, dependencies)
+	s.mu.Unlock()
+}
+
+// Invalidate removes changed queries and their transitive dependents. The
+// returned procedure identities are sorted and unique for deterministic
+// telemetry. Reverse traversal is completed before affected metadata is
+// released, so callers can invalidate an old/new dependency union when a call
+// is removed or redirected without retaining unbounded historical edges.
+func (s *Store) Invalidate(changed ...Key) []string {
+	return s.InvalidateContext(context.Background(), changed...)
+}
+
+// InvalidateContext is the request-aware invalidation form. The context may
+// carry a recorder through Context.Metrics; callers without request telemetry
+// can use Invalidate.
+func (s *Store) InvalidateContext(ctx context.Context, changed ...Key) []string {
+	if s == nil || len(changed) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	queue := make([]string, 0, len(changed))
+	for _, key := range changed {
+		queue = append(queue, key.String())
+	}
+	return s.invalidateIDsLocked(queue, s.metricsFor(ctx))
+}
+
+// InvalidateProcedures removes all cached queries belonging to the supplied
+// procedure identities (or identity prefixes) and their reverse dependents.
+// LSP callers use path prefixes because a source edit can replace a procedure
+// declaration and therefore cannot always reconstruct the old full key.
+func (s *Store) InvalidateProcedures(procedures ...string) []string {
+	return s.InvalidateProceduresContext(context.Background(), procedures...)
+}
+
+// InvalidateProceduresContext is the request-aware procedure invalidation
+// form used when a workspace change is handled alongside a recorder.
+func (s *Store) InvalidateProceduresContext(ctx context.Context, procedures ...string) []string {
+	if s == nil || len(procedures) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	queue := make([]string, 0)
+	for id, key := range s.keys {
+		for _, procedure := range procedures {
+			if procedure != "" && (key.Procedure == procedure || strings.HasPrefix(key.Procedure, procedure)) {
+				queue = append(queue, id)
+				break
+			}
+		}
+	}
+	return s.invalidateIDsLocked(queue, s.metricsFor(ctx))
+}
+
+func (s *Store) invalidateIDsLocked(queue []string, metrics Metrics) []string {
+	seen := make(map[string]bool)
+	procedures := make(map[string]bool)
+	affected := make([]string, 0, len(queue))
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		affected = append(affected, id)
+		s.epochs[id]++
+		if key, ok := s.keys[id]; ok {
+			if key.Procedure != "" {
+				procedures[key.Procedure] = true
+			}
+		}
+		for parent := range s.reverse[id] {
+			queue = append(queue, parent)
+		}
+	}
+	for _, id := range affected {
+		s.removeNodeLocked(id)
+	}
+	if len(s.order) > s.maxEntries*2 {
+		compact := make([]string, 0, len(s.entries))
+		seenOrder := make(map[string]struct{}, len(s.entries))
+		for _, id := range s.order {
+			if _, ok := s.entries[id]; !ok {
+				continue
+			}
+			if _, ok := seenOrder[id]; ok {
+				continue
+			}
+			seenOrder[id] = struct{}{}
+			compact = append(compact, id)
+		}
+		s.order = compact
+	}
+	result := make([]string, 0, len(procedures))
+	for procedure := range procedures {
+		result = append(result, procedure)
+	}
+	for i := 1; i < len(result); i++ {
+		for j := i; j > 0 && result[j] < result[j-1]; j-- {
+			result[j], result[j-1] = result[j-1], result[j]
+		}
+	}
+	if metrics != nil {
+		metrics.RecordSemanticQueryInvalidatedProcedures(uint64(len(result)))
+	}
+	return result
+}
+
+func (s *Store) removeNodeLocked(id string) {
+	for _, dependencyID := range s.deps[id] {
+		if parents := s.reverse[dependencyID]; parents != nil {
+			delete(parents, id)
+			if len(parents) == 0 {
+				delete(s.reverse, dependencyID)
+				s.maybeRemoveDependencyMetadataLocked(dependencyID)
+			}
+		}
+	}
+	delete(s.deps, id)
+	delete(s.entries, id)
+	if len(s.reverse[id]) == 0 && s.pending[id] == nil && len(s.deps[id]) == 0 {
+		delete(s.reverse, id)
+		delete(s.keys, id)
+		delete(s.epochs, id)
+	}
+}
+
+func (s *Store) maybeRemoveDependencyMetadataLocked(id string) {
+	if _, ok := s.entries[id]; ok {
+		return
+	}
+	if s.pending[id] != nil || len(s.reverse[id]) != 0 || len(s.deps[id]) != 0 {
+		return
+	}
+	delete(s.keys, id)
+	delete(s.epochs, id)
+}
+
+func (s *Store) pruneEntriesLocked() {
+	for len(s.entries) > s.maxEntries && len(s.order) > 0 {
+		oldest := s.order[0]
+		s.order = s.order[1:]
+		if _, ok := s.entries[oldest]; !ok {
+			continue
+		}
+		s.removeNodeLocked(oldest)
+	}
+	if len(s.order) > s.maxEntries*2 {
+		compact := make([]string, 0, len(s.entries))
+		seen := make(map[string]struct{}, len(s.entries))
+		for _, id := range s.order {
+			if _, ok := s.entries[id]; !ok {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			compact = append(compact, id)
+		}
+		s.order = compact
+	}
+}
+
+func (s *Store) pruneRevisionsLocked() {
+	if len(s.revisions) <= s.maxRevisions {
+		return
+	}
+	for id, state := range s.revisions {
+		if len(s.revisions) <= s.maxRevisions {
+			break
+		}
+		if state.refs == 0 && id != s.latest {
+			delete(s.revisions, id)
+		}
+	}
+}

--- a/internal/analyze/semanticquery/query_test.go
+++ b/internal/analyze/semanticquery/query_test.go
@@ -207,3 +207,15 @@ func TestEvictionBoundsDependencyMetadata(t *testing.T) {
 		t.Fatalf("dependency metadata exceeded bounds: entries=%d keys=%d reverse=%d order=%d", len(store.entries), len(store.keys), len(store.reverse), len(store.order))
 	}
 }
+
+func TestRecordDependenciesBoundsMetadata(t *testing.T) {
+	store := New(Options{MaxEntries: 2})
+	for index := 0; index < 32; index++ {
+		parent := Key{Procedure: "M.Parent", Fingerprint: Hash(fmt.Sprintf("parent-%d", index)), Kernel: "summary"}
+		dependency := Key{Procedure: "M.Dependency", Fingerprint: Hash(fmt.Sprintf("dependency-%d", index)), Kernel: "module"}
+		store.RecordDependencies(parent, dependency)
+	}
+	if len(store.entries) > 2 || len(store.keys) > 4 || len(store.reverse) > 2 || len(store.deps) > 2 || len(store.order) > 4 {
+		t.Fatalf("recorded dependency metadata exceeded bounds: entries=%d keys=%d reverse=%d deps=%d order=%d", len(store.entries), len(store.keys), len(store.reverse), len(store.deps), len(store.order))
+	}
+}

--- a/internal/analyze/semanticquery/query_test.go
+++ b/internal/analyze/semanticquery/query_test.go
@@ -219,3 +219,18 @@ func TestRecordDependenciesBoundsMetadata(t *testing.T) {
 		t.Fatalf("recorded dependency metadata exceeded bounds: entries=%d keys=%d reverse=%d deps=%d order=%d", len(store.entries), len(store.keys), len(store.reverse), len(store.deps), len(store.order))
 	}
 }
+
+func TestRecordDependenciesPlaceholderDoesNotHit(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("r1")
+	defer revision.Close()
+	parent := Key{Procedure: "M.Parent", Fingerprint: Hash("parent"), Kernel: "summary"}
+	dependency := Key{Procedure: "M.Dependency", Fingerprint: Hash("dependency"), Kernel: "module"}
+	store.RecordDependencies(parent, dependency)
+	value, hit, err := Evaluate(context.Background(), revision, parent, []Key{dependency}, func(context.Context) (int, error) {
+		return 42, nil
+	})
+	if err != nil || hit || value != 42 {
+		t.Fatalf("metadata placeholder evaluation = %d, hit %v, err %v", value, hit, err)
+	}
+}

--- a/internal/analyze/semanticquery/query_test.go
+++ b/internal/analyze/semanticquery/query_test.go
@@ -1,0 +1,209 @@
+package semanticquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type testMetrics struct {
+	hits, misses, invalidated, recomputed atomic.Uint64
+}
+
+func (m *testMetrics) RecordSemanticQueryHit()                           { m.hits.Add(1) }
+func (m *testMetrics) RecordSemanticQueryMiss()                          { m.misses.Add(1) }
+func (m *testMetrics) RecordSemanticQueryInvalidatedProcedures(n uint64) { m.invalidated.Add(n) }
+func (m *testMetrics) RecordSemanticQueryRecomputedKernel()              { m.recomputed.Add(1) }
+
+func TestHashAndKeyAreStable(t *testing.T) {
+	if Hash("a", "bc") == Hash("ab", "c") {
+		t.Fatal("length-prefixed hashes collided")
+	}
+	key := Key{Procedure: "module\x00proc", Fingerprint: Hash("body"), Kernel: "array", Config: "cfg", Capability: "cap"}
+	if key.String() == "" || key.String() != (Key{Procedure: "module\x00proc", Fingerprint: Hash("body"), Kernel: "array", Config: "cfg", Capability: "cap"}).String() {
+		t.Fatal("query key is not stable")
+	}
+}
+
+func TestEvaluateSingleFlightAndReuse(t *testing.T) {
+	metrics := &testMetrics{}
+	store := New(Options{Metrics: metrics})
+	revision := store.Begin("r1")
+	defer revision.Close()
+	key := Key{Procedure: "M.P", Fingerprint: Hash("body"), Kernel: "array"}
+	var builds atomic.Int32
+	var wg sync.WaitGroup
+	values := make([]int, 8)
+	for i := range values {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			value, _, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) {
+				builds.Add(1)
+				return 42, nil
+			})
+			if err != nil {
+				t.Errorf("evaluate: %v", err)
+				return
+			}
+			values[index] = value
+		}(i)
+	}
+	wg.Wait()
+	if builds.Load() != 1 {
+		t.Fatalf("builds = %d, want 1", builds.Load())
+	}
+	for _, value := range values {
+		if value != 42 {
+			t.Fatalf("value = %d, want 42", value)
+		}
+	}
+	if _, hit, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) { return 0, errors.New("must not build") }); err != nil || !hit {
+		t.Fatalf("reuse = hit %v, err %v", hit, err)
+	}
+	if metrics.recomputed.Load() != 1 || metrics.hits.Load() == 0 || metrics.misses.Load() == 0 {
+		t.Fatalf("metrics = hits %d misses %d recomputed %d", metrics.hits.Load(), metrics.misses.Load(), metrics.recomputed.Load())
+	}
+}
+
+func TestEvaluateRechecksDependencyFingerprintsOnHit(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("r1")
+	defer revision.Close()
+	key := Key{Procedure: "M.P", Fingerprint: Hash("body"), Kernel: "array"}
+	firstDependency := Key{Procedure: "M.Callee", Fingerprint: Hash("v1"), Kernel: "effect"}
+	secondDependency := Key{Procedure: "M.Callee", Fingerprint: Hash("v2"), Kernel: "effect"}
+	if value, hit, err := Evaluate(context.Background(), revision, key, []Key{firstDependency}, func(context.Context) (int, error) { return 1, nil }); err != nil || hit || value != 1 {
+		t.Fatalf("first evaluation = %d, hit %v, err %v", value, hit, err)
+	}
+	value, hit, err := Evaluate(context.Background(), revision, key, []Key{secondDependency}, func(context.Context) (int, error) { return 2, nil })
+	if err != nil || hit || value != 2 {
+		t.Fatalf("dependency change = %d, hit %v, err %v", value, hit, err)
+	}
+}
+
+func TestCanceledBuildIsRetryable(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("r1")
+	defer revision.Close()
+	key := Key{Procedure: "M.P", Fingerprint: Hash("body"), Kernel: "http"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) { return 0, ctx.Err() }); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled error = %v", err)
+	}
+	value, hit, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) { return 7, nil })
+	if err != nil || hit || value != 7 {
+		t.Fatalf("retry = %d, hit %v, err %v", value, hit, err)
+	}
+}
+
+func TestPanickingBuildDoesNotPoisonKey(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("r1")
+	defer revision.Close()
+	key := Key{Procedure: "M.P", Fingerprint: Hash("panic"), Kernel: "array"}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("panic was swallowed")
+			}
+		}()
+		_, _, _ = Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) {
+			panic("boom")
+		})
+	}()
+	value, hit, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) { return 9, nil })
+	if err != nil || hit || value != 9 {
+		t.Fatalf("retry after panic = %d, hit %v, err %v", value, hit, err)
+	}
+}
+
+func TestInvalidateTraversesReverseDependenciesDeterministically(t *testing.T) {
+	metrics := &testMetrics{}
+	store := New(Options{Metrics: metrics})
+	revision := store.Begin("r1")
+	defer revision.Close()
+	callee := Key{Procedure: "M.Callee", Fingerprint: Hash("callee"), Kernel: "effect"}
+	caller := Key{Procedure: "M.Caller", Fingerprint: Hash("caller"), Kernel: "array"}
+	project := Key{Procedure: "project", Fingerprint: Hash("project"), Kernel: "summary"}
+	for _, item := range []struct {
+		key   Key
+		value int
+	}{{callee, 1}, {caller, 2}, {project, 3}} {
+		if _, _, err := Evaluate(context.Background(), revision, item.key, nil, func(context.Context) (int, error) { return item.value, nil }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store.RecordDependencies(caller, callee)
+	store.RecordDependencies(project, caller)
+	got := store.Invalidate(callee)
+	want := []string{"M.Callee", "M.Caller", "project"}
+	if len(got) != len(want) {
+		t.Fatalf("invalidated = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("invalidated = %#v, want %#v", got, want)
+		}
+	}
+	if metrics.invalidated.Load() != uint64(len(want)) {
+		t.Fatalf("invalidated telemetry = %d", metrics.invalidated.Load())
+	}
+}
+
+func TestInvalidateProceduresFindsPrefixAndDependents(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("r1")
+	defer revision.Close()
+	callee := Key{Procedure: "C:\\src\\Main.bas::Main::Callee::0", Fingerprint: Hash("callee"), Kernel: "array"}
+	caller := Key{Procedure: "C:\\src\\Main.bas::Main::Caller::1", Fingerprint: Hash("caller"), Kernel: "array"}
+	project := Key{Procedure: "project", Fingerprint: Hash("project"), Kernel: "summary"}
+	for _, key := range []Key{callee, caller, project} {
+		if _, _, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) { return 1, nil }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store.RecordDependencies(caller, callee)
+	store.RecordDependencies(project, caller)
+	got := store.InvalidateProcedures(`C:\src\Main.bas::Main::Caller`)
+	want := []string{caller.Procedure, project.Procedure}
+	if len(got) != len(want) {
+		t.Fatalf("invalidated = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("invalidated = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestClosedRevisionRejectsQueries(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("r1")
+	revision.Close()
+	_, _, err := Evaluate(context.Background(), revision, Key{Kernel: "x"}, nil, func(context.Context) (int, error) { return 1, nil })
+	if !errors.Is(err, ErrRevisionClosed) {
+		t.Fatalf("error = %v, want ErrRevisionClosed", err)
+	}
+}
+
+func TestEvictionBoundsDependencyMetadata(t *testing.T) {
+	store := New(Options{MaxEntries: 2})
+	revision := store.Begin("r1")
+	defer revision.Close()
+	for index := 0; index < 32; index++ {
+		key := Key{Procedure: "M.P", Fingerprint: Hash(fmt.Sprintf("%d", index)), Kernel: "array"}
+		dependency := Key{Procedure: "M.Module", Fingerprint: Hash(fmt.Sprintf("dep-%d", index)), Kernel: "module"}
+		if _, _, err := Evaluate(context.Background(), revision, key, []Key{dependency}, func(context.Context) (int, error) { return index, nil }); err != nil {
+			t.Fatal(err)
+		}
+		store.Invalidate(key)
+	}
+	if len(store.entries) > 2 || len(store.keys) > 4 || len(store.reverse) > 4 || len(store.order) > 4 {
+		t.Fatalf("dependency metadata exceeded bounds: entries=%d keys=%d reverse=%d order=%d", len(store.entries), len(store.keys), len(store.reverse), len(store.order))
+	}
+}

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -27,6 +27,7 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 
 	"github.com/harumiWeb/xlflow/internal/analyze"
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
 	"github.com/harumiWeb/xlflow/internal/config"
 	formsintel "github.com/harumiWeb/xlflow/internal/excel/forms/intel"
 	"github.com/harumiWeb/xlflow/internal/lint"
@@ -97,12 +98,15 @@ type Server struct {
 	overlayBuilds       atomic.Uint64
 	overlayPublications atomic.Uint64
 
-	docLifecycleMu           sync.Mutex
-	docLifecycles            map[string]*sync.Mutex
-	projectSummaryCache      revisionCache[effects.ProjectSummary]
-	resolutionCache          revisionCache[projectResolutionResult]
-	projectConstantsCache    revisionCache[projectConstantsResult]
-	resolutionTypeLibSymbols []procedureir.ResolverSymbol
+	docLifecycleMu            sync.Mutex
+	docLifecycles             map[string]*sync.Mutex
+	projectSummaryCache       revisionCache[effects.ProjectSummary]
+	resolutionCache           revisionCache[projectResolutionResult]
+	projectConstantsCache     revisionCache[projectConstantsResult]
+	semanticQueries           *semanticquery.Store
+	semanticInvalidationMu    sync.Mutex
+	semanticInvalidationPaths map[string]struct{}
+	resolutionTypeLibSymbols  []procedureir.ResolverSymbol
 }
 
 type projectResolutionResult struct {
@@ -209,13 +213,15 @@ func New(opts Options) (*Server, func(), error) {
 				return out, nil
 			},
 		},
-		docs:            docs,
-		logger:          logger,
-		semanticTokens:  newSemanticTokenCache(),
-		codeLensConfig:  intel.DefaultCodeLensConfig(),
-		diagStates:      make(map[string]*diagnosticState),
-		docLifecycles:   make(map[string]*sync.Mutex),
-		analysisPermits: make(chan struct{}, max(1, runtime.GOMAXPROCS(0)/2)),
+		docs:                      docs,
+		logger:                    logger,
+		semanticTokens:            newSemanticTokenCache(),
+		codeLensConfig:            intel.DefaultCodeLensConfig(),
+		diagStates:                make(map[string]*diagnosticState),
+		docLifecycles:             make(map[string]*sync.Mutex),
+		semanticQueries:           semanticquery.DefaultStore(),
+		semanticInvalidationPaths: make(map[string]struct{}),
+		analysisPermits:           make(chan struct{}, max(1, runtime.GOMAXPROCS(0)/2)),
 	}
 	s.analysis = s.newWorkspaceAnalysisIndex()
 	s.analyzer.DocumentSymbolsFunc = s.cachedDocumentSourceSymbols
@@ -227,6 +233,11 @@ func New(opts Options) (*Server, func(), error) {
 	s.diagnosticsRequest = s.analyzer.DiagnosticsRequestContext
 	s.defaultDiagnosticsRequest = reflect.ValueOf(s.diagnosticsRequest).Pointer()
 	s.projectDiagnosticsRequest = func(ctx context.Context, request intel.DiagnosticRequest, project intel.ProjectAnalysisSnapshot) intel.DiagnosticResult {
+		ctx = semanticquery.WithContext(ctx, semanticquery.Context{
+			Store:    s.semanticQueries,
+			Revision: fmt.Sprintf("lsp-%d", project.Revision),
+			Metrics:  analysisstats.FromContext(ctx),
+		})
 		initializeCapabilityTelemetry(ctx)
 		projectByPath := make(map[string]intel.ProjectAnalysisDocument, len(project.Documents))
 		capabilityDocuments := make([]analyze.ProjectCapabilityDocument, 0, len(project.Documents))
@@ -714,6 +725,16 @@ func (s *Server) scheduleByRefDependentDiagnostics(ctx *glsp.Context, changedURI
 }
 
 func (s *Server) scheduleProjectDependentDiagnostics(ctx *glsp.Context, changedURI string, paths []string) {
+	if s.semanticQueries != nil && len(paths) > 0 {
+		s.semanticInvalidationMu.Lock()
+		if s.semanticInvalidationPaths == nil {
+			s.semanticInvalidationPaths = make(map[string]struct{})
+		}
+		for _, path := range paths {
+			s.semanticInvalidationPaths[path] = struct{}{}
+		}
+		s.semanticInvalidationMu.Unlock()
+	}
 	if !s.opts.Config.Analyze.DetectErrorSuppressionPropagation || len(paths) == 0 {
 		return
 	}
@@ -727,6 +748,22 @@ func (s *Server) scheduleProjectDependentDiagnostics(ctx *glsp.Context, changedU
 		if caller, ok := openByPath[symbolFileKey(path)]; ok {
 			s.scheduleDiagnosticsOnly(ctx, caller)
 		}
+	}
+}
+
+func (s *Server) flushSemanticInvalidations(ctx context.Context) {
+	if s.semanticQueries == nil {
+		return
+	}
+	s.semanticInvalidationMu.Lock()
+	paths := make([]string, 0, len(s.semanticInvalidationPaths))
+	for path := range s.semanticInvalidationPaths {
+		paths = append(paths, path)
+	}
+	s.semanticInvalidationPaths = make(map[string]struct{})
+	s.semanticInvalidationMu.Unlock()
+	if len(paths) > 0 {
+		s.semanticQueries.InvalidateProceduresContext(ctx, paths...)
 	}
 }
 
@@ -1793,6 +1830,8 @@ func (s *Server) runDiagnosticsBody(
 	measurement := s.startPerformance("diagnostics", doc)
 	recorder := analysisstats.NewRecorder()
 	runCtx = analysisstats.WithRecorder(runCtx, recorder)
+	runCtx = semanticquery.WithContext(runCtx, semanticquery.Context{Store: s.semanticQueries, Metrics: recorder})
+	s.flushSemanticInvalidations(runCtx)
 	if mode == intel.DiagnosticModeFull {
 		initializeCapabilityTelemetry(runCtx)
 	}

--- a/internal/vba/analysisstats/recorder.go
+++ b/internal/vba/analysisstats/recorder.go
@@ -142,9 +142,16 @@ const (
 	CounterPlannedKernelRuns
 	CounterSkippedKernelRuns
 	CounterSemanticResultsReused
+	// Semantic query counters are kept at the end of the fixed enum so adding
+	// them does not renumber the counters used by existing procedure-profile
+	// bitsets.
+	CounterSemanticQueryHits
+	CounterSemanticQueryMisses
+	CounterSemanticQueryInvalidatedProcedures
+	CounterSemanticQueryRecomputedKernels
 )
 
-const counterCount = int(CounterSemanticResultsReused) + 1
+const counterCount = int(CounterSemanticQueryRecomputedKernels) + 1
 
 // WorkCounterCount is the fixed number of counter slots used by
 // DomainAggregate. It is exposed for compile-time guards in lightweight
@@ -205,6 +212,10 @@ const (
 	PlannedKernelRunsCounter                   = "planned_kernel_runs"
 	SkippedKernelRunsCounter                   = "skipped_kernel_runs"
 	SemanticResultsReusedCounter               = "semantic_results_reused"
+	SemanticQueryHitsCounter                   = "semantic_query_hits"
+	SemanticQueryMissesCounter                 = "semantic_query_misses"
+	SemanticQueryInvalidatedProceduresCounter  = "semantic_query_invalidated_procedures"
+	SemanticQueryRecomputedKernelsCounter      = "semantic_query_recomputed_kernels"
 )
 
 var counterNames = [...]string{
@@ -261,6 +272,10 @@ var counterNames = [...]string{
 	PlannedKernelRunsCounter,
 	SkippedKernelRunsCounter,
 	SemanticResultsReusedCounter,
+	SemanticQueryHitsCounter,
+	SemanticQueryMissesCounter,
+	SemanticQueryInvalidatedProceduresCounter,
+	SemanticQueryRecomputedKernelsCounter,
 }
 
 // These paired array declarations fail compilation if a counter is added
@@ -580,6 +595,43 @@ func (r *Recorder) AddMax(name string, value uint64) {
 		r.counters[name] = value
 	}
 	r.mu.Unlock()
+}
+
+// Semantic query counters describe process-local revision-scoped query-store
+// activity. They are additive, opt-in telemetry and are emitted only through
+// the existing performance-log paths; they are not part of analysis results.
+// The singular helpers record one observation, while the plural forms allow a
+// caller that already has an aggregate count to publish it with one lock.
+func (r *Recorder) RecordSemanticQueryHit() {
+	r.RecordSemanticQueryHits(1)
+}
+
+func (r *Recorder) RecordSemanticQueryHits(count uint64) {
+	r.AddSum(SemanticQueryHitsCounter, count)
+}
+
+func (r *Recorder) RecordSemanticQueryMiss() {
+	r.RecordSemanticQueryMisses(1)
+}
+
+func (r *Recorder) RecordSemanticQueryMisses(count uint64) {
+	r.AddSum(SemanticQueryMissesCounter, count)
+}
+
+func (r *Recorder) RecordSemanticQueryInvalidatedProcedure() {
+	r.RecordSemanticQueryInvalidatedProcedures(1)
+}
+
+func (r *Recorder) RecordSemanticQueryInvalidatedProcedures(count uint64) {
+	r.AddSum(SemanticQueryInvalidatedProceduresCounter, count)
+}
+
+func (r *Recorder) RecordSemanticQueryRecomputedKernel() {
+	r.RecordSemanticQueryRecomputedKernels(1)
+}
+
+func (r *Recorder) RecordSemanticQueryRecomputedKernels(count uint64) {
+	r.AddSum(SemanticQueryRecomputedKernelsCounter, count)
 }
 
 // RecordModuleFactBuild records one construction of the immutable file-level

--- a/internal/vba/analysisstats/recorder_test.go
+++ b/internal/vba/analysisstats/recorder_test.go
@@ -90,6 +90,41 @@ func TestRecordFactBuildCountersNilSafe(t *testing.T) {
 	recorder.RecordProcedureFactBuild()
 }
 
+func TestSemanticQueryTelemetryCounters(t *testing.T) {
+	recorder := NewRecorder()
+	recorder.RecordSemanticQueryHit()
+	recorder.RecordSemanticQueryHits(2)
+	recorder.RecordSemanticQueryMiss()
+	recorder.RecordSemanticQueryMisses(3)
+	recorder.RecordSemanticQueryInvalidatedProcedure()
+	recorder.RecordSemanticQueryInvalidatedProcedures(4)
+	recorder.RecordSemanticQueryRecomputedKernel()
+	recorder.RecordSemanticQueryRecomputedKernels(5)
+
+	_, counters := recorder.Totals()
+	want := []Counter{
+		{Name: SemanticQueryHitsCounter, Value: 3},
+		{Name: SemanticQueryInvalidatedProceduresCounter, Value: 5},
+		{Name: SemanticQueryMissesCounter, Value: 4},
+		{Name: SemanticQueryRecomputedKernelsCounter, Value: 6},
+	}
+	if !reflect.DeepEqual(counters, want) {
+		t.Fatalf("semantic query counters = %+v, want %+v", counters, want)
+	}
+}
+
+func TestSemanticQueryTelemetryCountersNilSafe(t *testing.T) {
+	var recorder *Recorder
+	recorder.RecordSemanticQueryHit()
+	recorder.RecordSemanticQueryHits(2)
+	recorder.RecordSemanticQueryMiss()
+	recorder.RecordSemanticQueryMisses(2)
+	recorder.RecordSemanticQueryInvalidatedProcedure()
+	recorder.RecordSemanticQueryInvalidatedProcedures(2)
+	recorder.RecordSemanticQueryRecomputedKernel()
+	recorder.RecordSemanticQueryRecomputedKernels(2)
+}
+
 func TestCapabilityBuildTelemetry(t *testing.T) {
 	recorder := NewRecorder()
 
@@ -307,6 +342,10 @@ func TestDomainAndCounterNamesAreStable(t *testing.T) {
 		{CounterPlannedKernelRuns, PlannedKernelRunsCounter},
 		{CounterSkippedKernelRuns, SkippedKernelRunsCounter},
 		{CounterSemanticResultsReused, SemanticResultsReusedCounter},
+		{CounterSemanticQueryHits, SemanticQueryHitsCounter},
+		{CounterSemanticQueryMisses, SemanticQueryMissesCounter},
+		{CounterSemanticQueryInvalidatedProcedures, SemanticQueryInvalidatedProceduresCounter},
+		{CounterSemanticQueryRecomputedKernels, SemanticQueryRecomputedKernelsCounter},
 	}
 	for _, test := range planCounterNames {
 		if got := test.counter.String(); got != test.want {
@@ -325,12 +364,20 @@ func TestAnalysisPlanCountersMergeAsFixedWorkCounters(t *testing.T) {
 	aggregate.AddCounter(CounterPlannedKernelRuns, 3)
 	aggregate.AddCounter(CounterSkippedKernelRuns, 1)
 	aggregate.AddCounter(CounterSemanticResultsReused, 4)
+	aggregate.AddCounter(CounterSemanticQueryHits, 5)
+	aggregate.AddCounter(CounterSemanticQueryMisses, 6)
+	aggregate.AddCounter(CounterSemanticQueryInvalidatedProcedures, 7)
+	aggregate.AddCounter(CounterSemanticQueryRecomputedKernels, 8)
 	aggregate.Merge()
 
 	_, counters := recorder.Totals()
 	want := []Counter{
 		{Name: AnalysisPlansCounter, Value: 2},
 		{Name: PlannedKernelRunsCounter, Value: 3},
+		{Name: SemanticQueryHitsCounter, Value: 5},
+		{Name: SemanticQueryInvalidatedProceduresCounter, Value: 7},
+		{Name: SemanticQueryMissesCounter, Value: 6},
+		{Name: SemanticQueryRecomputedKernelsCounter, Value: 8},
 		{Name: SemanticResultsReusedCounter, Value: 4},
 		{Name: SkippedKernelRunsCounter, Value: 1},
 	}


### PR DESCRIPTION
## Summary

- Implement the revision-scoped semantic query DAG requested by #715.
- Reuse unaffected semantic kernel results across batch and LSP revisions while preserving deterministic diagnostics and process-local cache ownership.
- Track the remaining end-to-end wall-time optimization work in #724.

## Implementation

- Add `internal/analyze/semanticquery` with deterministic query keys, dependency edges, reverse invalidation, single-flight evaluation, cancellation and panic safety, bounded eviction, and revision handles.
- Integrate query reuse into array, generic dataflow, and HTTP dataflow procedure results, including defensive finding copies and physical-work telemetry.
- Add source, module, configuration, capability, effect-summary, and call-resolution fingerprints and dependency leaves.
- Queue and flush LSP semantic invalidations with request-scoped telemetry.
- Add semantic-query hit, miss, invalidation, and recomputation counters.
- Document ownership, invalidation boundaries, cancellation behavior, and verification requirements in ADR-0048 and the semantic query specification.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./...` — passed.
- Focused race tests for `internal/analyze/semanticquery` and `internal/analyze` — passed.
- `rtk task corpus:metrics` — passed.
- `rtk pnpm format:check` — passed.
- `rtk pnpm docs:check` — contract and link checks passed; the existing generated `vitepress/reference/error-code-inventory.md` remains stale.

## Performance observations

In the same three-iteration `ronecone` `analyze-only` benchmark, physical work decreased as follows:

- Array kernel runs: 912 → 462 per operation.
- Generic dataflow kernel runs: 1296 → 622 per operation.
- HTTP dataflow kernel runs: 13 → 5 per operation.

The current end-to-end benchmark is not yet faster than `origin/main` (9.68 s/op versus 10.28 s/op on the same host). Fingerprint and invalidation overhead is tracked separately in #724.

## Related issues

- Related to #715.
- Follow-up: #724.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reuses semantic analysis results across compatible revisions, reducing repeated computation.
  * Preserves consistent diagnostics across batch and live analysis.
  * Safely handles cancellations, invalidation, concurrency, and stale results.

* **Documentation**
  * Added specifications and architecture guidance for revision-scoped semantic query reuse.
  * Documented developer-only performance counters and verification requirements.

* **Bug Fixes**
  * Prevents cached mutable results from affecting subsequent analyses.
  * Ensures canceled or failed computations can be retried safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->