### PR TITLE
perf(analyze): optimize semantic query fingerprints and invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Reduced revision-scoped semantic query overhead by sharing prepared,
+  kernel-specific fingerprints across procedure lanes, using comparable cache
+  keys and exact document/procedure invalidation indexes, and separating cold,
+  warm, local-edit, and dependency-edit corpus benchmarks. Diagnostic, JSON,
+  LSP, cancellation, and process-local cache contracts remain unchanged.
+
 - Added process-local, revision-scoped semantic query reuse for unchanged
   analyzer work. Dependency-aware invalidation, cancellation safety, and
   stderr-only query telemetry preserve existing batch/LSP diagnostics; disk

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -181,17 +181,25 @@ tasks:
   bench:corpus:
     desc: Benchmark the analyzer stage for the slowest real-world corpus projects
     cmds:
-      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only$' -benchmem -benchtime=1x -count 2
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 2
         platforms: [windows]
-      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only$' -benchmem -benchtime=1x -count 2
+      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 2
+        platforms: [linux, darwin]
+
+  bench:corpus-semantic-query:
+    desc: Collect serial cold/warm/edit semantic-query benchmark samples for the corpus
+    cmds:
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 10
+        platforms: [windows]
+      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(std-vba|ronecone)/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 10
         platforms: [linux, darwin]
 
   bench:corpus-ronecone:
     desc: Benchmark the single-project ROneCOne analyzer stress fixture
     cmds:
-      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count 2
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 2
         platforms: [windows]
-      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count 2
+      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 2
         platforms: [linux, darwin]
 
   bench:analyze:

--- a/docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md
+++ b/docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md
@@ -54,6 +54,28 @@ fingerprints and revision-local IR/CFG IDs are not workspace-global identities;
 the canonical identity and current dependency fingerprints are required before
 an entry can be reused.
 
+### Amendment: fingerprint and invalidation overhead reduction (#724)
+
+The revision-owned analyzer projection prepares immutable configuration, TypeDB,
+module, capability, procedure, effect, and call-resolution leaves once before
+procedure workers run. The three reusable procedure lanes share those inputs;
+they do not serialize the same large maps or plans again for each lane. A
+procedure fingerprint contains procedure-local source and signature facts,
+while module, capability, data-flow, effect, and resolution leaves remain
+explicit dependencies at the kernel boundary. This separation may reduce a
+dependency set only when the kernel does not read the removed leaf; it must not
+weaken fail-open behavior for incomplete or ambiguous input.
+
+The store's internal identity is a comparable `Key` rather than a serialized
+string. Dependencies are canonicalized and deduplicated at publication, and
+reverse edges plus pending/epoch/eviction metadata use the same key. Exact
+document and procedure indexes service LSP invalidation, so a normalized path
+does not require scanning every cached key. These are private representations;
+the process-local lifetime, cancellation/single-flight behavior, late-result
+rejection, diagnostic projection, and public output contracts remain those
+decided by this ADR. No disk cache, cross-process format, or public API is
+introduced.
+
 ### Query graph and invalidation
 
 The graph contains immutable source/module and capability inputs, procedure

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1797,6 +1797,47 @@ ownership and invalidation contract is in
 `docs/specs/vba-semantic-query-dag.md` and
 `docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md`.
 
+### Fingerprint and invalidation overhead verification (#724)
+
+The #724 benchmark harness keeps cache cost and cache benefit separate for
+both the single-module ROneCOne workload and the representative many-file
+`std-vba` workload. Run the following leaves serially on the fixed Windows
+host and Go toolchain, using at least ten `-benchtime=1x -benchmem` samples for
+the retained performance record:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/(ronecone|std-vba)/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchtime=1x -count=10 -benchmem
+```
+
+`cold` uses a fresh process-local semantic query store for every operation;
+`warm` primes one store outside the timed region; `local-edit` changes only a
+benchmark-owned procedure body; and `dependency-edit` cycles benchmark-owned
+callee body, signature, effect, and caller redirect edits while keeping the
+caller/callee modules independent of the checked-in corpus sources. Retain
+`ns/op`, `B/op`, `allocs/op`, findings and
+warnings, semantic-query hits/misses/invalidations/recomputations, and the
+array, generic-dataflow, and HTTP physical-kernel counters. Record median and
+spread with the host, Go version, power state, and baseline SHAs
+`149ab7bb` (pre-#715) and `f47e3b56` (#715 implementation) when a comparison
+is performed. Query counters are developer telemetry only; never copy them to
+corpus snapshots or `reviews/diagnostics.jsonl`.
+
+The benchmark harness is measurement-only: it must not update snapshots or
+review classifications. Run corpus metrics and the verify-only corpus test
+twice after implementation. Any unexplained snapshot, finding, range,
+severity, evidence, ordering, suppression, or review-ledger change is a
+stop-and-investigate condition.
+
+The 2026-08-26 implementation smoke samples were collected on Windows/amd64,
+12th Gen Intel(R) Core(TM) i7-12700, Go 1.26.6. They are spot observations,
+not the required ten-sample baseline comparison: ROneCOne warm was 7.975--8.003
+s/op with 2,221 semantic-query hits, and the dependency-edit case was 8.019
+s/op with 2,223 hits, 4 misses, and 4 recomputed kernels. The `std-vba` warm
+spot was 13.503 s/op with 3,713 hits. The formal comparison against
+`149ab7bb` and `f47e3b56`, including median/spread, cold allocation limits, and
+95% confidence testing, remains unverified until the serial `-count=10`
+collection is retained on the fixed benchmark host.
+
 ## Related
 
 - `docs/adr/ADR-0029-vendored-static-analysis-corpus.md`

--- a/docs/specs/vba-semantic-query-dag.md
+++ b/docs/specs/vba-semantic-query-dag.md
@@ -19,6 +19,41 @@ file or serialization format, or share entries across processes. Parser and
 tree-sitter reuse, cold parsing optimization, and distributed caching remain
 outside this specification.
 
+## Fingerprint ownership and compact invalidation (#724)
+
+During revision construction the analyzer prepares immutable fingerprints for
+configuration, TypeDB, module declarations/context, array/data-flow capability leaves,
+procedure-local source/signature/features, effect summaries, and call
+resolution. Procedure workers share these facts across the array, generic
+data-flow, and HTTP lanes. A procedure-local fingerprint does not embed broad
+module maps; each lane records only the module/capability leaf it actually
+reads. A changed producer therefore changes downstream dependencies only when
+the leaf or output consumed by that downstream query changes. Unknown,
+recovered, ambiguous, and incomplete inputs remain conservative and fail open.
+
+The private store uses the comparable `semanticquery.Key` directly for cache,
+pending, reverse-edge, epoch, and eviction metadata. Published dependency
+slices are duplicate-free and canonical; procedure/document entry indexes are
+maintained as keys are added and removed. LSP passes normalized document paths
+to exact invalidation rather than scanning all key strings. Finding defensive
+copies and deterministic projection boundaries are unchanged.
+
+The developer benchmark contract has four independent revision cases for both
+ROneCOne and the representative `std-vba` many-file corpus:
+
+- `analyze-only/cold` creates a fresh process-local store per operation;
+- `analyze-only/warm` primes one store outside the timer and measures unchanged
+  repeated revisions;
+- `analyze-only/local-edit` changes only a benchmark-owned procedure body; and
+- `analyze-only/dependency-edit` cycles benchmark-owned callee body, signature,
+  effect, and caller-redirect edits while retaining independent caller/callee
+  modules.
+
+Each case reports wall time and allocations together with hits, misses,
+invalidated procedures, recomputed kernels, and the existing physical-kernel
+counters. Benchmark output is observational developer telemetry, not a cache
+compatibility contract or a corpus snapshot input.
+
 ## Ownership and revision lifetime
 
 The store owns immutable Go values and dependency metadata. Query values may

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -820,7 +820,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	analysisCtx := analysis.buildContextWithObjectAnalysisPlan(parsedFiles, objectAnalysis, capabilityPlan, procedureir.ProcedureOnlyResolver(resolutionResolver))
 	analysisCtx.queryRevision = queryRevision
 	recordArrayInterproceduralTelemetry(ctx, analysisCtx)
-	prepareSemanticQueryFacts(analysis, parsedFiles, analysisCtx)
+	prepareSemanticQueryFacts(analysis, parsedFiles, &analysisCtx)
 	finishArrayCapability(nil)
 	finishStage(len(analysisCtx.procedures), nil)
 	finishStage = analysisstats.Measure(ctx, "project_context_indexes")
@@ -1789,7 +1789,7 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 		contextFiles[0].Procedures = procedures
 		recordArrayInterproceduralTelemetry(ctx, analysisCtx)
 		analysisCtx.projectEffects = projectEffects
-		prepareSemanticQueryFacts(analyzer, contextFiles, analysisCtx)
+		prepareSemanticQueryFacts(analyzer, contextFiles, &analysisCtx)
 		// prepareSemanticQueryFacts attaches the immutable projection to the
 		// context-file slice; refresh the value copy used by realtime workers.
 		file = contextFiles[0]

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -357,6 +357,7 @@ type analysisContext struct {
 	arrayStats                *arrayInterproceduralStats
 	arrayByRefEntryStates     map[string]map[int]bool
 	arrayByRefEntryConditions map[string]map[int]string
+	arrayCapabilityIndex      *semanticArrayCapabilityIndex
 	procedures                map[string]procedureSignature
 	procedureResolver         procedureir.Resolver
 	objectAnalysis            *objectAnalysisContext
@@ -411,6 +412,11 @@ type parsedFile struct {
 	ArrayOptionBaseSet          bool
 	ConstantValues              map[string]constexpr.Value
 	DataFlowModuleBindings      map[string]bool
+	// semanticQueryFacts is populated once the immutable revision capabilities
+	// (effects, resolution and array participant state) are ready.  Procedure
+	// query lanes share this pointer so they do not rebuild the same source,
+	// dependency, or capability fingerprints for every lane.
+	semanticQueryFacts *semanticFileQueryFacts
 }
 
 type parsedFileAnalysisResult struct {
@@ -745,6 +751,13 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		for i := range parsedFiles {
 			materializeProcedureAnalysisPlans(&parsedFiles[i], projectEffects, analysis.Config.Analyze)
 		}
+		// Keep the revision-owned procedure projection authoritative for the
+		// semantic query preparation pass. The worker path still derives a
+		// defensive copy, but the prepared effect leaf must come from the same
+		// resolved project summary that those workers consume.
+		for i := range parsedFiles {
+			parsedFiles[i].Procedures = sourceProceduresWithEffects(parsedFiles[i], projectEffects)
+		}
 		// Effects can add conservative feature seeds (for example, an
 		// application-state mutation discovered through a propagated call or a
 		// With Application member). Recompute the capability plan before any
@@ -807,6 +820,7 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	analysisCtx := analysis.buildContextWithObjectAnalysisPlan(parsedFiles, objectAnalysis, capabilityPlan, procedureir.ProcedureOnlyResolver(resolutionResolver))
 	analysisCtx.queryRevision = queryRevision
 	recordArrayInterproceduralTelemetry(ctx, analysisCtx)
+	prepareSemanticQueryFacts(analysis, parsedFiles, analysisCtx)
 	finishArrayCapability(nil)
 	finishStage(len(analysisCtx.procedures), nil)
 	finishStage = analysisstats.Measure(ctx, "project_context_indexes")
@@ -1768,8 +1782,17 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 		file = contextFiles[0]
 		materializedProcedures := sourceProceduresWithEffects(file, projectEffects)
 		procedures = rebindRealtimeProcedureProjection(procedures, materializedProcedures)
+		// The prepared query facts are built from the context-file projection;
+		// attach the effect-bearing materialized procedures before preparation so
+		// callee effect leaves and procedure effect summaries stay coherent with
+		// the findings path below.
+		contextFiles[0].Procedures = procedures
 		recordArrayInterproceduralTelemetry(ctx, analysisCtx)
 		analysisCtx.projectEffects = projectEffects
+		prepareSemanticQueryFacts(analyzer, contextFiles, analysisCtx)
+		// prepareSemanticQueryFacts attaches the immutable projection to the
+		// context-file slice; refresh the value copy used by realtime workers.
+		file = contextFiles[0]
 		for i, proc := range procedures {
 			if i&0x1f == 0 {
 				if err := ctx.Err(); err != nil {

--- a/internal/analyze/semantic_query_integration.go
+++ b/internal/analyze/semantic_query_integration.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+	"github.com/harumiWeb/xlflow/internal/vba/effects"
 )
 
 // withSemanticQueryContext makes the process-local store and the request's
@@ -31,6 +33,378 @@ func withSemanticQueryContext(ctx context.Context) (context.Context, semanticque
 	return semanticquery.WithContext(ctx, value), value
 }
 
+// semanticQueryRevisionFacts are immutable inputs shared by every file and
+// every semantic lane in one analyzer revision.  The values deliberately stay
+// opaque strings at the semanticquery boundary, while the analyzer keeps the
+// expensive projections (configuration, type database, source and call
+// resolution) alive for the lifetime of the revision.
+type semanticQueryRevisionFacts struct {
+	config       string
+	configDigest string
+	analyzer     string
+	typeDB       string
+	arrayIndex   *semanticArrayCapabilityIndex
+}
+
+// semanticArrayCapabilityIndex is a normalized, immutable projection of the
+// project-wide array summaries. The old query path rebuilt and formatted every
+// source map for each procedure. Values are formatted once at revision setup;
+// procedure capabilities then perform direct leaf lookups only.
+type semanticArrayCapabilityIndex struct {
+	returns           map[string]string
+	allocationGuards  map[string]string
+	byRefAllocations  map[string]string
+	conditional       map[string]string
+	length            map[string]string
+	moduleAllocations map[string]string
+	moduleEntryStates map[string]string
+	byRefEntryStates  map[string]string
+	byRefConditions   map[string]string
+	participants      map[string]string
+}
+
+type semanticFileQueryFacts struct {
+	revision   *semanticQueryRevisionFacts
+	module     string
+	array      string
+	dataflow   string
+	procedures map[int]*semanticProcedureQueryFacts
+}
+
+type semanticProcedureQueryFacts struct {
+	identity          string
+	base              string
+	plan              string
+	effects           string
+	capabilities      map[string]string
+	capabilityDigests map[string]string
+	callDependencies  []semanticquery.Key
+}
+
+// prepareSemanticQueryFacts builds the revision/file/procedure projections
+// once, after all project capabilities have been materialized.  It is called
+// before procedure workers start and the resulting pointers are immutable.
+func prepareSemanticQueryFacts(a Analyzer, files []parsedFile, ctx analysisContext) {
+	configFingerprint := semanticConfigFingerprint(a.Config)
+	revision := &semanticQueryRevisionFacts{
+		config:       configFingerprint,
+		configDigest: semanticquery.Hash(configFingerprint),
+		analyzer:     semanticAnalyzerCapability(a),
+		typeDB:       semanticTypeDBFingerprint(a),
+	}
+	revision.arrayIndex = buildSemanticArrayCapabilityIndex(ctx)
+	ctx.arrayCapabilityIndex = revision.arrayIndex
+	targetFacts := make(map[string]*semanticProcedureQueryFacts)
+	for index := range files {
+		file := &files[index]
+		module := semanticModuleFactsFingerprint(*file)
+		file.moduleFactsFingerprint = module
+		facts := &semanticFileQueryFacts{
+			revision:   revision,
+			module:     module,
+			array:      semanticArrayModuleFingerprint(*file),
+			dataflow:   semanticDataflowModuleFingerprint(*file),
+			procedures: make(map[int]*semanticProcedureQueryFacts, len(file.Procedures)),
+		}
+		for _, proc := range file.procedures() {
+			capabilities := make(map[string]string, 3)
+			// Only lanes that the materialized plan can execute need a prepared
+			// capability. This keeps the revision setup from scanning the array
+			// indexes for procedures that are known not to enter that kernel.
+			if !proc.PlanReady || proc.Plan.runsKernel(procedureKernelArray) {
+				capabilities["array"] = semanticAnalysisCapabilityUncached(ctx, *file, proc, "array")
+			}
+			if !proc.PlanReady || proc.Plan.runsDataflowLane(procedureDataflowLaneGeneric) {
+				capabilities["dataflow"] = semanticAnalysisCapabilityUncached(analysisContext{}, *file, proc, "dataflow")
+			}
+			if !proc.PlanReady || proc.Plan.runsDataflowLane(procedureDataflowLaneHTTP) {
+				capabilities["http"] = semanticAnalysisCapabilityUncached(analysisContext{}, *file, proc, "http")
+			}
+			capabilityDigests := make(map[string]string, len(capabilities))
+			for kernel, capability := range capabilities {
+				capabilityDigests[kernel] = semanticquery.Hash(capability, revision.analyzer, revision.typeDB)
+			}
+			procedure := &semanticProcedureQueryFacts{
+				identity:          semanticProcedureIdentity(*file, proc),
+				base:              semanticProcedureBaseFingerprint(a, *file, proc),
+				plan:              semanticProcedurePlanFingerprint(proc.Plan),
+				effects:           semanticquery.Hash(semanticProcedureEffectFingerprint(proc.Effects)),
+				capabilities:      capabilities,
+				capabilityDigests: capabilityDigests,
+			}
+			facts.procedures[proc.Index] = procedure
+			targetFacts[semanticCallTargetKey(file.Path, proc.Module+"."+proc.Name, string(proc.ProcedureKind), proc.StartLine)] = procedure
+		}
+		file.semanticQueryFacts = facts
+	}
+	for index := range files {
+		file := &files[index]
+		facts := file.semanticQueryFacts
+		if facts == nil {
+			continue
+		}
+		for _, proc := range file.procedures() {
+			if procedure := facts.procedures[proc.Index]; procedure != nil {
+				procedure.callDependencies = semanticCallDependencies(*file, proc, targetFacts)
+			}
+		}
+	}
+}
+
+func buildSemanticArrayCapabilityIndex(ctx analysisContext) *semanticArrayCapabilityIndex {
+	return &semanticArrayCapabilityIndex{
+		returns:           normalizeSemanticCapabilityMap(ctx.arrayReturns),
+		allocationGuards:  normalizeSemanticCapabilityMap(ctx.arrayAllocationGuards),
+		byRefAllocations:  normalizeSemanticCapabilityMap(ctx.arrayByRefAllocations),
+		conditional:       normalizeSemanticCapabilityMap(ctx.arrayByRefConditionalAllocations),
+		length:            normalizeSemanticCapabilityMap(ctx.arrayByRefLengthAllocations),
+		moduleAllocations: normalizeSemanticCapabilityMap(ctx.arrayModuleAllocations),
+		moduleEntryStates: normalizeSemanticCapabilityMap(ctx.arrayModuleEntryStates),
+		byRefEntryStates:  normalizeSemanticCapabilityMap(ctx.arrayByRefEntryStates),
+		byRefConditions:   normalizeSemanticCapabilityMap(ctx.arrayByRefEntryConditions),
+		participants:      normalizeSemanticCapabilityMap(ctx.arrayParticipants),
+	}
+}
+
+func normalizeSemanticCapabilityMap[T any, M ~map[string]T](values M) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	grouped := make(map[string][]string, len(values))
+	for key, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "" {
+			continue
+		}
+		grouped[normalized] = append(grouped[normalized], fmt.Sprintf("%#v", value))
+	}
+	result := make(map[string]string, len(grouped))
+	for key, values := range grouped {
+		sort.Strings(values)
+		unique := values[:0]
+		for _, value := range values {
+			if len(unique) == 0 || unique[len(unique)-1] != value {
+				unique = append(unique, value)
+			}
+		}
+		result[key] = strings.Join(unique, "\x1f")
+	}
+	return result
+}
+
+func semanticConfigFingerprint(cfg config.Config) string {
+	return semanticStableJSON(cfg.Analyze)
+}
+
+func semanticDataflowModuleFingerprint(file parsedFile) string {
+	if len(file.DataFlowModuleBindings) == 0 {
+		return ""
+	}
+	return semanticStableJSON(file.DataFlowModuleBindings)
+}
+
+func semanticArrayModuleFingerprint(file parsedFile) string {
+	facts := file.ModuleFacts
+	if facts == nil {
+		return ""
+	}
+	return semanticquery.Hash(
+		semanticStableJSON(facts.moduleDeclarations),
+		semanticStableJSON(facts.arrayOperationsByName),
+		semanticStableJSON(facts.arrayOperationsByLine),
+		semanticStableJSON(file.ArrayIntegerModuleConstants),
+		semanticStableJSON(file.RangeValueModuleConstants),
+		semanticStableJSON(file.ConstantValues),
+		fmt.Sprintf("option-base:%d:%t", file.ArrayOptionBase, file.ArrayOptionBaseSet),
+	)
+}
+
+func semanticProcedureBaseFingerprint(a Analyzer, file parsedFile, proc sourceProcedure) string {
+	start, end := proc.StartByte, proc.EndByte
+	if start < 0 {
+		start = 0
+	}
+	if end < start {
+		end = start
+	}
+	if start > len(file.Source) {
+		start = len(file.Source)
+	}
+	if end > len(file.Source) {
+		end = len(file.Source)
+	}
+	body := file.Source[start:end]
+	return semanticquery.Hash(
+		a.RootDir,
+		semanticCanonicalPath(file.Path),
+		file.Module,
+		file.ModuleKind,
+		proc.Name,
+		proc.Kind,
+		string(proc.ProcedureKind),
+		proc.ReturnType,
+		string(body),
+		semanticProcedureNearbyFingerprint(file, proc),
+		semanticProcedureFeatureFingerprint(proc.Features),
+	)
+}
+
+// procedureAnalysisPlan and procedureFeatureSet intentionally keep their
+// compact bit fields private. JSON cannot observe those fields, so the query
+// boundary uses explicit scalar encodings instead of serializing a misleading
+// empty object for every plan or feature set.
+func semanticProcedurePlanFingerprint(plan procedureAnalysisPlan) string {
+	return fmt.Sprintf("%d:%d:%d:%d:%d:%d:%d:%d",
+		plan.enabled,
+		plan.planned,
+		plan.enabledKernels,
+		plan.plannedKernels,
+		plan.enabledProjections,
+		plan.plannedProjections,
+		plan.enabledDataflowLanes,
+		plan.plannedDataflowLanes,
+	)
+}
+
+func semanticProcedureFeatureFingerprint(features procedureFeatureSet) string {
+	return fmt.Sprintf("%d:%d", uint64(features.present), uint64(features.unknown))
+}
+
+func semanticProcedureEffectFingerprint(summary *effects.ProcedureSummary) string {
+	if summary == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(semanticEffectKinds)+8)
+	for _, kind := range semanticEffectKinds {
+		if summary.Has(kind) {
+			parts = append(parts, "effect:"+string(kind))
+		}
+	}
+	for _, uncertainty := range append(append([]effects.CallUncertainty(nil), summary.DirectUncertainty...), summary.PropagatedUncertainty...) {
+		parts = append(parts, "uncertainty:"+string(uncertainty.Kind))
+	}
+	sort.Strings(parts)
+	parts = append(parts,
+		fmt.Sprintf("error-handler:%t", summary.Error.HasErrorHandler),
+		fmt.Sprintf("error-resume-next:%t", summary.Error.UsesResumeNext),
+		fmt.Sprintf("error-suppresses:%t", summary.Error.SuppressesErrors),
+		fmt.Sprintf("error-rethrows:%t", summary.Error.RethrowsErrors),
+		fmt.Sprintf("error-success:%t", summary.Error.ReturnsSuccessFlag),
+		fmt.Sprintf("error-raises:%t", summary.Error.MayRaise),
+		fmt.Sprintf("error-logs:%t", summary.Error.LogsAndContinues),
+	)
+	return semanticquery.Hash(parts...)
+}
+
+var semanticEffectKinds = [...]effects.EffectKind{
+	effects.WritesCells,
+	effects.ChangesWorkbook,
+	effects.OpensWorkbook,
+	effects.OpensFile,
+	effects.ClosesWorkbook,
+	effects.DisablesEvents,
+	effects.RestoresEvents,
+	effects.ChangesCalculation,
+	effects.Recalculates,
+	effects.ChangesSelection,
+	effects.ChangesControls,
+	effects.ShowsDialog,
+	effects.LaunchesProcess,
+	effects.SuppressesErrors,
+	effects.RaisesError,
+	effects.ChangesApplicationState,
+	effects.RestoresApplicationState,
+}
+
+// semanticProcedureNearbyFingerprint covers the small source window used by
+// finding evidence. The procedure body already covers all lines inside the
+// declaration; two lines on either side are enough to keep NearbyCode fresh
+// without making an edit elsewhere in the module invalidate every procedure.
+func semanticProcedureNearbyFingerprint(file parsedFile, proc sourceProcedure) string {
+	if len(file.Lines) == 0 {
+		return ""
+	}
+	start := proc.StartLine - 3 // StartLine is one-based; include two prior lines.
+	if start < 0 {
+		start = 0
+	}
+	end := proc.EndLine + 2 // Include two following lines (exclusive index below).
+	if end > len(file.Lines) {
+		end = len(file.Lines)
+	}
+	if end <= start {
+		return ""
+	}
+	return semanticStableJSON(file.Lines[start:end])
+}
+
+func semanticCallTargetKey(file, qualifiedName, kind string, line int) string {
+	return strings.Join([]string{
+		semanticCanonicalPath(file),
+		strings.ToLower(strings.TrimSpace(qualifiedName)),
+		strings.ToLower(strings.TrimSpace(kind)),
+		fmt.Sprintf("%d", line),
+	}, "\x00")
+}
+
+func semanticCallDependencies(file parsedFile, proc sourceProcedure, targetFacts map[string]*semanticProcedureQueryFacts) []semanticquery.Key {
+	dependencies := make([]semanticquery.Key, 0, proc.Calls.Len())
+	for index := 0; index < proc.Calls.Len(); index++ {
+		call, ok := proc.Calls.At(index)
+		if !ok {
+			continue
+		}
+		resolutionFingerprint := semanticStableJSON(call.Resolution)
+		if len(call.Resolution.Candidates) == 0 {
+			dependencies = append(dependencies, semanticquery.Key{
+				Procedure:   semanticCanonicalPath(file.Path),
+				Fingerprint: semanticquery.Hash(fmt.Sprintf("call:%d", call.ID), resolutionFingerprint),
+				Kernel:      "call-resolution",
+			})
+			continue
+		}
+		fingerprint := semanticquery.Hash(resolutionFingerprint)
+		for _, candidate := range call.Resolution.Candidates {
+			dependencies = append(dependencies, semanticquery.Key{
+				Procedure:   fmt.Sprintf("%s::%s::%s::%d", semanticCanonicalPath(candidate.File), candidate.QualifiedName, candidate.Kind, candidate.Line),
+				Fingerprint: fingerprint,
+				Kernel:      "call-resolution",
+			})
+			if target := targetFacts[semanticCallTargetKey(candidate.File, candidate.QualifiedName, candidate.Kind, candidate.Line)]; target != nil {
+				dependencies = append(dependencies,
+					semanticquery.Key{Procedure: target.identity, Fingerprint: target.base, Kernel: "callee-source"},
+					semanticquery.Key{Procedure: target.identity, Fingerprint: target.effects, Kernel: "callee-effect"},
+				)
+			}
+		}
+	}
+	if len(dependencies) < 2 {
+		return dependencies
+	}
+	sort.Slice(dependencies, func(i, j int) bool {
+		if dependencies[i].Procedure != dependencies[j].Procedure {
+			return dependencies[i].Procedure < dependencies[j].Procedure
+		}
+		if dependencies[i].Fingerprint != dependencies[j].Fingerprint {
+			return dependencies[i].Fingerprint < dependencies[j].Fingerprint
+		}
+		if dependencies[i].Kernel != dependencies[j].Kernel {
+			return dependencies[i].Kernel < dependencies[j].Kernel
+		}
+		if dependencies[i].Config != dependencies[j].Config {
+			return dependencies[i].Config < dependencies[j].Config
+		}
+		return dependencies[i].Capability < dependencies[j].Capability
+	})
+	unique := dependencies[:0]
+	for _, dependency := range dependencies {
+		if len(unique) == 0 || unique[len(unique)-1] != dependency {
+			unique = append(unique, dependency)
+		}
+	}
+	return unique
+}
+
 func semanticQueryRevisionID(rootDir string, cfg config.Config, files []parsedFile) string {
 	configBytes, err := json.Marshal(cfg.Analyze)
 	if err != nil {
@@ -46,65 +420,97 @@ func semanticQueryRevisionID(rootDir string, cfg config.Config, files []parsedFi
 }
 
 func semanticProcedureIdentity(file parsedFile, proc sourceProcedure) string {
-	return fmt.Sprintf("%s::%s::%s::%d", file.Path, file.Module, proc.Name, proc.Index)
+	return fmt.Sprintf("%s::%s::%s::%s", semanticCanonicalPath(file.Path), file.Module, proc.Name, proc.ProcedureKind)
+}
+
+// semanticCanonicalPath is the analyzer-side counterpart of the LSP
+// symbolFileKey. Query identities and exact document invalidation must agree
+// on cleaned, case-insensitive Windows paths even when one side originated in
+// a URI and the other originated in a workspace snapshot.
+func semanticCanonicalPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = filepath.Clean(path)
+	if runtime.GOOS == "windows" {
+		path = strings.ToLower(path)
+	}
+	return path
 }
 
 func semanticProcedureQueryKey(a Analyzer, file parsedFile, proc sourceProcedure, kernel string, plan procedureAnalysisPlan, capability string) semanticquery.Key {
-	start, end := proc.StartByte, proc.EndByte
-	if start < 0 {
-		start = 0
+	if facts := file.semanticQueryFacts; facts != nil {
+		if procedure := facts.procedures[proc.Index]; procedure != nil {
+			if preparedCapability, ok := procedure.capabilities[kernel]; ok {
+				capability = preparedCapability
+			}
+			planFingerprint := procedure.plan
+			if planFingerprint == "" {
+				planFingerprint = semanticProcedurePlanFingerprint(plan)
+			}
+			capabilityDigest := procedure.capabilityDigests[kernel]
+			if capabilityDigest == "" {
+				capabilityDigest = semanticquery.Hash(capability, facts.revision.analyzer, facts.revision.typeDB)
+			}
+			return semanticquery.Key{
+				Procedure:   procedure.identity,
+				Fingerprint: procedure.base,
+				Kernel:      kernel + ":" + planFingerprint,
+				Config:      facts.revision.configDigest,
+				Capability:  capabilityDigest,
+			}
+		}
 	}
-	if end < start {
-		end = start
-	}
-	if start > len(file.Source) {
-		start = len(file.Source)
-	}
-	if end > len(file.Source) {
-		end = len(file.Source)
-	}
-	body := file.Source[start:end]
-	configBytes, err := json.Marshal(a.Config.Analyze)
-	if err != nil {
-		configBytes = []byte(fmt.Sprintf("%#v", a.Config.Analyze))
-	}
-	fingerprint := semanticquery.Hash(
-		a.RootDir,
-		file.Path,
-		file.Module,
-		file.ModuleKind,
-		semanticModuleFactsFingerprint(file),
-		proc.Name,
-		proc.Kind,
-		string(proc.ProcedureKind),
-		proc.ReturnType,
-		fmt.Sprintf("%d", proc.Index),
-		fmt.Sprintf("%d:%d:%d:%d", proc.StartLine, proc.EndLine, proc.StartByte, proc.EndByte),
-		fmt.Sprintf("option-base:%d:%t", file.ArrayOptionBase, file.ArrayOptionBaseSet),
-		fmt.Sprintf("%#v", file.ArrayIntegerModuleConstants),
-		fmt.Sprintf("%#v", file.RangeValueModuleConstants),
-		fmt.Sprintf("%#v", file.ConstantValues),
-		fmt.Sprintf("%#v", file.DataFlowModuleBindings),
-		string(body),
-		fmt.Sprintf("%#v", proc.Features),
-		semanticStableJSON(proc.Effects),
-	)
+	fingerprint := semanticProcedureBaseFingerprint(a, file, proc)
 	return semanticquery.Key{
 		Procedure:   semanticProcedureIdentity(file, proc),
 		Fingerprint: fingerprint,
-		Kernel:      kernel + ":" + fmt.Sprintf("%#v", plan),
-		Config:      semanticquery.Hash(string(configBytes)),
+		Kernel:      kernel + ":" + semanticProcedurePlanFingerprint(plan),
+		Config:      semanticquery.Hash(semanticConfigFingerprint(a.Config)),
 		Capability:  semanticquery.Hash(capability, semanticAnalyzerCapability(a), semanticTypeDBFingerprint(a)),
 	}
 }
 
 func semanticQueryDependencies(key semanticquery.Key, file parsedFile, proc sourceProcedure) []semanticquery.Key {
+	if facts := file.semanticQueryFacts; facts != nil {
+		if procedure := facts.procedures[proc.Index]; procedure != nil {
+			kernel := key.Kernel
+			if delimiter := strings.IndexByte(kernel, ':'); delimiter >= 0 {
+				kernel = kernel[:delimiter]
+			}
+			dependencies := []semanticquery.Key{
+				{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "source"},
+				{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "config", Config: key.Config},
+				{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "capability", Capability: key.Capability},
+				{Procedure: key.Procedure, Fingerprint: procedure.effects, Kernel: "effect-summary"},
+			}
+			// Keep module inputs at the leaf granularity consumed by each lane.
+			// The array leaf contains module array indexes/constants; dataflow and
+			// HTTP use their module binding/declaration leaves. This prevents an
+			// unrelated lane from being invalidated by a changed map.
+			switch kernel {
+			case "array":
+				dependencies = append(dependencies, semanticquery.Key{Procedure: semanticCanonicalPath(file.Path), Fingerprint: facts.array, Kernel: "array-module"})
+			case "dataflow":
+				dependencies = append(dependencies, semanticquery.Key{Procedure: semanticCanonicalPath(file.Path), Fingerprint: facts.dataflow, Kernel: "dataflow-module"})
+			case "http":
+				dependencies = append(dependencies,
+					semanticquery.Key{Procedure: semanticCanonicalPath(file.Path), Fingerprint: facts.module, Kernel: "module-context"},
+					semanticquery.Key{Procedure: semanticCanonicalPath(file.Path), Fingerprint: facts.dataflow, Kernel: "dataflow-module"},
+				)
+			default:
+				dependencies = append(dependencies, semanticquery.Key{Procedure: semanticCanonicalPath(file.Path), Fingerprint: facts.module, Kernel: "module-context"})
+			}
+			return append(dependencies, procedure.callDependencies...)
+		}
+	}
 	dependencies := []semanticquery.Key{
 		{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "source"},
 		{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "config", Config: key.Config},
 		{Procedure: key.Procedure, Fingerprint: key.Fingerprint, Kernel: "capability", Capability: key.Capability},
-		{Procedure: file.Path, Fingerprint: semanticquery.Hash(semanticModuleFactsFingerprint(file)), Kernel: "module"},
-		{Procedure: key.Procedure, Fingerprint: semanticStableJSON(proc.Effects), Kernel: "effect-summary"},
+		{Procedure: semanticCanonicalPath(file.Path), Fingerprint: semanticquery.Hash(semanticModuleFactsFingerprint(file)), Kernel: "module"},
+		{Procedure: key.Procedure, Fingerprint: semanticProcedureEffectFingerprint(proc.Effects), Kernel: "effect-summary"},
 	}
 	for index := 0; index < proc.Calls.Len(); index++ {
 		call, ok := proc.Calls.At(index)
@@ -114,7 +520,7 @@ func semanticQueryDependencies(key semanticquery.Key, file parsedFile, proc sour
 		resolutionFingerprint := semanticStableJSON(call.Resolution)
 		if len(call.Resolution.Candidates) == 0 {
 			dependencies = append(dependencies, semanticquery.Key{
-				Procedure:   file.Path,
+				Procedure:   semanticCanonicalPath(file.Path),
 				Fingerprint: semanticquery.Hash(fmt.Sprintf("call:%d", call.ID), resolutionFingerprint),
 				Kernel:      "call-resolution",
 			})
@@ -122,7 +528,7 @@ func semanticQueryDependencies(key semanticquery.Key, file parsedFile, proc sour
 		}
 		for _, candidate := range call.Resolution.Candidates {
 			dependencies = append(dependencies, semanticquery.Key{
-				Procedure:   fmt.Sprintf("%s::%s::%s::%d", candidate.File, candidate.QualifiedName, candidate.Kind, candidate.Line),
+				Procedure:   fmt.Sprintf("%s::%s::%s::%d", semanticCanonicalPath(candidate.File), candidate.QualifiedName, candidate.Kind, candidate.Line),
 				Fingerprint: semanticquery.Hash(resolutionFingerprint),
 				Kernel:      "call-resolution",
 			})
@@ -132,22 +538,23 @@ func semanticQueryDependencies(key semanticquery.Key, file parsedFile, proc sour
 }
 
 func semanticAnalyzerCapability(a Analyzer) string {
-	return semanticquery.Hash(fmt.Sprintf("%#v", a.visibleConstants), fmt.Sprintf("%#v", a.visibleConstantValues))
+	return semanticquery.Hash(semanticStableJSON(a.visibleConstants), semanticStableJSON(a.visibleConstantValues))
 }
 
 func semanticTypeDBFingerprint(a Analyzer) string {
 	if a.typeDB == nil {
 		return ""
 	}
-	if value, ok := semanticTypeDBFingerprints.Load(a.typeDB); ok {
-		return value.(string)
-	}
-	fingerprint := semanticStableJSON(a.typeDB.AllConstantsList())
-	actual, _ := semanticTypeDBFingerprints.LoadOrStore(a.typeDB, fingerprint)
-	return actual.(string)
+	// The DB is immutable for an analyzer revision. Serialize its compact
+	// canonical maps directly instead of materializing and retaining a large
+	// AllConstantsList for every short-lived DB pointer created by tests or
+	// realtime requests. encoding/json orders map keys, while the candidate
+	// buckets retain their deterministic load order.
+	return semanticquery.Hash(
+		semanticStableJSON(a.typeDB.Constants),
+		semanticStableJSON(a.typeDB.ConstantCandidates),
+	)
 }
-
-var semanticTypeDBFingerprints sync.Map // map[*vbadb.DB]string
 
 func semanticModuleFactsFingerprint(file parsedFile) string {
 	if file.moduleFactsFingerprint != "" {
@@ -158,18 +565,26 @@ func semanticModuleFactsFingerprint(file parsedFile) string {
 		return ""
 	}
 	return semanticquery.Hash(
-		fmt.Sprintf("%#v", facts.moduleDeclarations),
-		fmt.Sprintf("%#v", facts.constants),
-		fmt.Sprintf("%#v", facts.moduleConstantNames),
-		fmt.Sprintf("%#v", facts.procedureNames),
-		fmt.Sprintf("%#v", facts.privateModule),
-		fmt.Sprintf("%#v", facts.arrayOperationsByName),
-		fmt.Sprintf("%#v", facts.arrayOperationsByLine),
-		fmt.Sprintf("%#v", facts.lineFacts),
+		semanticStableJSON(facts.moduleDeclarations),
+		semanticStableJSON(facts.constants),
+		semanticStableJSON(facts.moduleConstantNames),
+		semanticStableJSON(facts.procedureNames),
+		semanticStableJSON(facts.privateModule),
 	)
 }
 
 func semanticAnalysisCapability(ctx analysisContext, file parsedFile, proc sourceProcedure, kernel string) string {
+	if facts := file.semanticQueryFacts; facts != nil {
+		if procedure := facts.procedures[proc.Index]; procedure != nil {
+			if capability, ok := procedure.capabilities[kernel]; ok {
+				return capability
+			}
+		}
+	}
+	return semanticAnalysisCapabilityUncached(ctx, file, proc, kernel)
+}
+
+func semanticAnalysisCapabilityUncached(ctx analysisContext, file parsedFile, proc sourceProcedure, kernel string) string {
 	// These maps are immutable for one analysis context. Including the relevant
 	// capability projection in the key prevents a stale value when resolution,
 	// effect summaries, or array participant closure changes.
@@ -178,7 +593,7 @@ func semanticAnalysisCapability(ctx analysisContext, file parsedFile, proc sourc
 		parts := []string{
 			fmt.Sprintf("%t", proc.ArrayParticipant),
 			fmt.Sprintf("%t", proc.ArrayParticipantReady),
-			semanticStableJSON(proc.Effects),
+			semanticProcedureEffectFingerprint(proc.Effects),
 			fmt.Sprintf("%#v", ctx.arrayModuleConfigurations[file.Path]),
 		}
 		keys := []string{arrayProcedureKey(proc), strings.ToLower(proc.Name)}
@@ -193,24 +608,49 @@ func semanticAnalysisCapability(ctx analysisContext, file parsedFile, proc sourc
 				}
 			}
 		}
+		var (
+			returns, allocationGuards, byRefAllocations map[string]string
+			conditional, length, moduleAllocations      map[string]string
+			moduleEntryStates, byRefEntryStates         map[string]string
+			byRefConditions, participants               map[string]string
+		)
+		if index := ctx.arrayCapabilityIndex; index != nil {
+			returns = index.returns
+			allocationGuards = index.allocationGuards
+			byRefAllocations = index.byRefAllocations
+			conditional = index.conditional
+			length = index.length
+			moduleAllocations = index.moduleAllocations
+			moduleEntryStates = index.moduleEntryStates
+			byRefEntryStates = index.byRefEntryStates
+			byRefConditions = index.byRefConditions
+			participants = index.participants
+		}
 		parts = append(parts,
-			semanticMapSubset(ctx.arrayReturns, keys),
-			semanticMapSubset(ctx.arrayAllocationGuards, keys),
-			semanticMapSubset(ctx.arrayByRefAllocations, keys),
-			semanticMapSubset(ctx.arrayByRefConditionalAllocations, keys),
-			semanticMapSubset(ctx.arrayByRefLengthAllocations, keys),
-			semanticMapSubset(ctx.arrayModuleAllocations, keys),
-			semanticMapSubset(ctx.arrayModuleEntryStates, keys),
-			semanticMapSubset(ctx.arrayByRefEntryStates, keys),
-			semanticMapSubset(ctx.arrayByRefEntryConditions, keys),
-			semanticMapSubset(ctx.arrayParticipants, keys),
+			semanticArrayCapabilitySubset(returns, ctx.arrayReturns, keys),
+			semanticArrayCapabilitySubset(allocationGuards, ctx.arrayAllocationGuards, keys),
+			semanticArrayCapabilitySubset(byRefAllocations, ctx.arrayByRefAllocations, keys),
+			semanticArrayCapabilitySubset(conditional, ctx.arrayByRefConditionalAllocations, keys),
+			semanticArrayCapabilitySubset(length, ctx.arrayByRefLengthAllocations, keys),
+			semanticArrayCapabilitySubset(moduleAllocations, ctx.arrayModuleAllocations, keys),
+			semanticArrayCapabilitySubset(moduleEntryStates, ctx.arrayModuleEntryStates, keys),
+			semanticArrayCapabilitySubset(byRefEntryStates, ctx.arrayByRefEntryStates, keys),
+			semanticArrayCapabilitySubset(byRefConditions, ctx.arrayByRefEntryConditions, keys),
+			semanticArrayCapabilitySubset(participants, ctx.arrayParticipants, keys),
 		)
 		return semanticquery.Hash(parts...)
 	case "dataflow", "http":
-		return semanticquery.Hash(fmt.Sprintf("%#v", file.DataFlowModuleBindings), semanticStableJSON(proc.Effects))
+		return semanticquery.Hash(semanticDataflowModuleFingerprint(file), semanticProcedureEffectFingerprint(proc.Effects))
 	default:
-		return semanticquery.Hash(semanticStableJSON(proc.Effects))
+		return semanticquery.Hash(semanticProcedureEffectFingerprint(proc.Effects))
 	}
+}
+
+func semanticArrayCapabilitySubset[T any, M ~map[string]T](prepared map[string]string, fallback M, wanted []string) string {
+	if prepared == nil {
+		return semanticMapSubset(fallback, wanted)
+	}
+	return semanticNormalizedMapSubset(prepared, wanted)
 }
 
 func semanticStableJSON(value any) string {
@@ -221,27 +661,75 @@ func semanticStableJSON(value any) string {
 	return string(encoded)
 }
 
-func semanticMapSubset[T any, M ~map[string]T](values M, wanted []string) string {
+func semanticNormalizedMapSubset(values map[string]string, wanted []string) string {
 	if len(values) == 0 || len(wanted) == 0 {
 		return ""
 	}
-	lookup := make(map[string]struct{}, len(wanted))
+	selected := make(map[string]struct{}, len(wanted))
 	for _, key := range wanted {
 		key = strings.ToLower(strings.TrimSpace(key))
-		if key != "" {
-			lookup[key] = struct{}{}
+		if _, ok := values[key]; ok {
+			selected[key] = struct{}{}
 		}
 	}
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		if _, ok := lookup[strings.ToLower(key)]; ok {
-			keys = append(keys, key)
-		}
+	keys := make([]string, 0, len(selected))
+	for key := range selected {
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	parts := make([]string, 0, len(keys))
 	for _, key := range keys {
-		parts = append(parts, fmt.Sprintf("%s=%#v", key, values[key]))
+		parts = append(parts, key+"="+values[key])
+	}
+	return strings.Join(parts, ";")
+}
+
+func semanticMapSubset[T any, M ~map[string]T](values M, wanted []string) string {
+	if len(values) == 0 || len(wanted) == 0 {
+		return ""
+	}
+	lookup := make(map[string]string, len(wanted))
+	for _, key := range wanted {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized != "" {
+			lookup[normalized] = key
+		}
+	}
+	selected := make(map[string]T, len(lookup))
+	for normalized, original := range lookup {
+		// Production indexes are normalized at construction time, so this is
+		// the common O(1) path. The exact lookup handles compatibility maps
+		// whose keys retain source casing.
+		if value, ok := values[original]; ok {
+			selected[original] = value
+			continue
+		}
+		if value, ok := values[normalized]; ok {
+			selected[normalized] = value
+			continue
+		}
+		found := ""
+		// Focused callers may provide non-normalized maps. Scan only when a
+		// requested leaf was not found directly; avoid the old full-map scan
+		// for the normal analyzer path.
+		for key := range values {
+			if strings.EqualFold(key, normalized) {
+				found = key
+				break
+			}
+		}
+		if found != "" {
+			selected[found] = values[found]
+		}
+	}
+	keys := make([]string, 0, len(selected))
+	for key := range selected {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%#v", key, selected[key]))
 	}
 	return strings.Join(parts, ";")
 }

--- a/internal/analyze/semantic_query_integration.go
+++ b/internal/analyze/semantic_query_integration.go
@@ -243,6 +243,7 @@ func semanticProcedureBaseFingerprint(a Analyzer, file parsedFile, proc sourcePr
 		proc.Kind,
 		string(proc.ProcedureKind),
 		proc.ReturnType,
+		fmt.Sprintf("position:%d:%d", proc.StartLine, proc.EndLine),
 		string(body),
 		semanticProcedureNearbyFingerprint(file, proc),
 		semanticProcedureFeatureFingerprint(proc.Features),

--- a/internal/analyze/semantic_query_integration.go
+++ b/internal/analyze/semantic_query_integration.go
@@ -84,7 +84,7 @@ type semanticProcedureQueryFacts struct {
 // prepareSemanticQueryFacts builds the revision/file/procedure projections
 // once, after all project capabilities have been materialized.  It is called
 // before procedure workers start and the resulting pointers are immutable.
-func prepareSemanticQueryFacts(a Analyzer, files []parsedFile, ctx analysisContext) {
+func prepareSemanticQueryFacts(a Analyzer, files []parsedFile, ctx *analysisContext) {
 	configFingerprint := semanticConfigFingerprint(a.Config)
 	revision := &semanticQueryRevisionFacts{
 		config:       configFingerprint,
@@ -92,7 +92,7 @@ func prepareSemanticQueryFacts(a Analyzer, files []parsedFile, ctx analysisConte
 		analyzer:     semanticAnalyzerCapability(a),
 		typeDB:       semanticTypeDBFingerprint(a),
 	}
-	revision.arrayIndex = buildSemanticArrayCapabilityIndex(ctx)
+	revision.arrayIndex = buildSemanticArrayCapabilityIndex(*ctx)
 	ctx.arrayCapabilityIndex = revision.arrayIndex
 	targetFacts := make(map[string]*semanticProcedureQueryFacts)
 	for index := range files {
@@ -112,7 +112,7 @@ func prepareSemanticQueryFacts(a Analyzer, files []parsedFile, ctx analysisConte
 			// capability. This keeps the revision setup from scanning the array
 			// indexes for procedures that are known not to enter that kernel.
 			if !proc.PlanReady || proc.Plan.runsKernel(procedureKernelArray) {
-				capabilities["array"] = semanticAnalysisCapabilityUncached(ctx, *file, proc, "array")
+				capabilities["array"] = semanticAnalysisCapabilityUncached(*ctx, *file, proc, "array")
 			}
 			if !proc.PlanReady || proc.Plan.runsDataflowLane(procedureDataflowLaneGeneric) {
 				capabilities["dataflow"] = semanticAnalysisCapabilityUncached(analysisContext{}, *file, proc, "dataflow")

--- a/internal/analyze/semantic_query_integration_test.go
+++ b/internal/analyze/semantic_query_integration_test.go
@@ -230,6 +230,14 @@ func TestSemanticArrayModuleFingerprintIncludesDeclarations(t *testing.T) {
 	}
 }
 
+func TestPrepareSemanticQueryFactsPublishesPreparedArrayIndex(t *testing.T) {
+	ctx := analysisContext{}
+	prepareSemanticQueryFacts(Analyzer{}, nil, &ctx)
+	if ctx.arrayCapabilityIndex == nil {
+		t.Fatal("prepared array capability index was not published to the caller context")
+	}
+}
+
 func TestSemanticProcedureIdentityUsesCanonicalPath(t *testing.T) {
 	file := parsedFile{Path: filepath.Join("workspace", "nested", "..", "Main.bas"), Module: "Main"}
 	proc := sourceProcedure{Name: "Run", ProcedureKind: procedureir.ProcedureSub}

--- a/internal/analyze/semantic_query_integration_test.go
+++ b/internal/analyze/semantic_query_integration_test.go
@@ -2,6 +2,7 @@ package analyze
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,6 +12,8 @@ import (
 	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+	"github.com/harumiWeb/xlflow/internal/vba/effects"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 func TestSemanticQueryReusesProcedureKernelsAcrossBatchRevisions(t *testing.T) {
@@ -91,5 +94,184 @@ End Sub
 	}
 	if changedCounters[analysisstats.SemanticQueryRecomputedKernelsCounter] >= firstCounters[analysisstats.SemanticQueryRecomputedKernelsCounter] {
 		t.Fatalf("local edit recomputed every kernel: first=%v changed=%v", firstCounters, changedCounters)
+	}
+}
+
+func TestSemanticQueryWarmMatchesFreshAcrossRevisionChanges(t *testing.T) {
+	dir := t.TempDir()
+	callee := `Option Explicit
+Public Function Compute(value As Long) As Long
+    Compute = value
+End Function
+`
+	caller := `Option Explicit
+Public Sub Run()
+    Dim result As Long
+    result = Compute(1)
+End Sub
+`
+	other := `Option Explicit
+Public Function ComputeOther(value As Long) As Long
+    ComputeOther = value
+End Function
+`
+	writeCase := func(calleeSource, callerSource string) {
+		writeModule(t, dir, "Callee.bas", calleeSource)
+		writeModule(t, dir, "Caller.bas", callerSource)
+		writeModule(t, dir, "Other.bas", other)
+	}
+	baseConfig := config.Default()
+	writeCase(callee, caller)
+	warmStore := semanticquery.New(semanticquery.Options{})
+	run := func(store *semanticquery.Store, cfg config.Config) (Result, error) {
+		ctx := semanticquery.WithContext(context.Background(), semanticquery.Context{Store: store})
+		return (Analyzer{RootDir: dir, Config: cfg}).RunResultContext(ctx)
+	}
+	if _, err := run(warmStore, baseConfig); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name      string
+		callee    string
+		caller    string
+		configure func(config.Config) config.Config
+	}{
+		{
+			name:   "body",
+			callee: strings.Replace(callee, "Compute = value", "Compute = value + 1", 1),
+			caller: caller,
+		},
+		{
+			name:   "signature",
+			callee: strings.Replace(callee, "value As Long", "value As Variant", 1),
+			caller: caller,
+		},
+		{
+			name:   "resolution-redirect",
+			callee: callee,
+			caller: strings.Replace(caller, "Compute(1)", "ComputeOther(1)", 1),
+		},
+		{
+			name:   "call-add",
+			callee: callee,
+			caller: strings.Replace(caller, "End Sub", "    Call ComputeOther(2)\nEnd Sub", 1),
+		},
+		{
+			name:   "call-remove",
+			callee: callee,
+			caller: strings.Replace(caller, "    result = Compute(1)\n", "", 1),
+		},
+		{
+			name:   "effect",
+			callee: strings.Replace(callee, "    Compute = value", "    Range(\"A1\").Value = value\n    Compute = value", 1),
+			caller: caller,
+		},
+		{
+			name:   "module-context",
+			callee: strings.Replace(callee, "Option Explicit\n", "Option Explicit\nPublic Const ContextMarker As Long = 1\n", 1),
+			caller: caller,
+		},
+		{
+			name:   "configuration",
+			callee: callee,
+			caller: caller,
+			configure: func(cfg config.Config) config.Config {
+				cfg.Analyze.DetectRangeValueArrayShape = !cfg.Analyze.DetectRangeValueArrayShape
+				return cfg
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writeCase(tc.callee, tc.caller)
+			cfg := baseConfig
+			if tc.configure != nil {
+				cfg = tc.configure(cfg)
+			}
+			warm, err := run(warmStore, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fresh, err := run(semanticquery.New(semanticquery.Options{}), cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(warm.Findings, fresh.Findings) {
+				t.Fatalf("warm findings differ from fresh recomputation: warm=%#v fresh=%#v", warm.Findings, fresh.Findings)
+			}
+			if !reflect.DeepEqual(warm.Warnings, fresh.Warnings) || !reflect.DeepEqual(warm.PreflightFindings, fresh.PreflightFindings) {
+				t.Fatalf("warm auxiliary results differ from fresh recomputation: warm warnings=%#v preflight=%#v fresh warnings=%#v preflight=%#v", warm.Warnings, warm.PreflightFindings, fresh.Warnings, fresh.PreflightFindings)
+			}
+			warmJSON, err := json.Marshal(warm)
+			if err != nil {
+				t.Fatal(err)
+			}
+			freshJSON, err := json.Marshal(fresh)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(warmJSON) != string(freshJSON) {
+				t.Fatalf("warm JSON differs from fresh recomputation:\nwarm=%s\nfresh=%s", warmJSON, freshJSON)
+			}
+		})
+	}
+}
+
+func TestSemanticArrayModuleFingerprintIncludesDeclarations(t *testing.T) {
+	facts := &moduleAnalysisFacts{
+		moduleDeclarations: map[string]sourceDeclaration{"value": {}},
+	}
+	file := parsedFile{ModuleFacts: facts}
+	before := semanticArrayModuleFingerprint(file)
+	facts.moduleDeclarations["other"] = sourceDeclaration{}
+	after := semanticArrayModuleFingerprint(file)
+	if before == after {
+		t.Fatal("array module fingerprint ignored a module declaration change")
+	}
+}
+
+func TestSemanticProcedureIdentityUsesCanonicalPath(t *testing.T) {
+	file := parsedFile{Path: filepath.Join("workspace", "nested", "..", "Main.bas"), Module: "Main"}
+	proc := sourceProcedure{Name: "Run", ProcedureKind: procedureir.ProcedureSub}
+	want := semanticCanonicalPath(file.Path) + "::Main::Run::sub"
+	if got := semanticProcedureIdentity(file, proc); got != want {
+		t.Fatalf("procedure identity = %q, want %q", got, want)
+	}
+}
+
+func TestSemanticProcedureFingerprintIncludesNearbyEvidence(t *testing.T) {
+	file := parsedFile{
+		Path:   "Main.bas",
+		Lines:  []string{"Option Explicit", "", "Public Sub Run()", "    Range(\"A1\").Value = 1", "End Sub", "", "' evidence"},
+		Source: []byte("Option Explicit\n\nPublic Sub Run()\n    Range(\"A1\").Value = 1\nEnd Sub\n\n' evidence\n"),
+	}
+	proc := sourceProcedure{Name: "Run", Kind: "Sub", ProcedureKind: procedureir.ProcedureSub, StartLine: 3, EndLine: 5, StartByte: 20, EndByte: 68}
+	before := semanticProcedureBaseFingerprint(Analyzer{RootDir: "workspace"}, file, proc)
+	file.Lines[6] = "' changed evidence"
+	after := semanticProcedureBaseFingerprint(Analyzer{RootDir: "workspace"}, file, proc)
+	if before == after {
+		t.Fatal("procedure fingerprint ignored nearby evidence source")
+	}
+}
+
+func TestSemanticPreparedPlanFingerprintIncludesPrivateBits(t *testing.T) {
+	base := procedureAnalysisPlan{enabled: 1, planned: 1, enabledKernels: 1, plannedKernels: 1}
+	changed := base
+	changed.plannedDataflowLanes = 1
+	if semanticProcedurePlanFingerprint(base) == semanticProcedurePlanFingerprint(changed) {
+		t.Fatal("prepared plan fingerprint ignored private plan bits")
+	}
+	features := procedureFeatureSet{present: featureArray}
+	unknown := procedureFeatureSet{present: featureArray, unknown: featureDataflow}
+	if semanticProcedureFeatureFingerprint(features) == semanticProcedureFeatureFingerprint(unknown) {
+		t.Fatal("procedure feature fingerprint ignored unknown bits")
+	}
+}
+
+func TestSemanticEffectFingerprintIncludesEffectLeaves(t *testing.T) {
+	without := &effects.ProcedureSummary{}
+	with := &effects.ProcedureSummary{Direct: []effects.Evidence{{Effect: effects.WritesCells}}}
+	if semanticProcedureEffectFingerprint(without) == semanticProcedureEffectFingerprint(with) {
+		t.Fatal("effect fingerprint ignored a changed effect leaf")
 	}
 }

--- a/internal/analyze/semantic_query_integration_test.go
+++ b/internal/analyze/semantic_query_integration_test.go
@@ -262,6 +262,28 @@ func TestSemanticProcedureFingerprintIncludesNearbyEvidence(t *testing.T) {
 	}
 }
 
+func TestSemanticProcedureFingerprintIncludesSourcePosition(t *testing.T) {
+	file := parsedFile{
+		Path:   "Main.bas",
+		Source: []byte("Public Sub Run()\nEnd Sub\n"),
+	}
+	proc := sourceProcedure{
+		Name:          "Run",
+		Kind:          "Sub",
+		ProcedureKind: procedureir.ProcedureSub,
+		StartLine:     1,
+		EndLine:       2,
+		StartByte:     0,
+		EndByte:       len(file.Source) - 1,
+	}
+	moved := proc
+	moved.StartLine++
+	moved.EndLine++
+	if semanticProcedureBaseFingerprint(Analyzer{RootDir: "workspace"}, file, proc) == semanticProcedureBaseFingerprint(Analyzer{RootDir: "workspace"}, file, moved) {
+		t.Fatal("procedure fingerprint ignored a source position change")
+	}
+}
+
 func TestSemanticPreparedPlanFingerprintIncludesPrivateBits(t *testing.T) {
 	base := procedureAnalysisPlan{enabled: 1, planned: 1, enabledKernels: 1, plannedKernels: 1}
 	changed := base

--- a/internal/analyze/semanticquery/query.go
+++ b/internal/analyze/semanticquery/query.go
@@ -331,6 +331,7 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 		if err == nil {
 			err = ctx.Err()
 		}
+		unchanged := err == nil && len(staleReasons) > 0 && hadPrevious && reflect.DeepEqual(previous.value, value)
 		s.mu.Lock()
 		delete(s.pending, stable)
 		if err == nil && s.epochs[stable] == epoch {
@@ -347,7 +348,6 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 				s.order = append(s.order, stable)
 			}
 			s.recordDependenciesLocked(stable, key, dependencies)
-			unchanged := len(staleReasons) > 0 && hadPrevious && reflect.DeepEqual(previous.value, value)
 			if len(staleReasons) > 0 {
 				for _, parent := range parents {
 					// Dependents are red because this immediate producer was
@@ -385,6 +385,7 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 
 func (s *Store) dependenciesMatchLocked(parent Key, dependencies []Key) bool {
 	stored := s.deps[parent]
+	dependencies = deduplicateDependencies(dependencies)
 	if len(stored.ids) != len(dependencies) || stored.digest != dependencySetDigest(dependencies) {
 		return false
 	}
@@ -514,20 +515,9 @@ func (s *Store) recordDependenciesLocked(parent Key, parentKey Key, dependencies
 		}
 	}
 	s.indexKeyLocked(parentKey)
-	ids := make([]Key, 0, len(dependencies))
-	for _, dependency := range dependencies {
+	ids := append([]Key(nil), deduplicateDependencies(dependencies)...)
+	for _, dependency := range ids {
 		dependencyID := dependency
-		duplicate := false
-		for _, existing := range ids {
-			if existing == dependencyID {
-				duplicate = true
-				break
-			}
-		}
-		if duplicate {
-			continue
-		}
-		ids = append(ids, dependencyID)
 		s.indexKeyLocked(dependency)
 		parents := s.reverse[dependencyID]
 		if parents == nil {
@@ -538,6 +528,35 @@ func (s *Store) recordDependenciesLocked(parent Key, parentKey Key, dependencies
 	}
 	sort.Slice(ids, func(i, j int) bool { return keyLess(ids[i], ids[j]) })
 	s.deps[parent] = dependencySet{ids: ids, digest: dependencySetDigest(ids)}
+}
+
+// deduplicateDependencies preserves the caller's order when all dependencies
+// are already unique. The hit path therefore stays allocation-free for the
+// normal case; a copy is created only when a caller supplied a duplicate.
+func deduplicateDependencies(dependencies []Key) []Key {
+	for index := 0; index < len(dependencies); index++ {
+		for previous := 0; previous < index; previous++ {
+			if dependencies[previous] != dependencies[index] {
+				continue
+			}
+			unique := make([]Key, 0, len(dependencies)-1)
+			unique = append(unique, dependencies[:index]...)
+			for _, dependency := range dependencies[index+1:] {
+				duplicate := false
+				for _, existing := range unique {
+					if existing == dependency {
+						duplicate = true
+						break
+					}
+				}
+				if !duplicate {
+					unique = append(unique, dependency)
+				}
+			}
+			return unique
+		}
+	}
+	return dependencies
 }
 
 func keyLess(left, right Key) bool {
@@ -695,11 +714,7 @@ func (s *Store) invalidateIDsLocked(queue []Key, metrics Metrics) []string {
 	for procedure := range procedures {
 		result = append(result, procedure)
 	}
-	for i := 1; i < len(result); i++ {
-		for j := i; j > 0 && result[j] < result[j-1]; j-- {
-			result[j], result[j-1] = result[j-1], result[j]
-		}
-	}
+	sort.Strings(result)
 	if metrics != nil {
 		metrics.RecordSemanticQueryInvalidatedProcedures(uint64(len(result)))
 	}
@@ -845,4 +860,3 @@ func (s *Store) pruneRevisionsLocked() {
 		}
 	}
 }
-

--- a/internal/analyze/semanticquery/query.go
+++ b/internal/analyze/semanticquery/query.go
@@ -96,7 +96,6 @@ func FromContext(ctx context.Context) Context {
 }
 
 type cacheValue struct {
-	key   Key
 	value any
 }
 
@@ -300,7 +299,7 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 		s.mu.Lock()
 		delete(s.pending, stable)
 		if err == nil && s.epochs[stable] == epoch {
-			s.entries[stable] = cacheValue{key: key, value: value}
+			s.entries[stable] = cacheValue{value: value}
 			s.keys[stable] = key
 			s.order = append(s.order, stable)
 			s.recordDependenciesLocked(stable, key, dependencies)
@@ -402,7 +401,7 @@ func (s *Store) RecordDependencies(parent Key, dependencies ...Key) {
 	s.mu.Lock()
 	stable := parent.String()
 	if _, ok := s.entries[stable]; !ok {
-		s.entries[stable] = cacheValue{key: parent, value: dependencyRecord{}}
+		s.entries[stable] = cacheValue{value: dependencyRecord{}}
 		s.order = append(s.order, stable)
 	}
 	s.recordDependenciesLocked(stable, parent, dependencies)

--- a/internal/analyze/semanticquery/query.go
+++ b/internal/analyze/semanticquery/query.go
@@ -10,6 +10,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -108,6 +110,15 @@ type pendingValue struct {
 	done chan struct{}
 }
 
+// dependencySet keeps one parent's dependencies in canonical order and
+// retains an order-independent digest for the common hit-path rejection. The
+// exact membership check remains as a collision guard, but it does not build a
+// temporary map or stringify keys.
+type dependencySet struct {
+	ids    []Key
+	digest [32]byte
+}
+
 type revisionState struct {
 	id   string
 	refs int
@@ -119,13 +130,24 @@ type revisionState struct {
 type Store struct {
 	mu sync.Mutex
 
-	entries map[string]cacheValue
-	order   []string
-	pending map[string]*pendingValue
-	reverse map[string]map[string]Key
-	keys    map[string]Key
-	epochs  map[string]uint64
-	deps    map[string][]string
+	// Key is comparable, so keep it as the cache identity directly.  The
+	// previous string identity required building a NUL-delimited string for
+	// every lookup and retained a second copy of every key in keys.
+	entries map[Key]cacheValue
+	order   []Key
+	pending map[Key]*pendingValue
+	reverse map[Key]map[Key]struct{}
+	epochs  map[Key]uint64
+	deps    map[Key]dependencySet
+	stale   map[Key]map[Key]struct{}
+
+	// procedureEntries contains exact procedure identities and their
+	// structural prefixes (document, document::module, and so on).  Keeping
+	// these indexes means document/procedure invalidation does not scan every
+	// query key. documentEntries is kept separately so a normalized document
+	// path has an explicit, exact lookup path.
+	procedureEntries map[string]map[Key]struct{}
+	documentEntries  map[string]map[Key]struct{}
 
 	revisions    map[string]*revisionState
 	sequence     uint64
@@ -145,16 +167,18 @@ func New(opts Options) *Store {
 		maxRevisions = 4
 	}
 	return &Store{
-		entries:      make(map[string]cacheValue),
-		pending:      make(map[string]*pendingValue),
-		reverse:      make(map[string]map[string]Key),
-		keys:         make(map[string]Key),
-		epochs:       make(map[string]uint64),
-		deps:         make(map[string][]string),
-		revisions:    make(map[string]*revisionState),
-		maxEntries:   maxEntries,
-		maxRevisions: maxRevisions,
-		metrics:      opts.Metrics,
+		entries:          make(map[Key]cacheValue),
+		pending:          make(map[Key]*pendingValue),
+		reverse:          make(map[Key]map[Key]struct{}),
+		epochs:           make(map[Key]uint64),
+		deps:             make(map[Key]dependencySet),
+		stale:            make(map[Key]map[Key]struct{}),
+		procedureEntries: make(map[string]map[Key]struct{}),
+		documentEntries:  make(map[string]map[Key]struct{}),
+		revisions:        make(map[string]*revisionState),
+		maxEntries:       maxEntries,
+		maxRevisions:     maxRevisions,
+		metrics:          opts.Metrics,
 	}
 }
 
@@ -238,7 +262,7 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 	}
 	s := r.store
 	metrics := s.metricsFor(ctx)
-	stable := key.String()
+	stable := key
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, false, err
@@ -250,16 +274,18 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 				s.mu.Unlock()
 				continue
 			}
-			if !s.dependenciesMatchLocked(stable, dependencies) {
-				s.invalidateIDsLocked([]string{stable}, metrics)
+			if _, stale := s.stale[stable]; !stale {
+				if !s.dependenciesMatchLocked(stable, dependencies) {
+					s.invalidateIDsLocked([]Key{stable}, metrics)
+					s.mu.Unlock()
+					continue
+				}
 				s.mu.Unlock()
-				continue
+				if metrics != nil {
+					metrics.RecordSemanticQueryHit()
+				}
+				return cached.value, true, nil
 			}
-			s.mu.Unlock()
-			if metrics != nil {
-				metrics.RecordSemanticQueryHit()
-			}
-			return cached.value, true, nil
 		}
 		if pending := s.pending[stable]; pending != nil {
 			done := pending.done
@@ -273,7 +299,15 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 		}
 		pending := &pendingValue{done: make(chan struct{})}
 		epoch := s.epochs[stable]
+		previous, hadPrevious := s.entries[stable]
+		if hadPrevious {
+			if _, metadataOnly := previous.value.(dependencyRecord); metadataOnly {
+				hadPrevious = false
+			}
+		}
+		staleReasons := append([]Key(nil), s.staleReasonsLocked(stable)...)
 		s.pending[stable] = pending
+		s.indexKeyLocked(stable)
 		if metrics != nil {
 			metrics.RecordSemanticQueryMiss()
 		}
@@ -286,6 +320,7 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 				if recovered := recover(); recovered != nil {
 					s.mu.Lock()
 					delete(s.pending, stable)
+					s.maybeRemoveKeyMetadataLocked(stable)
 					close(pending.done)
 					s.mu.Unlock()
 					panic(recovered)
@@ -299,39 +334,148 @@ func (r *Revision) Evaluate(ctx context.Context, key Key, dependencies []Key, bu
 		s.mu.Lock()
 		delete(s.pending, stable)
 		if err == nil && s.epochs[stable] == epoch {
+			parents := make([]Key, 0, len(s.reverse[stable]))
+			for parent := range s.reverse[stable] {
+				parents = append(parents, parent)
+			}
+			hadEntry := false
+			if _, ok := s.entries[stable]; ok {
+				hadEntry = true
+			}
 			s.entries[stable] = cacheValue{value: value}
-			s.keys[stable] = key
-			s.order = append(s.order, stable)
+			if !hadEntry {
+				s.order = append(s.order, stable)
+			}
 			s.recordDependenciesLocked(stable, key, dependencies)
+			unchanged := len(staleReasons) > 0 && hadPrevious && reflect.DeepEqual(previous.value, value)
+			if len(staleReasons) > 0 {
+				for _, parent := range parents {
+					// Dependents are red because this immediate producer was
+					// invalidated, not because of the producer's own upstream
+					// reason. Clear or retain that edge-local reason only.
+					s.clearStaleReasonLocked(parent, stable)
+					if !unchanged {
+						s.markStaleReasonLocked(parent, stable)
+					}
+				}
+			}
+			s.clearStaleLocked(stable)
 			s.pruneEntriesLocked()
 			if metrics != nil {
 				metrics.RecordSemanticQueryRecomputedKernel()
 			}
+		}
+		epochChanged := s.epochs[stable] != epoch
+		if err != nil || epochChanged {
+			s.maybeRemoveKeyMetadataLocked(stable)
 		}
 		close(pending.done)
 		s.mu.Unlock()
 		if err != nil {
 			return nil, false, err
 		}
+		if epochChanged {
+			// A newer revision invalidated this build while it was running. Do
+			// not expose the uncommitted value; retry against the current epoch.
+			continue
+		}
 		return value, false, nil
 	}
 }
 
-func (s *Store) dependenciesMatchLocked(parent string, dependencies []Key) bool {
+func (s *Store) dependenciesMatchLocked(parent Key, dependencies []Key) bool {
 	stored := s.deps[parent]
-	if len(stored) != len(dependencies) {
+	if len(stored.ids) != len(dependencies) || stored.digest != dependencySetDigest(dependencies) {
 		return false
 	}
-	seen := make(map[string]struct{}, len(dependencies))
-	for _, dependency := range dependencies {
-		seen[dependency.String()] = struct{}{}
-	}
-	for _, dependencyID := range stored {
-		if _, ok := seen[dependencyID]; !ok {
+	// Stored dependencies are deduplicated by recordDependenciesLocked. A
+	// membership comparison is deliberately allocation-free on the hit path;
+	// dependency slices are normally tiny, and order is not semantically
+	// significant. The digest above rejects almost all changed sets before this
+	// collision-safe comparison runs.
+	for _, dependencyID := range stored.ids {
+		found := false
+		for _, dependency := range dependencies {
+			if dependency == dependencyID {
+				found = true
+				break
+			}
+		}
+		if !found {
 			return false
 		}
 	}
 	return true
+}
+
+func dependencyKeyDigest(key Key) [32]byte {
+	h := sha256.New()
+	for _, part := range []string{key.Procedure, key.Fingerprint, key.Kernel, key.Config, key.Capability} {
+		_, _ = fmt.Fprintf(h, "%d:", len(part))
+		_, _ = h.Write([]byte(part))
+	}
+	var digest [32]byte
+	copy(digest[:], h.Sum(nil))
+	return digest
+}
+
+func dependencySetDigest(dependencies []Key) [32]byte {
+	var digest [32]byte
+	for _, dependency := range dependencies {
+		item := dependencyKeyDigest(dependency)
+		for index := range digest {
+			digest[index] ^= item[index]
+		}
+	}
+	return digest
+}
+
+func (s *Store) staleReasonsLocked(id Key) []Key {
+	reasons := s.stale[id]
+	if len(reasons) == 0 {
+		return nil
+	}
+	out := make([]Key, 0, len(reasons))
+	for reason := range reasons {
+		out = append(out, reason)
+	}
+	return out
+}
+
+// markStaleReasonLocked marks a cached value red because the producer named
+// by reason changed. Reasons are retained so an unchanged producer output can
+// clear only the invalidation it caused while preserving unrelated red state.
+func (s *Store) markStaleReasonLocked(id, reason Key) {
+	reasons := s.stale[id]
+	if reasons == nil {
+		if _, hasEntry := s.entries[id]; !hasEntry {
+			// A pending or not-yet-created node still needs an epoch bump to
+			// reject a late publication, but it has no value to mark stale.
+			s.epochs[id]++
+			return
+		}
+		reasons = make(map[Key]struct{})
+		s.stale[id] = reasons
+	}
+	reasons[reason] = struct{}{}
+	// Repeated invalidations of the same producer still advance the epoch so
+	// an in-flight build cannot publish across the newer source snapshot.
+	s.epochs[id]++
+}
+
+func (s *Store) clearStaleReasonLocked(id, reason Key) {
+	reasons := s.stale[id]
+	if len(reasons) == 0 {
+		return
+	}
+	delete(reasons, reason)
+	if len(reasons) == 0 {
+		delete(s.stale, id)
+	}
+}
+
+func (s *Store) clearStaleLocked(id Key) {
+	delete(s.stale, id)
 }
 
 func (s *Store) metricsFor(ctx context.Context) Metrics {
@@ -359,34 +503,57 @@ func Evaluate[T any](ctx context.Context, r *Revision, key Key, dependencies []K
 	return result, hit, nil
 }
 
-func (s *Store) recordDependenciesLocked(parent string, parentKey Key, dependencies []Key) {
-	for _, dependencyID := range s.deps[parent] {
+func (s *Store) recordDependenciesLocked(parent Key, parentKey Key, dependencies []Key) {
+	for _, dependencyID := range s.deps[parent].ids {
 		if parents := s.reverse[dependencyID]; parents != nil {
 			delete(parents, parent)
 			if len(parents) == 0 {
 				delete(s.reverse, dependencyID)
+				s.maybeRemoveKeyMetadataLocked(dependencyID)
 			}
 		}
 	}
-	s.keys[parent] = parentKey
-	ids := make([]string, 0, len(dependencies))
-	seen := make(map[string]struct{}, len(dependencies))
+	s.indexKeyLocked(parentKey)
+	ids := make([]Key, 0, len(dependencies))
 	for _, dependency := range dependencies {
-		dependencyID := dependency.String()
-		if _, ok := seen[dependencyID]; ok {
+		dependencyID := dependency
+		duplicate := false
+		for _, existing := range ids {
+			if existing == dependencyID {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
 			continue
 		}
-		seen[dependencyID] = struct{}{}
 		ids = append(ids, dependencyID)
-		s.keys[dependencyID] = dependency
+		s.indexKeyLocked(dependency)
 		parents := s.reverse[dependencyID]
 		if parents == nil {
-			parents = make(map[string]Key)
+			parents = make(map[Key]struct{})
 			s.reverse[dependencyID] = parents
 		}
-		parents[parent] = parentKey
+		parents[parent] = struct{}{}
 	}
-	s.deps[parent] = ids
+	sort.Slice(ids, func(i, j int) bool { return keyLess(ids[i], ids[j]) })
+	s.deps[parent] = dependencySet{ids: ids, digest: dependencySetDigest(ids)}
+}
+
+func keyLess(left, right Key) bool {
+	if left.Procedure != right.Procedure {
+		return left.Procedure < right.Procedure
+	}
+	if left.Fingerprint != right.Fingerprint {
+		return left.Fingerprint < right.Fingerprint
+	}
+	if left.Kernel != right.Kernel {
+		return left.Kernel < right.Kernel
+	}
+	if left.Config != right.Config {
+		return left.Config < right.Config
+	}
+	return left.Capability < right.Capability
 }
 
 // RecordDependencies records a dependency for an already-computed query. It
@@ -399,21 +566,22 @@ func (s *Store) RecordDependencies(parent Key, dependencies ...Key) {
 		return
 	}
 	s.mu.Lock()
-	stable := parent.String()
+	stable := parent
 	if _, ok := s.entries[stable]; !ok {
 		s.entries[stable] = cacheValue{value: dependencyRecord{}}
 		s.order = append(s.order, stable)
 	}
+	s.indexKeyLocked(parent)
 	s.recordDependenciesLocked(stable, parent, dependencies)
 	s.pruneEntriesLocked()
 	s.mu.Unlock()
 }
 
-// Invalidate removes changed queries and their transitive dependents. The
+// Invalidate marks changed queries and their transitive dependents red. The
 // returned procedure identities are sorted and unique for deterministic
-// telemetry. Reverse traversal is completed before affected metadata is
-// released, so callers can invalidate an old/new dependency union when a call
-// is removed or redirected without retaining unbounded historical edges.
+// telemetry. Reverse traversal reports the full affected closure, while
+// values are reevaluated lazily: an unchanged producer output clears its
+// dependents back to green instead of forcing the whole closure to rebuild.
 func (s *Store) Invalidate(changed ...Key) []string {
 	return s.InvalidateContext(context.Background(), changed...)
 }
@@ -427,17 +595,15 @@ func (s *Store) InvalidateContext(ctx context.Context, changed ...Key) []string 
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	queue := make([]string, 0, len(changed))
-	for _, key := range changed {
-		queue = append(queue, key.String())
-	}
+	queue := append([]Key(nil), changed...)
 	return s.invalidateIDsLocked(queue, s.metricsFor(ctx))
 }
 
-// InvalidateProcedures removes all cached queries belonging to the supplied
-// procedure identities (or identity prefixes) and their reverse dependents.
-// LSP callers use path prefixes because a source edit can replace a procedure
-// declaration and therefore cannot always reconstruct the old full key.
+// InvalidateProcedures marks all cached queries belonging to the supplied
+// procedure identities (or identity prefixes), plus their reverse dependents,
+// red. LSP callers use path prefixes because a source edit can replace a
+// procedure declaration and therefore cannot always reconstruct the old full
+// key.
 func (s *Store) InvalidateProcedures(procedures ...string) []string {
 	return s.InvalidateProceduresContext(context.Background(), procedures...)
 }
@@ -450,57 +616,80 @@ func (s *Store) InvalidateProceduresContext(ctx context.Context, procedures ...s
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	queue := make([]string, 0)
-	for id, key := range s.keys {
-		for _, procedure := range procedures {
-			if procedure != "" && (key.Procedure == procedure || strings.HasPrefix(key.Procedure, procedure)) {
-				queue = append(queue, id)
-				break
-			}
+	queue := make([]Key, 0)
+	for _, procedure := range procedures {
+		if procedure == "" {
+			continue
+		}
+		for id := range s.procedureEntries[procedure] {
+			queue = append(queue, id)
+		}
+		for id := range s.documentEntries[procedure] {
+			queue = append(queue, id)
 		}
 	}
 	return s.invalidateIDsLocked(queue, s.metricsFor(ctx))
 }
 
-func (s *Store) invalidateIDsLocked(queue []string, metrics Metrics) []string {
-	seen := make(map[string]bool)
-	procedures := make(map[string]bool)
-	affected := make([]string, 0, len(queue))
-	for len(queue) > 0 {
-		id := queue[0]
-		queue = queue[1:]
-		if seen[id] {
+func (s *Store) invalidateIDsLocked(queue []Key, metrics Metrics) []string {
+	// Stale reasons are the immediate producer keys on each reverse edge. A
+	// shared sentinel for a multi-root invalidation would let an unchanged
+	// rebuild of root A clear the same reason from a dependent that is still
+	// stale because of root B; edge-local reasons preserve recovery while this
+	// remains one reverse traversal.
+	roots := make([]Key, 0, len(queue))
+	rootSeen := make(map[Key]struct{}, len(queue))
+	for _, root := range queue {
+		if _, ok := rootSeen[root]; ok {
 			continue
 		}
-		seen[id] = true
-		affected = append(affected, id)
-		s.epochs[id]++
-		if key, ok := s.keys[id]; ok {
-			if key.Procedure != "" {
-				procedures[key.Procedure] = true
-			}
+		rootSeen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+	seen := make(map[Key]bool)
+	procedures := make(map[string]bool)
+	affected := make([]Key, 0, len(roots))
+	rootQueue := append([]Key(nil), roots...)
+	for _, root := range roots {
+		if seen[root] {
+			continue
 		}
+		seen[root] = true
+		affected = append(affected, root)
+		if root.Procedure != "" {
+			procedures[root.Procedure] = true
+		}
+		// A root has no invalidating edge in the supplied set, so use its own
+		// identity as the reason that its cached value is red.
+		s.markStaleReasonLocked(root, root)
+	}
+	for len(rootQueue) > 0 {
+		id := rootQueue[0]
+		rootQueue = rootQueue[1:]
 		for parent := range s.reverse[id] {
-			queue = append(queue, parent)
+			// The parent is red because this immediate producer is red. If
+			// another changed root reaches the same parent, it contributes a
+			// separate reason rather than sharing a batch sentinel.
+			s.markStaleReasonLocked(parent, id)
+			if seen[parent] {
+				continue
+			}
+			seen[parent] = true
+			affected = append(affected, parent)
+			if parent.Procedure != "" {
+				procedures[parent.Procedure] = true
+			}
+			rootQueue = append(rootQueue, parent)
 		}
+	}
+	if len(affected) == 0 {
+		if metrics != nil {
+			metrics.RecordSemanticQueryInvalidatedProcedures(0)
+		}
+		return nil
 	}
 	for _, id := range affected {
-		s.removeNodeLocked(id)
-	}
-	if len(s.order) > s.maxEntries*2 {
-		compact := make([]string, 0, len(s.entries))
-		seenOrder := make(map[string]struct{}, len(s.entries))
-		for _, id := range s.order {
-			if _, ok := s.entries[id]; !ok {
-				continue
-			}
-			if _, ok := seenOrder[id]; ok {
-				continue
-			}
-			seenOrder[id] = struct{}{}
-			compact = append(compact, id)
-		}
-		s.order = compact
+		s.maybeRemoveKeyMetadataLocked(id)
 	}
 	result := make([]string, 0, len(procedures))
 	for procedure := range procedures {
@@ -517,34 +706,104 @@ func (s *Store) invalidateIDsLocked(queue []string, metrics Metrics) []string {
 	return result
 }
 
-func (s *Store) removeNodeLocked(id string) {
-	for _, dependencyID := range s.deps[id] {
+func (s *Store) removeNodeLocked(id Key) {
+	for _, dependencyID := range s.deps[id].ids {
 		if parents := s.reverse[dependencyID]; parents != nil {
 			delete(parents, id)
 			if len(parents) == 0 {
 				delete(s.reverse, dependencyID)
-				s.maybeRemoveDependencyMetadataLocked(dependencyID)
+				s.maybeRemoveKeyMetadataLocked(dependencyID)
 			}
 		}
 	}
 	delete(s.deps, id)
 	delete(s.entries, id)
-	if len(s.reverse[id]) == 0 && s.pending[id] == nil && len(s.deps[id]) == 0 {
+	delete(s.stale, id)
+	if len(s.reverse[id]) == 0 && s.pending[id] == nil && len(s.deps[id].ids) == 0 {
 		delete(s.reverse, id)
-		delete(s.keys, id)
+		s.removeKeyIndexLocked(id)
 		delete(s.epochs, id)
 	}
 }
 
-func (s *Store) maybeRemoveDependencyMetadataLocked(id string) {
+func (s *Store) maybeRemoveKeyMetadataLocked(id Key) {
 	if _, ok := s.entries[id]; ok {
 		return
 	}
-	if s.pending[id] != nil || len(s.reverse[id]) != 0 || len(s.deps[id]) != 0 {
+	if s.pending[id] != nil || len(s.reverse[id]) != 0 || len(s.deps[id].ids) != 0 {
 		return
 	}
-	delete(s.keys, id)
+	s.removeKeyIndexLocked(id)
 	delete(s.epochs, id)
+	delete(s.stale, id)
+}
+
+func addKeyIndex(index map[string]map[Key]struct{}, name string, key Key) {
+	if name == "" {
+		return
+	}
+	keys := index[name]
+	if keys == nil {
+		keys = make(map[Key]struct{})
+		index[name] = keys
+	}
+	keys[key] = struct{}{}
+}
+
+func removeKeyIndex(index map[string]map[Key]struct{}, name string, key Key) {
+	if keys := index[name]; keys != nil {
+		delete(keys, key)
+		if len(keys) == 0 {
+			delete(index, name)
+		}
+	}
+}
+
+// indexKeyLocked records all stable structural identities understood by
+// InvalidateProcedures. Prefix strings are slices of the procedure identity,
+// so indexing does not need another serialization of the Key itself.
+func (s *Store) indexKeyLocked(key Key) {
+	procedure := key.Procedure
+	if procedure == "" {
+		return
+	}
+	addKeyIndex(s.procedureEntries, procedure, key)
+	first := strings.Index(procedure, "::")
+	if first < 0 {
+		addKeyIndex(s.documentEntries, procedure, key)
+		return
+	}
+	addKeyIndex(s.documentEntries, procedure[:first], key)
+	for end := first; end >= 0; {
+		addKeyIndex(s.procedureEntries, procedure[:end], key)
+		next := strings.Index(procedure[end+2:], "::")
+		if next < 0 {
+			break
+		}
+		end += 2 + next
+	}
+}
+
+func (s *Store) removeKeyIndexLocked(key Key) {
+	procedure := key.Procedure
+	if procedure == "" {
+		return
+	}
+	removeKeyIndex(s.procedureEntries, procedure, key)
+	first := strings.Index(procedure, "::")
+	if first < 0 {
+		removeKeyIndex(s.documentEntries, procedure, key)
+		return
+	}
+	removeKeyIndex(s.documentEntries, procedure[:first], key)
+	for end := first; end >= 0; {
+		removeKeyIndex(s.procedureEntries, procedure[:end], key)
+		next := strings.Index(procedure[end+2:], "::")
+		if next < 0 {
+			break
+		}
+		end += 2 + next
+	}
 }
 
 func (s *Store) pruneEntriesLocked() {
@@ -557,8 +816,8 @@ func (s *Store) pruneEntriesLocked() {
 		s.removeNodeLocked(oldest)
 	}
 	if len(s.order) > s.maxEntries*2 {
-		compact := make([]string, 0, len(s.entries))
-		seen := make(map[string]struct{}, len(s.entries))
+		compact := make([]Key, 0, len(s.entries))
+		seen := make(map[Key]struct{}, len(s.entries))
 		for _, id := range s.order {
 			if _, ok := s.entries[id]; !ok {
 				continue
@@ -586,3 +845,4 @@ func (s *Store) pruneRevisionsLocked() {
 		}
 	}
 }
+

--- a/internal/analyze/semanticquery/query_test.go
+++ b/internal/analyze/semanticquery/query_test.go
@@ -28,6 +28,38 @@ func TestHashAndKeyAreStable(t *testing.T) {
 	}
 }
 
+func TestComparableKeyIdentityDoesNotCollapseStringSeparatorCollision(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("separator-collision")
+	defer revision.Close()
+	first := Key{Procedure: "a\x00b", Fingerprint: "c", Kernel: "array"}
+	second := Key{Procedure: "a", Fingerprint: "b\x00c", Kernel: "array"}
+	if first.String() != second.String() {
+		t.Fatalf("test keys should collide under the old string identity: %q != %q", first.String(), second.String())
+	}
+	if value, _, err := Evaluate(context.Background(), revision, first, nil, func(context.Context) (int, error) { return 1, nil }); err != nil || value != 1 {
+		t.Fatalf("first evaluation = %d, err %v", value, err)
+	}
+	if value, hit, err := Evaluate(context.Background(), revision, second, nil, func(context.Context) (int, error) { return 2, nil }); err != nil || hit || value != 2 {
+		t.Fatalf("second evaluation = %d, hit %v, err %v", value, hit, err)
+	}
+}
+
+func TestEvaluateDependencySetIsOrderIndependent(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("dependency-order")
+	defer revision.Close()
+	parent := Key{Procedure: "M.P", Fingerprint: Hash("parent"), Kernel: "array"}
+	first := Key{Procedure: "M.First", Fingerprint: Hash("first"), Kernel: "effect"}
+	second := Key{Procedure: "M.Second", Fingerprint: Hash("second"), Kernel: "effect"}
+	if _, hit, err := Evaluate(context.Background(), revision, parent, []Key{first, second}, func(context.Context) (int, error) { return 1, nil }); err != nil || hit {
+		t.Fatalf("first evaluation hit=%v err=%v", hit, err)
+	}
+	if value, hit, err := Evaluate(context.Background(), revision, parent, []Key{second, first}, func(context.Context) (int, error) { return 2, nil }); err != nil || !hit || value != 1 {
+		t.Fatalf("reordered evaluation = %d, hit %v, err %v", value, hit, err)
+	}
+}
+
 func TestEvaluateSingleFlightAndReuse(t *testing.T) {
 	metrics := &testMetrics{}
 	store := New(Options{Metrics: metrics})
@@ -116,6 +148,12 @@ func TestPanickingBuildDoesNotPoisonKey(t *testing.T) {
 			panic("boom")
 		})
 	}()
+	store.mu.Lock()
+	if len(store.pending) != 0 || len(store.procedureEntries) != 0 || len(store.documentEntries) != 0 || len(store.epochs) != 0 {
+		store.mu.Unlock()
+		t.Fatalf("panic left query metadata: pending=%d procedures=%d documents=%d epochs=%d", len(store.pending), len(store.procedureEntries), len(store.documentEntries), len(store.epochs))
+	}
+	store.mu.Unlock()
 	value, hit, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) { return 9, nil })
 	if err != nil || hit || value != 9 {
 		t.Fatalf("retry after panic = %d, hit %v, err %v", value, hit, err)
@@ -155,6 +193,165 @@ func TestInvalidateTraversesReverseDependenciesDeterministically(t *testing.T) {
 	}
 }
 
+func TestInvalidateUsesOutputEqualityForGreenRecovery(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("green-recovery")
+	defer revision.Close()
+	callee := Key{Procedure: "M.Callee", Fingerprint: Hash("callee"), Kernel: "effect"}
+	caller := Key{Procedure: "M.Caller", Fingerprint: Hash("caller"), Kernel: "array"}
+	project := Key{Procedure: "project", Fingerprint: Hash("project"), Kernel: "summary"}
+	var callerBuilds, projectBuilds atomic.Int32
+	if _, _, err := Evaluate(context.Background(), revision, callee, nil, func(context.Context) (int, error) { return 1, nil }); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Evaluate(context.Background(), revision, caller, []Key{callee}, func(context.Context) (int, error) {
+		callerBuilds.Add(1)
+		return 7, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Evaluate(context.Background(), revision, project, []Key{caller}, func(context.Context) (int, error) {
+		projectBuilds.Add(1)
+		return 9, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store.Invalidate(callee)
+	if value, hit, err := Evaluate(context.Background(), revision, caller, []Key{callee}, func(context.Context) (int, error) {
+		callerBuilds.Add(1)
+		return 7, nil
+	}); err != nil || hit || value != 7 {
+		t.Fatalf("unchanged caller = %d, hit %v, err %v", value, hit, err)
+	}
+	if value, hit, err := Evaluate(context.Background(), revision, project, []Key{caller}, func(context.Context) (int, error) {
+		projectBuilds.Add(1)
+		return 9, nil
+	}); err != nil || !hit || value != 9 {
+		t.Fatalf("green project = %d, hit %v, err %v", value, hit, err)
+	}
+	if callerBuilds.Load() != 2 || projectBuilds.Load() != 1 {
+		t.Fatalf("build counts after green recovery = caller %d project %d", callerBuilds.Load(), projectBuilds.Load())
+	}
+
+	store.Invalidate(callee)
+	if value, hit, err := Evaluate(context.Background(), revision, caller, []Key{callee}, func(context.Context) (int, error) {
+		callerBuilds.Add(1)
+		return 8, nil
+	}); err != nil || hit || value != 8 {
+		t.Fatalf("changed caller = %d, hit %v, err %v", value, hit, err)
+	}
+	if value, hit, err := Evaluate(context.Background(), revision, project, []Key{caller}, func(context.Context) (int, error) {
+		projectBuilds.Add(1)
+		return 10, nil
+	}); err != nil || hit || value != 10 {
+		t.Fatalf("changed project = %d, hit %v, err %v", value, hit, err)
+	}
+}
+
+func TestInvalidateMultipleRootsKeepsUnrecoveredRootRed(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("multi-root-red")
+	defer revision.Close()
+	first := Key{Procedure: "M.First", Fingerprint: Hash("first"), Kernel: "effect"}
+	second := Key{Procedure: "M.Second", Fingerprint: Hash("second"), Kernel: "effect"}
+	parent := Key{Procedure: "M.Parent", Fingerprint: Hash("parent"), Kernel: "array"}
+	if _, _, err := Evaluate(context.Background(), revision, first, nil, func(context.Context) (int, error) { return 1, nil }); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Evaluate(context.Background(), revision, second, nil, func(context.Context) (int, error) { return 2, nil }); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Evaluate(context.Background(), revision, parent, []Key{first, second}, func(context.Context) (int, error) { return 3, nil }); err != nil {
+		t.Fatal(err)
+	}
+
+	store.Invalidate(first, second)
+	if value, hit, err := Evaluate(context.Background(), revision, first, nil, func(context.Context) (int, error) { return 1, nil }); err != nil || hit || value != 1 {
+		t.Fatalf("unchanged first = %d, hit %v, err %v", value, hit, err)
+	}
+	var parentBuilds atomic.Int32
+	if value, hit, err := Evaluate(context.Background(), revision, parent, []Key{first, second}, func(context.Context) (int, error) {
+		parentBuilds.Add(1)
+		return 3, nil
+	}); err != nil || hit || value != 3 {
+		t.Fatalf("parent with unrecovered second = %d, hit %v, err %v", value, hit, err)
+	}
+	if parentBuilds.Load() != 1 {
+		t.Fatal("parent incorrectly recovered while the second root remained stale")
+	}
+}
+
+func TestEvaluateRetriesAfterConcurrentInvalidation(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("epoch-retry")
+	defer revision.Close()
+	key := Key{Procedure: "M.P", Fingerprint: Hash("body"), Kernel: "array"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	result := make(chan struct {
+		value int
+		hit   bool
+		err   error
+	}, 1)
+	var builds atomic.Int32
+	go func() {
+		value, hit, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) {
+			if builds.Add(1) == 1 {
+				close(started)
+				<-release
+				return 1, nil
+			}
+			return 2, nil
+		})
+		result <- struct {
+			value int
+			hit   bool
+			err   error
+		}{value: value, hit: hit, err: err}
+	}()
+	<-started
+	store.Invalidate(key)
+	close(release)
+	got := <-result
+	if got.err != nil || got.hit || got.value != 2 {
+		t.Fatalf("concurrent invalidation result = %#v, want value 2 and miss", got)
+	}
+	if builds.Load() != 2 {
+		t.Fatalf("build count = %d, want 2", builds.Load())
+	}
+}
+
+func TestInvalidateMarksTransitiveClosureBeforeIntermediateRebuild(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("transitive-red")
+	defer revision.Close()
+	leaf := Key{Procedure: "M.Leaf", Fingerprint: Hash("leaf"), Kernel: "effect"}
+	middle := Key{Procedure: "M.Middle", Fingerprint: Hash("middle"), Kernel: "array"}
+	top := Key{Procedure: "project", Fingerprint: Hash("top"), Kernel: "summary"}
+	if _, _, err := Evaluate(context.Background(), revision, leaf, nil, func(context.Context) (int, error) { return 1, nil }); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Evaluate(context.Background(), revision, middle, []Key{leaf}, func(context.Context) (int, error) { return 2, nil }); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Evaluate(context.Background(), revision, top, []Key{middle}, func(context.Context) (int, error) { return 3, nil }); err != nil {
+		t.Fatal(err)
+	}
+	store.Invalidate(leaf)
+	var builds atomic.Int32
+	value, hit, err := Evaluate(context.Background(), revision, top, []Key{middle}, func(context.Context) (int, error) {
+		builds.Add(1)
+		return 3, nil
+	})
+	if err != nil || hit || value != 3 {
+		t.Fatalf("transitive top evaluation = %d, hit %v, err %v", value, hit, err)
+	}
+	if builds.Load() != 1 {
+		t.Fatalf("top was not marked stale before middle rebuild: builds=%d", builds.Load())
+	}
+}
+
 func TestInvalidateProceduresFindsPrefixAndDependents(t *testing.T) {
 	store := New(Options{})
 	revision := store.Begin("r1")
@@ -181,6 +378,33 @@ func TestInvalidateProceduresFindsPrefixAndDependents(t *testing.T) {
 	}
 }
 
+func TestInvalidateProceduresUsesDocumentIndex(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("document-index")
+	defer revision.Close()
+	mainA := Key{Procedure: `C:\src\Main.bas::Main::A::0`, Fingerprint: Hash("a"), Kernel: "array"}
+	mainB := Key{Procedure: `C:\src\Main.bas::Main::B::1`, Fingerprint: Hash("b"), Kernel: "array"}
+	other := Key{Procedure: `C:\src\Other.bas::Main::A::0`, Fingerprint: Hash("other"), Kernel: "array"}
+	for _, key := range []Key{mainA, mainB, other} {
+		if _, _, err := Evaluate(context.Background(), revision, key, nil, func(context.Context) (int, error) { return 1, nil }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := store.InvalidateProcedures(`C:\src\Main.bas`)
+	want := []string{mainA.Procedure, mainB.Procedure}
+	if len(got) != len(want) {
+		t.Fatalf("invalidated = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("invalidated = %#v, want %#v", got, want)
+		}
+	}
+	if _, hit, err := Evaluate(context.Background(), revision, other, nil, func(context.Context) (int, error) { return 2, nil }); err != nil || !hit {
+		t.Fatalf("unrelated document entry hit=%v err=%v", hit, err)
+	}
+}
+
 func TestClosedRevisionRejectsQueries(t *testing.T) {
 	store := New(Options{})
 	revision := store.Begin("r1")
@@ -203,8 +427,8 @@ func TestEvictionBoundsDependencyMetadata(t *testing.T) {
 		}
 		store.Invalidate(key)
 	}
-	if len(store.entries) > 2 || len(store.keys) > 4 || len(store.reverse) > 4 || len(store.order) > 4 {
-		t.Fatalf("dependency metadata exceeded bounds: entries=%d keys=%d reverse=%d order=%d", len(store.entries), len(store.keys), len(store.reverse), len(store.order))
+	if len(store.entries) > 2 || len(store.procedureEntries) > 4 || len(store.documentEntries) > 4 || len(store.reverse) > 4 || len(store.order) > 4 {
+		t.Fatalf("dependency metadata exceeded bounds: entries=%d procedures=%d documents=%d reverse=%d order=%d", len(store.entries), len(store.procedureEntries), len(store.documentEntries), len(store.reverse), len(store.order))
 	}
 }
 
@@ -215,8 +439,8 @@ func TestRecordDependenciesBoundsMetadata(t *testing.T) {
 		dependency := Key{Procedure: "M.Dependency", Fingerprint: Hash(fmt.Sprintf("dependency-%d", index)), Kernel: "module"}
 		store.RecordDependencies(parent, dependency)
 	}
-	if len(store.entries) > 2 || len(store.keys) > 4 || len(store.reverse) > 2 || len(store.deps) > 2 || len(store.order) > 4 {
-		t.Fatalf("recorded dependency metadata exceeded bounds: entries=%d keys=%d reverse=%d deps=%d order=%d", len(store.entries), len(store.keys), len(store.reverse), len(store.deps), len(store.order))
+	if len(store.entries) > 2 || len(store.procedureEntries) > 4 || len(store.documentEntries) > 4 || len(store.reverse) > 2 || len(store.deps) > 2 || len(store.order) > 4 {
+		t.Fatalf("recorded dependency metadata exceeded bounds: entries=%d procedures=%d documents=%d reverse=%d deps=%d order=%d", len(store.entries), len(store.procedureEntries), len(store.documentEntries), len(store.reverse), len(store.deps), len(store.order))
 	}
 }
 
@@ -234,3 +458,4 @@ func TestRecordDependenciesPlaceholderDoesNotHit(t *testing.T) {
 		t.Fatalf("metadata placeholder evaluation = %d, hit %v, err %v", value, hit, err)
 	}
 }
+

--- a/internal/analyze/semanticquery/query_test.go
+++ b/internal/analyze/semanticquery/query_test.go
@@ -60,6 +60,20 @@ func TestEvaluateDependencySetIsOrderIndependent(t *testing.T) {
 	}
 }
 
+func TestEvaluateDependencySetDeduplicatesOnHit(t *testing.T) {
+	store := New(Options{})
+	revision := store.Begin("dependency-duplicates")
+	defer revision.Close()
+	parent := Key{Procedure: "M.P", Fingerprint: Hash("parent"), Kernel: "array"}
+	dependency := Key{Procedure: "M.Callee", Fingerprint: Hash("callee"), Kernel: "effect"}
+	if _, hit, err := Evaluate(context.Background(), revision, parent, []Key{dependency}, func(context.Context) (int, error) { return 1, nil }); err != nil || hit {
+		t.Fatalf("first evaluation hit=%v err=%v", hit, err)
+	}
+	if value, hit, err := Evaluate(context.Background(), revision, parent, []Key{dependency, dependency}, func(context.Context) (int, error) { return 2, nil }); err != nil || !hit || value != 1 {
+		t.Fatalf("duplicate dependency evaluation = %d, hit %v, err %v", value, hit, err)
+	}
+}
+
 func TestEvaluateSingleFlightAndReuse(t *testing.T) {
 	metrics := &testMetrics{}
 	store := New(Options{Metrics: metrics})
@@ -458,4 +472,3 @@ func TestRecordDependenciesPlaceholderDoesNotHit(t *testing.T) {
 		t.Fatalf("metadata placeholder evaluation = %d, hit %v, err %v", value, hit, err)
 	}
 }
-

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -219,7 +219,7 @@ func New(opts Options) (*Server, func(), error) {
 		codeLensConfig:            intel.DefaultCodeLensConfig(),
 		diagStates:                make(map[string]*diagnosticState),
 		docLifecycles:             make(map[string]*sync.Mutex),
-		semanticQueries:           semanticquery.DefaultStore(),
+		semanticQueries:           semanticquery.New(semanticquery.Options{}),
 		semanticInvalidationPaths: make(map[string]struct{}),
 		analysisPermits:           make(chan struct{}, max(1, runtime.GOMAXPROCS(0)/2)),
 	}

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -763,7 +763,22 @@ func (s *Server) flushSemanticInvalidations(ctx context.Context) {
 	s.semanticInvalidationPaths = make(map[string]struct{})
 	s.semanticInvalidationMu.Unlock()
 	if len(paths) > 0 {
-		s.semanticQueries.InvalidateProceduresContext(ctx, paths...)
+		normalized := make([]string, 0, len(paths))
+		seen := make(map[string]struct{}, len(paths))
+		for _, path := range paths {
+			path = symbolFileKey(path)
+			if path == "" {
+				continue
+			}
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			normalized = append(normalized, path)
+		}
+		if len(normalized) > 0 {
+			s.semanticQueries.InvalidateProceduresContext(ctx, normalized...)
+		}
 	}
 }
 

--- a/internal/lspserver/server_test.go
+++ b/internal/lspserver/server_test.go
@@ -19,6 +19,11 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
+const (
+	jsonrpcDiagnosticsWaitTimeout = 10 * time.Second
+	jsonrpcIntegrationTimeout     = 15 * time.Second
+)
+
 func TestCheckLoadsBuiltinDatabase(t *testing.T) {
 	if err := Check(Options{RootDir: t.TempDir(), Config: config.Default()}); err != nil {
 		t.Fatal(err)
@@ -622,7 +627,7 @@ func TestCompletionReturnsTypeCandidates(t *testing.T) {
 }
 
 func TestJSONRPCIntegrationInitializeOpenCompletionAndExit(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), jsonrpcIntegrationTimeout)
 	defer cancel()
 	root := t.TempDir()
 	s, cleanup, err := New(Options{RootDir: root, Config: config.Default()})
@@ -789,10 +794,11 @@ func TestJSONRPCIntegrationInitializeOpenCompletionAndExit(t *testing.T) {
 	if !ok || args["name"] != "UnsavedRun" || args["moduleName"] != "Main" || args["qualifiedName"] != "Main.UnsavedRun" || args["kind"] != "sub" {
 		t.Fatalf("code lens args = %#v", lenses[0].Command.Arguments)
 	}
-	deadline := time.Now().Add(5 * time.Second)
-	for !recorder.seen(string(protocol.ServerTextDocumentPublishDiagnostics)) && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), jsonrpcDiagnosticsWaitTimeout)
+	published := recorder.waitForDiagnostics(waitCtx, func(params []protocol.PublishDiagnosticsParams) bool {
+		return len(params) > 0
+	})
+	waitCancel()
 
 	var shutdown any
 	if err := clientConn.Call(ctx, string(protocol.MethodShutdown), nil, &shutdown); err != nil {
@@ -802,7 +808,7 @@ func TestJSONRPCIntegrationInitializeOpenCompletionAndExit(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = serverConn.Close()
-	if !recorder.seen(string(protocol.ServerTextDocumentPublishDiagnostics)) {
+	if !published {
 		t.Fatalf("expected publishDiagnostics notification, got %v", recorder.methods())
 	}
 }
@@ -1224,11 +1230,11 @@ func TestJSONRPCPublishesArgumentDiagnostics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(time.Second)
 	seenCountMismatch := false
 	seenArrayObjectMismatch := false
-	for time.Now().Before(deadline) {
-		for _, params := range recorder.publishDiagnostics() {
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), jsonrpcDiagnosticsWaitTimeout)
+	matched := recorder.waitForDiagnostics(waitCtx, func(params []protocol.PublishDiagnosticsParams) bool {
+		for _, params := range params {
 			for _, diag := range params.Diagnostics {
 				if strings.Contains(diag.Message, "Argument count mismatch") {
 					seenCountMismatch = true
@@ -1238,11 +1244,12 @@ func TestJSONRPCPublishesArgumentDiagnostics(t *testing.T) {
 				}
 			}
 		}
-		if seenCountMismatch && seenArrayObjectMismatch {
-			_ = serverConn.Close()
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+		return seenCountMismatch && seenArrayObjectMismatch
+	})
+	waitCancel()
+	if matched {
+		_ = serverConn.Close()
+		return
 	}
 	_ = serverConn.Close()
 	t.Fatalf("VB030 publishDiagnostics missing count=%t array/Object=%t: %+v", seenCountMismatch, seenArrayObjectMismatch, recorder.publishDiagnostics())
@@ -1385,9 +1392,9 @@ func TestJSONRPCPublishesParserRecoveryContextAndRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		for _, params := range recorder.publishDiagnostics() {
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), jsonrpcDiagnosticsWaitTimeout)
+	matched := recorder.waitForDiagnostics(waitCtx, func(params []protocol.PublishDiagnosticsParams) bool {
+		for _, params := range params {
 			for _, diagnostic := range params.Diagnostics {
 				if diagnostic.Message != expected.Message {
 					continue
@@ -1398,10 +1405,14 @@ func TestJSONRPCPublishesParserRecoveryContextAndRange(t *testing.T) {
 					int(diagnostic.Range.End.Character) != expected.Range.End.Character {
 					t.Fatalf("published VB014 = %+v, want message and range from %+v", diagnostic, expected)
 				}
-				return
+				return true
 			}
 		}
-		time.Sleep(10 * time.Millisecond)
+		return false
+	})
+	waitCancel()
+	if matched {
+		return
 	}
 	t.Fatalf("VB014 publishDiagnostics missing: %+v", recorder.publishDiagnostics())
 }
@@ -1438,25 +1449,19 @@ func TestJSONRPCPublishesProcedureNameConstantDiagnostics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(time.Second)
 	seenMismatch := false
-	for time.Now().Before(deadline) {
-		for _, params := range recorder.publishDiagnostics() {
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), jsonrpcDiagnosticsWaitTimeout)
+	seenMismatch = recorder.waitForDiagnostics(waitCtx, func(params []protocol.PublishDiagnosticsParams) bool {
+		for _, params := range params {
 			for _, diag := range params.Diagnostics {
 				if strings.Contains(diag.Message, `Local constant "PROCEDURE_NAME" is "OldName" but its enclosing procedure is "Foo".`) {
-					seenMismatch = true
-					break
+					return true
 				}
 			}
-			if seenMismatch {
-				break
-			}
 		}
-		if seenMismatch {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return false
+	})
+	waitCancel()
 	if !seenMismatch {
 		_ = serverConn.Close()
 		t.Fatalf("VB044 publishDiagnostics missing: %+v", recorder.publishDiagnostics())
@@ -1472,24 +1477,23 @@ func TestJSONRPCPublishesProcedureNameConstantDiagnostics(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	deadline = time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		published := recorder.publishDiagnostics()
-		if len(published) > before {
-			latest := published[len(published)-1]
-			hasVB044 := false
-			for _, diag := range latest.Diagnostics {
-				if strings.Contains(diag.Message, "enclosing procedure") {
-					hasVB044 = true
-					break
-				}
-			}
-			if !hasVB044 {
-				_ = serverConn.Close()
-				return
+	waitCtx, waitCancel = context.WithTimeout(context.Background(), jsonrpcDiagnosticsWaitTimeout)
+	cleared := recorder.waitForDiagnostics(waitCtx, func(published []protocol.PublishDiagnosticsParams) bool {
+		if len(published) <= before {
+			return false
+		}
+		latest := published[len(published)-1]
+		for _, diag := range latest.Diagnostics {
+			if strings.Contains(diag.Message, "enclosing procedure") {
+				return false
 			}
 		}
-		time.Sleep(10 * time.Millisecond)
+		return true
+	})
+	waitCancel()
+	if cleared {
+		_ = serverConn.Close()
+		return
 	}
 	_ = serverConn.Close()
 	t.Fatalf("VB044 diagnostic did not clear after didChange: %+v", recorder.publishDiagnostics())
@@ -1531,12 +1535,12 @@ func TestJSONRPCPublishesAnalyzerDiagnostics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), jsonrpcDiagnosticsWaitTimeout)
+	matched := recorder.waitForDiagnostics(waitCtx, func(params []protocol.PublishDiagnosticsParams) bool {
 		seenRangeFind := false
 		seenObjectGuard := false
 		seenDictionaryIteration := false
-		for _, params := range recorder.publishDiagnostics() {
+		for _, params := range params {
 			for _, diag := range params.Diagnostics {
 				if strings.Contains(diag.Message, "Range.Find result found is dereferenced") {
 					seenRangeFind = true
@@ -1549,11 +1553,12 @@ func TestJSONRPCPublishesAnalyzerDiagnostics(t *testing.T) {
 				}
 			}
 		}
-		if seenRangeFind && seenObjectGuard && seenDictionaryIteration {
-			_ = serverConn.Close()
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+		return seenRangeFind && seenObjectGuard && seenDictionaryIteration
+	})
+	waitCancel()
+	if matched {
+		_ = serverConn.Close()
+		return
 	}
 	_ = serverConn.Close()
 	t.Fatalf("analyzer publishDiagnostics missing VBA201, VBA212, or VBA213: %+v", recorder.publishDiagnostics())
@@ -2038,9 +2043,10 @@ func TestSemanticTokensFullUsesOpenDocumentAndValidEncoding(t *testing.T) {
 }
 
 type rpcRecorder struct {
-	mu          sync.Mutex
-	methodsSeen []string
-	paramsSeen  map[string][]json.RawMessage
+	mu                sync.Mutex
+	methodsSeen       []string
+	paramsSeen        map[string][]json.RawMessage
+	diagnosticsSignal chan struct{}
 }
 
 func (r *rpcRecorder) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
@@ -2053,21 +2059,19 @@ func (r *rpcRecorder) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 		copied := append(json.RawMessage(nil), (*req.Params)...)
 		r.paramsSeen[req.Method] = append(r.paramsSeen[req.Method], copied)
 	}
+	if req.Method == string(protocol.ServerTextDocumentPublishDiagnostics) {
+		if r.diagnosticsSignal == nil {
+			r.diagnosticsSignal = make(chan struct{}, 1)
+		}
+		select {
+		case r.diagnosticsSignal <- struct{}{}:
+		default:
+		}
+	}
 	r.mu.Unlock()
 	if !req.Notif {
 		_ = conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: "method not found"})
 	}
-}
-
-func (r *rpcRecorder) seen(method string) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for _, candidate := range r.methodsSeen {
-		if candidate == method {
-			return true
-		}
-	}
-	return false
 }
 
 func (r *rpcRecorder) methods() []string {
@@ -2087,6 +2091,28 @@ func (r *rpcRecorder) publishDiagnostics() []protocol.PublishDiagnosticsParams {
 		}
 	}
 	return out
+}
+
+func (r *rpcRecorder) waitForDiagnostics(ctx context.Context, predicate func([]protocol.PublishDiagnosticsParams) bool) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		if predicate(r.publishDiagnostics()) {
+			return true
+		}
+		r.mu.Lock()
+		if r.diagnosticsSignal == nil {
+			r.diagnosticsSignal = make(chan struct{}, 1)
+		}
+		signal := r.diagnosticsSignal
+		r.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return false
+		case <-signal:
+		}
+	}
 }
 
 func hasCompletionItem(items []protocol.CompletionItem, label string) bool {

--- a/internal/lspserver/server_test.go
+++ b/internal/lspserver/server_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
 	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
 	"github.com/sourcegraph/jsonrpc2"
@@ -279,6 +280,28 @@ func TestNewCreatesLogFileWithoutStartingServer(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(root, logPath)); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestNewOwnsSemanticQueryStorePerServer(t *testing.T) {
+	first, firstCleanup, err := New(Options{RootDir: t.TempDir(), Config: config.Default()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer firstCleanup()
+	second, secondCleanup, err := New(Options{RootDir: t.TempDir(), Config: config.Default()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer secondCleanup()
+	if first.semanticQueries == nil || second.semanticQueries == nil {
+		t.Fatal("server semantic query store is nil")
+	}
+	if first.semanticQueries == second.semanticQueries {
+		t.Fatal("servers share a semantic query store")
+	}
+	if first.semanticQueries == semanticquery.DefaultStore() || second.semanticQueries == semanticquery.DefaultStore() {
+		t.Fatal("LSP server uses the process-global semantic query store")
 	}
 }
 

--- a/internal/staticanalysis/corpus/benchmark_test.go
+++ b/internal/staticanalysis/corpus/benchmark_test.go
@@ -2,11 +2,14 @@ package corpus
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/analyze"
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticquery"
+	"github.com/harumiWeb/xlflow/internal/config"
 	"github.com/harumiWeb/xlflow/internal/typedb"
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 )
@@ -46,8 +49,17 @@ func BenchmarkRealWorldCorpus(b *testing.B) {
 			b.Run("full-pipeline", func(b *testing.B) {
 				benchmarkRealWorldCorpusFullPipeline(b, corpusRoot, project)
 			})
-			b.Run("analyze-only", func(b *testing.B) {
-				benchmarkRealWorldCorpusAnalyzeOnly(b, corpusRoot, project)
+			b.Run("analyze-only/cold", func(b *testing.B) {
+				benchmarkRealWorldCorpusAnalyzeOnlyMode(b, corpusRoot, project, corpusBenchmarkCold)
+			})
+			b.Run("analyze-only/warm", func(b *testing.B) {
+				benchmarkRealWorldCorpusAnalyzeOnlyMode(b, corpusRoot, project, corpusBenchmarkWarm)
+			})
+			b.Run("analyze-only/local-edit", func(b *testing.B) {
+				benchmarkRealWorldCorpusEditMode(b, corpusRoot, project, corpusBenchmarkLocalEdit)
+			})
+			b.Run("analyze-only/dependency-edit", func(b *testing.B) {
+				benchmarkRealWorldCorpusEditMode(b, corpusRoot, project, corpusBenchmarkDependencyEdit)
 			})
 		})
 	}
@@ -78,7 +90,27 @@ func benchmarkRealWorldCorpusFullPipeline(b *testing.B, corpusRoot string, proje
 	b.ReportMetric(float64(surfaces)/float64(b.N), "surfaces/op")
 }
 
-func benchmarkRealWorldCorpusAnalyzeOnly(b *testing.B, corpusRoot string, project Project) {
+type corpusBenchmarkMode uint8
+
+const (
+	corpusBenchmarkCold corpusBenchmarkMode = iota
+	corpusBenchmarkWarm
+)
+
+type corpusBenchmarkEditMode uint8
+
+const (
+	corpusBenchmarkLocalEdit corpusBenchmarkEditMode = iota
+	corpusBenchmarkDependencyEdit
+)
+
+// benchmarkRealWorldCorpusAnalyzeOnlyMode keeps cold and warm measurements
+// independent. Cold runs deliberately use a new process-local query store for
+// each operation, while warm runs prime one store outside the timed region and
+// reuse it for every measured operation. The source workspace is materialized
+// once in both cases so filesystem setup is not confused with query-store
+// overhead.
+func benchmarkRealWorldCorpusAnalyzeOnlyMode(b *testing.B, corpusRoot string, project Project, mode corpusBenchmarkMode) {
 	workspace, err := MaterializeThirdPartyProject(corpusRoot, project, MaterializeOptions{TempRoot: b.TempDir()})
 	if err != nil {
 		b.Fatalf("materialize %q: %v", project.ID, err)
@@ -95,20 +127,143 @@ func benchmarkRealWorldCorpusAnalyzeOnly(b *testing.B, corpusRoot string, projec
 	}
 
 	recorder := analysisstats.NewRecorder()
-	ctx := analysisstats.WithRecorder(context.Background(), recorder)
+	var store *semanticquery.Store
+	if mode == corpusBenchmarkWarm {
+		store = semanticquery.New(semanticquery.Options{})
+		// Prime the same revision before starting the timer. The prime context
+		// intentionally has no recorder so its misses/recomputations are not
+		// reported as part of the warm operation metrics.
+		if _, _, err := runCorpusAnalyzeOnly(contextWithSemanticQueryStore(context.Background(), store, nil), workspace.Root, cfg); err != nil {
+			b.Fatalf("prime analysis %q: %v", project.ID, err)
+		}
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	var findings, warnings int
 	for i := 0; i < b.N; i++ {
-		result, err := (analyze.Analyzer{RootDir: workspace.Root, Config: cfg}).RunResultContext(ctx)
+		if mode == corpusBenchmarkCold {
+			store = semanticquery.New(semanticquery.Options{})
+		}
+		result, resultWarnings, err := runCorpusAnalyzeOnly(contextWithSemanticQueryStore(context.Background(), store, recorder), workspace.Root, cfg)
 		if err != nil {
 			b.Fatalf("analyze %q: %v", project.ID, err)
 		}
-		findings += len(result.Findings)
-		warnings += len(result.Warnings)
+		findings += result
+		warnings += resultWarnings
 	}
 	b.ReportMetric(float64(findings)/float64(b.N), "findings/op")
 	b.ReportMetric(float64(project.SourceCounts.Total()), "source-files/op")
+	b.ReportMetric(float64(warnings)/float64(b.N), "warnings/op")
+	reportCorpusAnalysisRecorderMetrics(b, recorder, b.N)
+}
+
+func contextWithSemanticQueryStore(ctx context.Context, store *semanticquery.Store, recorder *analysisstats.Recorder) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if recorder != nil {
+		ctx = analysisstats.WithRecorder(ctx, recorder)
+	}
+	return semanticquery.WithContext(ctx, semanticquery.Context{Store: store, Metrics: recorder})
+}
+
+func runCorpusAnalyzeOnly(ctx context.Context, root string, cfg config.Config) (findings, warnings int, err error) {
+	result, err := (analyze.Analyzer{RootDir: root, Config: cfg}).RunResultContext(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	return len(result.Findings), len(result.Warnings), nil
+}
+
+// benchmarkRealWorldCorpusEditMode exercises revision reuse with benchmark-
+// owned modules. The dependency case cycles callee body/signature/effect edits
+// and a caller redirect. The files are deliberately independent from the
+// checked-in corpus so the benchmark never mutates a real source fixture. File
+// writes are outside the timed region; the timed operation includes parsing,
+// revision fingerprinting, invalidation, and analysis of the edited revision.
+func benchmarkRealWorldCorpusEditMode(b *testing.B, corpusRoot string, project Project, mode corpusBenchmarkEditMode) {
+	workspace, err := MaterializeThirdPartyProject(corpusRoot, project, MaterializeOptions{TempRoot: b.TempDir()})
+	if err != nil {
+		b.Fatalf("materialize %q: %v", project.ID, err)
+	}
+	b.Cleanup(func() {
+		if err := workspace.Close(); err != nil {
+			b.Errorf("cleanup %q: %v", project.ID, err)
+		}
+	})
+	exec := productionExecutor()
+	cfg, err := exec.loadConfig(workspace.Root)
+	if err != nil {
+		b.Fatalf("load config for %q: %v", project.ID, err)
+	}
+	moduleRoot := filepath.Join(workspace.Root, "src", "modules")
+	localPath := filepath.Join(moduleRoot, "Benchmark724Local.bas")
+	calleePath := filepath.Join(moduleRoot, "Benchmark724DependencyCallee.bas")
+	callerPath := filepath.Join(moduleRoot, "Benchmark724DependencyCaller.bas")
+	redirectPath := filepath.Join(moduleRoot, "Benchmark724DependencyRedirect.bas")
+	// Prime with a state that differs from the first timed operation so a
+	// benchtime=1x run still exercises one real revision edit.
+	localSource := []byte("Attribute VB_Name = \"Benchmark724Local\"\nOption Explicit\nPublic Sub BenchmarkLocal()\n    Dim values() As Long\n    ReDim values(1 To 2)\n    values(1) = 0\nEnd Sub\n")
+	calleeSource := []byte("Attribute VB_Name = \"Benchmark724DependencyCallee\"\nOption Explicit\nPublic Function Benchmark724DependencyCallee(value As Long) As Long\n    Dim values() As Long\n    ReDim values(1 To 2)\n    values(1) = value\n    Range(\"A1\").Value = value\n    Benchmark724DependencyCallee = value\nEnd Function\n")
+	callerSource := []byte("Attribute VB_Name = \"Benchmark724DependencyCaller\"\nOption Explicit\nPublic Sub Benchmark724DependencyCaller()\n    Dim value As Long\n    value = Benchmark724DependencyCallee(1)\nEnd Sub\n")
+	redirectSource := []byte("Attribute VB_Name = \"Benchmark724DependencyRedirect\"\nOption Explicit\nPublic Function Benchmark724DependencyRedirect(value As Long) As Long\n    Benchmark724DependencyRedirect = value\nEnd Function\n")
+	for path, source := range map[string][]byte{localPath: localSource, calleePath: calleeSource, callerPath: callerSource, redirectPath: redirectSource} {
+		if err := os.WriteFile(path, source, 0o644); err != nil {
+			b.Fatalf("write benchmark module %q: %v", path, err)
+		}
+	}
+	store := semanticquery.New(semanticquery.Options{})
+	if _, _, err := runCorpusAnalyzeOnly(contextWithSemanticQueryStore(context.Background(), store, nil), workspace.Root, cfg); err != nil {
+		b.Fatalf("prime edit analysis %q: %v", project.ID, err)
+	}
+	recorder := analysisstats.NewRecorder()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var findings, warnings int
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		if mode == corpusBenchmarkLocalEdit {
+			body := "    values(1) = 1\n"
+			if i&1 == 1 {
+				body = "    values(1) = 2\n"
+			}
+			updated := []byte("Attribute VB_Name = \"Benchmark724Local\"\nOption Explicit\nPublic Sub BenchmarkLocal()\n    Dim values() As Long\n    ReDim values(1 To 2)\n" + body + "End Sub\n")
+			if err := os.WriteFile(localPath, updated, 0o644); err != nil {
+				b.Fatalf("write local edit: %v", err)
+			}
+		} else {
+			variant := i & 3
+			parameterType := "Long"
+			if variant == 2 {
+				parameterType = "Variant"
+			}
+			calleeBody := "    Dim values() As Long\n    ReDim values(1 To 2)\n    values(1) = value\n    Benchmark724DependencyCallee = value\n"
+			if variant == 1 {
+				calleeBody = "    Dim values() As Long\n    ReDim values(1 To 2)\n    values(1) = value\n    Range(\"A1\").Value = value\n    Benchmark724DependencyCallee = value\n"
+			}
+			updated := []byte("Attribute VB_Name = \"Benchmark724DependencyCallee\"\nOption Explicit\nPublic Function Benchmark724DependencyCallee(value As " + parameterType + ") As Long\n" + calleeBody + "End Function\n")
+			if err := os.WriteFile(calleePath, updated, 0o644); err != nil {
+				b.Fatalf("write dependency edit: %v", err)
+			}
+			if variant == 3 {
+				callerSource = []byte("Attribute VB_Name = \"Benchmark724DependencyCaller\"\nOption Explicit\nPublic Sub Benchmark724DependencyCaller()\n    Dim value As Long\n    value = Benchmark724DependencyRedirect(1)\nEnd Sub\n")
+			} else {
+				callerSource = []byte("Attribute VB_Name = \"Benchmark724DependencyCaller\"\nOption Explicit\nPublic Sub Benchmark724DependencyCaller()\n    Dim value As Long\n    value = Benchmark724DependencyCallee(1)\nEnd Sub\n")
+			}
+			if err := os.WriteFile(callerPath, callerSource, 0o644); err != nil {
+				b.Fatalf("write dependency caller edit: %v", err)
+			}
+		}
+		b.StartTimer()
+		result, resultWarnings, err := runCorpusAnalyzeOnly(contextWithSemanticQueryStore(context.Background(), store, recorder), workspace.Root, cfg)
+		if err != nil {
+			b.Fatalf("analyze edit %q: %v", project.ID, err)
+		}
+		findings += result
+		warnings += resultWarnings
+	}
+	b.ReportMetric(float64(findings)/float64(b.N), "findings/op")
+	b.ReportMetric(float64(project.SourceCounts.Total()+4), "source-files/op")
 	b.ReportMetric(float64(warnings)/float64(b.N), "warnings/op")
 	reportCorpusAnalysisRecorderMetrics(b, recorder, b.N)
 }

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -999,6 +999,10 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `selected_by`
 - `selected_index`
 - `semantic_kernel_runs`
+- `semantic_query_hits`
+- `semantic_query_invalidated_procedures`
+- `semantic_query_misses`
+- `semantic_query_recomputed_kernels`
 - `semantic_results_reused`
 - `sensitive_module_constant`
 - `session_args_invalid`


### PR DESCRIPTION
## Summary

- Precompute revision-owned semantic fingerprints and kernel-specific dependency leaves to reduce repeated serialization, hashing, and capability-map scans.
- Compact semantic-query dependencies, reverse-edge metadata, exact document invalidation, epoch handling, and late-publication rejection while preserving conservative invalidation and deterministic outputs.
- Add cold, warm, local-edit, and dependency-edit corpus benchmark cases for `std-vba` and ROneCOne, with semantic-query and physical-kernel counters.
- Replace fixed polling in JSON-RPC diagnostic tests with notification-signaled condition waits so race runs do not fail at the 1-second boundary.

## Compatibility

- Public CLI, JSON, LSP, and configuration schemas are unchanged.
- Cache lifetime remains process-local; no disk or cross-process cache is introduced.
- Findings, diagnostic ordering/projections, suppression, cancellation, and concurrent-revision behavior remain covered by the existing and added tests.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./... -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/lspserver -count=1`
- Focused JSON-RPC notification tests under `-race`, repeated three times.
- `rtk pnpm format:check`
- `rtk git diff --check`
- Final independent review: no clear defects found.

Closes #724


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved repeated analysis performance by reusing unchanged semantic-analysis results across revisions.
  - Reduced unnecessary recomputation after local edits while selectively refreshing affected results after dependency changes.

- **Reliability**
  - Preserved existing diagnostic and language-server behavior while improving cancellation and concurrent analysis safety.
  - Added safeguards to ensure cached results are invalidated when relevant source or configuration changes occur.

- **Documentation**
  - Added architecture and verification documentation describing semantic-analysis reuse, invalidation, and performance benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->