### PR TITLE
perf(analyze): migrate advanced Array CFG paths to compact solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ All notable changes to xlflow will be documented in this file.
   snapshot, CLI JSON, and LSP contracts. HTTP nested-map scalarization and
   source-line/edge-refinement Array paths remain follow-up migrations.
 
+- Extended the indexed semantic-state solver to advanced Array CFG paths,
+  including source-line lifecycle ordering, normal-edge refinement,
+  exceptional/uncertain edge handling, and combined runtime/evidence lanes.
+  Indexed cursors keep semantic slots separate from diagnostic sidecars while
+  preserving `VBA208`, `VBA227`, and `VBA249` findings, evidence, ordering, and
+  conservative `ReliableExceptional` behavior. A preflight compatibility
+  boundary retains the legacy walker for unsupported participant or transfer
+  contracts; compact/legacy counts and fallback reasons remain
+  developer-only telemetry. The five-sample ROneCOne measurement and focused
+  CPU/heap alloc-space profile are recorded in the corpus specification; the
+  retained leaf profile shows a material reduction versus the #713 baseline.
+
 - Restricted array interprocedural fixed-point planning to semantic
   participants discovered from array operations, parameters/returns,
   ByRef/module-state dependencies, and resolved caller/callee closure.

--- a/docs/adr/ADR-0047-compact-semantic-state-solver.md
+++ b/docs/adr/ADR-0047-compact-semantic-state-solver.md
@@ -119,8 +119,9 @@ and unrelated semantic domains remain outside this decision.
 The shared solver boundary now accepts source-line transfers and an explicit
 edge-policy result. A policy may refine a normal edge, retain the predecessor
 input for an exceptional or uncertain edge, or suppress propagation for an
-edge that is not a continuation after a completed `Stop`/termination. A nil
-policy retains the historical default of propagating the predecessor input;
+edge that is not a continuation after a completed `Stop`/termination. With a
+nil policy, the solver propagates transfer output on normal edges and retains
+predecessor input on exceptional or uncertain edges;
 adapters that do not need refinement therefore remain source-compatible. Edge
 refinement is evaluated only for normal continuation edges. This keeps
 conditional allocation, allocation guards, and module-configuration branches

--- a/docs/adr/ADR-0047-compact-semantic-state-solver.md
+++ b/docs/adr/ADR-0047-compact-semantic-state-solver.md
@@ -104,15 +104,75 @@ must not cause state copies or affect equality.
 
 The first migration covers the HTTP scheduler boundary (`solveHTTPStates`)
 and the ordinary block-level `arrayFlowState` walk. HTTP's nested state is
-not yet compacted into semantic-unit slots. Array source-line traversal,
-edge-refinement callbacks, and interprocedural evidence walkers remain on
-their compatibility path until their callback contracts can be migrated
-without changing the VBA227/VBA208/VBA249 boundary. Existing diagnostic IDs,
-severity, ranges, messages, suppression, JSON, LSP projections,
-batch/realtime parity, and performance-counter meanings remain unchanged.
-Generic
-`internal/vba/dataflow`, CFG storage, cross-run caching, and unrelated semantic
-domains remain outside this decision.
+not yet compacted into semantic-unit slots. Issue #721 amends this boundary
+for the remaining Array paths without changing the semantic lattice. The
+source-line lifecycle lane, normal-edge refinement, exceptional/uncertain
+edges, and combined runtime/evidence lanes use the same indexed solver when
+their participant index and transfer contract can be built before execution.
+Existing diagnostic IDs, severity, ranges, messages, suppression, JSON, LSP
+projections, batch/realtime parity, and performance-counter meanings remain
+unchanged. Generic `internal/vba/dataflow`, CFG storage, cross-run caching,
+and unrelated semantic domains remain outside this decision.
+
+### Amendment: advanced Array paths on the indexed solver (Issue #721)
+
+The shared solver boundary now accepts source-line transfers and an explicit
+edge-policy result. A policy may refine a normal edge, retain the predecessor
+input for an exceptional or uncertain edge, or suppress propagation for an
+edge that is not a continuation after a completed `Stop`/termination. A nil
+policy retains the historical default of propagating the predecessor input;
+adapters that do not need refinement therefore remain source-compatible. Edge
+refinement is evaluated only for normal continuation edges. This keeps
+conditional allocation, allocation guards, and module-configuration branches
+out of exceptional and uncertain propagation.
+
+The Array adapter indexes one fixed semantic participant catalog and transfers
+through an internal cursor over compact slots. The legacy map adapter keeps
+the same transfer, join, module-call effect, ByRef/return summary, and
+evidence-read callback contract for differential tests, while retaining map
+storage as the compatibility oracle. Joins update reusable output and edge
+scratch in place. The compact solver boundary does not materialize a new
+whole-state map for block scheduling; domain callbacks may retain their
+documented copy-on-write behavior for legacy-compatible branch refinements.
+Dimension and preserve shapes are immutable values; an update creates a new
+shape value only when the shape itself changes.
+
+The base and runtime lanes for one `CFGView` are solved as one indexed lane
+group. The `VBA227` source-line lane that excludes the normal continuation is a
+separate solver group so physical source-line order remains observable. A
+completed stop suppresses all successor edges. Finding buffers, runtime
+findings, ByRef-call evidence, module-entry contributions, and return
+candidates remain lane-local sidecars rather than fixed-point state; the
+existing deduplication and `sortFindings` stages remain authoritative for
+evidence and result ordering.
+
+Exceptional and uncertain edges retain the legacy conservative rule: they
+receive predecessor input state. Under `On Error Resume Next`, the adapter may
+retain predecessor output only when `ReliableExceptional` proves a plain
+`ReDim`, `Array`, `Split`, or `Filter` allocation. `ReDim Preserve` does not
+receive that exceptional allocation proof when its prior allocation or shape
+is unknown. This rule applies equally to the source-line and combined lanes.
+
+Compatibility selection is a preflight decision. `auto` selects the indexed
+solver when the participant catalog is fixed, the cursor can represent every
+semantic write, and the requested lane contracts are supported. Index-build
+failure, an empty semantic state that still needs declaration-side diagnostics,
+or an explicitly unsupported transfer contract selects the legacy walker.
+Recovered or incomplete CFG input is not by itself a fallback reason when it
+can be indexed and retains the same unknown/uncertain semantics. Cancellation,
+transfer failure, or another execution-time error does not trigger a partial
+legacy retry. The legacy walker remains available for compatibility and
+differential testing; forced `compact` and `legacy` strategies are test and
+benchmark controls only.
+
+Compact/legacy walk counts and fallback reasons (empty-state, index-build, or
+unsupported-contract) are developer-only telemetry.
+They are not part of semantic state, normal CLI JSON, LSP payloads, corpus
+snapshots, or the diagnostic review ledger. The specified ROneCOne benchmark
+and alloc-space profile were collected against the #713 baseline. The focused
+three-leaf profile shows a material reduction; end-to-end wall time remains
+observational because host-load variance is high, and the profile paths and
+values are retained in the corpus specification.
 
 ## Consequences
 

--- a/docs/specs/array-lifecycle-safety.md
+++ b/docs/specs/array-lifecycle-safety.md
@@ -52,6 +52,47 @@ as another fixed-point walk. These policy choices are deliberate and do not
 change diagnostic code, severity, message, range, ordering, suppression, or
 Batch/realtime parity.
 
+## Indexed solver migration boundary (#721)
+
+The block-level, source-line lifecycle, edge-refined, and combined
+runtime/evidence Array walks share one indexed semantic-state boundary when
+the fixed participant catalog and transfer callbacks are available. The
+source-line lane retains physical source-line order in its own solver group;
+the base and runtime lanes for one CFG view share an indexed lane group. The
+solver cursor is used for allocation, shape, alias, module-call, ByRef, and
+return-summary state. The legacy map adapter preserves the same
+transfer/evidence callback contract and remains the differential oracle and
+compatibility fallback.
+
+Only normal continuation edges receive conditional-allocation,
+allocation-guard, and module-configuration refinement. Exceptional and
+uncertain edges receive predecessor input state. With `On Error Resume Next`,
+`ReliableExceptional` permits predecessor output only for a proven plain
+`ReDim`, `Array`, `Split`, or `Filter` allocation; `ReDim Preserve` remains
+unknown when its prior allocation or shape is not proven. A completed `Stop`
+suppresses all successor propagation. These edge rules apply to `VBA227`,
+`VBA208`, `VBA249`, and their combined evidence lanes without changing the
+existing allocation or shape lattice.
+
+Semantic slots contain only bounded allocation, shape, alias, and summary
+facts needed by the fixed point. Diagnostic findings, runtime findings,
+ByRef-call evidence, module-entry contributions, and return candidates are
+lane-local sidecars. They do not enlarge state equality or force a requeue;
+the existing deduplication, evidence canonicalization, and deterministic
+`sortFindings` stages remain authoritative for output order and multiplicity.
+
+`auto` chooses compact only after a preflight check confirms a fixed
+participant index and representable semantic writes. Index construction
+failure, an empty semantic state that still needs declaration-side diagnostics,
+or an unsupported transfer contract use the legacy walker. Recovered or
+incomplete CFG input remains on compact when it can be indexed with the
+existing unknown/uncertain semantics; recovery alone is not a fallback reason.
+Cancellation and execution-time failures do not cause a partial legacy retry.
+Forced compact/legacy selection is reserved for tests and benchmarks, and
+strategy/fallback telemetry, including fallback reason counters, is
+developer-only rather than a CLI, JSON, LSP,
+snapshot, or review-ledger field.
+
 ## State model
 
 The analyzer carries a case-insensitive variable state through the procedure

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1759,6 +1759,105 @@ remain explicitly on the compatibility walker and require a follow-up
 migration with differential evidence. No corpus snapshot or review-ledger
 change is justified by this partial migration.
 
+### Advanced Array indexed-solver verification requirements (#721)
+
+Issue #721 extends the indexed semantic-state solver to the Array paths that
+were intentionally left on the #713 compatibility walker: physical
+source-line lifecycle analysis, normal-edge refinement, exceptional and
+uncertain edges, and combined runtime/evidence lanes. The migration must
+preserve `VBA208`, `VBA227`, and `VBA249` finding identity, source locations,
+severity, evidence, multiplicity, suppression, and deterministic ordering.
+The legacy walker remains both the compatibility fallback and the
+differential oracle.
+
+The compact path uses one fixed semantic participant index and an indexed
+cursor for allocation, shape, alias, module-call, ByRef, and return-summary
+state. It must not materialize a whole `arrayFlowState`, build a union-key map,
+or copy a complete state for each block or edge. Diagnostic findings, runtime
+findings, ByRef-call evidence, module-entry contributions, and return
+candidates remain lane-local sidecars and must not affect fixed-point equality.
+The source-line lane is a separate solver group that retains physical line
+order; base and runtime lanes for one `CFGView` share one indexed lane group.
+
+Normal edges alone may apply conditional-allocation, allocation-guard, and
+module-configuration refinement. Exceptional and uncertain edges retain
+predecessor input state. `ReliableExceptional` may retain predecessor output
+only for a proven plain `ReDim`, `Array`, `Split`, or `Filter` allocation under
+`On Error Resume Next`; `ReDim Preserve` remains conservative when its prior
+allocation or shape is unknown. A completed `Stop` suppresses every successor
+edge. Recovered or incomplete CFG input is compact-eligible when it can be
+indexed with the existing unknown/uncertain semantics.
+
+`auto` chooses compact only after preflight confirms that the participant
+catalog is fixed, all semantic writes are representable, and the requested
+transfer contract is supported. Index-construction failure, a
+participant-out-of-catalog write known before execution, or an unsupported
+transfer contract uses the legacy walker. Cancellation and execution-time
+errors do not trigger a partial legacy retry. Compact/legacy strategy counts
+and fallback reasons are developer-only telemetry and never enter corpus
+snapshots or `reviews/diagnostics.jsonl`.
+
+The required differential matrix covers source-line ordering and multiline
+statements, loops and recursive CFGs, normal/exceptional/uncertain edges,
+plain `ReDim` versus `ReDim Preserve`, `Array`/`Split`/`Filter`, object arrays,
+module-configuration branches, conditional allocation guards, aliases,
+module calls, recursive ByRef/helper chains, array-return summaries, and the
+combined `VBA208`/`VBA227`/`VBA249` lanes. Forced legacy and compact runs must
+compare the complete ordered finding records, source ranges, evidence and
+runtime context, multiplicity, suppression, exit status, and normal JSON.
+Any unexplained difference is a stop-and-investigate condition; it is not a
+reason to refresh a snapshot.
+
+Use the following commands on the same Windows machine and Go toolchain as
+the #713 record. The race and corpus commands are required verification; the
+benchmark command is the one-sample profile source and must also be run as
+five serial samples for the reported median:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/analyze
+rtk task corpus:test
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=1 -timeout=10m
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=5 -timeout=10m
+```
+
+The #713 post-migration sample is the comparison baseline for the advanced
+Array paths (`8.93e9 ns/op`, `11,203,650,096 B/op`, `81,659,543 allocs/op`,
+approximately 1.58 GB `cloneArrayState`, 0.53 GB `meetArrayState`, and
+0.09 GB `cloneHTTPState`). The original #713 starting sample remains the
+combined-target reference (approximately 1.62 GB, 0.53 GB, and 0.07 GB).
+Issue #721's final five serial ROneCOne samples were collected on the current
+Windows/Go environment. Their median was 9.700 s/op, 10,386,967,992 B/op,
+and 92,124,549 allocs/op. The five timings were 30.424, 16.039, 9.111,
+9.700, and 9.159 s/op; the first two samples show the host-load variance
+that is why wall time is not a CI threshold. The final one-sample profile run
+emitted 1,307 compact Array walks, zero legacy walks, and zero fallbacks. The
+final leaf profile is the evidence used for the allocation comparison:
+
+The profiled one-sample result was 9,085,157,800 ns/op,
+10,419,480,376 B/op, and 92,125,359 allocs/op.
+
+| measure                         |            #713 post-migration baseline |                      #721 result | status                                           |
+| ------------------------------- | --------------------------------------: | -------------------------------: | ------------------------------------------------ |
+| ROneCOne `ns/op`                |                                  8.93e9 |  9,700,135,400 (five-run median) | measured; high host-load variance                |
+| ROneCOne `B/op`                 |                          11,203,650,096 | 10,386,967,992 (five-run median) | measured; not a cross-issue target claim         |
+| ROneCOne `allocs/op`            |                              81,659,543 |     92,124,549 (five-run median) | measured; not a cross-issue target claim         |
+| `cloneArrayState` alloc-space   |                                ~1.58 GB |                       ~0.0065 GB | measured; material reduction                     |
+| `meetArrayState` alloc-space    |                                ~0.53 GB |              0 GB in focused top | measured; material reduction                     |
+| `cloneHTTPState` alloc-space    |                                ~0.09 GB |                       ~0.1005 GB | measured; retained for the HTTP follow-up        |
+| combined three-leaf alloc-space | ~2.20 GB post-#713; ~2.22 GB #713 start |                        ~0.107 GB | measured; ~95% reduction versus #713 post sample |
+
+Retain one CPU and heap profile for the one-sample run and inspect
+`-sample_index=alloc_space` for `cloneArrayState`, `meetArrayState`, and
+`cloneHTTPState`. The retained profiles are
+`C:\temp\xlflow-issue721-final2.cpu.pprof` and
+`C:\temp\xlflow-issue721-final2.mem.pprof`; their focused leaves were
+approximately 0.0065 GB, 0 GB, and 0.1005 GB respectively (about 0.107 GB
+combined). Report the final five-sample median, `B/op`, `allocs/op`, compact
+and legacy walk counts, fallback reasons, and profile paths. The focused
+alloc-space profile demonstrates the three-leaf reduction; the large
+end-to-end benchmark values remain recorded for follow-up rather than
+treated as a CI time threshold.
+
 ### Revision-scoped semantic query DAG verification requirements (#715)
 
 Issue #715 adds process-local, revision-scoped reuse for immutable semantic

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -713,17 +713,61 @@ across revisions or nested worker pools.
 The solver stores present slots in dense bitset-backed storage for small or
 dense domains and sorted sparse storage for wide, sparse domains. Domain joins
 update the destination in place and report changed slots, so unchanged blocks
-are not requeued. Exceptional and uncertain edges retain predecessor input
-state. HTTP and Array adapters keep their existing conservative lattice and
-diagnostic projection contracts; source ranges, representative evidence, and
-finding multiplicity are not part of semantic state.
+are not requeued. HTTP and Array adapters keep their existing conservative
+lattice and diagnostic projection contracts; source ranges, representative
+evidence, and finding multiplicity are not part of semantic state.
 
-This is an incremental migration boundary. Array source-line traversal,
-edge-refinement paths, and interprocedural evidence walkers continue to use
-their compatibility walker until their callback contracts can be represented
-without changing VBA227/VBA208/VBA249 behavior. The shared solver API and
-dense/sparse/hybrid benchmarks are internal implementation details and do not
-add CLI, JSON, or LSP fields.
+#### Advanced Array transfer contract (#721)
+
+The Array adapter extends the shared solver with source-line transfers and an
+explicit edge-policy result. Normal edges may apply conditional allocation,
+allocation-guard, or module-configuration refinement. Exceptional and
+uncertain edges retain predecessor input state, except that
+`ReliableExceptional` may retain predecessor output for a proven plain
+`ReDim`, `Array`, `Split`, or `Filter` allocation. `ReDim Preserve` remains
+conservative when its prior allocation or shape is unknown. A completed
+`Stop` suppresses every successor edge. A nil edge policy means ordinary
+propagation, preserving the compatibility behavior of adapters without edge
+refinement.
+
+The source-line lifecycle lane evaluates physical source lines in order and
+uses a separate solver group for the graph with normal continuation removed;
+the base and runtime lanes for one `CFGView` share one indexed lane group.
+Module-call effects, ByRef entries, return summaries, and array aliases read
+and write an indexed cursor over one fixed semantic participant catalog. The
+legacy map adapter keeps the same transfer/evidence callback contract for
+differential tests and remains the compatibility oracle. Compact joins update
+reusable output/edge scratch in place and must not materialize a whole
+`arrayFlowState`, union-key map, or full-state copy for block scheduling.
+Dimension and preserve shapes remain immutable values and are copied only when
+the shape itself changes.
+
+Finding buffers, runtime findings, ByRef-call evidence, module-entry
+contributions, and return candidates are lane-local sidecars. They do not
+participate in fixed-point equality or requeue decisions. Existing
+deduplication, source/range/evidence canonicalization, and final
+`sortFindings` ordering remain the authority for observable output. This
+preserves `VBA208`, `VBA227`, and `VBA249` diagnostics, locations, evidence,
+multiplicity, suppression, and batch/realtime parity.
+
+`auto` selects the indexed path only after a preflight compatibility check
+proves that the participant catalog is fixed, every semantic write is
+representable by the cursor, and the requested transfer callbacks are
+supported. Index construction failure, an empty semantic state that still
+needs declaration-side diagnostics, or an unsupported transfer contract
+selects the legacy walker. Recovered or incomplete CFG input is not itself a
+fallback reason when it is indexable and retains the same unknown/uncertain
+semantics.
+Cancellation and execution-time transfer errors do not trigger a partial
+legacy retry. Forced `compact` and `legacy` modes are internal test and
+benchmark controls; the legacy walker remains the documented compatibility
+and differential oracle.
+
+Solver strategy counts and fallback reasons (empty-state, index-build, or
+unsupported-contract) are developer-only telemetry.
+They are not public IR fields and never appear in CLI JSON, LSP payloads,
+corpus snapshots, or the diagnostic review ledger. The shared solver API and
+dense/sparse/hybrid benchmarks remain internal implementation details.
 
 ### Batch procedure-worker boundary
 

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -106,8 +106,12 @@ type Result struct {
 }
 
 type Analyzer struct {
-	RootDir                    string
-	Config                     config.Config
+	RootDir string
+	Config  config.Config
+	// arrayStrategy is intentionally private and test/benchmark-only.  The
+	// zero value selects the production auto compatibility decision; tests may
+	// force the indexed or legacy oracle without changing public configuration.
+	arrayStrategy              arrayCFGStrategy
 	PathFilter                 func(string) bool
 	typeDB                     *vbadb.DB
 	typeDBResolutionIncomplete bool
@@ -367,8 +371,81 @@ type analysisContext struct {
 }
 
 type arrayInterproceduralStats struct {
-	cfgWalks uint64
-	revisits uint64
+	mu                  sync.Mutex
+	cfgWalks            uint64
+	revisits            uint64
+	compactWalks        uint64
+	legacyWalks         uint64
+	fallbackWalks       uint64
+	fallbackEmptyState  uint64
+	fallbackIndex       uint64
+	fallbackUnsupported uint64
+	strategy            arrayCFGStrategy
+}
+
+// Array CFG walks can be materialized concurrently while a procedure plan is
+// evaluated. Keep the developer-only counters race-free without imposing any
+// synchronization on the semantic state itself.
+func (s *arrayInterproceduralStats) addCFGWalk() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.cfgWalks++
+	s.mu.Unlock()
+}
+
+func (s *arrayInterproceduralStats) addRevisit() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.revisits++
+	s.mu.Unlock()
+}
+
+func (s *arrayInterproceduralStats) addCompactWalk() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.compactWalks++
+	s.mu.Unlock()
+}
+
+func (s *arrayInterproceduralStats) addLegacyWalk() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.legacyWalks++
+	s.mu.Unlock()
+}
+
+func (s *arrayInterproceduralStats) addFallbackReason(reason arrayFallbackReason) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.fallbackWalks++
+	switch reason {
+	case arrayFallbackEmptyState:
+		s.fallbackEmptyState++
+	case arrayFallbackIndex:
+		s.fallbackIndex++
+	default:
+		s.fallbackUnsupported++
+	}
+	s.mu.Unlock()
+}
+
+func (s *arrayInterproceduralStats) snapshot() (cfgWalks, revisits, compactWalks, legacyWalks, fallbackWalks, fallbackEmptyState, fallbackIndex, fallbackUnsupported uint64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cfgWalks, s.revisits, s.compactWalks, s.legacyWalks, s.fallbackWalks, s.fallbackEmptyState, s.fallbackIndex, s.fallbackUnsupported
 }
 
 type procedureSignature struct {
@@ -2176,7 +2253,7 @@ func (a Analyzer) buildContextWithObjectAnalysisPlan(files []parsedFile, objectA
 		arrayModuleConfigurations:        map[string]arrayModuleConfigurationState{},
 		arrayModuleEntryStates:           arrayModuleEntryStates{},
 		arrayPrivateTargets:              map[string]sourceProcedure{},
-		arrayStats:                       &arrayInterproceduralStats{},
+		arrayStats:                       &arrayInterproceduralStats{strategy: a.arrayStrategy},
 		arrayByRefEntryStates:            map[string]map[int]bool{},
 		arrayByRefEntryConditions:        map[string]map[int]string{},
 		procedures:                       map[string]procedureSignature{},
@@ -2319,8 +2396,15 @@ func recordArrayInterproceduralTelemetry(ctx context.Context, analysisCtx analys
 	}
 	recorder.AddSum(analysisstats.ArrayParticipantProceduresCounter, uint64(len(analysisCtx.arrayParticipants)))
 	if analysisCtx.arrayStats != nil {
-		recorder.AddSum(analysisstats.ArrayInterproceduralCFGWalksCounter, analysisCtx.arrayStats.cfgWalks)
-		recorder.AddSum(analysisstats.ArrayWorklistRevisitsCounter, analysisCtx.arrayStats.revisits)
+		cfgWalks, revisits, compactWalks, legacyWalks, fallbackWalks, fallbackEmptyState, fallbackIndex, fallbackUnsupported := analysisCtx.arrayStats.snapshot()
+		recorder.AddSum(analysisstats.ArrayInterproceduralCFGWalksCounter, cfgWalks)
+		recorder.AddSum(analysisstats.ArrayWorklistRevisitsCounter, revisits)
+		recorder.AddSum("array_compact_cfg_walks", compactWalks)
+		recorder.AddSum("array_legacy_cfg_walks", legacyWalks)
+		recorder.AddSum("array_cfg_fallbacks", fallbackWalks)
+		recorder.AddSum("array_cfg_fallback_empty_state", fallbackEmptyState)
+		recorder.AddSum("array_cfg_fallback_index", fallbackIndex)
+		recorder.AddSum("array_cfg_fallback_unsupported", fallbackUnsupported)
 	}
 }
 

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -6025,11 +6025,22 @@ Public Sub Run()
 End Sub
 `)
 
-	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
-	if err != nil {
-		t.Fatal(err)
+	var legacy, compact []Finding
+	for _, strategy := range []arrayCFGStrategy{arrayCFGStrategyLegacy, arrayCFGStrategyCompact} {
+		findings, err := (Analyzer{RootDir: dir, Config: config.Default(), arrayStrategy: strategy}).Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strategy == arrayCFGStrategyLegacy {
+			legacy = findings
+		} else {
+			compact = findings
+		}
 	}
-	if got := findingsByCode(findings, "VBA227"); len(got) != 0 {
+	if !reflect.DeepEqual(legacy, compact) {
+		t.Fatalf("legacy and compact Array findings differ: legacy=%+v compact=%+v", legacy, compact)
+	}
+	if got := findingsByCode(compact, "VBA227"); len(got) != 0 {
 		t.Fatalf("a positive-count dispatch should not report its case-local array access: %+v", got)
 	}
 }

--- a/internal/analyze/array_compact_solver.go
+++ b/internal/analyze/array_compact_solver.go
@@ -18,8 +18,10 @@ type arrayCompactLattice struct{}
 func unknownArrayValue() arrayValue { return arrayValue{kind: arrayUnknown} }
 
 func (arrayCompactLattice) Clone(value arrayValue) arrayValue {
-	value.dimensions = append([]arrayDimension(nil), value.dimensions...)
-	value.preserveShape = append([]arrayDimension(nil), value.preserveShape...)
+	// Array shapes are immutable once published into the compact lattice.  Array
+	// transfers replace a shape with a newly parsed slice instead of mutating a
+	// slice held by an existing value, so a solver scratch copy only needs to
+	// copy the value header.  Legacy map ownership still uses cloneArrayState.
 	return value
 }
 
@@ -37,20 +39,85 @@ func (l arrayCompactLattice) Join(dst *arrayValue, src arrayValue) bool {
 
 type arrayCompactAdapter struct {
 	environment semanticstate.Environment
+	// names is the adapter-owned immutable participant order. Calling
+	// Environment.Names repeatedly returns a defensive copy; retaining this
+	// slice avoids a per-cursor/per-transfer allocation while preserving the
+	// environment's external ownership boundary.
+	names []string
 }
 
-func newArrayCompactAdapter(initial arrayFlowState) arrayCompactAdapter {
-	names := make([]string, 0, len(initial))
-	for name := range initial {
+func newArrayCompactAdapter(initials ...arrayFlowState) arrayCompactAdapter {
+	nameSet := make(map[string]struct{})
+	for _, initial := range initials {
+		for name := range initial {
+			nameSet[name] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
 		names = append(names, name)
 	}
-	return arrayCompactAdapter{environment: semanticstate.NewEnvironment(names, names)}
+	environment := semanticstate.NewEnvironment(names, names)
+	return arrayCompactAdapter{environment: environment, names: environment.Names()}
+}
+
+// newArrayCompactAdapterForLines extends the initial semantic participants
+// with assignment targets visible in the current CFG only. Callers often hold
+// a module-wide source slice; scanning that entire slice would add unrelated
+// procedures to every dense solver state. Array transfer deliberately tracks a
+// small number of scalar witnesses (for example an ArrayLength result used as
+// an allocation guard), so those witnesses are collected from the CFG's own
+// statement ranges before indexing.
+func newArrayCompactAdapterForLines(graph *vbacfg.CFGView, lines []string, initials ...arrayFlowState) arrayCompactAdapter {
+	nameSet := make(map[string]struct{})
+	for _, initial := range initials {
+		for name := range initial {
+			nameSet[name] = struct{}{}
+		}
+	}
+	addAssignments := func(text string) {
+		for _, line := range strings.Split(text, "\n") {
+			if lhs, _, _, ok := arrayAssignment(line); ok {
+				name := strings.ToLower(cleanIdentifier(lhs))
+				if name != "" {
+					nameSet[name] = struct{}{}
+				}
+			}
+		}
+	}
+	if graph != nil {
+		graph.ForEachBlock(func(block vbacfg.Block) bool {
+			if block.Statement == nil {
+				return true
+			}
+			addAssignments(block.Statement.Text)
+			start := block.Statement.Range.StartLine
+			end := block.Statement.Range.EndLine
+			if start < 1 {
+				start = block.Range.StartLine
+			}
+			if end < start {
+				end = start
+			}
+			if start >= 1 && end <= len(lines) {
+				for line := start; line <= end; line++ {
+					addAssignments(lines[line-1])
+				}
+			}
+			return true
+		})
+	}
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	environment := semanticstate.NewEnvironment(names, names)
+	return arrayCompactAdapter{environment: environment, names: environment.Names()}
 }
 
 func (a arrayCompactAdapter) toFlow(view semanticstate.StateView[arrayValue]) arrayFlowState {
-	names := a.environment.Names()
-	flow := make(arrayFlowState, len(names))
-	for _, name := range names {
+	flow := make(arrayFlowState, len(a.names))
+	for _, name := range a.names {
 		flow[name] = unknownArrayValue()
 	}
 	view.ForEach(func(id semanticstate.SymbolID, value arrayValue) bool {
@@ -66,7 +133,7 @@ func (a arrayCompactAdapter) toFlow(view semanticstate.StateView[arrayValue]) ar
 
 func (a arrayCompactAdapter) fromFlow(state *semanticstate.State[arrayValue], flow arrayFlowState) {
 	state.Reset()
-	for _, name := range a.environment.Names() {
+	for _, name := range a.names {
 		value, ok := flow[name]
 		if !ok {
 			value = unknownArrayValue()
@@ -83,69 +150,203 @@ func (a arrayCompactAdapter) initialState(state *semanticstate.State[arrayValue]
 	a.fromFlow(state, initial)
 }
 
+// arrayCompactCursor is the compatibility boundary for the existing Array
+// transfer callbacks.  Its map is allocated once per lane/scratch role and is
+// reused for every transfer or edge.  The fixed-point state itself remains in
+// semanticstate slots; the cursor prevents a fresh whole-state map and shape
+// copy from being allocated at every callback boundary.
+type arrayCompactCursor struct {
+	adapter arrayCompactAdapter
+	flow    arrayFlowState
+}
+
+func (a arrayCompactAdapter) newCursor() *arrayCompactCursor {
+	flow := make(arrayFlowState, len(a.names))
+	for _, name := range a.names {
+		flow[name] = unknownArrayValue()
+	}
+	return &arrayCompactCursor{adapter: a, flow: flow}
+}
+
+func (c *arrayCompactCursor) load(view semanticstate.StateView[arrayValue]) arrayFlowState {
+	if c == nil {
+		return nil
+	}
+	for _, name := range c.adapter.names {
+		c.flow[name] = unknownArrayValue()
+	}
+	view.ForEach(func(id semanticstate.SymbolID, value arrayValue) bool {
+		name, ok := c.adapter.environment.Name(id)
+		if ok {
+			c.flow[name] = value
+		}
+		return true
+	})
+	return c.flow
+}
+
+func (c *arrayCompactCursor) store(state *semanticstate.State[arrayValue], flow arrayFlowState) {
+	if c == nil || state == nil {
+		return
+	}
+	state.Reset()
+	for _, name := range c.adapter.names {
+		value, ok := flow[name]
+		if !ok {
+			value = unknownArrayValue()
+		}
+		id, ok := c.adapter.environment.Symbol(name)
+		if ok {
+			state.Set(id, value)
+		}
+	}
+}
+
+// arrayCompactLane is the callback-compatible policy used by the indexed
+// solver. Keeping the callbacks at this boundary lets the existing Array
+// transfer code remain the source of diagnostic/evidence semantics while the
+// fixed-point state itself stays in indexed slots.
+type arrayCompactLane struct {
+	initial             arrayFlowState
+	stats               *arrayInterproceduralStats
+	visit               func(text string, line int, in arrayFlowState) arrayFlowState
+	edgeState           func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState
+	stop                func(text string, line int) bool
+	reliableExceptional func(statement *procedureir.Statement, in, out arrayFlowState) bool
+	sourceLines         bool
+	// Conditional allocation facts are relational evidence: a positive branch
+	// can prove allocation while the sibling branch retains the count source.
+	// Preserve that source on the compact positive candidate so a later Select
+	// Case can re-establish the same proof after the paths meet. The legacy map
+	// walker obtains this behavior from its edge-local map ownership.
+	preserveConditionalEvidence bool
+}
+
 // walkArrayCFGCompact runs one array policy on the shared semanticstate
 // solver. Callback compatibility is intentionally retained at this boundary,
 // so diagnostic/evidence code still receives arrayFlowState while joins happen
 // directly in indexed slots without union-map allocation.
 func walkArrayCFGCompact(ctx context.Context, graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, sourceLines bool) error {
+	return walkArrayCFGCompactLanes(ctx, graph, lines, []arrayCompactLane{{
+		initial:                     initial,
+		visit:                       visit,
+		edgeState:                   edgeState,
+		sourceLines:                 sourceLines,
+		preserveConditionalEvidence: edgeState != nil,
+	}})
+}
+
+// walkArrayCFGCompactAdvanced is the Array-specific indexed solver boundary
+// for source-line and edge-refined paths. It is intentionally kept in this
+// package so the generic semanticstate solver does not acquire VBA policy.
+func walkArrayCFGCompactAdvanced(ctx context.Context, graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, reliableExceptional func(statement *procedureir.Statement, in, out arrayFlowState) bool, sourceLines bool) error {
+	return walkArrayCFGCompactLanes(ctx, graph, lines, []arrayCompactLane{{
+		initial:                     initial,
+		visit:                       visit,
+		edgeState:                   edgeState,
+		stop:                        stop,
+		reliableExceptional:         reliableExceptional,
+		sourceLines:                 sourceLines,
+		preserveConditionalEvidence: edgeState != nil,
+	}})
+}
+
+func walkArrayCFGCompactLanes(ctx context.Context, graph *vbacfg.CFGView, lines []string, policies []arrayCompactLane) error {
 	if graph == nil {
 		return nil
 	}
-	adapter := newArrayCompactAdapter(initial)
+	if len(policies) == 0 {
+		return nil
+	}
+	initials := make([]arrayFlowState, 0, len(policies))
+	for _, policy := range policies {
+		initials = append(initials, policy.initial)
+	}
+	adapter := newArrayCompactAdapterForLines(graph, lines, initials...)
 	index, err := semanticstate.NewIndexView(*graph)
 	if err != nil {
 		return err
 	}
 	lattice := arrayCompactLattice{}
-	lane := semanticstate.Lane[arrayValue]{
-		Initialize: func(_ context.Context, _ semanticstate.LaneOrdinal, state *semanticstate.State[arrayValue]) error {
-			adapter.initialState(state, initial)
-			return nil
-		},
-		Transfer: func(_ context.Context, _ semanticstate.LaneOrdinal, ordinal semanticstate.BlockOrdinal, input semanticstate.StateView[arrayValue], output *semanticstate.State[arrayValue]) error {
-			_, ok := index.Block(ordinal)
-			if !ok {
+	lanes := make([]semanticstate.Lane[arrayValue], len(policies))
+	for laneIndex, policy := range policies {
+		policy := policy
+		stopped := make(map[semanticstate.BlockOrdinal]bool)
+		transferCursor := adapter.newCursor()
+		inputCursor := adapter.newCursor()
+		outputCursor := adapter.newCursor()
+		candidateCursor := adapter.newCursor()
+		conditionalSources := map[string]string{}
+		lanes[laneIndex] = semanticstate.Lane[arrayValue]{
+			Initialize: func(_ context.Context, _ semanticstate.LaneOrdinal, state *semanticstate.State[arrayValue]) error {
+				adapter.initialState(state, policy.initial)
 				return nil
-			}
-			block, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(ordinal))
-			if !ok {
+			},
+			Transfer: func(_ context.Context, _ semanticstate.LaneOrdinal, ordinal semanticstate.BlockOrdinal, input semanticstate.StateView[arrayValue], output *semanticstate.State[arrayValue]) error {
+				block, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(ordinal))
+				if !ok {
+					return nil
+				}
+				in := transferCursor.load(input)
+				out, wasStopped := arrayCompactVisitBlockWithStop(lines, block, in, policy.visit, policy.stop, policy.sourceLines)
+				if wasStopped {
+					stopped[ordinal] = true
+					output.Reset()
+					return nil
+				}
+				transferCursor.store(output, out)
 				return nil
-			}
-			in := adapter.toFlow(input)
-			out := arrayCompactVisitBlock(lines, block, in, visit, sourceLines)
-			adapter.fromFlow(output, out)
-			return nil
-		},
-		Edge: func(_ context.Context, _ semanticstate.LaneOrdinal, edge semanticstate.Edge, _ semanticstate.StateView[arrayValue], _ semanticstate.StateView[arrayValue], candidate *semanticstate.State[arrayValue]) error {
-			// The legacy walker applies edgeState only to normal edges. Exceptional
-			// and uncertain edges carry the predecessor input state and must not
-			// receive normal-edge refinements (guards/Select facts).
-			if edgeState == nil || edge.Class == vbacfg.EdgeExceptional || edge.Uncertain {
-				return nil
-			}
-			_, ok := index.Block(edge.From)
-			if !ok {
-				return nil
-			}
-			from, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(edge.From))
-			if !ok {
-				return nil
-			}
-			_, ok = index.Block(edge.To)
-			if !ok {
-				return nil
-			}
-			to, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(edge.To))
-			if !ok {
-				return nil
-			}
-			flow := adapter.toFlow(candidate.View())
-			refined := edgeState(from, vbacfg.Edge{ID: edge.ID, From: from.ID, To: to.ID, Kind: edge.Kind, Class: edge.Class, Uncertain: edge.Uncertain}, flow)
-			adapter.fromFlow(candidate, refined)
-			return nil
-		},
+			},
+			EdgeDecision: func(_ context.Context, _ semanticstate.LaneOrdinal, edge semanticstate.Edge, input semanticstate.StateView[arrayValue], output semanticstate.StateView[arrayValue], candidate *semanticstate.State[arrayValue]) (semanticstate.EdgeDisposition, error) {
+				// A stopped block must suppress every successor, including the
+				// exceptional/uncertain paths that semanticstate initializes from input.
+				if stopped[edge.From] {
+					return semanticstate.EdgeSuppress, nil
+				}
+				if edge.Class == vbacfg.EdgeExceptional {
+					if policy.sourceLines && policy.reliableExceptional != nil {
+						from, fromOK := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(edge.From))
+						if fromOK {
+							in := inputCursor.load(input)
+							out := outputCursor.load(output)
+							if policy.reliableExceptional(from.Statement, in, out) {
+								candidateCursor.store(candidate, out)
+							}
+						}
+					}
+					return semanticstate.EdgePropagate, nil
+				}
+				// The legacy walker applies edgeState only to normal edges.
+				if policy.edgeState == nil || edge.Uncertain {
+					return semanticstate.EdgePropagate, nil
+				}
+				from, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(edge.From))
+				if !ok {
+					return semanticstate.EdgePropagate, nil
+				}
+				to, ok := graph.BlockAtOrdinal(vbacfg.BlockOrdinal(edge.To))
+				if !ok {
+					return semanticstate.EdgePropagate, nil
+				}
+				flow := candidateCursor.load(candidate.View())
+				if policy.preserveConditionalEvidence {
+					clear(conditionalSources)
+					for name, value := range flow {
+						if value.allocationCountSource != "" {
+							conditionalSources[name] = value.allocationCountSource
+						}
+					}
+				}
+				refined := policy.edgeState(from, vbacfg.Edge{ID: edge.ID, From: from.ID, To: to.ID, Kind: edge.Kind, Class: edge.Class, Uncertain: edge.Uncertain}, flow)
+				if policy.preserveConditionalEvidence {
+					refined = preserveArrayConditionalEvidence(conditionalSources, refined)
+				}
+				candidateCursor.store(candidate, refined)
+				return semanticstate.EdgePropagate, nil
+			},
+		}
 	}
-	solver, err := semanticstate.NewSolver(index, adapter.environment, lattice, []semanticstate.Lane[arrayValue]{lane})
+	solver, err := semanticstate.NewSolver(index, adapter.environment, lattice, lanes)
 	if err != nil {
 		return err
 	}
@@ -153,9 +354,88 @@ func walkArrayCFGCompact(ctx context.Context, graph *vbacfg.CFGView, lines []str
 	return err
 }
 
-func arrayCompactVisitBlock(lines []string, block vbacfg.Block, in arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, sourceLines bool) arrayFlowState {
+// walkArrayCFGCombinedCompact groups compatible Array policies by CFG view and
+// advances each group with one indexed solver. Base/runtime lanes share their
+// graph and therefore share the scheduler; the source-line VBA227 graph is a
+// separate group because its edge set intentionally differs.
+//
+// The bool result distinguishes a preflight incompatibility (which callers
+// may handle with the legacy walker) from a solve-time error (which must not be
+// retried after callbacks have already produced findings/evidence).
+func walkArrayCFGCombinedCompact(ctx context.Context, lines []string, lanes []arrayCFGWorklistLane) (bool, error) {
+	type compactGroup struct {
+		graph    *vbacfg.CFGView
+		policies []arrayCompactLane
+	}
+	groups := make([]compactGroup, 0, len(lanes))
+	groupByGraph := make(map[*vbacfg.CFGView]int, len(lanes))
+	for _, lane := range lanes {
+		if lane.Graph == nil || lane.Visit == nil {
+			continue
+		}
+		// Declaration-only lanes have no semantic participants.  Their transfer
+		// callbacks still emit scalar/object diagnostics from the variables side
+		// table, so compacting an empty state would lose those findings.  Let the
+		// caller use the legacy adapter for the whole combined walk instead.
+		if len(lane.Initial) == 0 {
+			return false, nil
+		}
+		if _, err := semanticstate.NewIndexView(*lane.Graph); err != nil {
+			return false, nil
+		}
+		groupIndex, ok := groupByGraph[lane.Graph]
+		if !ok {
+			groupIndex = len(groups)
+			groupByGraph[lane.Graph] = groupIndex
+			groups = append(groups, compactGroup{graph: lane.Graph})
+		}
+		groups[groupIndex].policies = append(groups[groupIndex].policies, arrayCompactLane{
+			initial:                     lane.Initial,
+			stats:                       lane.Stats,
+			visit:                       lane.Visit,
+			edgeState:                   lane.EdgeState,
+			stop:                        lane.Stop,
+			reliableExceptional:         lane.ReliableExceptional,
+			sourceLines:                 lane.SourceLines,
+			preserveConditionalEvidence: lane.EdgeState != nil,
+		})
+	}
+	for _, group := range groups {
+		statsSeen := map[*arrayInterproceduralStats]bool{}
+		for _, policy := range group.policies {
+			if policy.stats == nil || statsSeen[policy.stats] {
+				continue
+			}
+			statsSeen[policy.stats] = true
+			policy.stats.addCompactWalk()
+		}
+		if err := walkArrayCFGCompactLanes(ctx, group.graph, lines, group.policies); err != nil {
+			return true, err
+		}
+	}
+	return true, nil
+}
+
+// preserveArrayConditionalEvidence keeps a count/length witness attached to a
+// compact positive candidate after an edge policy turns it into an allocated
+// value.  The witness is deliberately retained only when the policy cleared
+// it; conflicting witnesses still meet to an empty string in meetArrayValue.
+func preserveArrayConditionalEvidence(sources map[string]string, after arrayFlowState) arrayFlowState {
+	for name, source := range sources {
+		value, ok := after[name]
+		if !ok || value.kind != arrayAllocated || value.allocationCountSource != "" {
+			continue
+		}
+		value.allocationCountSource = source
+		after[name] = value
+	}
+	return after
+}
+
+func arrayCompactVisitBlockWithStop(lines []string, block vbacfg.Block, visitIn arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool) (arrayFlowState, bool) {
+	in := visitIn
 	if visit == nil || block.Statement == nil {
-		return in
+		return in, false
 	}
 	if !sourceLines {
 		line := block.Statement.Range.StartLine
@@ -166,7 +446,8 @@ func arrayCompactVisitBlock(lines []string, block vbacfg.Block, in arrayFlowStat
 		if strings.TrimSpace(text) == "" && line >= 1 && line <= len(lines) {
 			text = normalizedCodeLine(lines[line-1])
 		}
-		return visit(text, line, in)
+		out := visit(text, line, in)
+		return out, stop != nil && stop(text, line)
 	}
 	start := block.Statement.Range.StartLine
 	if start == 0 {
@@ -178,14 +459,17 @@ func arrayCompactVisitBlock(lines []string, block vbacfg.Block, in arrayFlowStat
 	}
 	out := in
 	if block.Statement.Kind == procedureir.StatementSelect && start >= 1 && start <= len(lines) {
-		return visit(normalizedCodeLine(lines[start-1]), start, out)
+		text := normalizedCodeLine(lines[start-1])
+		out = visit(text, start, out)
+		return out, stop != nil && stop(text, start)
 	}
 	if start == end && start >= 1 && start <= len(lines) {
 		text := block.Statement.Text
 		if strings.TrimSpace(text) == "" {
 			text = normalizedCodeLine(lines[start-1])
 		}
-		return visit(text, start, out)
+		out = visit(text, start, out)
+		return out, stop != nil && stop(text, start)
 	}
 	if start >= 1 && end <= len(lines) {
 		for line := start; line <= end; line++ {
@@ -194,12 +478,16 @@ func arrayCompactVisitBlock(lines []string, block vbacfg.Block, in arrayFlowStat
 				continue
 			}
 			out = visit(text, line, out)
+			if stop != nil && stop(text, line) {
+				return out, true
+			}
 		}
-		return out
+		return out, false
 	}
 	text := block.Statement.Text
 	if strings.TrimSpace(text) == "" && start >= 1 && start <= len(lines) {
 		text = normalizedCodeLine(lines[start-1])
 	}
-	return visit(text, start, out)
+	out = visit(text, start, out)
+	return out, stop != nil && stop(text, start)
 }

--- a/internal/analyze/array_compact_solver_test.go
+++ b/internal/analyze/array_compact_solver_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/analyze/semanticstate"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 func TestArrayCompactAdapterDegradesAbsentSymbolsToUnknown(t *testing.T) {
@@ -34,5 +37,191 @@ func TestArrayCompactAdapterDegradesAbsentSymbolsToUnknown(t *testing.T) {
 	destinationOnly := initial["allocated"]
 	if !(arrayCompactLattice{}).Join(&destinationOnly, unknownArrayValue()) || destinationOnly.kind != arrayUnknown {
 		t.Fatalf("unknown join = %#v, want unknown", destinationOnly)
+	}
+}
+
+func TestArrayCompactAdapterIndexesOnlyCurrentCFGAssignments(t *testing.T) {
+	statement := &procedureir.Statement{ID: 1, Kind: procedureir.StatementAssignment, Text: "values = Array(1)", Range: vbaast.Range{StartLine: 1, EndLine: 1}}
+	graph := vbacfg.Graph{
+		Blocks: []vbacfg.Block{
+			{ID: 0, Kind: vbacfg.BlockEntry},
+			{ID: 1, Kind: vbacfg.BlockStatement, StatementID: statement.ID, Statement: statement},
+			{ID: 2, Kind: vbacfg.BlockNormalExit},
+		},
+		Edges: []vbacfg.Edge{
+			{ID: 0, From: 0, To: 1, Kind: vbacfg.EdgeFallthrough, Class: vbacfg.EdgeNormal},
+			{ID: 1, From: 1, To: 2, Kind: vbacfg.EdgeProcedureExit, Class: vbacfg.EdgeNormal},
+		},
+		Entry: 0, NormalExit: 2, ExceptionalExit: 2, TerminationExit: 2, UnknownExit: 2,
+	}
+	view := graph.View(vbacfg.EdgeFilter{})
+	adapter := newArrayCompactAdapterForLines(&view, []string{"values = Array(1)", "unrelated = Array(2)"}, arrayFlowState{
+		"values": {kind: arrayUnknown, knownArray: true},
+	})
+	if _, ok := adapter.environment.Symbol("values"); !ok {
+		t.Fatal("current CFG assignment target was not indexed")
+	}
+	if _, ok := adapter.environment.Symbol("unrelated"); ok {
+		t.Fatal("assignment from an unrelated procedure was indexed")
+	}
+}
+
+func TestArrayCompactAdvancedPreservesSourceLinesAndEdgeSemantics(t *testing.T) {
+	redim := &procedureir.Statement{ID: 1, Kind: procedureir.StatementReDim, Text: "ReDim values(0)", Range: vbaast.Range{StartLine: 1, EndLine: 1}}
+	normal := &procedureir.Statement{ID: 2, Kind: procedureir.StatementCall, Text: "normal", Range: vbaast.Range{StartLine: 2, EndLine: 2}}
+	exceptional := &procedureir.Statement{ID: 3, Kind: procedureir.StatementCall, Text: "exceptional", Range: vbaast.Range{StartLine: 3, EndLine: 3}}
+	uncertain := &procedureir.Statement{ID: 4, Kind: procedureir.StatementCall, Text: "uncertain", Range: vbaast.Range{StartLine: 4, EndLine: 4}}
+	graph := vbacfg.Graph{
+		Blocks: []vbacfg.Block{
+			{ID: 0, Kind: vbacfg.BlockEntry},
+			{ID: 1, Kind: vbacfg.BlockStatement, StatementID: redim.ID, Statement: redim},
+			{ID: 2, Kind: vbacfg.BlockStatement, StatementID: normal.ID, Statement: normal},
+			{ID: 3, Kind: vbacfg.BlockStatement, StatementID: exceptional.ID, Statement: exceptional},
+			{ID: 4, Kind: vbacfg.BlockStatement, StatementID: uncertain.ID, Statement: uncertain},
+			{ID: 5, Kind: vbacfg.BlockNormalExit},
+		},
+		Edges: []vbacfg.Edge{
+			{ID: 0, From: 0, To: 1, Kind: vbacfg.EdgeFallthrough, Class: vbacfg.EdgeNormal},
+			{ID: 1, From: 1, To: 2, Kind: vbacfg.EdgeFallthrough, Class: vbacfg.EdgeNormal},
+			{ID: 2, From: 1, To: 3, Kind: vbacfg.EdgeError, Class: vbacfg.EdgeExceptional},
+			{ID: 3, From: 1, To: 4, Kind: vbacfg.EdgeBranchFalse, Class: vbacfg.EdgeNormal, Uncertain: true},
+			{ID: 4, From: 2, To: 5, Kind: vbacfg.EdgeProcedureExit, Class: vbacfg.EdgeNormal},
+			{ID: 5, From: 3, To: 5, Kind: vbacfg.EdgeProcedureExit, Class: vbacfg.EdgeNormal},
+			{ID: 6, From: 4, To: 5, Kind: vbacfg.EdgeProcedureExit, Class: vbacfg.EdgeNormal},
+		},
+		Entry: 0, NormalExit: 5, ExceptionalExit: 5, TerminationExit: 5, UnknownExit: 5,
+	}
+	view := graph.View(vbacfg.EdgeFilter{})
+	initial := arrayFlowState{"values": {kind: arrayUnallocated, knownArray: true, origin: arrayOriginLocal}}
+	seen := map[string]arrayValue{}
+	var edgeCalls []vbacfg.Edge
+	if err := walkArrayCFGCompactAdvanced(t.Context(), &view, []string{"ReDim values(0)", "normal", "exceptional", "uncertain"}, initial,
+		func(text string, line int, in arrayFlowState) arrayFlowState {
+			if line > 1 {
+				seen[text] = in["values"]
+			}
+			if text == "ReDim values(0)" {
+				value := in["values"]
+				value.kind = arrayAllocated
+				in["values"] = value
+			}
+			return in
+		},
+		func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
+			edgeCalls = append(edgeCalls, edge)
+			if block.ID != 1 {
+				return out
+			}
+			value := out["values"]
+			value.kind = arrayAllocated
+			value.knownArray = true
+			out["values"] = value
+			return out
+		}, nil, func(_ *procedureir.Statement, _, _ arrayFlowState) bool { return true }, true); err != nil {
+		t.Fatal(err)
+	}
+	if got := seen["normal"]; got.kind != arrayAllocated {
+		t.Fatalf("normal edge state = %#v, want allocated", got)
+	}
+	if got := seen["exceptional"]; got.kind != arrayAllocated {
+		t.Fatalf("reliable exceptional edge state = %#v, want transferred output, edges=%+v", got, edgeCalls)
+	}
+	if got := seen["uncertain"]; got.kind != arrayUnallocated {
+		t.Fatalf("uncertain edge state = %#v, want predecessor input (unallocated), edges=%+v", got, edgeCalls)
+	}
+}
+
+func TestArrayCompactAdvancedPreservesPhysicalSourceLineOrder(t *testing.T) {
+	statement := &procedureir.Statement{ID: 1, Kind: procedureir.StatementCall, Text: "first\nsecond", Range: vbaast.Range{StartLine: 1, EndLine: 2}}
+	graph := vbacfg.Graph{
+		Blocks: []vbacfg.Block{{ID: 0, Kind: vbacfg.BlockEntry}, {ID: 1, Kind: vbacfg.BlockStatement, StatementID: statement.ID, Statement: statement}, {ID: 2, Kind: vbacfg.BlockNormalExit}},
+		Edges:  []vbacfg.Edge{{ID: 0, From: 0, To: 1, Kind: vbacfg.EdgeFallthrough, Class: vbacfg.EdgeNormal}, {ID: 1, From: 1, To: 2, Kind: vbacfg.EdgeProcedureExit, Class: vbacfg.EdgeNormal}},
+		Entry:  0, NormalExit: 2, ExceptionalExit: 2, TerminationExit: 2, UnknownExit: 2,
+	}
+	view := graph.View(vbacfg.EdgeFilter{})
+	var lines []int
+	initial := arrayFlowState{"values": {kind: arrayUnknown, knownArray: true, origin: arrayOriginLocal}}
+	if err := walkArrayCFGCompactAdvanced(t.Context(), &view, []string{"first", "second"}, initial, func(_ string, line int, in arrayFlowState) arrayFlowState {
+		lines = append(lines, line)
+		return in
+	}, nil, nil, nil, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 2 || lines[0] != 1 || lines[1] != 2 {
+		t.Fatalf("source-line visit order = %v, want [1 2]", lines)
+	}
+}
+
+func TestArrayCompactReliableExceptionalRejectsReDimPreserve(t *testing.T) {
+	in := arrayFlowState{"values": {kind: arrayUnallocated, knownArray: true, origin: arrayOriginLocal}}
+	out := arrayFlowState{"values": {kind: arrayAllocated, knownArray: true, origin: arrayOriginLocal}}
+	plain := &procedureir.Statement{Kind: procedureir.StatementReDim, Text: "ReDim values(0)"}
+	preserve := &procedureir.Statement{Kind: procedureir.StatementReDim, Text: "ReDim Preserve values(0)"}
+	if !arrayAllocationTransferIsReliable(plain, in, out) {
+		t.Fatal("plain ReDim should be reliable across an exceptional edge")
+	}
+	if arrayAllocationTransferIsReliable(preserve, in, out) {
+		t.Fatal("ReDim Preserve must not be treated as a reliable exceptional allocation")
+	}
+}
+
+func TestArrayCompactAdvancedStopSuppressesSuccessors(t *testing.T) {
+	first := &procedureir.Statement{ID: 1, Kind: procedureir.StatementCall, Text: "stop", Range: vbaast.Range{StartLine: 1, EndLine: 1}}
+	second := &procedureir.Statement{ID: 2, Kind: procedureir.StatementCall, Text: "successor", Range: vbaast.Range{StartLine: 2, EndLine: 2}}
+	graph := vbacfg.Graph{
+		Blocks: []vbacfg.Block{{ID: 0, Kind: vbacfg.BlockEntry}, {ID: 1, Kind: vbacfg.BlockStatement, StatementID: first.ID, Statement: first}, {ID: 2, Kind: vbacfg.BlockStatement, StatementID: second.ID, Statement: second}, {ID: 3, Kind: vbacfg.BlockNormalExit}},
+		Edges:  []vbacfg.Edge{{ID: 0, From: 0, To: 1, Kind: vbacfg.EdgeFallthrough, Class: vbacfg.EdgeNormal}, {ID: 1, From: 1, To: 2, Kind: vbacfg.EdgeFallthrough, Class: vbacfg.EdgeNormal}, {ID: 2, From: 2, To: 3, Kind: vbacfg.EdgeProcedureExit, Class: vbacfg.EdgeNormal}},
+		Entry:  0, NormalExit: 3, ExceptionalExit: 3, TerminationExit: 3, UnknownExit: 3,
+	}
+	view := graph.View(vbacfg.EdgeFilter{})
+	visited := map[string]bool{}
+	initial := arrayFlowState{"values": {kind: arrayUnknown, knownArray: true, origin: arrayOriginLocal}}
+	if err := walkArrayCFGCompactAdvanced(t.Context(), &view, []string{"stop", "successor"}, initial, func(text string, _ int, in arrayFlowState) arrayFlowState {
+		visited[text] = true
+		return in
+	}, nil, func(text string, _ int) bool { return text == "stop" }, nil, true); err != nil {
+		t.Fatal(err)
+	}
+	if !visited["stop"] || visited["successor"] {
+		t.Fatalf("stop visited=%v, successor visited=%v; want successor suppressed", visited["stop"], visited["successor"])
+	}
+}
+
+func TestArrayLegacyExceptionalEdgeKeepsPredecessorInput(t *testing.T) {
+	call := &procedureir.Statement{ID: 1, Kind: procedureir.StatementCall, Text: "moduleCall", Range: vbaast.Range{StartLine: 1, EndLine: 1}}
+	exceptional := &procedureir.Statement{ID: 2, Kind: procedureir.StatementCall, Text: "handler", Range: vbaast.Range{StartLine: 2, EndLine: 2}}
+	graph := vbacfg.Graph{
+		Blocks: []vbacfg.Block{
+			{ID: 0, Kind: vbacfg.BlockEntry},
+			{ID: 1, Kind: vbacfg.BlockStatement, StatementID: call.ID, Statement: call},
+			{ID: 2, Kind: vbacfg.BlockStatement, StatementID: exceptional.ID, Statement: exceptional},
+			{ID: 3, Kind: vbacfg.BlockNormalExit},
+		},
+		Edges: []vbacfg.Edge{
+			{ID: 0, From: 0, To: 1, Kind: vbacfg.EdgeFallthrough, Class: vbacfg.EdgeNormal},
+			{ID: 1, From: 1, To: 2, Kind: vbacfg.EdgeError, Class: vbacfg.EdgeExceptional},
+			{ID: 2, From: 1, To: 3, Kind: vbacfg.EdgeFallthrough, Class: vbacfg.EdgeNormal},
+			{ID: 3, From: 2, To: 3, Kind: vbacfg.EdgeProcedureExit, Class: vbacfg.EdgeNormal},
+		},
+		Entry: 0, NormalExit: 3, ExceptionalExit: 3, TerminationExit: 3, UnknownExit: 3,
+	}
+	view := graph.View(vbacfg.EdgeFilter{})
+	initial := arrayFlowState{"values": {kind: arrayUnallocated, knownArray: true, origin: arrayOriginLocal}}
+	var handlerState arrayValue
+	walkArrayCFGWorklistLegacy(&view, []string{"moduleCall", "handler"}, initial,
+		func(text string, _ int, in arrayFlowState) arrayFlowState {
+			if text == "moduleCall" {
+				value := in["values"]
+				value.kind = arrayAllocated
+				value.knownArray = true
+				in["values"] = value
+			}
+			if text == "handler" {
+				handlerState = in["values"]
+			}
+			return in
+		}, nil, nil, false)
+	if handlerState.kind != arrayUnallocated {
+		t.Fatalf("exceptional handler state = %#v, want predecessor input %#v", handlerState, initial["values"])
 	}
 }

--- a/internal/analyze/array_kernel_benchmark_test.go
+++ b/internal/analyze/array_kernel_benchmark_test.go
@@ -82,6 +82,57 @@ func BenchmarkArrayAnalysisKernel(b *testing.B) {
 	}
 }
 
+// BenchmarkArrayAdvancedCFGStrategies compares the migrated source-line,
+// edge-refined, combined, and ByRef workloads against the retained legacy
+// oracle. The strategy selector is private and benchmark-only; production
+// analysis uses auto.
+func BenchmarkArrayAdvancedCFGStrategies(b *testing.B) {
+	workloads := []arrayKernelBenchmarkWorkload{
+		arrayKernelBenchmarkWorkloads()[2], // wide ReDim/P preserve CFG
+		arrayKernelBenchmarkWorkloads()[3], // edge-heavy branches
+		arrayKernelBenchmarkWorkloads()[5], // ByRef/module summary path
+	}
+	strategies := []struct {
+		name     string
+		strategy arrayCFGStrategy
+	}{
+		{name: "auto", strategy: arrayCFGStrategyAuto},
+		{name: "compact", strategy: arrayCFGStrategyCompact},
+		{name: "legacy", strategy: arrayCFGStrategyLegacy},
+	}
+	for _, workload := range workloads {
+		workload := workload
+		for _, strategy := range strategies {
+			strategy := strategy
+			b.Run(workload.name+"/"+strategy.name, func(b *testing.B) {
+				root := b.TempDir()
+				writeArrayKernelBenchmarkProject(b, root, workload)
+				b.Setenv(typedb.EnvDir, filepath.Join(b.TempDir(), "typelib"))
+				cfg := config.Default()
+				configureArrayBenchmarkRulesAll(&cfg)
+				recorder := analysisstats.NewRecorder()
+				ctx := analysisstats.WithRecorder(context.Background(), recorder)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := (Analyzer{RootDir: root, Config: cfg, arrayStrategy: strategy.strategy}).RunResultContext(ctx); err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.StopTimer()
+				_, counters := recorder.Totals()
+				for _, name := range []string{"array_compact_cfg_walks", "array_legacy_cfg_walks", "array_cfg_fallbacks"} {
+					for _, counter := range counters {
+						if counter.Name == name {
+							b.ReportMetric(float64(counter.Value)/float64(b.N), name+"/op")
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
 // TestArrayKernelBenchmarkFixtureScale keeps the benchmark matrix visible to
 // ordinary test runs without executing the analyzer for every workload.
 func TestArrayKernelBenchmarkFixtureScale(t *testing.T) {
@@ -127,6 +178,41 @@ func TestArrayKernelProjectionWorkCounters(t *testing.T) {
 	// rebuilding the main array fixed point.
 	if all["array_cfg_walks"] > single["array_cfg_walks"]+1 {
 		t.Fatalf("array CFG walks = single %d/all %d, want at most one secondary pass", single["array_cfg_walks"], all["array_cfg_walks"])
+	}
+}
+
+func TestArrayCFGStrategyTelemetry(t *testing.T) {
+	workload := arrayKernelBenchmarkWorkloads()[5]
+	for _, strategy := range []struct {
+		name     string
+		strategy arrayCFGStrategy
+		wantKey  string
+	}{
+		{name: "compact", strategy: arrayCFGStrategyCompact, wantKey: "array_compact_cfg_walks"},
+		{name: "legacy", strategy: arrayCFGStrategyLegacy, wantKey: "array_legacy_cfg_walks"},
+	} {
+		strategy := strategy
+		t.Run(strategy.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeArrayKernelBenchmarkProject(t, root, workload)
+			t.Setenv(typedb.EnvDir, filepath.Join(t.TempDir(), "typelib"))
+			cfg := config.Default()
+			configureArrayBenchmarkRulesAll(&cfg)
+			recorder := analysisstats.NewRecorder()
+			if _, err := (Analyzer{RootDir: root, Config: cfg, arrayStrategy: strategy.strategy}).RunResultContext(analysisstats.WithRecorder(context.Background(), recorder)); err != nil {
+				t.Fatal(err)
+			}
+			_, counters := recorder.Totals()
+			found := false
+			for _, counter := range counters {
+				if counter.Name == strategy.wantKey && counter.Value > 0 {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("strategy %s did not report %s: %+v", strategy.name, strategy.wantKey, counters)
+			}
+		})
 	}
 }
 

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -7,10 +7,27 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticstate"
 	"github.com/harumiWeb/xlflow/internal/lint"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/constexpr"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+type arrayCFGStrategy uint8
+
+const (
+	arrayCFGStrategyAuto arrayCFGStrategy = iota
+	arrayCFGStrategyCompact
+	arrayCFGStrategyLegacy
+)
+
+type arrayFallbackReason uint8
+
+const (
+	arrayFallbackUnsupported arrayFallbackReason = iota
+	arrayFallbackEmptyState
+	arrayFallbackIndex
 )
 
 // arrayAllocation is deliberately a three-point lattice.  In particular,
@@ -272,7 +289,7 @@ func (a Analyzer) arrayLifecycleFindingsPreparedWithRuntimeEntryContext(cancelCt
 	lanes := make([]arrayCFGWorklistLane, 0, 3)
 	if baseLaneRequested {
 		lanes = append(lanes, arrayCFGWorklistLane{
-			Graph: &baseView, Initial: initial,
+			Graph: &baseView, Initial: initial, Stats: ctx.arrayStats,
 			Visit: func(text string, line int, in arrayFlowState) arrayFlowState {
 				out, issues := a.arrayTransfer(file, proc, ctx, variables, in, text, line, constants, capacityGuards)
 				for _, call := range arrayCallsAtLine(proc.Calls, line) {
@@ -301,7 +318,7 @@ func (a Analyzer) arrayLifecycleFindingsPreparedWithRuntimeEntryContext(cancelCt
 		vba227Graph := arrayVBA227Graph(proc, ctx)
 		vba227Initial := arrayEntryStateForProcedure(file, proc, ctx, moduleDecls, vba227Variables)
 		lanes = append(lanes, arrayCFGWorklistLane{
-			Graph: &vba227Graph, Initial: vba227Initial, SourceLines: true,
+			Graph: &vba227Graph, Initial: vba227Initial, Stats: ctx.arrayStats, SourceLines: true,
 			ReliableExceptional: func(statement *procedureir.Statement, in, out arrayFlowState) bool {
 				return arrayAllocationTransferIsReliable(statement, in, out)
 			},
@@ -335,7 +352,7 @@ func (a Analyzer) arrayLifecycleFindingsPreparedWithRuntimeEntryContext(cancelCt
 		runtimeSeen := map[string]bool{}
 		runtimeState := arrayInitialState(variables)
 		lanes = append(lanes, arrayCFGWorklistLane{
-			Graph: &baseView, Initial: runtimeState,
+			Graph: &baseView, Initial: runtimeState, Stats: ctx.arrayStats,
 			Visit: func(text string, line int, in arrayFlowState) arrayFlowState {
 				for _, issue := range deterministicArrayRuntimeIssues(text, line, in, variables, constants) {
 					key := strconv.Itoa(issue.line) + ":" + issue.kind + ":" + issue.operationKey
@@ -868,35 +885,74 @@ func arrayResumeNextCapacityProofApplies(guards []arrayResumeNextCapacityGuard, 
 // uncertain edges retain the predecessor's input state because the statement
 // may not have completed before control leaves the block.
 func walkArrayCFG(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState) {
-	walkArrayCFGWithEdges(graph, lines, initial, visit, nil)
+	walkArrayCFGWorklist(graph, lines, initial, visit, nil, nil, false)
 }
 
-func walkArrayCFGWithEdges(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState) {
-	walkArrayCFGWithStop(graph, lines, initial, visit, edgeState, nil)
+func walkArrayCFGWithEdgesStats(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stats *arrayInterproceduralStats) {
+	walkArrayCFGWithStopStats(graph, lines, initial, visit, edgeState, nil, stats)
 }
 
-func walkArrayCFGWithStop(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool) {
-	walkArrayCFGWorklist(graph, lines, initial, visit, edgeState, stop, false)
+func walkArrayCFGWithStopStats(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, stats *arrayInterproceduralStats) {
+	walkArrayCFGWorklistStats(graph, lines, initial, visit, edgeState, stop, false, stats)
 }
 
-// walkArrayCFGWithSourceLines is used only by VBA227's lifecycle pass. The
-// regular walker keeps the historical block-level semantics required by
-// VBA208 and VBA249; this variant additionally exposes source-line order
-// inside a CFG block so an allocation and a later access on the same loop body
-// can be analyzed in sequence.
-func walkArrayCFGWithSourceLines(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState) {
-	walkArrayCFGWorklist(graph, lines, initial, visit, edgeState, nil, true)
+func walkArrayCFGWithSourceLinesReliableStats(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, reliableExceptional func(statement *procedureir.Statement, in, out arrayFlowState) bool, stats *arrayInterproceduralStats) {
+	walkArrayCFGWorklistStatsWithReliable(graph, lines, initial, visit, edgeState, nil, true, stats, reliableExceptional)
 }
 
 func walkArrayCFGWorklist(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool) {
-	// The compact solver owns the ordinary block-level walk. Stop callbacks
-	// need an explicit edge-suppression protocol that semanticstate intentionally
-	// does not expose, while source-line and edge-refinement lanes still carry
-	// policy-specific metadata through the legacy callback boundary. Keep those
-	// paths on the proven walker until their evidence contract is migrated.
-	if stop == nil && !sourceLines && edgeState == nil {
-		if err := walkArrayCFGCompact(context.Background(), graph, lines, initial, visit, edgeState, sourceLines); err == nil {
+	walkArrayCFGWorklistStats(graph, lines, initial, visit, edgeState, stop, sourceLines, nil)
+}
+
+func walkArrayCFGWorklistStats(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool, stats *arrayInterproceduralStats) {
+	walkArrayCFGWorklistStatsWithReliable(graph, lines, initial, visit, edgeState, stop, sourceLines, stats, nil)
+}
+
+func walkArrayCFGWorklistStatsWithReliable(graph *vbacfg.CFGView, lines []string, initial arrayFlowState, visit func(text string, line int, in arrayFlowState) arrayFlowState, edgeState func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState, stop func(text string, line int) bool, sourceLines bool, stats *arrayInterproceduralStats, reliableExceptional func(statement *procedureir.Statement, in, out arrayFlowState) bool) {
+	strategy := arrayCFGStrategyAuto
+	if stats != nil {
+		strategy = stats.strategy
+	}
+	if strategy == arrayCFGStrategyLegacy {
+		if stats != nil {
+			stats.addLegacyWalk()
+		}
+		walkArrayCFGWorklistLegacy(graph, lines, initial, visit, edgeState, stop, sourceLines)
+		return
+	}
+	// The Array adapter owns the policy-specific source-line, edge, and stop
+	// semantics at the indexed solver boundary. Only index/solver construction
+	// incompatibility falls back to the legacy map worklist; a solve-time error
+	// is not retried after analysis has begun.
+	// A zero-slot state cannot carry the declaration-only scalar/object checks
+	// that still consult the variables side table from the transfer callback.
+	// Keep those paths on the legacy adapter; this is an intentional
+	// compatibility boundary rather than an attempt to enlarge the compact
+	// lattice with non-array declarations.
+	if graph != nil && len(initial) > 0 {
+		if _, err := semanticstate.NewIndexView(*graph); err == nil {
+			if stats != nil {
+				stats.addCompactWalk()
+			}
+			if stop == nil && !sourceLines && edgeState == nil && reliableExceptional == nil {
+				_ = walkArrayCFGCompact(context.Background(), graph, lines, initial, visit, nil, false)
+			} else {
+				_ = walkArrayCFGCompactAdvanced(context.Background(), graph, lines, initial, visit, edgeState, stop, reliableExceptional, sourceLines)
+			}
 			return
+		}
+	}
+	if stats != nil {
+		stats.addLegacyWalk()
+		if graph != nil {
+			// A forced compact run is a test/benchmark oracle. Unsupported graph
+			// or participant layouts use this same compatibility fallback; do not
+			// retry the compact solver after callbacks have started.
+			reason := arrayFallbackIndex
+			if len(initial) == 0 {
+				reason = arrayFallbackEmptyState
+			}
+			stats.addFallbackReason(reason)
 		}
 	}
 	walkArrayCFGWorklistLegacy(graph, lines, initial, visit, edgeState, stop, sourceLines)
@@ -939,7 +995,10 @@ func walkArrayCFGWorklistLegacy(graph *vbacfg.CFGView, lines []string, initial a
 				if strings.TrimSpace(text) == "" && line >= 1 && line <= len(lines) {
 					text = normalizedCodeLine(lines[line-1])
 				}
-				out = visit(text, line, in)
+				// The transfer callback owns the block-local copy.  Keeping the
+				// predecessor input untouched is required for exceptional and
+				// uncertain edges, which deliberately propagate `in` below.
+				out = visit(text, line, out)
 				if stop != nil && stop(text, line) {
 					continue
 				}
@@ -1040,6 +1099,7 @@ func walkArrayCFGWorklistLegacy(graph *vbacfg.CFGView, lines []string, initial a
 type arrayCFGWorklistLane struct {
 	Graph   *vbacfg.CFGView
 	Initial arrayFlowState
+	Stats   *arrayInterproceduralStats
 
 	// Visit receives a private copy of the lane's block input state and returns
 	// the state to propagate to outgoing edges.  In source-line mode it is
@@ -1078,6 +1138,46 @@ type arrayCFGWorklistLane struct {
 func walkArrayCFGCombined(ctx context.Context, lines []string, lanes []arrayCFGWorklistLane) error {
 	if len(lanes) == 0 {
 		return ctx.Err()
+	}
+	strategy := arrayCFGStrategyAuto
+	for _, lane := range lanes {
+		if lane.Stats == nil || lane.Stats.strategy == arrayCFGStrategyAuto {
+			continue
+		}
+		strategy = lane.Stats.strategy
+		break
+	}
+	if strategy != arrayCFGStrategyLegacy {
+		if handled, err := walkArrayCFGCombinedCompact(ctx, lines, lanes); handled {
+			return err
+		}
+	}
+	// A forced compact run remains observable through the same compatibility
+	// fallback when a lane cannot be indexed; no second compact attempt is
+	// made after callbacks have started.
+	fallbackReason := arrayFallbackUnsupported
+	for _, lane := range lanes {
+		if len(lane.Initial) == 0 {
+			fallbackReason = arrayFallbackEmptyState
+			break
+		}
+		if lane.Graph != nil {
+			if _, err := semanticstate.NewIndexView(*lane.Graph); err != nil {
+				fallbackReason = arrayFallbackIndex
+				break
+			}
+		}
+	}
+	seenStats := map[*arrayInterproceduralStats]bool{}
+	for _, lane := range lanes {
+		if lane.Stats == nil || seenStats[lane.Stats] {
+			continue
+		}
+		seenStats[lane.Stats] = true
+		lane.Stats.addLegacyWalk()
+		if strategy != arrayCFGStrategyLegacy {
+			lane.Stats.addFallbackReason(fallbackReason)
+		}
 	}
 
 	type graphIndex struct {
@@ -1150,7 +1250,9 @@ func walkArrayCFGCombined(ctx context.Context, lines []string, lanes []arrayCFGW
 					if strings.TrimSpace(text) == "" && line >= 1 && line <= len(lines) {
 						text = normalizedCodeLine(lines[line-1])
 					}
-					out = lane.Visit(text, line, in)
+					// Keep the predecessor input immutable to the block transfer;
+					// exceptional and uncertain edges must receive that input state.
+					out = lane.Visit(text, line, out)
 					stopped = lane.Stop != nil && lane.Stop(text, line)
 				} else {
 					start := block.Statement.Range.StartLine
@@ -2741,7 +2843,7 @@ func inferArrayByRefAllocationSummaries(files []parsedFile, ctx analysisContext,
 		index := queue[head]
 		queued[index] = false
 		if head >= len(procedures) && ctx.arrayStats != nil {
-			ctx.arrayStats.revisits++
+			ctx.arrayStats.addRevisit()
 		}
 		procedure := procedures[index]
 		key := arrayProcedureKey(procedure.proc)
@@ -2749,7 +2851,7 @@ func inferArrayByRefAllocationSummaries(files []parsedFile, ctx analysisContext,
 			continue
 		}
 		if ctx.arrayStats != nil && procedure.proc.Graph != nil {
-			ctx.arrayStats.cfgWalks++
+			ctx.arrayStats.addCFGWalk()
 		}
 		value := arrayByRefAllocationSummaryForProcedure(procedure.file, procedure.proc, targets, summaries, ctx, dominators[key])
 		old := arrayByRefAllocationSummaries{key: contributions[key]}
@@ -2858,7 +2960,13 @@ func arrayByRefFlowAllocations(file parsedFile, proc sourceProcedure, ctx analys
 	variables := arrayVariables(file, proc, moduleDecls)
 	initial := arrayInitialState(variables)
 	graph := arrayVBA227Graph(proc, ctx)
-	var normalExit arrayFlowState
+	parameterNames := make([]string, 0, proc.Params.Len())
+	for _, parameter := range proc.Params.AllIndexed() {
+		if parameterIsByRefArray(parameter) {
+			parameterNames = append(parameterNames, strings.ToLower(parameter.Name))
+		}
+	}
+	var normalExit map[string]arrayValue
 	hasNormalExit := false
 	visit := func(text string, line int, in arrayFlowState) arrayFlowState {
 		out, _ := (Analyzer{}).arrayTransfer(file, proc, ctx, variables, in, text, line, nil, nil)
@@ -2872,15 +2980,20 @@ func arrayByRefFlowAllocations(file parsedFile, proc sourceProcedure, ctx analys
 		out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, variables)
 		if edge.To == graph.NormalExit() {
 			if !hasNormalExit {
-				normalExit = cloneArrayState(out)
+				normalExit = make(map[string]arrayValue, len(parameterNames))
+				for _, name := range parameterNames {
+					normalExit[name] = out[name]
+				}
 				hasNormalExit = true
 			} else {
-				normalExit = meetArrayState(normalExit, out)
+				for _, name := range parameterNames {
+					normalExit[name] = meetArrayValue(normalExit[name], out[name])
+				}
 			}
 		}
 		return out
 	}
-	walkArrayCFGWithSourceLines(&graph, file.Lines, initial, visit, edgeState)
+	walkArrayCFGWithSourceLinesReliableStats(&graph, file.Lines, initial, visit, edgeState, arrayAllocationTransferIsReliable, ctx.arrayStats)
 	if !hasNormalExit {
 		return nil
 	}
@@ -3234,7 +3347,14 @@ func applyArrayModuleCallEffects(state arrayFlowState, file parsedFile, proc sou
 	}
 	declarations := newDeclarationScope(file, proc)
 	declarations.module = moduleDecls
-	updated := cloneArrayState(state)
+	// Callers pass a block-local state to this transfer callback. The legacy
+	// walkers keep predecessor input separate before invoking it, while the
+	// compact cursor owns the map outright; update that private state in place
+	// so module/ByRef effects do not reintroduce whole-state copies.
+	updated := state
+	if updated == nil {
+		updated = arrayFlowState{}
+	}
 	markArgument := func(name string) {
 		name = strings.ToLower(cleanIdentifier(name))
 		variable, known := variables[name]
@@ -3554,7 +3674,7 @@ func inferArrayModuleAllocationSummaries(files []parsedFile, ctx analysisContext
 		index := queue[head]
 		queued[index] = false
 		if head >= len(procedures) && ctx.arrayStats != nil {
-			ctx.arrayStats.revisits++
+			ctx.arrayStats.addRevisit()
 		}
 		procedure := procedures[index]
 		if !arrayProcedureIsParticipant(ctx, procedure.proc) {
@@ -4039,13 +4159,13 @@ func inferArrayModuleEntryStates(a Analyzer, files []parsedFile, ctx analysisCon
 		}
 		graph := arrayVBA227Graph(procedure.proc, ctx)
 		if ctx.arrayStats != nil {
-			ctx.arrayStats.cfgWalks++
+			ctx.arrayStats.addCFGWalk()
 		}
-		walkArrayCFGWithEdges(&graph, procedure.file.Lines, initial, visit, func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
+		walkArrayCFGWithEdgesStats(&graph, procedure.file.Lines, initial, visit, func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
 			out = applyArrayConditionalAllocationBranch(out, &graph, block, edge)
 			out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, variables)
 			return applyArrayModuleConfigurationBranch(out, block.Statement, edge, ctx.arrayModuleConfigurations[procedure.file.Path], variables, procedure.file, procedure.proc, procedure.moduleDecls)
-		})
+		}, ctx.arrayStats)
 		return candidates
 	}
 
@@ -4062,7 +4182,7 @@ func inferArrayModuleEntryStates(a Analyzer, files []parsedFile, ctx analysisCon
 		queued[index] = false
 		key := procedures[index].key
 		if head >= len(procedures) && ctx.arrayStats != nil {
-			ctx.arrayStats.revisits++
+			ctx.arrayStats.addRevisit()
 		}
 		contribution := evaluate(procedures[index], entries)
 		if arrayModuleEntryContributionsEqual(contributions[key], contribution) {
@@ -4328,14 +4448,14 @@ func inferArrayByRefEntryStates(a Analyzer, files []parsedFile, ctx analysisCont
 			return evidence
 		}
 		if ctx.arrayStats != nil {
-			ctx.arrayStats.cfgWalks++
+			ctx.arrayStats.addCFGWalk()
 		}
 		baseView := proc.Graph.View(vbacfg.EdgeFilter{})
-		walkArrayCFGWithEdges(&baseView, file.Lines, initial, visit, func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
+		walkArrayCFGWithEdgesStats(&baseView, file.Lines, initial, visit, func(block vbacfg.Block, edge vbacfg.Edge, out arrayFlowState) arrayFlowState {
 			out = applyArrayConditionalAllocationBranch(out, &baseView, block, edge)
 			out = applyArrayAllocationGuard(out, block.Statement, edge, ctx.arrayAllocationGuards, variables)
 			return applyArrayModuleConfigurationBranch(out, block.Statement, edge, ctx.arrayModuleConfigurations[file.Path], variables, file, proc, moduleDecls)
-		})
+		}, ctx.arrayStats)
 		return evidence
 	}
 
@@ -4365,7 +4485,7 @@ func inferArrayByRefEntryStates(a Analyzer, files []parsedFile, ctx analysisCont
 		index := queue[head]
 		queued[index] = false
 		if head >= len(callers) && ctx.arrayStats != nil {
-			ctx.arrayStats.revisits++
+			ctx.arrayStats.addRevisit()
 		}
 		caller := callers[index]
 		key := arrayProcedureKey(caller.proc)
@@ -6170,10 +6290,10 @@ func inferArrayReturnSummaries(files []parsedFile, arrayAllocationGuards map[str
 		base := arrayOptionBase(procedure.file)
 		procedureHasErrorHandling := arrayProcedureHasErrorHandling(proc)
 		if participantCtx.arrayStats != nil {
-			participantCtx.arrayStats.cfgWalks++
+			participantCtx.arrayStats.addCFGWalk()
 		}
 		baseView := proc.Graph.View(vbacfg.EdgeFilter{})
-		walkArrayCFGWithStop(&baseView, procedure.file.Lines, arrayInitialState(procedure.variables), func(text string, line int, in arrayFlowState) arrayFlowState {
+		walkArrayCFGWithStopStats(&baseView, procedure.file.Lines, arrayInitialState(procedure.variables), func(text string, line int, in arrayFlowState) arrayFlowState {
 			if lhs, rhs, indexed, ok := arrayAssignment(text); ok && !indexed && strings.EqualFold(lhs, proc.Name) {
 				value, known := arrayExpressionState(rhs, in, ctx)
 				returnCandidates[line] = candidate{value: value, ok: known && value.kind == arrayAllocated && value.knownArray && value.origin != arrayOriginRangeValue}
@@ -6184,7 +6304,7 @@ func inferArrayReturnSummaries(files []parsedFile, arrayAllocationGuards map[str
 			return applyArrayAllocationGuard(out, block.Statement, edge, arrayAllocationGuards, procedure.variables)
 		}, func(text string, _ int) bool {
 			return !procedureHasErrorHandling && arraySummaryStatementAlwaysFails(text, base, procedure.constants)
-		})
+		}, participantCtx.arrayStats)
 		returnLines := make([]int, 0, len(returnCandidates))
 		for line := range returnCandidates {
 			returnLines = append(returnLines, line)
@@ -6254,7 +6374,7 @@ func inferArrayReturnSummaries(files []parsedFile, arrayAllocationGuards map[str
 			continue
 		}
 		if head >= len(procedures) && participantCtx.arrayStats != nil {
-			participantCtx.arrayStats.revisits++
+			participantCtx.arrayStats.addRevisit()
 		}
 		key := arrayProcedureKey(procedure.proc)
 		value, hasContribution := evaluate(procedure, summaries)

--- a/internal/analyze/http_transport.go
+++ b/internal/analyze/http_transport.go
@@ -215,6 +215,11 @@ func solveHTTPStates(ctx context.Context, a Analyzer, file parsedFile, proc sour
 				state.Set(symbol, cloneHTTPState(initial))
 				return nil
 			},
+			// HTTP has no edge-specific refinement. Keep the adapter on the
+			// explicit policy path while documenting that every edge propagates.
+			EdgeDecision: func(_ context.Context, _ semanticstate.LaneOrdinal, _ semanticstate.Edge, _, _ semanticstate.StateView[httpAnalysisState], _ *semanticstate.State[httpAnalysisState]) (semanticstate.EdgeDisposition, error) {
+				return semanticstate.EdgePropagate, nil
+			},
 			Transfer: func(_ context.Context, _ semanticstate.LaneOrdinal, block semanticstate.BlockOrdinal, input semanticstate.StateView[httpAnalysisState], output *semanticstate.State[httpAnalysisState]) error {
 				value, ok := input.Value(symbol)
 				if !ok {

--- a/internal/analyze/semanticstate/semanticstate_test.go
+++ b/internal/analyze/semanticstate/semanticstate_test.go
@@ -186,6 +186,119 @@ func TestSolverSnapshotsInputBeforeSelfEdgePropagation(t *testing.T) {
 	}
 }
 
+func TestSolverEdgeDecisionCanSuppressPropagation(t *testing.T) {
+	env := NewEnvironment([]string{"value"})
+	index, err := NewIndex(cfg.Graph{
+		Blocks: []cfg.Block{
+			{ID: 0, Kind: cfg.BlockEntry},
+			{ID: 1, Kind: cfg.BlockStatement},
+			{ID: 2, Kind: cfg.BlockNormalExit},
+		},
+		Edges: []cfg.Edge{
+			{ID: 0, From: 0, To: 1, Kind: cfg.EdgeFallthrough, Class: cfg.EdgeNormal},
+			{ID: 1, From: 1, To: 2, Kind: cfg.EdgeProcedureExit, Class: cfg.EdgeNormal},
+		},
+		Entry: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, _ := env.Symbol("value")
+	solver, err := NewSolver[int](index, env, maxLattice{}, []Lane[int]{{
+		Initialize: func(_ context.Context, _ LaneOrdinal, state *State[int]) error {
+			state.Set(value, 1)
+			return nil
+		},
+		Transfer: func(_ context.Context, _ LaneOrdinal, _ BlockOrdinal, in StateView[int], out *State[int]) error {
+			out.CloneFrom(in, nil)
+			return nil
+		},
+		EdgeDecision: func(_ context.Context, _ LaneOrdinal, edge Edge, _ StateView[int], _ StateView[int], _ *State[int]) (EdgeDisposition, error) {
+			if edge.ID == 0 {
+				return EdgeSuppress, nil
+			}
+			return EdgePropagate, nil
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := solver.Solve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := result.State(1, 0).Value(value); ok {
+		t.Fatal("suppressed edge unexpectedly reached destination")
+	}
+	if _, ok := result.State(2, 0).Value(value); ok {
+		t.Fatal("suppressed predecessor unexpectedly reached successor")
+	}
+}
+
+func TestSolverEdgeDecisionUsesInputForExceptionalAndUncertainEdges(t *testing.T) {
+	env := NewEnvironment([]string{"value"})
+	index, err := NewIndex(cfg.Graph{
+		Blocks: []cfg.Block{
+			{ID: 0, Kind: cfg.BlockEntry},
+			{ID: 1, Kind: cfg.BlockStatement},
+			{ID: 2, Kind: cfg.BlockStatement},
+			{ID: 3, Kind: cfg.BlockNormalExit},
+			{ID: 4, Kind: cfg.BlockNormalExit},
+		},
+		Edges: []cfg.Edge{
+			{ID: 0, From: 0, To: 1, Kind: cfg.EdgeFallthrough, Class: cfg.EdgeNormal},
+			{ID: 1, From: 1, To: 2, Kind: cfg.EdgeError, Class: cfg.EdgeExceptional},
+			{ID: 2, From: 1, To: 3, Kind: cfg.EdgeBranchTrue, Class: cfg.EdgeNormal, Uncertain: true},
+			{ID: 3, From: 1, To: 4, Kind: cfg.EdgeProcedureExit, Class: cfg.EdgeNormal},
+		},
+		Entry: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, _ := env.Symbol("value")
+	solver, err := NewSolver[int](index, env, maxLattice{}, []Lane[int]{{
+		Initialize: func(_ context.Context, _ LaneOrdinal, state *State[int]) error {
+			state.Set(value, 1)
+			return nil
+		},
+		Transfer: func(_ context.Context, _ LaneOrdinal, block BlockOrdinal, in StateView[int], out *State[int]) error {
+			out.CloneFrom(in, nil)
+			if block == 1 {
+				out.Set(value, 4)
+			}
+			return nil
+		},
+		EdgeDecision: func(_ context.Context, _ LaneOrdinal, edge Edge, input, output StateView[int], candidate *State[int]) (EdgeDisposition, error) {
+			if edge.Class != cfg.EdgeExceptional && !edge.Uncertain {
+				return EdgePropagate, nil
+			}
+			inputValue, inputOK := input.Value(value)
+			outputValue, outputOK := output.Value(value)
+			candidateValue, candidateOK := candidate.View().Value(value)
+			if !inputOK || !outputOK || !candidateOK || inputValue != 1 || outputValue != 4 || candidateValue != 1 {
+				t.Fatalf("edge %d states: input=(%d,%v) output=(%d,%v) candidate=(%d,%v)", edge.ID, inputValue, inputOK, outputValue, outputOK, candidateValue, candidateOK)
+			}
+			return EdgePropagate, nil
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := solver.Solve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, block := range []BlockOrdinal{2, 3} {
+		if got, ok := result.State(block, 0).Value(value); !ok || got != 1 {
+			t.Fatalf("edge to block %d joined output instead of input: %d, %v", block, got, ok)
+		}
+	}
+	if got, ok := result.State(4, 0).Value(value); !ok || got != 4 {
+		t.Fatalf("normal edge did not join output: %d, %v", got, ok)
+	}
+}
+
 func TestSolverCancellationDoesNotPublishPartialResult(t *testing.T) {
 	env := NewEnvironment([]string{"value"})
 	index, err := NewIndex(testGraph())

--- a/internal/analyze/semanticstate/solver.go
+++ b/internal/analyze/semanticstate/solver.go
@@ -213,7 +213,15 @@ func (s *Solver[T]) SolveContext(ctx context.Context) (Result[T], error) {
 				base = inputView
 			}
 			candidate.CloneFrom(base, s.lattice.Clone)
-			if lane.Edge != nil {
+			if lane.EdgeDecision != nil {
+				disposition, err := lane.EdgeDecision(ctx, item.Lane, edge, inputView, output.View(), candidate)
+				if err != nil {
+					return Result[T]{}, err
+				}
+				if disposition == EdgeSuppress {
+					continue
+				}
+			} else if lane.Edge != nil {
 				if err := lane.Edge(ctx, item.Lane, edge, inputView, output.View(), candidate); err != nil {
 					return Result[T]{}, err
 				}

--- a/internal/analyze/semanticstate/types.go
+++ b/internal/analyze/semanticstate/types.go
@@ -588,13 +588,35 @@ type TransferFunc[T any] func(context.Context, LaneOrdinal, BlockOrdinal, StateV
 // a domain has a narrow exception that remains valid across that edge.
 type EdgePolicy[T any] func(context.Context, LaneOrdinal, Edge, StateView[T], StateView[T], *State[T]) error
 
+// EdgeDisposition controls whether the candidate produced for an edge is
+// joined into the destination state. EdgePropagate preserves the normal
+// behavior; EdgeSuppress discards the candidate. The solver still invokes the
+// policy with a candidate initialized from predecessor output on normal edges
+// and predecessor input on exceptional or uncertain edges.
+type EdgeDisposition uint8
+
+const (
+	EdgePropagate EdgeDisposition = iota
+	EdgeSuppress
+)
+
+// EdgeDecisionFunc is the result-bearing form of EdgePolicy. It is available
+// alongside EdgePolicy so existing adapters can retain their nil-means-
+// propagate behavior while advanced adapters explicitly suppress an edge.
+type EdgeDecisionFunc[T any] func(context.Context, LaneOrdinal, Edge, StateView[T], StateView[T], *State[T]) (EdgeDisposition, error)
+
 // InitializeFunc seeds the entry state for one lane.
 type InitializeFunc[T any] func(context.Context, LaneOrdinal, *State[T]) error
 
 // Lane defines an independent transfer and edge policy. Lanes share indexed
 // scheduling but never share mutable state.
 type Lane[T any] struct {
-	Transfer   TransferFunc[T]
-	Edge       EdgePolicy[T]
-	Initialize InitializeFunc[T]
+	Transfer TransferFunc[T]
+	// Edge is the compatibility policy. A nil Edge policy propagates every
+	// edge, as it did before EdgeDecision was introduced.
+	Edge EdgePolicy[T]
+	// EdgeDecision is the explicit result-bearing policy. When present it takes
+	// precedence over Edge; EdgeSuppress skips the destination join.
+	EdgeDecision EdgeDecisionFunc[T]
+	Initialize   InitializeFunc[T]
 }

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -26,9 +26,15 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `array_bound`
 - `array_bounds`
 - `array_candidate_procedures`
+- `array_cfg_fallback_empty_state`
+- `array_cfg_fallback_index`
+- `array_cfg_fallback_unsupported`
+- `array_cfg_fallbacks`
 - `array_cfg_walks`
+- `array_compact_cfg_walks`
 - `array_interprocedural_cfg_walks`
 - `array_kernel_runs`
+- `array_legacy_cfg_walks`
 - `array_participant_procedures`
 - `array_projection_runs`
 - `array_subscript_out_of_bounds`


### PR DESCRIPTION
## Summary

- Migrate Array source-line lifecycle, edge-refined, exceptional/uncertain, and combined runtime/evidence CFG walks to the indexed semantic-state solver.
- Add reusable Array cursors, lane grouping, edge suppression, sidecar evidence, and an explicit compact compatibility fallback while retaining the legacy map walker as the differential oracle.
- Preserve `VBA208`, `VBA227`, and `VBA249` diagnostics, evidence, ordering, ByRef/module/return effects, and conservative `ReliableExceptional` behavior.
- Amend ADR-0047 and the Array/IR/corpus specifications, changelog, telemetry inventory, differential regressions, and allocation benchmarks.

The branch includes the current `origin/main` tip (`e4e18e93`, #726). Closes #721.

## Performance

- ROneCOne five-run median: `9,700,135,400 ns/op`, `10,386,967,992 B/op`, and `92,124,549 allocs/op`.
- Focused alloc-space: `cloneArrayState` about `0.0065 GB`, `meetArrayState` `0 GB`, and the three-leaf total about `0.107 GB` versus about `2.20 GB` post-#713.
- Retained profiles: `C:\temp\xlflow-issue721-final2.cpu.pprof` and `C:\temp\xlflow-issue721-final2.mem.pprof`.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -count=1`
- `rtk powershell -NoProfile -Command '$env:GOMAXPROCS="4"; & ".\scripts\dev\go.ps1" test -race ./internal/analyze -count=1 -timeout=20m'`
- `rtk task corpus:test` (snapshot unchanged)
- `rtk pnpm docs:check`
- `rtk pnpm format:check`
- Pre-commit lint, format, PowerShell, oxlint, and documentation checks passed.

The unconstrained Windows race invocation was also attempted but hit the host commit-limit error (1455); the constrained full race run completed without race reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved array lifecycle analysis across complex control-flow paths.
  * Preserved source-line ordering, diagnostic results, and conservative handling of uncertain or exceptional execution paths.
  * Added safer handling for allocation conditions, `Stop`, and `ReDim Preserve`.
  * Improved compatibility by automatically falling back to the legacy analysis path when needed.
  * Added developer-only performance and strategy telemetry.

* **Documentation**
  * Updated analysis specifications, verification requirements, and error-code references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->