### PR TITLE
fix: update tree-sitter-vba to v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Updated the tree-sitter-vba parser dependency to v0.12.2. Exported VBA
+  procedure attributes with multi-segment names now parse without recovery,
+  preserving downstream lint and analysis behavior.
+
 - Reduced revision-scoped semantic query overhead by sharing prepared,
   kernel-specific fingerprints across procedure lanes, using comparable cache
   keys and exact document/procedure invalidation indexes, and separating cold,

--- a/THIRD_PARTY_LICENCES.md
+++ b/THIRD_PARTY_LICENCES.md
@@ -14,7 +14,7 @@ This file is provided for attribution and licence review. It is not a substitute
 | `github.com/bmatcuk/doublestar/v4`      | `v4.10.0` | MIT               | `https://github.com/bmatcuk/doublestar/blob/v4.10.0/LICENSE`         |
 | `github.com/charmbracelet/bubbletea`    | `v1.3.10` | MIT               | `https://github.com/charmbracelet/bubbletea/blob/v1.3.10/LICENSE`    |
 | `github.com/charmbracelet/lipgloss`     |  `v1.1.0` | MIT               | `https://github.com/charmbracelet/lipgloss/blob/v1.1.0/LICENSE`      |
-| `github.com/harumiWeb/tree-sitter-vba`  | `v0.12.0` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.12.0/LICENSE`  |
+| `github.com/harumiWeb/tree-sitter-vba`  | `v0.12.2` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.12.2/LICENSE`  |
 | `github.com/sourcegraph/jsonrpc2`       |  `v0.2.0` | MIT               | `https://github.com/sourcegraph/jsonrpc2/blob/v0.2.0/LICENSE`        |
 | `github.com/spf13/cobra`                | `v1.10.2` | Apache-2.0        | `https://github.com/spf13/cobra/blob/v1.10.2/LICENSE.txt`            |
 | `github.com/tliron/glsp`                |  `v0.2.2` | Apache-2.0        | `https://github.com/tliron/glsp/blob/v0.2.2/LICENSE`                 |

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/harumiWeb/tree-sitter-vba v0.12.0
+	github.com/harumiWeb/tree-sitter-vba v0.12.2
 	github.com/richardlehane/mscfb v1.0.7
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-github.com/harumiWeb/tree-sitter-vba v0.12.0 h1:+ELRzi2pnKp8lfgRGUrHipDLtpWsrTDENXN41KF7Qo0=
-github.com/harumiWeb/tree-sitter-vba v0.12.0/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
+github.com/harumiWeb/tree-sitter-vba v0.12.2 h1:P2ytCKrhTU/iCK8FIhlbuVN9rnRydd3otCC/bADFjgI=
+github.com/harumiWeb/tree-sitter-vba v0.12.2/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/internal/vba/ast/ast_test.go
+++ b/internal/vba/ast/ast_test.go
@@ -237,6 +237,39 @@ End Property
 	}
 }
 
+func TestParserParsesVBEMultiSegmentProcedureAttributes(t *testing.T) {
+	parser, err := NewParser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parser.Close()
+
+	result := parser.Parse("Exported.bas", []byte(`Public Sub Foo()
+Attribute Foo.VB_ProcData.VB_Invoke_Func = " \n14"
+End Sub
+`))
+	defer result.Close()
+
+	if result.HasError || result.HasMissing {
+		t.Fatalf("unexpected recovery state: error=%t missing=%t tree=%s", result.HasError, result.HasMissing, result.Root.ToSexp())
+	}
+	found := false
+	Walk(result.Root, func(node *tree_sitter.Node) bool {
+		if node.Kind() != "attribute_statement" {
+			return true
+		}
+		name := node.ChildByFieldName("name")
+		if name == nil || name.Utf8Text(result.Source) != "Foo.VB_ProcData.VB_Invoke_Func" {
+			return true
+		}
+		found = name.Kind() == "qualified_member_expression" && name.NamedChildCount() == 3
+		return true
+	})
+	if !found {
+		t.Fatalf("multi-segment procedure Attribute was not parsed as a qualified member expression: %s", result.Root.ToSexp())
+	}
+}
+
 func TestParsedDocumentOwnsRecoveryStateAndClosesAfterReaders(t *testing.T) {
 	doc, err := ParseDocument("Broken.bas", []byte("Public Function Foo(ByVal x As String\nEnd Function\n"))
 	if err != nil {


### PR DESCRIPTION
## Summary

- Update `github.com/harumiWeb/tree-sitter-vba` from `v0.12.0` to `v0.12.2`.
- Add regression coverage for multi-segment VBE procedure attributes, which
  v0.12.2 parses without recovery nodes.
- Refresh the third-party licence inventory and changelog.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./...`
- `rtk task lint`
- `rtk pnpm format:check`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\check-third-party-licences.ps1`
- `rtk proxy task review:codex`
