### PR TITLE
perf(analyze): reduce static analysis allocations (#729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Reduced static-analysis allocation pressure for giant VBA modules by sharing
+  immutable module array-variable catalogs, lazily copying branch-local
+  Dictionary/Collection, Application-state, and generic data-flow maps, and
+  resolving VBA205 project procedure shadowing on demand. Added recovered and
+  unknown synthetic benchmark workloads and a ten-sample ROneCOne benchmark
+  task; diagnostic identity, ordering, JSON/LSP, batch/realtime, cancellation,
+  and process-local cache boundaries remain unchanged.
+
 ## v0.31.0
 
 - Updated the tree-sitter-vba parser dependency to v0.12.2. Exported VBA

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -195,11 +195,11 @@ tasks:
         platforms: [linux, darwin]
 
   bench:corpus-ronecone:
-    desc: Benchmark the single-project ROneCOne analyzer stress fixture
+    desc: Collect ten-sample ROneCOne analyzer stress-fixture measurements
     cmds:
-      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 2
+      - cmd: rtk powershell -NoProfile -ExecutionPolicy Bypass -File '.\scripts\dev\go.ps1' test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 10 -timeout=25m
         platforms: [windows]
-      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 2
+      - cmd: rtk go test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count 10 -timeout=25m
         platforms: [linux, darwin]
 
   bench:analyze:

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -2030,6 +2030,58 @@ spot was 13.503 s/op with 3,713 hits. The formal comparison against
 95% confidence testing, remains unverified until the serial `-count=10`
 collection is retained on the fixed benchmark host.
 
+### Analyzer state-allocation verification (#729)
+
+Issue #729 reduces procedure-local analyzer allocation pressure at the
+profile-backed branch and projection boundaries. Batch and realtime setup now
+materialize one immutable module array-variable catalog; procedure projections
+overlay only local declarations and accessed module scalars, while empty access
+projections retain the historical fail-open behavior. Dictionary/Collection,
+Application-state, and generic data-flow CFG states use copy-on-write map
+headers and clone nested facts only when a branch mutates them. VBA205 keeps
+project procedure visibility lazy instead of copying the complete project
+procedure map into every procedure's shadow set.
+
+The optimization is process-local and revision-local. It does not add disk or
+cross-process state, a user-facing performance option, or an additional worker
+pool. Existing deterministic append order and diagnostic identity, range,
+severity, evidence, multiplicity, suppression, JSON, LSP, cancellation, and
+batch/realtime paths remain the compatibility boundary. COW isolation is covered
+by focused tests for all three state families; recovered and unknown synthetic
+workloads are included in `BenchmarkSingleModuleSynthetic` alongside
+independent, declaration-heavy, call-chain, dense/cyclic, and CFG-heavy shapes.
+
+The retained Windows measurement command is:
+
+```powershell
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count=10 -timeout=25m
+```
+
+`task bench:corpus-ronecone` runs the same ten-sample command. On 2026-08-26,
+Windows/amd64, 12th Gen Intel(R) Core(TM) i7-12700, Go 1.26.6, the command
+completed successfully in 550.449 s. Every cold sample reported 1,565
+procedures and 510 findings; edit scenarios also recorded the expected query
+miss/recompute and array fallback counters. A spot comparison against the
+pre-change baseline was approximately 9.1 s/op, 9.08 GB/op, 81.5 M allocs/op
+(cold) and 8.54 s/op, 7.06 GB/op, 66.7 M allocs/op (warm), versus approximately
+8.0 s/op, 6.9 GB/op, 66.6 M allocs/op (cold) and 7.5 s/op, 5.5 GB/op, 55.5 M
+allocs/op (warm) after #729. These are host observations, not CI thresholds;
+the retained ten-sample output and alloc-space/alloc-object/in-use heap and CPU
+profiles are required for a formal baseline comparison.
+
+Run the following read-only checks after changing the analyzer:
+
+```powershell
+rtk proxy task corpus:test
+rtk proxy task corpus:test
+rtk proxy task corpus:metrics
+rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/analyze ./internal/vba/dataflow ./internal/lspserver -count=1 -timeout=30m
+```
+
+The benchmark and verification paths must not update corpus snapshots or
+`reviews/diagnostics.jsonl`; unexplained deltas remain a stop-and-investigate
+condition.
+
 ## Related
 
 - `docs/adr/ADR-0029-vendored-static-analysis-corpus.md`

--- a/docs/specs/static-analysis-corpus.md
+++ b/docs/specs/static-analysis-corpus.md
@@ -2057,7 +2057,7 @@ The retained Windows measurement command is:
 rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count=10 -timeout=25m
 ```
 
-`task bench:corpus-ronecone` runs the same ten-sample command. On 2026-08-26,
+`rtk task bench:corpus-ronecone` runs the same ten-sample command. On 2026-08-26,
 Windows/amd64, 12th Gen Intel(R) Core(TM) i7-12700, Go 1.26.6, the command
 completed successfully in 550.449 s. Every cold sample reported 1,565
 procedures and 510 findings; edit scenarios also recorded the expected query

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -3850,7 +3850,7 @@ func applicationStateExitWitnesses(proc sourceProcedure, property string, facts 
 }
 
 func applicationStateFlowAcrossEdge(proc sourceProcedure, state applicationStateFlow, block vbacfg.Block, edge vbacfg.Edge, property string, facts *procedureAnalysisFacts) applicationStateFlow {
-	out := cloneApplicationStateFlow(state)
+	out := cloneApplicationStateFlow(&state)
 	out.ViaExceptional = out.ViaExceptional || edge.Class == vbacfg.EdgeExceptional
 	if block.Statement == nil {
 		return out
@@ -3918,7 +3918,13 @@ func newApplicationStateFlow() applicationStateFlow {
 	return applicationStateFlow{Dirty: map[int]bool{}, Saved: map[string]applicationStateSnapshot{}}
 }
 
-func cloneApplicationStateFlow(in applicationStateFlow) applicationStateFlow {
+func cloneApplicationStateFlow(in *applicationStateFlow) applicationStateFlow {
+	if in == nil {
+		return newApplicationStateFlow()
+	}
+	in.dirtyShared = true
+	in.savedShared = true
+	in.snapshotMapsShared = true
 	// CFG edges fork this state frequently. Share the map headers and defer
 	// copying until a branch actually changes one of the maps. Snapshot maps
 	// are treated as shared as well because Saved values can alias one another.
@@ -4011,9 +4017,9 @@ func cloneApplicationStateSnapshot(in applicationStateSnapshot) applicationState
 
 func mergeApplicationStateFlow(current, incoming applicationStateFlow) (applicationStateFlow, bool) {
 	if current.Dirty == nil {
-		return cloneApplicationStateFlow(incoming), true
+		return cloneApplicationStateFlow(&incoming), true
 	}
-	next := cloneApplicationStateFlow(current)
+	next := cloneApplicationStateFlow(&current)
 	changed := false
 	for origin := range incoming.Dirty {
 		if !next.Dirty[origin] {

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -477,6 +477,11 @@ type parsedFile struct {
 	// Procedures. It is materialized once during batch/realtime file setup and
 	// reused by rule stages that solve array and object state.
 	ModuleDeclarations map[string]sourceDeclaration
+	// ArrayVariableCatalog is the immutable array-variable projection for
+	// module declarations. Procedure-local arrayVariables calls overlay their
+	// own declarations on this catalog instead of rescanning every module
+	// declaration for every procedure.
+	ArrayVariableCatalog map[string]arrayVariable
 	// ModuleFacts owns the immutable module declaration and procedure ownership
 	// indexes shared by all rule stages for this file revision.
 	ModuleFacts                 *moduleAnalysisFacts
@@ -799,6 +804,9 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 		procedures := sourceProceduresFromIRRef(&parsedFiles[i].IR, parsedFiles[i].CFG)
 		parsedFiles[i].Procedures = procedures
 		parsedFiles[i].ensureModuleAnalysisFacts()
+		if arrayAnalysisEnabled(analysis.Config.Analyze) {
+			parsedFiles[i].ArrayVariableCatalog = buildArrayVariableCatalog(parsedFiles[i], parsedFiles[i].moduleDecls())
+		}
 		parsedFiles[i].moduleFactsFingerprint = semanticModuleFactsFingerprint(parsedFiles[i])
 		materializeProcedureAnalysisPlans(&parsedFiles[i], projectEffects, analysis.Config.Analyze)
 		recordFactBuilds(ctx, len(procedures))
@@ -1816,10 +1824,11 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 		file.moduleFactsFingerprint = semanticModuleFactsFingerprint(file)
 		materializeProcedureAnalysisPlans(&file, projectEffects, cfg.Analyze)
 		recordFactBuilds(ctx, len(procedures))
-		if cfg.Analyze.DetectArrayLifecycleSafety || cfg.Analyze.DetectRedimPreserveDimension || cfg.Analyze.DetectObjectArrayComparison || cfg.Analyze.DetectDeterministicRuntimeErrors {
+		if arrayAnalysisEnabled(cfg.Analyze) {
 			file.ArrayOptionBase = optionBase(lines)
 			file.ArrayOptionBaseSet = true
 			file.ArrayIntegerModuleConstants = arrayIntegerModuleConstants(file)
+			file.ArrayVariableCatalog = buildArrayVariableCatalog(file, file.moduleDecls())
 		}
 		if cfg.Analyze.DetectNonShortCircuitObjectGuard && len(projectEffects.AllDirect()) == 0 && vba212SourceMayHaveGetter(file) {
 			projectEffects = buildSingleFileProjectEffects(file)
@@ -3362,7 +3371,7 @@ func (a Analyzer) rangeFindFindings(file parsedFile, proc sourceProcedure, lineN
 	return findings
 }
 
-func (a Analyzer) unqualifiedExcelFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, shadowed map[string]bool) []Finding {
+func (a Analyzer) unqualifiedExcelFindings(file parsedFile, proc sourceProcedure, lineNo int, stmt string, shadowed vba205ShadowedIdentifiers) []Finding {
 	if vba205NonExecutableStatement(stmt) {
 		return nil
 	}
@@ -3424,41 +3433,61 @@ func vba205NonExecutableStatement(stmt string) bool {
 		strings.HasPrefix(lower, "declare ")
 }
 
-func vba205ShadowedIdentifiersWithFacts(proc sourceProcedure, decls declarationScope, ctx analysisContext, facts *moduleAnalysisFacts) map[string]bool {
-	shadowed := make(map[string]bool, decls.len()+proc.Accesses.Len()+proc.Declarations.Len()+len(ctx.procedures))
-	decls.forEach(func(name string, _ sourceDeclaration) {
-		shadowed[strings.ToLower(name)] = true
-	})
+type vba205ShadowedIdentifiers struct {
+	decls      declarationScope
+	local      map[string]struct{}
+	procedures map[string]procedureSignature
+	resolver   procedureir.Resolver
+	proc       sourceProcedure
+	facts      *moduleAnalysisFacts
+}
+
+func vba205ShadowedIdentifiersWithFacts(proc sourceProcedure, decls declarationScope, ctx analysisContext, facts *moduleAnalysisFacts) vba205ShadowedIdentifiers {
+	shadowed := vba205ShadowedIdentifiers{
+		decls:      decls,
+		local:      make(map[string]struct{}, proc.Accesses.Len()+proc.Declarations.Len()),
+		procedures: ctx.procedures,
+		resolver:   ctx.procedureResolver,
+		proc:       proc,
+		facts:      facts,
+	}
 	for declaration := range proc.Declarations.All() {
 		switch declaration.Scope {
 		case procedureir.ScopeParameter, procedureir.ScopeLocal, procedureir.ScopeModule, procedureir.ScopeProject:
-			shadowed[strings.ToLower(declaration.Name)] = true
+			shadowed.local[strings.ToLower(declaration.Name)] = struct{}{}
 		}
 	}
 	for access := range proc.Accesses.All() {
 		switch access.Scope {
 		case procedureir.ScopeParameter, procedureir.ScopeLocal, procedureir.ScopeModule, procedureir.ScopeProject:
-			shadowed[strings.ToLower(access.Name)] = true
-		}
-	}
-	for name := range ctx.procedures {
-		if strings.Contains(name, ".") {
-			continue
-		}
-		// A procedure declared in the caller's own module is always visible to
-		// unqualified VBA calls (including Private procedures). The immutable
-		// module index avoids resolving the same local name through the full
-		// project resolver for every procedure and preserves the resolver path
-		// for cross-module visibility and ambiguity decisions.
-		if facts != nil && facts.hasProcedure(name) {
-			shadowed[name] = true
-			continue
-		}
-		if vba205ProcedureVisibleFrom(ctx.procedureResolver, proc, name) {
-			shadowed[name] = true
+			shadowed.local[strings.ToLower(access.Name)] = struct{}{}
 		}
 	}
 	return shadowed
+}
+
+func (shadowed vba205ShadowedIdentifiers) contains(name string) bool {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		return false
+	}
+	if _, ok := shadowed.local[key]; ok {
+		return true
+	}
+	if _, ok := shadowed.decls.lookup(key); ok {
+		return true
+	}
+	// A procedure declared in the caller's own module is always visible to
+	// unqualified VBA calls (including Private procedures). Resolve only the
+	// candidate root seen by the source scanner instead of copying every
+	// project procedure into every procedure's shadow set.
+	if shadowed.facts != nil && shadowed.facts.hasProcedure(key) {
+		return true
+	}
+	if _, ok := shadowed.procedures[key]; ok {
+		return vba205ProcedureVisibleFrom(shadowed.resolver, shadowed.proc, key)
+	}
+	return false
 }
 
 func vba205ProcedureVisibleFrom(resolver procedureir.Resolver, proc sourceProcedure, name string) bool {
@@ -3472,7 +3501,7 @@ func vba205ProcedureVisibleFrom(resolver procedureir.Resolver, proc sourceProced
 	return resolution.Status == procedureir.ResolutionMatched || resolution.Status == procedureir.ResolutionAmbiguous
 }
 
-func vba205QualifiedOrShadowedRoot(match, name string, shadowed map[string]bool) bool {
+func vba205QualifiedOrShadowedRoot(match, name string, shadowed vba205ShadowedIdentifiers) bool {
 	lowerMatch := strings.ToLower(match)
 	if strings.Contains(lowerMatch, "application.") {
 		return false
@@ -3481,7 +3510,7 @@ func vba205QualifiedOrShadowedRoot(match, name string, shadowed map[string]bool)
 	if dot := strings.IndexByte(rootName, '.'); dot >= 0 {
 		rootName = rootName[:dot]
 	}
-	return shadowed[rootName]
+	return shadowed.contains(rootName)
 }
 
 func addInStandardModule(cfg config.Config, file parsedFile) bool {
@@ -3736,9 +3765,12 @@ type applicationStateSnapshot struct {
 }
 
 type applicationStateFlow struct {
-	Dirty          map[int]bool
-	Saved          map[string]applicationStateSnapshot
-	ViaExceptional bool
+	Dirty              map[int]bool
+	Saved              map[string]applicationStateSnapshot
+	ViaExceptional     bool
+	dirtyShared        bool
+	savedShared        bool
+	snapshotMapsShared bool
 }
 
 type applicationStateExitWitness struct {
@@ -3887,14 +3919,74 @@ func newApplicationStateFlow() applicationStateFlow {
 }
 
 func cloneApplicationStateFlow(in applicationStateFlow) applicationStateFlow {
-	out := newApplicationStateFlow()
-	for origin := range in.Dirty {
-		out.Dirty[origin] = true
+	// CFG edges fork this state frequently. Share the map headers and defer
+	// copying until a branch actually changes one of the maps. Snapshot maps
+	// are treated as shared as well because Saved values can alias one another.
+	out := applicationStateFlow{
+		Dirty:              in.Dirty,
+		Saved:              in.Saved,
+		ViaExceptional:     in.ViaExceptional,
+		dirtyShared:        true,
+		savedShared:        true,
+		snapshotMapsShared: true,
 	}
-	for key, snapshot := range in.Saved {
-		out.Saved[key] = cloneApplicationStateSnapshot(snapshot)
+	if out.Dirty == nil {
+		out.Dirty = map[int]bool{}
+		out.dirtyShared = false
 	}
-	out.ViaExceptional = in.ViaExceptional
+	if out.Saved == nil {
+		out.Saved = map[string]applicationStateSnapshot{}
+		out.savedShared = false
+	}
+	return out
+}
+
+func (s *applicationStateFlow) ensureDirty() {
+	if s == nil || !s.dirtyShared {
+		return
+	}
+	out := make(map[int]bool, len(s.Dirty))
+	for origin := range s.Dirty {
+		out[origin] = true
+	}
+	s.Dirty = out
+	s.dirtyShared = false
+}
+
+func (s *applicationStateFlow) ensureSaved() {
+	if s == nil || !s.savedShared {
+		return
+	}
+	out := make(map[string]applicationStateSnapshot, len(s.Saved))
+	for key, snapshot := range s.Saved {
+		out[key] = snapshot
+	}
+	s.Saved = out
+	s.savedShared = false
+}
+
+func (s *applicationStateFlow) mutableSavedSnapshot(key string) (applicationStateSnapshot, bool) {
+	if s == nil {
+		return applicationStateSnapshot{}, false
+	}
+	s.ensureSaved()
+	snapshot, exists := s.Saved[key]
+	if !exists {
+		return applicationStateSnapshot{}, false
+	}
+	if s.snapshotMapsShared {
+		snapshot.Dirty = cloneIntBoolSet(snapshot.Dirty)
+		snapshot.Restores = cloneIntBoolSet(snapshot.Restores)
+		snapshot.GuardedBy = cloneIntBoolSet(snapshot.GuardedBy)
+	}
+	return snapshot, true
+}
+
+func cloneIntBoolSet(in map[int]bool) map[int]bool {
+	out := make(map[int]bool, len(in))
+	for key := range in {
+		out[key] = true
+	}
 	return out
 }
 
@@ -3925,6 +4017,7 @@ func mergeApplicationStateFlow(current, incoming applicationStateFlow) (applicat
 	changed := false
 	for origin := range incoming.Dirty {
 		if !next.Dirty[origin] {
+			next.ensureDirty()
 			next.Dirty[origin] = true
 			changed = true
 		}
@@ -3973,6 +4066,7 @@ func mergeApplicationStateFlow(current, incoming applicationStateFlow) (applicat
 			}
 		}
 		if !applicationStateSnapshotEqual(current.Saved[key], merged) {
+			next.ensureSaved()
 			next.Saved[key] = merged
 			changed = true
 		}
@@ -4009,15 +4103,20 @@ func applyApplicationStateStatement(proc sourceProcedure, state applicationState
 	if assignedProperty, value, isPropertyWrite := applicationPropertyAssignment(statement, facts); isPropertyWrite && assignedProperty == property {
 		if applicationStateSavedRestore(proc, state, statement, property, facts) {
 			variable, _ := applicationStateVariable(proc, statement.ID, value, procedureir.AccessRead)
-			state.Dirty = cloneApplicationStateSnapshot(state.Saved[variable]).Dirty
+			state.Dirty = cloneIntBoolSet(state.Saved[variable].Dirty)
+			state.dirtyShared = false
 			return state
 		}
 		if variable, ok := applicationStateVariable(proc, statement.ID, value, procedureir.AccessRead); ok {
 			if saved, exists := state.Saved[variable]; exists {
+				if len(saved.Restores) > 0 {
+					state.ensureDirty()
+				}
 				for origin := range saved.Restores {
 					delete(state.Dirty, origin)
 				}
 				if applicationStateMatchingGuard(proc, saved, statement, facts) {
+					state.ensureDirty()
 					for origin := range saved.Dirty {
 						state.Dirty[origin] = true
 					}
@@ -4031,13 +4130,16 @@ func applyApplicationStateStatement(proc sourceProcedure, state applicationState
 			// Loop backedges can revisit this assignment after its origin was saved;
 			// an origin must never be recorded as restoring itself.
 			if !saved.Unknown && !saved.Dirty[statement.ID] {
+				saved, _ = state.mutableSavedSnapshot(key)
 				if saved.Restores == nil {
 					saved.Restores = map[int]bool{}
 				}
 				saved.Restores[statement.ID] = true
+				state.ensureSaved()
 				state.Saved[key] = saved
 			}
 		}
+		state.ensureDirty()
 		state.Dirty[statement.ID] = true
 		return state
 	}
@@ -4046,8 +4148,9 @@ func applyApplicationStateStatement(proc sourceProcedure, state applicationState
 		return state
 	}
 	if isApplicationPropertyReference(statement.Value, statement, facts, property) {
+		state.ensureSaved()
 		state.Saved[variable] = applicationStateSnapshot{
-			Dirty:     cloneApplicationStateFlow(state).Dirty,
+			Dirty:     cloneIntBoolSet(state.Dirty),
 			Restores:  map[int]bool{},
 			GuardedBy: applicationStateDirectGuard(statement, facts),
 		}
@@ -4055,10 +4158,13 @@ func applyApplicationStateStatement(proc sourceProcedure, state applicationState
 	}
 	if source, ok := applicationStateVariable(proc, statement.ID, expressionText(statement.Value), procedureir.AccessRead); ok {
 		if saved, exists := state.Saved[source]; exists {
-			state.Saved[variable] = cloneApplicationStateSnapshot(saved)
+			state.ensureSaved()
+			state.Saved[variable] = saved
+			state.snapshotMapsShared = true
 			return state
 		}
 	}
+	state.ensureSaved()
 	state.Saved[variable] = applicationStateSnapshot{Dirty: map[int]bool{}, Restores: map[int]bool{}, GuardedBy: map[int]bool{}, Unknown: true}
 	return state
 }
@@ -4101,8 +4207,12 @@ func applyApplicationStateExceptionalRestore(proc sourceProcedure, state applica
 		return state
 	}
 	if applicationStateMatchingGuard(proc, saved, statement, facts) {
-		state.Dirty = cloneApplicationStateSnapshot(saved).Dirty
+		state.Dirty = cloneIntBoolSet(saved.Dirty)
+		state.dirtyShared = false
 		return state
+	}
+	if len(saved.Restores) > 0 {
+		state.ensureDirty()
 	}
 	for origin := range saved.Restores {
 		delete(state.Dirty, origin)

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -2456,7 +2456,7 @@ func TestApplicationStateFlowCloneCopiesMapsOnWrite(t *testing.T) {
 			},
 		},
 	}
-	branch := cloneApplicationStateFlow(original)
+	branch := cloneApplicationStateFlow(&original)
 	branch.ensureDirty()
 	branch.Dirty[2] = true
 	branch.ensureSaved()
@@ -2478,6 +2478,17 @@ func TestApplicationStateFlowCloneCopiesMapsOnWrite(t *testing.T) {
 	original.Dirty[4] = true
 	if branch.Dirty[4] {
 		t.Fatal("write to original application state leaked into cloned state")
+	}
+
+	original.ensureSaved()
+	snapshot, ok = original.mutableSavedSnapshot("saved")
+	if !ok {
+		t.Fatal("original saved snapshot was not available")
+	}
+	snapshot.Restores[4] = true
+	original.Saved["saved"] = snapshot
+	if branch.Saved["saved"].Restores[4] {
+		t.Fatal("nested write to original application state leaked into cloned state")
 	}
 }
 

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -2445,6 +2445,42 @@ End Sub
 	}
 }
 
+func TestApplicationStateFlowCloneCopiesMapsOnWrite(t *testing.T) {
+	original := applicationStateFlow{
+		Dirty: map[int]bool{1: true},
+		Saved: map[string]applicationStateSnapshot{
+			"saved": {
+				Dirty:     map[int]bool{1: true},
+				Restores:  map[int]bool{},
+				GuardedBy: map[int]bool{},
+			},
+		},
+	}
+	branch := cloneApplicationStateFlow(original)
+	branch.ensureDirty()
+	branch.Dirty[2] = true
+	branch.ensureSaved()
+	snapshot, ok := branch.mutableSavedSnapshot("saved")
+	if !ok {
+		t.Fatal("cloned saved snapshot was not available")
+	}
+	snapshot.Restores[3] = true
+	branch.Saved["saved"] = snapshot
+
+	if original.Dirty[2] {
+		t.Fatal("dirty-state write leaked from cloned application state")
+	}
+	if original.Saved["saved"].Restores[3] {
+		t.Fatal("nested saved-state write leaked from cloned application state")
+	}
+
+	original.ensureDirty()
+	original.Dirty[4] = true
+	if branch.Dirty[4] {
+		t.Fatal("write to original application state leaked into cloned state")
+	}
+}
+
 func TestAnalyzerApplicationStateAllowsEitherSameModuleRestoreAlias(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/analyze/array_analysis_test.go
+++ b/internal/analyze/array_analysis_test.go
@@ -79,3 +79,53 @@ func TestArrayLifecycleProjectionApplicableIncludesRecoveredSource(t *testing.T)
 		t.Fatal("recovered source indexed access should make the VBA227 projection applicable")
 	}
 }
+
+func TestArrayVariablesFiltersCatalogScalarsByProcedureAccess(t *testing.T) {
+	moduleDecls := map[string]sourceDeclaration{
+		"usedscalar":   {Name: "UsedScalar", Type: "Long"},
+		"unusedscalar": {Name: "UnusedScalar", Type: "Long"},
+		"values":       {Name: "values", Type: "Long", Array: true},
+	}
+	file := parsedFile{
+		Module:             "Main",
+		Lines:              []string{"Sub Run()", "", "End Sub"},
+		ModuleDeclarations: moduleDecls,
+		ArrayVariableCatalog: map[string]arrayVariable{
+			"usedscalar":   {name: "UsedScalar", typ: "Long", knownScalar: true},
+			"unusedscalar": {name: "UnusedScalar", typ: "Long", knownScalar: true},
+			"values":       {name: "values", typ: "Long", isArray: true},
+		},
+	}
+	proc := sourceProcedure{StartLine: 1, EndLine: 3, Accesses: newReadOnlySpan([]procedureir.VariableAccess{
+		{Name: "UsedScalar", Scope: procedureir.ScopeModule, Mode: procedureir.AccessRead},
+		{Name: "values", Scope: procedureir.ScopeModule, Mode: procedureir.AccessRead},
+	})}
+
+	variables := arrayVariables(file, proc, moduleDecls)
+	if _, ok := variables["usedscalar"]; !ok {
+		t.Fatal("accessed module scalar was filtered out")
+	}
+	if _, ok := variables["values"]; !ok {
+		t.Fatal("module array was filtered out")
+	}
+	if _, ok := variables["unusedscalar"]; ok {
+		t.Fatal("unaccessed module scalar retained in procedure projection")
+	}
+}
+
+func TestArrayVariablesFailsOpenWithoutAccessProjection(t *testing.T) {
+	moduleDecls := map[string]sourceDeclaration{
+		"modulevalue": {Name: "ModuleValue", Type: "Long"},
+	}
+	file := parsedFile{
+		Lines:              []string{"Sub Run()", "", "End Sub"},
+		ModuleDeclarations: moduleDecls,
+		ArrayVariableCatalog: map[string]arrayVariable{
+			"modulevalue": {name: "ModuleValue", typ: "Long", knownScalar: true},
+		},
+	}
+	variables := arrayVariables(file, sourceProcedure{StartLine: 1, EndLine: 3}, moduleDecls)
+	if _, ok := variables["modulevalue"]; !ok {
+		t.Fatal("module declaration must be retained when access projection is unavailable")
+	}
+}

--- a/internal/analyze/array_safety.go
+++ b/internal/analyze/array_safety.go
@@ -5320,29 +5320,81 @@ func arrayVariables(file parsedFile, proc sourceProcedure, moduleDecls map[strin
 			Object:     isObjectType(param.Type), Parameter: true, ParamArray: param.ParamArray,
 		}
 	}
-	variables := map[string]arrayVariable{}
-	decls.forEach(func(key string, decl sourceDeclaration) {
-		typeName := strings.TrimSpace(decl.Type)
-		// VBA declarations without an As clause are implicit Variant values.
-		// Treat them exactly like an explicit Variant so array-sensitive rules
-		// do not turn an unresolved value into a false scalar proof.
-		isVariant := typeName == "" || strings.EqualFold(typeName, "Variant")
-		variable := arrayVariable{name: decl.Name, typ: decl.Type, isArray: decl.Array, isVariant: isVariant, isObject: decl.Object, knownScalar: !isVariant && arrayKnownScalarType(typeName), parameter: decl.Parameter, static: decl.Static, paramArray: decl.ParamArray}
-		if decl.Array {
-			variable.dimensions, variable.fixed = declarationDimensions(file.Lines, decl.Line, decl.Name, base)
-			if len(decl.Dimensions) > 0 {
-				variable.dimensions = append([]arrayDimension(nil), decl.Dimensions...)
-			}
-			if decl.Fixed {
-				variable.fixed = true
-			}
-			if len(variable.dimensions) > 0 {
-				variable.fixed = true
+	catalog := file.ArrayVariableCatalog
+	if catalog == nil {
+		catalog = buildArrayVariableCatalog(file, moduleDecls)
+	}
+	usedModuleNames := make(map[string]struct{}, proc.Accesses.Len())
+	for access := range proc.Accesses.All() {
+		if name := strings.ToLower(strings.TrimSpace(access.Name)); name != "" {
+			usedModuleNames[name] = struct{}{}
+		}
+	}
+	// An empty access projection can mean a genuinely independent procedure,
+	// but it can also be the only reliable view left after parser recovery or
+	// an incomplete IR build. Preserve the historical fail-open behavior for
+	// that boundary instead of silently dropping module scalars from array
+	// classification.
+	includeAllModule := proc.Accesses.Len() == 0
+	moduleCapacity := len(usedModuleNames)
+	for _, variable := range catalog {
+		if includeAllModule || variable.isArray {
+			moduleCapacity++
+		}
+	}
+	variables := make(map[string]arrayVariable, moduleCapacity+len(decls.extra)+len(decls.local)+len(decls.parameters))
+	for key, variable := range catalog {
+		if !includeAllModule && !variable.isArray {
+			if _, used := usedModuleNames[key]; !used {
+				continue
 			}
 		}
 		variables[key] = variable
-	})
+	}
+	// Module declarations are immutable and already normalized in catalog.
+	// Only the procedure overlays need to be materialized here. Overlay order
+	// matches declarationScope.forEach: IR extras, source locals, parameters.
+	for key, decl := range decls.extra {
+		variables[key] = newArrayVariable(file, decl, base)
+	}
+	for key, decl := range decls.local {
+		variables[key] = newArrayVariable(file, decl, base)
+	}
+	for key, decl := range decls.parameters {
+		variables[key] = newArrayVariable(file, decl, base)
+	}
 	return variables
+}
+
+func buildArrayVariableCatalog(file parsedFile, moduleDecls map[string]sourceDeclaration) map[string]arrayVariable {
+	variables := make(map[string]arrayVariable, len(moduleDecls))
+	base := arrayOptionBase(file)
+	for key, decl := range moduleDecls {
+		variables[key] = newArrayVariable(file, decl, base)
+	}
+	return variables
+}
+
+func newArrayVariable(file parsedFile, decl sourceDeclaration, base int) arrayVariable {
+	typeName := strings.TrimSpace(decl.Type)
+	// VBA declarations without an As clause are implicit Variant values.
+	// Treat them exactly like an explicit Variant so array-sensitive rules
+	// do not turn an unresolved value into a false scalar proof.
+	isVariant := typeName == "" || strings.EqualFold(typeName, "Variant")
+	variable := arrayVariable{name: decl.Name, typ: decl.Type, isArray: decl.Array, isVariant: isVariant, isObject: decl.Object, knownScalar: !isVariant && arrayKnownScalarType(typeName), parameter: decl.Parameter, static: decl.Static, paramArray: decl.ParamArray}
+	if decl.Array {
+		variable.dimensions, variable.fixed = declarationDimensions(file.Lines, decl.Line, decl.Name, base)
+		if len(decl.Dimensions) > 0 {
+			variable.dimensions = append([]arrayDimension(nil), decl.Dimensions...)
+		}
+		if decl.Fixed {
+			variable.fixed = true
+		}
+		if len(variable.dimensions) > 0 {
+			variable.fixed = true
+		}
+	}
+	return variable
 }
 
 // arrayVBA227Variables overlays the narrow declaration facts needed by the

--- a/internal/analyze/benchmark_test.go
+++ b/internal/analyze/benchmark_test.go
@@ -372,6 +372,30 @@ func TestCanonicalLargeModuleBenchmarkFixtures(t *testing.T) {
 	}
 }
 
+func TestSingleModuleBenchmarkRecoveryMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		shape               string
+		recoveredStatements int
+		unknownStatements   int
+	}{
+		{shape: "recovered", recoveredStatements: 1},
+		{shape: "unknown", unknownStatements: 1},
+	} {
+		t.Run(tc.shape, func(t *testing.T) {
+			fixture := writeSingleModuleBenchmarkProject(t, t.TempDir(), singleModuleBenchmarkWorkload{shape: tc.shape, size: 1})
+			if fixture.procedures != 1 {
+				t.Fatalf("%s procedures = %d, want 1", tc.shape, fixture.procedures)
+			}
+			if fixture.recoveredStatements < tc.recoveredStatements {
+				t.Fatalf("%s recovered statements = %d, want at least %d", tc.shape, fixture.recoveredStatements, tc.recoveredStatements)
+			}
+			if fixture.unknownStatements < tc.unknownStatements {
+				t.Fatalf("%s unknown statements = %d, want at least %d", tc.shape, fixture.unknownStatements, tc.unknownStatements)
+			}
+		})
+	}
+}
+
 func TestSingleModuleBenchmarkFactBuildCounters(t *testing.T) {
 	root := t.TempDir()
 	fixture := writeSingleModuleBenchmarkProject(t, root, singleModuleBenchmarkWorkload{shape: "declarations", size: 2000})
@@ -398,8 +422,8 @@ type singleModuleBenchmarkWorkload struct {
 }
 
 func singleModuleBenchmarkWorkloads() []singleModuleBenchmarkWorkload {
-	workloads := make([]singleModuleBenchmarkWorkload, 0, 20)
-	for _, shape := range []string{"independent", "chain", "declarations"} {
+	workloads := make([]singleModuleBenchmarkWorkload, 0, 29)
+	for _, shape := range []string{"independent", "chain", "declarations", "recovered", "unknown"} {
 		for _, size := range []int{100, 500, 1000, 2000} {
 			workloads = append(workloads, singleModuleBenchmarkWorkload{shape: shape, size: size})
 		}
@@ -425,6 +449,8 @@ func (w singleModuleBenchmarkWorkload) benchmarkName() string {
 		unit = "declarations"
 	case "cfg-independent":
 		unit = "branches"
+	case "recovered", "unknown":
+		unit = "statements"
 	}
 	return fmt.Sprintf("%s/%d-%s", w.shape, w.size, unit)
 }
@@ -474,15 +500,17 @@ func (w singleModuleBenchmarkWorkload) expectedCalls() int {
 }
 
 type singleModuleBenchmarkFixture struct {
-	sourcePath         string
-	moduleCount        int
-	lines              int
-	procedures         int
-	moduleDeclarations int
-	calls              int
-	maxStatements      int
-	maxCFGBlocks       int
-	maxCFGEdges        int
+	sourcePath          string
+	moduleCount         int
+	lines               int
+	procedures          int
+	moduleDeclarations  int
+	calls               int
+	recoveredStatements int
+	unknownStatements   int
+	maxStatements       int
+	maxCFGBlocks        int
+	maxCFGEdges         int
 }
 
 func writeSingleModuleBenchmarkProject(tb testing.TB, root string, workload singleModuleBenchmarkWorkload) singleModuleBenchmarkFixture {
@@ -559,6 +587,14 @@ func singleModuleBenchmarkSource(workload singleModuleBenchmarkWorkload) string 
 		for index := 3; index < workload.size; index++ {
 			fmt.Fprintf(&source, "Private Sub Independent%04d()\n    Dim value As Long\n    value = %d\nEnd Sub\n\n", index, index)
 		}
+	case "recovered":
+		for index := 0; index < workload.size; index++ {
+			fmt.Fprintf(&source, "Private Sub Recovered%04d()\n    recoveredValue =\nEnd Sub\n\n", index)
+		}
+	case "unknown":
+		for index := 0; index < workload.size; index++ {
+			fmt.Fprintf(&source, "Private Sub Unknown%04d()\n    Open unknownPath For Input As #1\nEnd Sub\n\n", index)
+		}
 	}
 	return source.String()
 }
@@ -586,6 +622,14 @@ func inspectSingleModuleBenchmarkFixture(tb testing.TB, root, path, source strin
 			fixture.maxStatements = len(procedure.Statements)
 		}
 		fixture.calls += len(procedure.Calls)
+		for _, statement := range procedure.Statements {
+			if statement.Recovered || statement.Kind == procedureir.StatementRecovered {
+				fixture.recoveredStatements++
+			}
+			if statement.Kind == procedureir.StatementUnknown {
+				fixture.unknownStatements++
+			}
+		}
 	}
 	controlFlow := vbacfg.BuildDocument(ir)
 	for _, graph := range controlFlow.Graphs {

--- a/internal/analyze/dictionary_collection_safety.go
+++ b/internal/analyze/dictionary_collection_safety.go
@@ -39,9 +39,13 @@ type dcKeyExpr struct {
 }
 
 type dcFlowState struct {
-	Bindings map[string]string
-	Objects  map[string]dcObjectState
-	Scalars  map[string]dcKeyExpr
+	Bindings         map[string]string
+	Objects          map[string]dcObjectState
+	Scalars          map[string]dcKeyExpr
+	bindingsShared   bool
+	objectsShared    bool
+	objectMapsShared bool
+	scalarsShared    bool
 }
 
 type dcHelperEffect struct {
@@ -393,19 +397,22 @@ func dcOverlayState(flow, linear *dcFlowState) *dcFlowState {
 	out := flow.clone()
 	for key, id := range linear.Bindings {
 		if _, exists := out.Bindings[key]; !exists {
+			out.ensureBindings()
 			out.Bindings[key] = id
 		}
 		if object, ok := linear.Objects[id]; ok {
 			if flowObject, exists := out.Objects[id]; exists {
 				object.Empty = flowObject.Empty
-				object.Keys = dcCloneIntMap(flowObject.Keys)
-				object.Normalizations = dcCloneStringMap(flowObject.Normalizations)
+				object.Keys = flowObject.Keys
+				object.Normalizations = flowObject.Normalizations
 			}
+			out.ensureObjects()
 			out.Objects[id] = object
 		}
 	}
 	for key, value := range linear.Scalars {
 		if _, exists := out.Scalars[key]; !exists {
+			out.ensureScalars()
 			out.Scalars[key] = value
 		}
 	}
@@ -487,32 +494,33 @@ func (a Analyzer) dcTransfer(file parsedFile, proc sourceProcedure, statement pr
 		target := strings.ToLower(assignment.target)
 		if kind, late, ok := dcConstruction(assignment.rhs); ok {
 			id := "construct:" + strings.ToLower(file.Path) + ":" + strconv.Itoa(statement.ID) + ":" + target
-			state.Bindings[target] = id
-			state.Objects[id] = dcObjectState{Kind: kind, LateBound: late, Empty: 1, CompareMode: dcDefaultCompareMode(kind, true), Keys: map[string]int{}, Normalizations: map[string]string{}}
+			state.setBinding(target, id)
+			state.setObject(id, dcObjectState{Kind: kind, LateBound: late, Empty: 1, CompareMode: dcDefaultCompareMode(kind, true), Keys: map[string]int{}, Normalizations: map[string]string{}})
 			return
 		}
 		if source := strings.ToLower(cleanIdentifier(assignment.rhs)); state.Bindings[source] != "" && dcBareIdentifier(assignment.rhs) {
-			state.Bindings[target] = state.Bindings[source]
+			state.setBinding(target, state.Bindings[source])
 			return
 		}
 		if name, args, ok := dcSimpleFunctionCall(assignment.rhs); ok {
 			if summary, found := a.dcHelper(name); found && summary.Factory != dcUnknown {
 				id := "factory:" + strings.ToLower(file.Path) + ":" + strconv.Itoa(statement.ID) + ":" + target
-				state.Bindings[target] = id
-				state.Objects[id] = dcObjectState{Kind: summary.Factory, LateBound: summary.FactoryLate, Empty: 1, CompareMode: dcDefaultCompareMode(summary.Factory, true), Keys: map[string]int{}, Normalizations: map[string]string{}}
+				state.setBinding(target, id)
+				state.setObject(id, dcObjectState{Kind: summary.Factory, LateBound: summary.FactoryLate, Empty: 1, CompareMode: dcDefaultCompareMode(summary.Factory, true), Keys: map[string]int{}, Normalizations: map[string]string{}})
 				a.dcApplyHelperEffects(summary, args, state)
 				return
 			}
 		}
-		delete(state.Bindings, target)
+		state.deleteBinding(target)
 		return
 	}
 	if assignment := dcValueAssignment(text); assignment != nil {
 		key := strings.ToLower(assignment.target)
 		if expr, ok := dcParseKeyExpr(assignment.rhs, state.Scalars); ok {
+			state.ensureScalars()
 			state.Scalars[key] = expr
 		} else {
-			delete(state.Scalars, key)
+			state.deleteScalar(key)
 		}
 	}
 	if receiver, member, args, ok := dcMemberCall(text); ok {
@@ -520,15 +528,14 @@ func (a Analyzer) dcTransfer(file parsedFile, proc sourceProcedure, statement pr
 	}
 	if receiver, keyText, ok := dcDefaultAssignment(text); ok {
 		if id := state.Bindings[strings.ToLower(receiver)]; id != "" {
-			object := state.Objects[id]
-			if object.Kind == dcDictionary {
+			if object, exists := state.mutableObject(id, true); exists && object.Kind == dcDictionary {
 				expr, parsed := dcParseKeyExpr(keyText, state.Scalars)
 				if parsed {
 					object.Keys[dcKeyIdentity(expr)] = 1
 					dcObserveNormalization(&object, expr)
 				}
 				object.Empty = -1
-				state.Objects[id] = object
+				state.setObject(id, object)
 			}
 		}
 	}
@@ -541,11 +548,14 @@ func (a Analyzer) dcTransfer(file parsedFile, proc sourceProcedure, statement pr
 		}
 		for _, arg := range args {
 			if id := state.Bindings[strings.ToLower(cleanIdentifier(arg))]; id != "" && dcBareIdentifier(arg) {
-				object := state.Objects[id]
+				object, exists := state.mutableObject(id, true)
+				if !exists {
+					continue
+				}
 				object.Empty, object.CompareMode = 0, ""
 				object.Keys = map[string]int{}
 				object.Normalizations = map[string]string{}
-				state.Objects[id] = object
+				state.setObject(id, object)
 			}
 		}
 	}
@@ -556,7 +566,11 @@ func (a Analyzer) dcApplyMember(receiver, member string, args []string, state *d
 	if id == "" {
 		return
 	}
-	object := state.Objects[id]
+	cloneMaps := member == "add" || member == "remove"
+	object, exists := state.mutableObject(id, cloneMaps)
+	if !exists {
+		return
+	}
 	switch member {
 	case "add":
 		keyArg := 0
@@ -586,7 +600,7 @@ func (a Analyzer) dcApplyMember(receiver, member string, args []string, state *d
 			object.CompareMode = dcCompareMode(args[0])
 		}
 	}
-	state.Objects[id] = object
+	state.setObject(id, object)
 }
 
 func (a Analyzer) dcApplyHelperEffects(summary dcHelperSummary, args []string, state *dcFlowState) {
@@ -599,7 +613,11 @@ func (a Analyzer) dcApplyHelperEffects(summary dcHelperSummary, args []string, s
 		if id == "" || !dcBareIdentifier(args[effect.Param]) {
 			continue
 		}
-		object := state.Objects[id]
+		cloneMaps := effect.Member == "add" || effect.Member == "remove"
+		object, exists := state.mutableObject(id, cloneMaps)
+		if !exists {
+			continue
+		}
 		switch effect.Member {
 		case "add":
 			object.Empty = -1
@@ -623,7 +641,7 @@ func (a Analyzer) dcApplyHelperEffects(summary dcHelperSummary, args []string, s
 		case "comparemode":
 			object.CompareMode = ""
 		}
-		state.Objects[id] = object
+		state.setObject(id, object)
 	}
 }
 
@@ -659,7 +677,10 @@ func (a Analyzer) dcApplyGuard(statement procedureir.Statement, edge vbacfg.Edge
 	if id == "" {
 		return
 	}
-	object := state.Objects[id]
+	object, exists := state.mutableObject(id, true)
+	if !exists {
+		return
+	}
 	expr, parsed := dcParseKeyExpr(keyText, state.Scalars)
 	if !parsed {
 		return
@@ -670,7 +691,7 @@ func (a Analyzer) dcApplyGuard(statement procedureir.Statement, edge vbacfg.Edge
 	} else {
 		object.Keys[dcKeyIdentity(expr)] = -1
 	}
-	state.Objects[id] = object
+	state.setObject(id, object)
 }
 
 func (a Analyzer) dcStatementFindings(file parsedFile, proc sourceProcedure, statement procedureir.Statement, state *dcFlowState, loops []excelLoopRegion, narrow map[int]bool, constFacts *moduleAnalysisFacts, constNames map[string]bool, seen map[string]bool) []Finding {
@@ -890,19 +911,105 @@ func (s *dcFlowState) clone() *dcFlowState {
 	if s == nil {
 		return nil
 	}
-	out := &dcFlowState{Bindings: map[string]string{}, Objects: map[string]dcObjectState{}, Scalars: map[string]dcKeyExpr{}}
+	// Flow states are forked for every CFG edge. Keep the immutable map
+	// headers shared and copy only the map touched by the forked state.
+	s.bindingsShared = true
+	s.objectsShared = true
+	s.objectMapsShared = true
+	s.scalarsShared = true
+	return &dcFlowState{
+		Bindings:         s.Bindings,
+		Objects:          s.Objects,
+		Scalars:          s.Scalars,
+		bindingsShared:   true,
+		objectsShared:    true,
+		objectMapsShared: true,
+		scalarsShared:    true,
+	}
+}
+
+func (s *dcFlowState) ensureBindings() {
+	if s == nil || !s.bindingsShared {
+		return
+	}
+	out := make(map[string]string, len(s.Bindings))
 	for key, value := range s.Bindings {
-		out.Bindings[key] = value
+		out[key] = value
 	}
+	s.Bindings = out
+	s.bindingsShared = false
+}
+
+func (s *dcFlowState) ensureObjects() {
+	if s == nil || !s.objectsShared {
+		return
+	}
+	out := make(map[string]dcObjectState, len(s.Objects))
 	for key, value := range s.Objects {
-		value.Keys = dcCloneIntMap(value.Keys)
-		value.Normalizations = dcCloneStringMap(value.Normalizations)
-		out.Objects[key] = value
+		out[key] = value
 	}
+	s.Objects = out
+	s.objectsShared = false
+}
+
+func (s *dcFlowState) ensureScalars() {
+	if s == nil || !s.scalarsShared {
+		return
+	}
+	out := make(map[string]dcKeyExpr, len(s.Scalars))
 	for key, value := range s.Scalars {
-		out.Scalars[key] = value
+		out[key] = value
 	}
-	return out
+	s.Scalars = out
+	s.scalarsShared = false
+}
+
+func (s *dcFlowState) setBinding(key, value string) {
+	s.ensureBindings()
+	s.Bindings[key] = value
+}
+
+func (s *dcFlowState) deleteBinding(key string) {
+	if s == nil {
+		return
+	}
+	if _, exists := s.Bindings[key]; !exists {
+		return
+	}
+	s.ensureBindings()
+	delete(s.Bindings, key)
+}
+
+func (s *dcFlowState) deleteScalar(key string) {
+	if s == nil {
+		return
+	}
+	if _, exists := s.Scalars[key]; !exists {
+		return
+	}
+	s.ensureScalars()
+	delete(s.Scalars, key)
+}
+
+func (s *dcFlowState) setObject(id string, object dcObjectState) {
+	s.ensureObjects()
+	s.Objects[id] = object
+}
+
+func (s *dcFlowState) mutableObject(id string, cloneMaps bool) (dcObjectState, bool) {
+	if s == nil {
+		return dcObjectState{}, false
+	}
+	s.ensureObjects()
+	object, exists := s.Objects[id]
+	if !exists {
+		return dcObjectState{}, false
+	}
+	if cloneMaps && s.objectMapsShared {
+		object.Keys = dcCloneIntMap(object.Keys)
+		object.Normalizations = dcCloneStringMap(object.Normalizations)
+	}
+	return object, true
 }
 
 func dcMergeState(current, incoming *dcFlowState) (*dcFlowState, bool) {

--- a/internal/analyze/dictionary_collection_safety_test.go
+++ b/internal/analyze/dictionary_collection_safety_test.go
@@ -218,6 +218,41 @@ func TestDictionaryCollectionOverlayPreservesFlowContentFacts(t *testing.T) {
 	}
 }
 
+func TestDCFlowStateCloneCopiesMapsOnWrite(t *testing.T) {
+	original := &dcFlowState{
+		Bindings: map[string]string{"dict": "object"},
+		Objects: map[string]dcObjectState{
+			"object": {Kind: dcDictionary, Keys: map[string]int{"existing|": 1}, Normalizations: map[string]string{}},
+		},
+		Scalars: map[string]dcKeyExpr{"key": {Base: "key"}},
+	}
+	branch := original.clone()
+	branch.setBinding("alias", "object")
+	object, ok := branch.mutableObject("object", true)
+	if !ok {
+		t.Fatal("cloned object was not available")
+	}
+	object.Keys["branch|new"] = 1
+	branch.setObject("object", object)
+	branch.ensureScalars()
+	branch.Scalars["branch"] = dcKeyExpr{Base: "branch"}
+
+	if _, ok := original.Bindings["alias"]; ok {
+		t.Fatal("binding write leaked from cloned flow state")
+	}
+	if _, ok := original.Objects["object"].Keys["branch|new"]; ok {
+		t.Fatal("nested object write leaked from cloned flow state")
+	}
+	if _, ok := original.Scalars["branch"]; ok {
+		t.Fatal("scalar write leaked from cloned flow state")
+	}
+
+	original.setBinding("original", "object")
+	if _, ok := branch.Bindings["original"]; ok {
+		t.Fatal("write to original flow state leaked into cloned state")
+	}
+}
+
 func TestVBA207DoesNotInferFactsFromCompoundExistsCondition(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/vba/dataflow/analysis.go
+++ b/internal/vba/dataflow/analysis.go
@@ -90,8 +90,10 @@ type sqlObjectState struct {
 }
 
 type abstractState struct {
-	vars       map[string]value
-	sqlObjects map[string]sqlObjectState
+	vars             map[string]value
+	sqlObjects       map[string]sqlObjectState
+	varsShared       bool
+	sqlObjectsShared bool
 }
 
 type procedureAnalyzer struct {
@@ -323,7 +325,7 @@ func (a *procedureAnalyzer) runWithStatsAndRankContext(worklistRank map[cfg.Bloc
 				continue
 			}
 			next := cloneState(out)
-			a.applyGuard(id, edge, next)
+			a.applyGuard(id, edge, &next)
 			merged, changed := joinState(inStates[edge.To], next, inStates[edge.To].vars != nil)
 			if !changed {
 				continue
@@ -430,6 +432,7 @@ func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collec
 	recovered := statement.Recovered || statement.Kind == procedureir.StatementRecovered
 	if recovered {
 		if target := assignmentTarget(statement); target != "" {
+			state.ensureVars()
 			state.vars[target] = a.unknownValue(statement.Range, statement.ID, "recovered statement")
 		}
 	}
@@ -439,17 +442,18 @@ func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collec
 			return abstractState{}, err
 		}
 		assigned = appendPath(assigned, PathStep{Kind: "assignment", Label: statement.Text, Range: statement.Range, StatementID: statement.ID})
+		state.ensureVars()
 		state.vars[target] = assigned
 	}
 	if !recovered {
-		a.applySQLAssignment(statement, state)
+		a.applySQLAssignment(statement, &state)
 	}
 	for _, call := range a.callsByStatement[statement.ID] {
 		if err := a.contextErr(); err != nil {
 			return abstractState{}, err
 		}
-		a.applySourceWrite(call, state)
-		a.applySQLCallState(call, state)
+		a.applySourceWrite(call, &state)
+		a.applySQLCallState(call, &state)
 		if collectFindings {
 			a.inspectSink(call, state)
 			a.inspectSQL(call, state)
@@ -466,7 +470,10 @@ func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collec
 // to connect a CommandText assignment with a later Command.Execute call. It
 // deliberately does not attempt whole-project aliasing or interprocedural
 // propagation; those remain outside the procedure-local data-flow contract.
-func (a *procedureAnalyzer) applySQLAssignment(statement procedureir.Statement, state abstractState) {
+func (a *procedureAnalyzer) applySQLAssignment(statement procedureir.Statement, state *abstractState) {
+	if state == nil {
+		return
+	}
 	if state.sqlObjects == nil {
 		state.sqlObjects = map[string]sqlObjectState{}
 	}
@@ -481,8 +488,9 @@ func (a *procedureAnalyzer) applySQLAssignment(statement procedureir.Statement, 
 				object.identity = receiver
 			}
 			if statement.Value != nil {
-				object.commandText = a.evalExpression(*statement.Value, state)
+				object.commandText = a.evalExpression(*statement.Value, *state)
 			}
+			state.ensureSQLObjects()
 			state.sqlObjects[receiver] = object
 			propagateSQLAlias(state, receiver, object)
 		}
@@ -502,6 +510,7 @@ func (a *procedureAnalyzer) applySQLAssignment(statement procedureir.Statement, 
 		}
 	}
 	if kind := sqlObjectKindFromText(rhs); kind != sqlObjectUnknown {
+		state.ensureSQLObjects()
 		state.sqlObjects[target] = sqlObjectState{kind: kind, identity: target, parameters: map[string]value{}}
 		return
 	}
@@ -510,6 +519,7 @@ func (a *procedureAnalyzer) applySQLAssignment(statement procedureir.Statement, 
 			if object.identity == "" {
 				object.identity = source
 			}
+			state.ensureSQLObjects()
 			state.sqlObjects[target] = cloneSQLObjectState(object)
 			return
 		}
@@ -523,11 +533,15 @@ func (a *procedureAnalyzer) applySQLAssignment(statement procedureir.Statement, 
 		if object.parameters == nil {
 			object.parameters = map[string]value{}
 		}
+		state.ensureSQLObjects()
 		state.sqlObjects[target] = object
 	}
 }
 
-func (a *procedureAnalyzer) applySQLCallState(call procedureir.CallSite, state abstractState) {
+func (a *procedureAnalyzer) applySQLCallState(call procedureir.CallSite, state *abstractState) {
+	if state == nil {
+		return
+	}
 	if state.sqlObjects == nil {
 		state.sqlObjects = map[string]sqlObjectState{}
 	}
@@ -551,8 +565,9 @@ func (a *procedureAnalyzer) applySQLCallState(call procedureir.CallSite, state a
 						object.identity = target
 					}
 					if expression, exists := a.expressions[valueID]; exists {
-						object.commandText = a.evalExpression(expression, state)
+						object.commandText = a.evalExpression(expression, *state)
 					}
+					state.ensureSQLObjects()
 					state.sqlObjects[target] = object
 					propagateSQLAlias(state, target, object)
 				}
@@ -570,7 +585,11 @@ func (a *procedureAnalyzer) applySQLCallState(call procedureir.CallSite, state a
 	}
 }
 
-func propagateSQLAlias(state abstractState, name string, object sqlObjectState) {
+func propagateSQLAlias(state *abstractState, name string, object sqlObjectState) {
+	if state == nil {
+		return
+	}
+	state.ensureSQLObjects()
 	for aliasName, alias := range state.sqlObjects {
 		if aliasName == name || alias.identity != object.identity {
 			continue
@@ -581,7 +600,10 @@ func propagateSQLAlias(state abstractState, name string, object sqlObjectState) 
 	}
 }
 
-func markSQLParameterized(state abstractState, command string) {
+func markSQLParameterized(state *abstractState, command string) {
+	if state == nil {
+		return
+	}
 	object, ok := state.sqlObjects[command]
 	if !ok {
 		return
@@ -590,6 +612,7 @@ func markSQLParameterized(state abstractState, command string) {
 	if object.identity == "" {
 		object.identity = command
 	}
+	state.ensureSQLObjects()
 	state.sqlObjects[command] = object
 	for aliasName, alias := range state.sqlObjects {
 		if aliasName == command || alias.identity != object.identity {
@@ -963,7 +986,10 @@ func localeSensitiveTypeName(typ string) bool {
 	return false
 }
 
-func (a *procedureAnalyzer) applySourceWrite(call procedureir.CallSite, state abstractState) {
+func (a *procedureAnalyzer) applySourceWrite(call procedureir.CallSite, state *abstractState) {
+	if state == nil {
+		return
+	}
 	kind, label, ok := sourceCall(call)
 	if !ok || kind != SourceFileInput || len(call.Arguments.ExpressionIDs) == 0 {
 		return
@@ -978,6 +1004,7 @@ func (a *procedureAnalyzer) applySourceWrite(call procedureir.CallSite, state ab
 		if !exists || expression.Kind != procedureir.ExpressionIdentifier {
 			continue
 		}
+		state.ensureVars()
 		state.vars[canonicalName(expression.Text)] = valueFromSource(Source{
 			Kind: kind, Label: label, Range: call.Range, StatementID: call.StatementID,
 		}, PathStep{Kind: "source", Label: call.Callee.Text, Range: call.Range, StatementID: call.StatementID})
@@ -1767,7 +1794,10 @@ func (a *procedureAnalyzer) unknownTransform(input value, expression procedureir
 	return result
 }
 
-func (a *procedureAnalyzer) applyGuard(from cfg.BlockID, edge cfg.Edge, state abstractState) {
+func (a *procedureAnalyzer) applyGuard(from cfg.BlockID, edge cfg.Edge, state *abstractState) {
+	if state == nil {
+		return
+	}
 	if edge.Kind != cfg.EdgeBranchTrue && edge.Kind != cfg.EdgeCase {
 		return
 	}
@@ -1779,7 +1809,9 @@ func (a *procedureAnalyzer) applyGuard(from cfg.BlockID, edge cfg.Edge, state ab
 	if edge.Kind == cfg.EdgeBranchTrue {
 		if variable, ok := exactEqualityVariable(statement.Text); ok {
 			validated := state.vars[variable]
+			validated = cloneValue(validated)
 			markSafe(&validated)
+			state.ensureVars()
 			state.vars[variable] = validated
 		}
 	}
@@ -1794,7 +1826,9 @@ func (a *procedureAnalyzer) applyGuard(from cfg.BlockID, edge cfg.Edge, state ab
 		}
 		if variable != "" && caseLiteral(caseBlock.Statement.Text) {
 			validated := state.vars[variable]
+			validated = cloneValue(validated)
 			markSafe(&validated)
+			state.ensureVars()
 			state.vars[variable] = validated
 		}
 	}
@@ -2098,6 +2132,7 @@ func joinState(a, b abstractState, initialized bool) (abstractState, bool) {
 		merged, _ := joinValue(left, right, true)
 		previous, hadPrevious := a.vars[key]
 		if !hadPrevious || !isSameValue(previous, merged) {
+			result.ensureVars()
 			result.vars[key] = merged
 			changed = true
 		}
@@ -2113,6 +2148,7 @@ func joinState(a, b abstractState, initialized bool) (abstractState, bool) {
 		left, leftOK := a.sqlObjects[key]
 		right, rightOK := b.sqlObjects[key]
 		if !leftOK {
+			result.ensureSQLObjects()
 			result.sqlObjects[key] = cloneSQLObjectState(right)
 			changed = true
 			continue
@@ -2122,6 +2158,7 @@ func joinState(a, b abstractState, initialized bool) (abstractState, bool) {
 		}
 		merged := joinSQLObjectState(left, right)
 		if !sameSQLObjectState(left, merged) {
+			result.ensureSQLObjects()
 			result.sqlObjects[key] = merged
 			changed = true
 		}
@@ -2134,22 +2171,54 @@ func unknownStandaloneValue() value {
 }
 
 func cloneState(state abstractState) abstractState {
-	result := abstractState{vars: map[string]value{}, sqlObjects: map[string]sqlObjectState{}}
-	for key, variable := range state.vars {
-		result.vars[key] = cloneValue(variable)
+	result := abstractState{
+		vars:             state.vars,
+		sqlObjects:       state.sqlObjects,
+		varsShared:       true,
+		sqlObjectsShared: true,
 	}
-	for key, object := range state.sqlObjects {
-		result.sqlObjects[key] = cloneSQLObjectState(object)
+	if result.vars == nil {
+		result.vars = map[string]value{}
+		result.varsShared = false
+	}
+	if result.sqlObjects == nil {
+		result.sqlObjects = map[string]sqlObjectState{}
+		result.sqlObjectsShared = false
 	}
 	return result
 }
 
+func (s *abstractState) ensureVars() {
+	if s == nil || !s.varsShared {
+		return
+	}
+	out := make(map[string]value, len(s.vars))
+	for key, variable := range s.vars {
+		out[key] = variable
+	}
+	s.vars = out
+	s.varsShared = false
+}
+
+func (s *abstractState) ensureSQLObjects() {
+	if s == nil || !s.sqlObjectsShared {
+		return
+	}
+	out := make(map[string]sqlObjectState, len(s.sqlObjects))
+	for key, object := range s.sqlObjects {
+		out[key] = object
+	}
+	s.sqlObjects = out
+	s.sqlObjectsShared = false
+}
+
 func cloneSQLObjectState(input sqlObjectState) sqlObjectState {
 	result := input
-	result.commandText = cloneValue(input.commandText)
-	result.parameters = map[string]value{}
-	for key, parameter := range input.parameters {
-		result.parameters[key] = cloneValue(parameter)
+	if input.parameters != nil {
+		result.parameters = make(map[string]value, len(input.parameters))
+		for key, parameter := range input.parameters {
+			result.parameters[key] = parameter
+		}
 	}
 	return result
 }

--- a/internal/vba/dataflow/analysis.go
+++ b/internal/vba/dataflow/analysis.go
@@ -324,7 +324,7 @@ func (a *procedureAnalyzer) runWithStatsAndRankContext(worklistRank map[cfg.Bloc
 			if !reachable[edge.To] {
 				continue
 			}
-			next := cloneState(out)
+			next := cloneState(&out)
 			a.applyGuard(id, edge, &next)
 			merged, changed := joinState(inStates[edge.To], next, inStates[edge.To].vars != nil)
 			if !changed {
@@ -423,7 +423,7 @@ func (a *procedureAnalyzer) transfer(id cfg.BlockID, input abstractState, collec
 	if err := a.contextErr(); err != nil {
 		return abstractState{}, err
 	}
-	state := cloneState(input)
+	state := cloneState(&input)
 	block, ok := a.blocksByID[id]
 	if !ok || block.Statement == nil {
 		return state, nil
@@ -2109,9 +2109,9 @@ func joinValue(a, b value, initialized bool) (value, bool) {
 
 func joinState(a, b abstractState, initialized bool) (abstractState, bool) {
 	if !initialized {
-		return cloneState(b), true
+		return cloneState(&b), true
 	}
-	result := cloneState(a)
+	result := cloneState(&a)
 	changed := false
 	keys := map[string]bool{}
 	for key := range a.vars {
@@ -2170,7 +2170,12 @@ func unknownStandaloneValue() value {
 	return valueFromSourceState(Source{Kind: SourceUnknown, Label: "unknown input"}, StateUnknown, PathStep{Kind: "unknown_transformation", Label: "possibly unassigned value"})
 }
 
-func cloneState(state abstractState) abstractState {
+func cloneState(state *abstractState) abstractState {
+	if state == nil {
+		return abstractState{vars: map[string]value{}, sqlObjects: map[string]sqlObjectState{}}
+	}
+	state.varsShared = true
+	state.sqlObjectsShared = true
 	result := abstractState{
 		vars:             state.vars,
 		sqlObjects:       state.sqlObjects,

--- a/internal/vba/dataflow/analysis_test.go
+++ b/internal/vba/dataflow/analysis_test.go
@@ -317,7 +317,7 @@ func TestAbstractStateCloneCopiesMapsOnWrite(t *testing.T) {
 		vars:       map[string]value{"raw": unknownStandaloneValue()},
 		sqlObjects: map[string]sqlObjectState{"command": {kind: sqlObjectCommand, identity: "command"}},
 	}
-	branch := cloneState(original)
+	branch := cloneState(&original)
 	branch.ensureVars()
 	branch.vars["branch"] = unknownStandaloneValue()
 	branch.ensureSQLObjects()
@@ -334,6 +334,12 @@ func TestAbstractStateCloneCopiesMapsOnWrite(t *testing.T) {
 	original.vars["original"] = unknownStandaloneValue()
 	if _, ok := branch.vars["original"]; ok {
 		t.Fatal("write to original abstract state leaked into cloned state")
+	}
+
+	original.ensureSQLObjects()
+	original.sqlObjects["original"] = sqlObjectState{kind: sqlObjectCommand, identity: "original"}
+	if _, ok := branch.sqlObjects["original"]; ok {
+		t.Fatal("SQL object write to original abstract state leaked into cloned state")
 	}
 }
 

--- a/internal/vba/dataflow/analysis_test.go
+++ b/internal/vba/dataflow/analysis_test.go
@@ -312,6 +312,31 @@ func TestJoinStateDoesNotReportChangeForEquivalentMissingValue(t *testing.T) {
 	}
 }
 
+func TestAbstractStateCloneCopiesMapsOnWrite(t *testing.T) {
+	original := abstractState{
+		vars:       map[string]value{"raw": unknownStandaloneValue()},
+		sqlObjects: map[string]sqlObjectState{"command": {kind: sqlObjectCommand, identity: "command"}},
+	}
+	branch := cloneState(original)
+	branch.ensureVars()
+	branch.vars["branch"] = unknownStandaloneValue()
+	branch.ensureSQLObjects()
+	branch.sqlObjects["branch"] = sqlObjectState{kind: sqlObjectCommand, identity: "branch"}
+
+	if _, ok := original.vars["branch"]; ok {
+		t.Fatal("variable write leaked from cloned abstract state")
+	}
+	if _, ok := original.sqlObjects["branch"]; ok {
+		t.Fatal("SQL object write leaked from cloned abstract state")
+	}
+
+	original.ensureVars()
+	original.vars["original"] = unknownStandaloneValue()
+	if _, ok := branch.vars["original"]; ok {
+		t.Fatal("write to original abstract state leaked into cloned state")
+	}
+}
+
 func TestLooksDatabaseReceiverUsesIdentifierBoundaries(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Reduce repeated static-analysis state allocations with copy-on-write flow maps in application, dictionary/collection safety, and VBA dataflow analysis.
- Reuse an immutable module-level array-variable catalog and defer VBA205 scope materialization.
- Add recovery/unknown-statement benchmark coverage and document the ROneCOne stress-fixture measurements.
- Fixes #729

## Performance

On the ROneCOne `analyze-only` workload (Windows/amd64, local one-op measurements):

- Cold runtime: approximately 9.1s -> 8.0s (`~12%` faster)
- Warm runtime: approximately 8.5s -> 7.5s (`~12%` faster)
- Allocated bytes: approximately `22–24%` lower
- Allocations: approximately `17–18%` lower
- Findings remained at 510 for the unchanged workload

## Tests

- `rtk task lint`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/analyze ./internal/vba/dataflow ./internal/lspserver -count=1 -timeout=20m`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/analyze ./internal/vba/dataflow -run 'Test(ArrayVariables|DCFlowState|ApplicationStateFlow|AbstractStateClone)' -count=1 -timeout=10m`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/staticanalysis/corpus -run '^$' -bench '^BenchmarkRealWorldCorpus/ronecone/analyze-only/(cold|warm|local-edit|dependency-edit)$' -benchmem -benchtime=1x -count=10 -timeout=25m`
- `rtk proxy task corpus:test`
- `rtk proxy task corpus:metrics`
- `rtk pnpm format:check`
- `rtk pnpm docs:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced memory allocations during static analysis, improving efficiency for large VBA modules and complex projects.
  - Improved handling of shared analysis state to reduce unnecessary copying while preserving accurate results.

- **Reliability**
  - Strengthened analysis of arrays, application state, dictionaries, collections, SQL objects, and variable visibility.
  - Added safeguards to prevent changes in one analysis path from affecting another.

- **Testing**
  - Expanded coverage for recovered and unknown VBA statements, allocation behavior, and benchmark scenarios.
  - Added stress measurements using ten-sample ROneCOne workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->