### PR TITLE
perf(lsp): replace project snapshot materialization with resolution views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Reduced LSP project-resolution allocations by retaining canonical syntax-local
+  procedure IR and reading project-dependent call, access, event, and
+  resolution-diagnostic facts through immutable resolution views. Existing
+  diagnostic results and the materializing compatibility API remain unchanged.
+
 - Improved LSP workspace startup by publishing a bounded, lightweight
   declaration index independently from background semantic indexing. Cross-file
   symbol queries can now use declarations before IR/CFG preparation completes;

--- a/docs/adr/ADR-0021-procedure-analysis-ir.md
+++ b/docs/adr/ADR-0021-procedure-analysis-ir.md
@@ -60,8 +60,14 @@ IDs remain internal metadata and are omitted from serialized IR/JSON.
 `Diagnostics` and reads syntax/recovery facts from the immutable IR while
 reading project-dependent call, access, and event facts from the overlay. Batch
 analyzer resolution diagnostics use this view. Effects, ordinary analyzer
-rules, lint, LSP, metrics, and developer-only oracle consumers retain the
-materialized path unless they independently require an overlay migration.
+rules, lint, metrics, and developer-only oracle consumers may retain the
+materialized path when they require an independently owned document. The LSP
+project snapshot instead keeps the canonical syntax-local `DocumentIR` and
+attaches a `ResolvedDocumentView`; its capability, effect, realtime,
+dependency, and resolution-diagnostic consumers read the view, with only
+bounded per-procedure fact projections where a legacy loop requires
+value-shaped calls or accesses. The normal LSP path does not call
+`Resolve`/`Materialize`.
 
 Keep `Resolve` as the compatibility API for consumers that require an
 independently owned resolved `DocumentIR`: it may materialize a view and must

--- a/docs/specs/lsp-performance-profiling.md
+++ b/docs/specs/lsp-performance-profiling.md
@@ -176,6 +176,14 @@ the counter snapshot makes that distinction visible. Permit wait time is
 separate from execution time so an interactive request blocked behind a
 background worker can be measured without attributing the delay to analysis.
 
+Project snapshots retain the canonical syntax-local `DocumentIR` and attach a
+read-only `ResolvedDocumentView`. The normal snapshot and Full-diagnostic paths
+must therefore report `projectResolutionMaterialization` with zero results and
+`resolution_materializations` must remain zero. `Resolve`/`Materialize` remains
+available for compatibility consumers that explicitly require an independently
+owned resolved document; such fallback calls are the only work counted by that
+counter.
+
 All instrumentation is developer telemetry. It must remain disabled by
 default, use no LSP response fields, and preserve cancellation and generation
 safety. A profile is evidence about the selected benchmark checkpoint, not a

--- a/docs/specs/vba-analysis-ir.md
+++ b/docs/specs/vba-analysis-ir.md
@@ -840,6 +840,14 @@ continue to use materialized `Resolve`. This overlay boundary is internal and
 does not add a public CLI flag, configuration key, JSON field, diagnostic ID, or
 LSP capability.
 
+The LSP project snapshot stores the syntax-local `DocumentIR` together with a
+`ResolvedDocumentView`. Project capability planning, effects, realtime
+diagnostics, dependency edges, and compile-equivalent resolution diagnostics
+must consume that view; they must not materialize a resolved document for every
+indexed file. A legacy consumer may request a bounded per-procedure fact
+projection, but the declarations, statements, and expressions remain owned by
+the canonical revision IR.
+
 Issue #426 intentionally stops at procedure syntax and conservative name/call
 resolution. The separate CFG layer defined by
 `docs/specs/vba-control-flow-graph.md` consumes this IR to provide basic blocks,

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -499,6 +499,12 @@ type parsedFile struct {
 	// query lanes share this pointer so they do not rebuild the same source,
 	// dependency, or capability fingerprints for every lane.
 	semanticQueryFacts *semanticFileQueryFacts
+	// Resolution is the optional project-dependent overlay for this file. The
+	// projected procedure fact slices below are the only per-procedure copies
+	// made when a view is supplied; declarations, statements, and expressions
+	// remain owned by the canonical DocumentIR.
+	Resolution         *procedureir.ResolvedDocumentView
+	ResolvedProcedures []procedureir.ProcedureIR
 }
 
 type parsedFileAnalysisResult struct {
@@ -1763,6 +1769,18 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectContext(ctx context.Co
 // the snapshot-aware form used by LSP and other project callers that already
 // own a value-bearing constant environment.
 func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx context.Context, rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document, typeDB *vbadb.DB, projectEffects effects.ProjectSummary, projectConstants map[string]constexpr.Value) ([]Finding, error) {
+	return sourceRealtimeFindingsParsedIRCFGWithResolutionContext(ctx, rootDir, cfg, doc, ir, controlFlow, typeDB, projectEffects, projectConstants, nil)
+}
+
+// SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsViewContext is
+// the LSP project-aware entry point. It keeps the canonical syntax-local IR
+// and reads project-dependent call/access/event facts through resolution
+// views, avoiding a full resolved DocumentIR clone per file.
+func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsViewContext(ctx context.Context, rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document, typeDB *vbadb.DB, projectEffects effects.ProjectSummary, projectConstants map[string]constexpr.Value, resolution *procedureir.ResolvedDocumentView) ([]Finding, error) {
+	return sourceRealtimeFindingsParsedIRCFGWithResolutionContext(ctx, rootDir, cfg, doc, ir, controlFlow, typeDB, projectEffects, projectConstants, resolution)
+}
+
+func sourceRealtimeFindingsParsedIRCFGWithResolutionContext(ctx context.Context, rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document, typeDB *vbadb.DB, projectEffects effects.ProjectSummary, projectConstants map[string]constexpr.Value, resolution *procedureir.ResolvedDocumentView) ([]Finding, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -1805,7 +1823,7 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 		if dataFlowInputsEnabled(cfg.Analyze) {
 			dataFlowModuleBindings = dataFlowBindings(ir.Declarations)
 		}
-		procedures := sourceProceduresFromIRRef(&ir, controlFlow)
+		procedures, resolvedProcedures := sourceProceduresFromIRRefWithResolution(&ir, resolution, controlFlow)
 		file := parsedFile{
 			Path:                      view.Path,
 			Lines:                     lines,
@@ -1816,6 +1834,8 @@ func SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx c
 			IR:                        ir,
 			CFG:                       controlFlow,
 			Procedures:                procedures,
+			Resolution:                resolution,
+			ResolvedProcedures:        resolvedProcedures,
 			RangeValueModuleConstants: rangeValueConstants,
 			ConstantValues:            constantValues,
 			DataFlowModuleBindings:    dataFlowModuleBindings,
@@ -3125,6 +3145,9 @@ func (file *parsedFile) procedureProjection() []sourceProcedure {
 	if file.Procedures != nil {
 		return file.Procedures
 	}
+	if file.ResolvedProcedures != nil {
+		return sourceProceduresFromProcedureSlice(&file.IR, file.ResolvedProcedures, file.CFG)
+	}
 	return sourceProceduresFromIRRef(&file.IR, file.CFG)
 }
 
@@ -3151,16 +3174,38 @@ func procedureEffectIdentity(document procedureir.DocumentIR, symbol procedureir
 // procedure IR collections; facts and views alias the ProcedureIR storage for
 // the lifetime of the document revision.
 func sourceProceduresFromIRRef(document *procedureir.DocumentIR, controlFlow ...vbacfg.Document) []sourceProcedure {
+	return sourceProceduresFromProcedureSlice(document, document.Procedures, controlFlow...)
+}
+
+// sourceProceduresFromIRRefWithResolution builds analyzer projections over an
+// immutable resolution view. Only call/access/event fact slices are projected;
+// all syntax-local procedure payloads continue to alias the source IR.
+func sourceProceduresFromIRRefWithResolution(document *procedureir.DocumentIR, resolution *procedureir.ResolvedDocumentView, controlFlow ...vbacfg.Document) ([]sourceProcedure, []procedureir.ProcedureIR) {
+	if resolution == nil || !resolution.HasOverlay() {
+		return sourceProceduresFromIRRef(document, controlFlow...), nil
+	}
+	projected := make([]procedureir.ProcedureIR, len(document.Procedures))
+	for index := range projected {
+		if procedure, ok := resolution.ResolvedProcedure(index); ok {
+			projected[index] = procedure
+		} else {
+			projected[index] = document.Procedures[index]
+		}
+	}
+	return sourceProceduresFromProcedureSlice(document, projected, controlFlow...), projected
+}
+
+func sourceProceduresFromProcedureSlice(document *procedureir.DocumentIR, procedureValues []procedureir.ProcedureIR, controlFlow ...vbacfg.Document) []sourceProcedure {
 	if document == nil {
 		return nil
 	}
-	procedures := make([]sourceProcedure, 0, len(document.Procedures))
+	procedures := make([]sourceProcedure, 0, len(procedureValues))
 	module := strings.TrimSpace(document.ModuleName)
 	if module == "" {
 		module = strings.TrimSuffix(filepath.Base(document.Path), filepath.Ext(document.Path))
 	}
-	for procedureIndex := range document.Procedures {
-		procedure := &document.Procedures[procedureIndex]
+	for procedureIndex := range procedureValues {
+		procedure := &procedureValues[procedureIndex]
 		kind := "Sub"
 		switch procedure.Symbol.Kind {
 		case procedureir.ProcedureFunction:

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/typedb"
 	vbaast "github.com/harumiWeb/xlflow/internal/vba/ast"
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
+	"github.com/harumiWeb/xlflow/internal/vba/effects"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 	"github.com/harumiWeb/xlflow/internal/vbadb"
@@ -4551,6 +4552,47 @@ End Sub
 	}
 	if got := findingsByCode(realtime, "VBA218"); len(got) != 0 {
 		t.Fatalf("realtime analysis must not resolve cross-module CVErr wrappers: %+v", got)
+	}
+}
+
+func TestVBA218RealtimeProjectViewUsesResolvedLocalWrapperCall(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Main.bas")
+	source := []byte(`Option Explicit
+Private Function TryVisible(ByVal rng As Range) As Variant
+    On Error GoTo Missing
+    TryVisible = rng.SpecialCells(xlCellTypeVisible)
+    Exit Function
+Missing:
+    TryVisible = CVErr(xlErrNA)
+End Function
+Public Sub Run()
+    Dim rng As Range
+    Debug.Print TryVisible(rng)
+End Sub
+`)
+	doc, err := vbaast.ParseDocument(path, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+	ir, err := procedureir.BuildParsed(procedureir.BuildOptions{Path: path, ModuleName: "Main", ModuleKind: "standard"}, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlFlow := vbacfg.BuildDocument(ir)
+	view := procedureir.ResolveView(ir, procedureir.NewResolver([]procedureir.ResolverSymbol{
+		{Name: "TryVisible", Module: "Main", ModuleKind: "standard", Kind: string(procedureir.ProcedureFunction), Visibility: "Private", File: path, Line: 1},
+	}))
+	findings, err := SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsViewContext(
+		context.Background(), dir, config.Default(), doc, ir, controlFlow, nil, effects.ProjectSummary{}, nil, &view,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findingsByCode(findings, "VBA218"); len(got) != 1 || got[0].Line != 11 {
+		t.Fatalf("project resolution view should retain local CVErr wrapper finding: %+v", got)
 	}
 }
 

--- a/internal/analyze/excel_api_failure_contracts.go
+++ b/internal/analyze/excel_api_failure_contracts.go
@@ -214,14 +214,18 @@ func (a Analyzer) errorValueWrapperFindingsContext(ctx context.Context, file par
 		aliases = isErrorGuardAliases(file.Lines)
 	}
 	var findings []Finding
-	for i, irProcedure := range file.IR.Procedures {
+	for i := 0; i < procedures.Len(); i++ {
 		if i&0x1f == 0 {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
 		}
-		proc := procedureForLineView(procedures, irProcedure.Symbol.DeclarationRange.StartLine+1, len(file.Lines))
-		for _, call := range irProcedure.Calls {
+		irProcedure, ok := procedures.At(i)
+		if !ok || irProcedure.IR == nil {
+			continue
+		}
+		proc := procedureForLineView(procedures, irProcedure.StartLine+1, len(file.Lines))
+		for call := range irProcedure.Calls.All() {
 			if !wrapperCallMatches(call, wrappers) {
 				continue
 			}

--- a/internal/analyze/excel_loop_access.go
+++ b/internal/analyze/excel_loop_access.go
@@ -438,24 +438,25 @@ func buildRealtimeExcelLoopSummaries(file parsedFile, db *vbadb.DB, rootBindings
 		rootBindings = buildExcelRootBindingIndex([]parsedFile{file})
 	}
 	procedures := file.procedureView()
-	for i, candidate := range file.IR.Procedures {
-		if i >= procedures.Len() {
-			continue
-		}
-		key := excelProcedureKey(file.IR, candidate.Symbol)
+	for i := 0; i < procedures.Len(); i++ {
 		procedure, ok := procedures.At(i)
-		if !ok {
+		if !ok || procedure.IR == nil {
 			continue
 		}
+		key := excelProcedureKey(file.IR, procedure.IR.Symbol)
 		summaries[key] = directExcelAccessSummary(file, procedure, db, rootBindings, rootDir, cfg)
 	}
 	changed := true
 	for changed {
 		changed = false
-		for _, procedure := range file.IR.Procedures {
-			key := excelProcedureKey(file.IR, procedure.Symbol)
+		for i := 0; i < procedures.Len(); i++ {
+			procedure, ok := procedures.At(i)
+			if !ok || procedure.IR == nil {
+				continue
+			}
+			key := excelProcedureKey(file.IR, procedure.IR.Symbol)
 			current := summaries[key]
-			for _, call := range procedure.Calls {
+			for call := range procedure.Calls.All() {
 				callee, ok := excelHelperProcedureKey(file, call)
 				if !ok {
 					continue

--- a/internal/analyze/project_capabilities.go
+++ b/internal/analyze/project_capabilities.go
@@ -43,9 +43,10 @@ type projectCapabilityPlan struct {
 // LSP planning. LSP snapshots already own IR/CFG, so exposing this small value
 // avoids making the internal parsedFile representation part of the public API.
 type ProjectCapabilityDocument struct {
-	IR     procedureir.DocumentIR
-	CFG    vbacfg.Document
-	Source string
+	IR         procedureir.DocumentIR
+	Resolution procedureir.ResolvedDocumentView
+	CFG        vbacfg.Document
+	Source     string
 }
 
 // ProjectCapabilityRequirements is the public, read-only view needed by the
@@ -79,16 +80,17 @@ func PlanProjectCapabilities(cfg config.AnalyzeConfig, documents []ProjectCapabi
 		if module == "" {
 			module = strings.TrimSuffix(filepath.Base(document.IR.Path), filepath.Ext(document.IR.Path))
 		}
-		procedures := sourceProceduresFromIRRef(&document.IR, document.CFG)
+		procedures, resolvedProcedures := sourceProceduresFromIRRefWithResolution(&document.IR, &document.Resolution, document.CFG)
 		file := parsedFile{
-			Path:       document.IR.Path,
-			Lines:      normalizedSourceLines(document.Source),
-			Module:     module,
-			ModuleKind: document.IR.ModuleKind,
-			Source:     []byte(document.Source),
-			IR:         document.IR,
-			CFG:        document.CFG,
-			Procedures: procedures,
+			Path:               document.IR.Path,
+			Lines:              normalizedSourceLines(document.Source),
+			Module:             module,
+			ModuleKind:         document.IR.ModuleKind,
+			Source:             []byte(document.Source),
+			IR:                 document.IR,
+			CFG:                document.CFG,
+			Procedures:         procedures,
+			ResolvedProcedures: resolvedProcedures,
 		}
 		file.ensureModuleAnalysisFacts()
 		materializeProcedureAnalysisPlans(&file, effects.ProjectSummary{}, cfg)

--- a/internal/lspserver/performance_test.go
+++ b/internal/lspserver/performance_test.go
@@ -355,7 +355,6 @@ func TestLSPPreparationTelemetryReportsStagesAndCounters(t *testing.T) {
 		`stage="projectConstants"`,
 		`counter="resolution_resolver_builds" value=1`,
 		`counter="resolution_view_builds" value=1`,
-		`counter="resolution_materializations" value=2`,
 	} {
 		if !strings.Contains(output.String(), expected) {
 			t.Fatalf("preparation telemetry missing %q:\n%s", expected, output.String())
@@ -363,6 +362,9 @@ func TestLSPPreparationTelemetryReportsStagesAndCounters(t *testing.T) {
 	}
 	if got := s.performance.counterTotal(performanceCounterResolutionResolverBuilds); got != 1 {
 		t.Fatalf("resolver build counter = %d, want 1", got)
+	}
+	if got := s.performance.counterTotal(performanceCounterResolutionMaterializations); got != 0 {
+		t.Fatalf("resolution materializations = %d, want 0", got)
 	}
 }
 

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -118,8 +118,8 @@ type Server struct {
 
 type projectResolutionResult struct {
 	resolver           procedureir.Resolver
-	resolved           map[string]procedureir.DocumentIR
-	diagnosticResolved map[string]procedureir.DocumentIR
+	resolved           map[string]procedureir.ResolvedDocumentView
+	diagnosticResolved map[string]procedureir.ResolvedDocumentView
 }
 
 type projectConstantsResult struct {
@@ -251,26 +251,26 @@ func New(opts Options) (*Server, func(), error) {
 		initializeCapabilityTelemetry(ctx)
 		projectByPath := make(map[string]intel.ProjectAnalysisDocument, len(project.Documents))
 		capabilityDocuments := make([]analyze.ProjectCapabilityDocument, 0, len(project.Documents))
-		for _, projectDocument := range project.Documents {
-			projectByPath[symbolFileKey(projectDocument.IR.Path)] = projectDocument
-			capabilityDocuments = append(capabilityDocuments, analyze.ProjectCapabilityDocument{
-				IR: projectDocument.IR, CFG: projectDocument.CFG, Source: projectDocument.Source,
-			})
-		}
 		resolutionComplete := project.Complete && typeDB.Complete
-		resolutionResolver, resolvedProjectIR, resolvedDiagnosticIR := s.projectResolution(ctx, project, resolutionComplete)
-		for i := range capabilityDocuments {
-			if resolved, ok := resolvedProjectIR[symbolFileKey(capabilityDocuments[i].IR.Path)]; ok {
-				capabilityDocuments[i].IR = resolved
+		resolutionResolver, resolvedProjectViews, resolvedDiagnosticViews := s.projectResolution(ctx, project, resolutionComplete)
+		for _, projectDocument := range project.Documents {
+			key := symbolFileKey(projectDocument.IR.Path)
+			if resolved, ok := resolvedProjectViews[key]; ok {
+				projectDocument.Resolution = resolved
 			}
+			projectByPath[key] = projectDocument
+			capabilityDocuments = append(capabilityDocuments, analyze.ProjectCapabilityDocument{
+				IR: projectDocument.IR, Resolution: projectDocument.Resolution,
+				CFG: projectDocument.CFG, Source: projectDocument.Source,
+			})
 		}
 		capabilityRequirements := analyze.PlanProjectCapabilities(s.opts.Config.Analyze, capabilityDocuments)
 		var projectEffects effects.ProjectSummary
 		if capabilityRequirements.Effects {
-			projectEffects = s.projectEffectSummaryWithResolution(ctx, project, resolvedProjectIR, resolutionComplete)
+			projectEffects = s.projectEffectSummaryWithResolution(ctx, project, resolvedProjectViews, resolutionComplete)
 		}
 		// Resolution is built before planning because the planner needs its
-		// completeness and resolved IR. ProjectConstants is currently part of
+		// completeness and its resolution views. ProjectConstants is currently part of
 		// the unconditional compile-equivalent baseline, but keep this boundary
 		// explicit so optional plans can skip it if that contract changes.
 		var projectConstants projectConstantsResult
@@ -282,15 +282,13 @@ func New(opts Options) (*Server, func(), error) {
 		analyzer.ConstantValues = projectConstants.values
 		analyzer.RealtimeFindingsFunc = func(ctx context.Context, rootDir string, cfg config.Config, doc *vbaast.ParsedDocument, ir procedureir.DocumentIR, controlFlow vbacfg.Document) ([]intel.RealtimeFinding, error) {
 			projectKey := symbolFileKey(ir.Path)
+			var resolution *procedureir.ResolvedDocumentView
 			if projectDocument, ok := projectByPath[projectKey]; ok {
-				if resolved, resolvedOK := resolvedProjectIR[projectKey]; resolvedOK {
-					ir = resolved
-				} else {
-					ir = projectDocument.IR
-				}
+				ir = projectDocument.IR
+				resolution = &projectDocument.Resolution
 				controlFlow = projectDocument.CFG
 			}
-			findings, err := analyze.SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsContext(ctx, rootDir, cfg, doc, ir, controlFlow, typeDB.DB, projectEffects, projectConstants.values)
+			findings, err := analyze.SourceRealtimeFindingsParsedIRCFGWithTypeDBAndProjectConstantsViewContext(ctx, rootDir, cfg, doc, ir, controlFlow, typeDB.DB, projectEffects, projectConstants.values, resolution)
 			if err != nil {
 				return nil, err
 			}
@@ -298,16 +296,11 @@ func New(opts Options) (*Server, func(), error) {
 			for _, finding := range findings {
 				out = append(out, intel.RealtimeFinding{Code: finding.Code, Severity: finding.Severity, Line: finding.Line, Column: finding.Column, EndLine: finding.EndLine, EndColumn: finding.EndColumn, Message: finding.Message})
 			}
-			// Compile-equivalent diagnostics use the full-resolution clone cached
-			// with this project revision. The realtime/effects path keeps the
-			// procedure-only view cached above for parity with batch analysis.
-			var resolvedForDiagnostics procedureir.DocumentIR
-			if cached, ok := resolvedDiagnosticIR[projectKey]; ok {
-				resolvedForDiagnostics = cached
-			} else {
-				resolvedForDiagnostics = procedureir.Resolve(ir, resolutionResolver)
+			resolvedForDiagnostics, ok := resolvedDiagnosticViews[projectKey]
+			if !ok {
+				resolvedForDiagnostics = procedureir.ResolveView(ir, resolutionResolver)
 			}
-			for _, diagnostic := range procedureir.Diagnostics(resolvedForDiagnostics, project.Complete && typeDB.Complete) {
+			for _, diagnostic := range procedureir.DiagnosticsView(resolvedForDiagnostics, project.Complete && typeDB.Complete) {
 				out = append(out, intel.RealtimeFinding{Code: diagnostic.Code, Severity: "error",
 					Line: diagnostic.Range.StartLine, Column: diagnostic.Range.StartColumn,
 					EndLine: diagnostic.Range.EndLine, EndColumn: diagnostic.Range.EndColumn, Message: diagnostic.Message})
@@ -443,17 +436,17 @@ func (s *Server) projectEffectSummary(project intel.ProjectAnalysisSnapshot) eff
 	return s.projectEffectSummaryWithResolution(context.Background(), project, nil, false)
 }
 
-func (s *Server) projectEffectSummaryWithResolution(ctx context.Context, project intel.ProjectAnalysisSnapshot, resolved map[string]procedureir.DocumentIR, complete bool) effects.ProjectSummary {
+func (s *Server) projectEffectSummaryWithResolution(ctx context.Context, project intel.ProjectAnalysisSnapshot, resolved map[string]procedureir.ResolvedDocumentView, complete bool) effects.ProjectSummary {
 	return s.projectSummaryCache.getOrBuild(project.Revision, complete, func() effects.ProjectSummary {
 		measurement := s.performance.start("project/preparation", performanceStageProjectEffects, "interactive", "")
 		finishCapability := analysisstats.MeasureCapabilityBuild(ctx, analysisstats.CapabilityEffectsBuildsCounter)
 		documents := make([]effects.Document, len(project.Documents))
 		for i, document := range project.Documents {
-			ir := document.IR
-			if resolvedIR, ok := resolved[symbolFileKey(document.IR.Path)]; ok {
-				ir = resolvedIR
+			if view, ok := resolved[symbolFileKey(document.IR.Path)]; ok {
+				documents[i] = effects.Document{IR: document.IR, Resolution: view, CFG: document.CFG}
+			} else {
+				documents[i] = effects.Document{IR: document.IR, CFG: document.CFG}
 			}
-			documents[i] = effects.Document{IR: ir, CFG: document.CFG}
 		}
 		summary := effects.Build(documents)
 		finishCapability(nil)
@@ -2196,11 +2189,10 @@ func (s *Server) newWorkspaceAnalysisIndex() *workspaceAnalysisIndex {
 	return index
 }
 
-// projectResolution caches the canonical resolver and its resolved document
-// IR for one workspace revision. Full diagnostics can be requested several
-// times for the same coherent snapshot; rebuilding TypeLib enum candidates
-// and resolving every document on each request is unnecessary work.
-func (s *Server) projectResolution(ctx context.Context, project intel.ProjectAnalysisSnapshot, complete bool) (procedureir.Resolver, map[string]procedureir.DocumentIR, map[string]procedureir.DocumentIR) {
+// projectResolution caches the canonical resolver and immutable resolution
+// views for one workspace revision. Full diagnostics can be requested several
+// times for the same coherent snapshot without cloning every DocumentIR.
+func (s *Server) projectResolution(ctx context.Context, project intel.ProjectAnalysisSnapshot, complete bool) (procedureir.Resolver, map[string]procedureir.ResolvedDocumentView, map[string]procedureir.ResolvedDocumentView) {
 	result := s.resolutionCache.getOrBuild(project.Revision, complete, func() projectResolutionResult {
 		finishCapability := analysisstats.MeasureCapabilityBuild(ctx, analysisstats.CapabilityResolutionBuildsCounter)
 		resolverMeasurement := s.performance.start("project/preparation", performanceStageProjectResolver, "interactive", "")
@@ -2210,21 +2202,19 @@ func (s *Server) projectResolution(ctx context.Context, project intel.ProjectAna
 		procedureResolver := procedureir.ProcedureOnlyResolver(resolver)
 		viewMeasurement := s.performance.start("project/preparation", performanceStageProjectResolutionView, "interactive", "")
 		s.performance.addCounter(performanceCounterResolutionViewBuilds, 1, "project/preparation", performanceStageProjectResolutionView, "interactive", "")
-		resolved := make(map[string]procedureir.DocumentIR, len(project.Documents))
-		diagnosticResolved := make(map[string]procedureir.DocumentIR, len(project.Documents))
+		resolved := make(map[string]procedureir.ResolvedDocumentView, len(project.Documents))
+		diagnosticResolved := make(map[string]procedureir.ResolvedDocumentView, len(project.Documents))
 		viewMeasurement.finish(len(project.Documents), 0, nil)
 		materializationMeasurement := s.performance.start("project/preparation", performanceStageResolutionMaterialize, "interactive", "")
-		materializations := 0
 		for _, document := range project.Documents {
 			// The workspace index resolver intentionally has no TypeDB dependency;
-			// apply the cached TypeDB-aware resolver here once per project revision.
-			resolved[symbolFileKey(document.IR.Path)] = procedureir.Resolve(document.IR, procedureResolver)
-			materializations++
-			diagnosticResolved[symbolFileKey(document.IR.Path)] = procedureir.Resolve(document.IR, resolver)
-			materializations++
+			// apply the cached TypeDB-aware resolver here once per project revision
+			// while retaining the syntax-local IR as the canonical owner.
+			resolved[symbolFileKey(document.IR.Path)] = procedureir.ResolveView(document.IR, procedureResolver)
+			diagnosticResolved[symbolFileKey(document.IR.Path)] = procedureir.ResolveView(document.IR, resolver)
 		}
-		materializationMeasurement.finish(materializations, 0, nil)
-		s.performance.addCounter(performanceCounterResolutionMaterializations, uint64(materializations), "project/preparation", performanceStageResolutionMaterialize, "interactive", "")
+		materializationMeasurement.finish(0, 0, nil)
+		s.performance.addCounter(performanceCounterResolutionMaterializations, 0, "project/preparation", performanceStageResolutionMaterialize, "interactive", "")
 		finishCapability(nil)
 		return projectResolutionResult{resolver: resolver, resolved: resolved, diagnosticResolved: diagnosticResolved}
 	})

--- a/internal/lspserver/workspace_analysis_index.go
+++ b/internal/lspserver/workspace_analysis_index.go
@@ -971,16 +971,13 @@ func (x *workspaceAnalysisIndex) projectSnapshotClass(class string) intel.Projec
 	var sites []calls.CallSite
 	var typeReferences []calls.TypeReference
 	materializationMeasurement := x.performance.start("workspace/project", performanceStageResolutionMaterialize, class, x.root)
-	materializations := 0
 	for _, entry := range entries {
-		resolvedIR := procedureir.Resolve(entry.procedureIR, resolver)
-		materializations++
-		result.Documents = append(result.Documents, intel.ProjectAnalysisDocument{IR: resolvedIR, CFG: entry.controlFlow, Source: entry.source})
+		resolution := procedureir.ResolveView(entry.procedureIR, resolver)
+		result.Documents = append(result.Documents, intel.ProjectAnalysisDocument{IR: entry.procedureIR, Resolution: resolution, CFG: entry.controlFlow, Source: entry.source})
 		sites = append(sites, entry.callSites...)
 		typeReferences = append(typeReferences, entry.typeReferences...)
 	}
-	materializationMeasurement.finish(materializations, 0, nil)
-	x.performance.addCounter(performanceCounterResolutionMaterializations, uint64(materializations), "workspace/project", performanceStageResolutionMaterialize, class, x.root)
+	materializationMeasurement.finish(0, 0, nil)
 	resolvedCalls := make([]calls.Call, len(sites))
 	for i, site := range sites {
 		resolvedCalls[i] = callResolver.Resolve(site)

--- a/internal/lspserver/workspace_project_analysis.go
+++ b/internal/lspserver/workspace_project_analysis.go
@@ -94,7 +94,11 @@ func buildProjectDependencyViewWithPerformanceClass(snapshot intel.ProjectAnalys
 	view := projectDependencyView{procedures: make(map[string]projectProcedureState), reverse: make(map[string][]string)}
 	for _, document := range snapshot.Documents {
 		performance.addCounter(performanceCounterProcedureFingerprintBuilds, uint64(len(document.IR.Procedures)), "workspace/project", performanceStageDependencyUpdate, class, document.IR.Path)
-		for _, procedure := range document.IR.Procedures {
+		for procedureIndex, sourceProcedure := range document.IR.Procedures {
+			procedure := sourceProcedure
+			if resolved, ok := document.Resolution.ResolvedProcedure(procedureIndex); ok {
+				procedure = resolved
+			}
 			key := projectProcedureKey(document.IR.Path, procedure.Symbol.QualifiedName, string(procedure.Symbol.Kind), procedure.Symbol.DeclarationRange.StartLine)
 			encoded, _ := json.Marshal(procedure)
 			sum := sha256.Sum256(encoded)

--- a/internal/lspserver/workspace_project_analysis_test.go
+++ b/internal/lspserver/workspace_project_analysis_test.go
@@ -77,8 +77,8 @@ func TestWorkspaceProjectSnapshotHoldsResolvedIRAndDefensiveCFG(t *testing.T) {
 	if snapshot.Revision == 0 {
 		t.Fatal("published project snapshot revision was not advanced")
 	}
-	resolution := snapshot.Documents[0].IR.Procedures[0].Calls[0].Resolution
-	if resolution.Status != procedureir.ResolutionMatched || len(resolution.Candidates) != 1 {
+	resolution, ok := snapshot.Documents[0].Resolution.ResolvedCall(0, snapshot.Documents[0].IR.Procedures[0].Calls[0].ID)
+	if !ok || resolution.Resolution.Status != procedureir.ResolutionMatched || len(resolution.Resolution.Candidates) != 1 {
 		t.Fatalf("resolution = %#v", resolution)
 	}
 	snapshot.Documents[0].IR.Procedures[0].Symbol.Name = "Mutated"
@@ -134,7 +134,11 @@ func TestWorkspaceProjectSnapshotResolverCandidatesUseDisplayPaths(t *testing.T)
 	if !snapshot.Complete || len(snapshot.Documents) != 1 {
 		t.Fatalf("snapshot = %#v", snapshot)
 	}
-	candidates := snapshot.Documents[0].IR.Procedures[0].Calls[0].Resolution.Candidates
+	resolved, ok := snapshot.Documents[0].Resolution.ResolvedCall(0, snapshot.Documents[0].IR.Procedures[0].Calls[0].ID)
+	if !ok {
+		t.Fatal("call resolution was not attached to snapshot view")
+	}
+	candidates := resolved.Resolution.Candidates
 	if len(candidates) != 1 || candidates[0].File != filepath.ToSlash(filepath.Join("src", "modules", "Main.bas")) {
 		t.Fatalf("resolver candidates = %#v, want workspace display path", candidates)
 	}

--- a/internal/vba/effects/build.go
+++ b/internal/vba/effects/build.go
@@ -140,7 +140,11 @@ func collectInputs(documents []Document) []procedureInput {
 		for _, graph := range doc.CFG.Graphs {
 			graphs[graph.Procedure.QualifiedName+"\x00"+string(graph.Procedure.Kind)] = graph
 		}
-		for _, proc := range doc.IR.Procedures {
+		for procedureIndex, sourceProc := range doc.IR.Procedures {
+			proc := sourceProc
+			if resolved, ok := doc.Resolution.ResolvedProcedure(procedureIndex); ok {
+				proc = resolved
+			}
 			graph := graphs[proc.Symbol.QualifiedName+"\x00"+string(proc.Symbol.Kind)]
 			out = append(out, procedureInput{id: identity(doc.IR, proc), proc: proc, graph: graph, reachable: reachableStatements(proc, graph)})
 		}

--- a/internal/vba/effects/effects_test.go
+++ b/internal/vba/effects/effects_test.go
@@ -50,6 +50,28 @@ End Sub
 	}
 }
 
+func TestBuildUsesResolutionViewWithoutReplacingCanonicalIR(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Main.bas")
+	ir, err := procedureir.BuildSource(procedureir.BuildOptions{Path: path, ModuleName: "Main", ModuleKind: "standard"}, []byte("Public Sub Caller()\n  Call Target\nEnd Sub\nPublic Sub Target()\nEnd Sub\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := procedureir.NewSymbolResolver([]procedureir.ResolverSymbol{
+		{Name: "Caller", Module: "Main", ModuleKind: "standard", Kind: string(procedureir.ProcedureSub), Visibility: "Public", File: path, Line: 0},
+		{Name: "Target", Module: "Main", ModuleKind: "standard", Kind: string(procedureir.ProcedureSub), Visibility: "Public", File: path, Line: 3},
+	})
+	view := procedureir.ResolveView(ir, resolver)
+	viewSummary := Build([]Document{{IR: ir, Resolution: view, CFG: cfg.BuildDocument(ir)}})
+	materialized := procedureir.Resolve(ir, resolver)
+	materializedSummary := Build([]Document{{IR: materialized, CFG: cfg.BuildDocument(materialized)}})
+	if !reflect.DeepEqual(viewSummary.All(), materializedSummary.All()) {
+		t.Fatalf("view effects differ from compatibility materialization:\nview=%+v\nmaterialized=%+v", viewSummary.All(), materializedSummary.All())
+	}
+	if ir.Procedures[0].Calls[0].Resolution.Status != procedureir.ResolutionNotAttempted {
+		t.Fatalf("resolution view modified canonical IR: %+v", ir.Procedures[0].Calls[0].Resolution)
+	}
+}
+
 func TestRestoresEventsAndCellMutations(t *testing.T) {
 	summary := buildSources(t, sourceFile{"Helpers.bas", "Helpers", `Private savedEvents As Boolean
 Public Sub Restore()

--- a/internal/vba/effects/types.go
+++ b/internal/vba/effects/types.go
@@ -409,10 +409,15 @@ func (m *provenanceMaterialization) materialize(index int) ProcedureSummary {
 	return out
 }
 
-// Document pairs already-resolved IR with the CFG built from that exact IR.
+// Document pairs canonical syntax-local IR and an optional resolution view
+// with the CFG built from that exact IR.
 type Document struct {
-	IR  procedureir.DocumentIR
-	CFG cfg.Document
+	// IR is the canonical syntax-local document. Resolution, when present,
+	// supplies project-dependent call/access/event facts without replacing IR
+	// with a deep-copied resolved document.
+	IR         procedureir.DocumentIR
+	Resolution procedureir.ResolvedDocumentView
+	CFG        cfg.Document
 }
 
 func identity(doc procedureir.DocumentIR, proc procedureir.ProcedureIR) ProcedureIdentity {

--- a/internal/vba/intel/procedure_diagnostics.go
+++ b/internal/vba/intel/procedure_diagnostics.go
@@ -46,13 +46,20 @@ type DiagnosticResult struct {
 }
 
 // ProjectAnalysisDocument is an immutable, protocol-neutral document input for
-// project-aware Full diagnostics. IR calls and source-derived constant values
-// are resolved against the exact workspace snapshot represented by Revision;
-// CFG is built from the same IR.
+// project-aware Full diagnostics. The canonical syntax-local IR and its
+// optional resolution view come from the exact workspace snapshot represented
+// by Revision; CFG is built from the same IR.
 type ProjectAnalysisDocument struct {
-	IR     procedureir.DocumentIR
-	CFG    vbacfg.Document
-	Source string
+	// IR is the canonical syntax-local document for this project revision.
+	// Consumers must treat it as immutable and read project-dependent facts
+	// through Resolution instead of expecting them to be written into IR.
+	IR procedureir.DocumentIR
+	// Resolution is an optional immutable overlay over IR. A zero value means
+	// that the document has no project resolution attached (for example in
+	// compatibility/unit-test inputs).
+	Resolution procedureir.ResolvedDocumentView
+	CFG        vbacfg.Document
+	Source     string
 }
 
 // ProjectAnalysisSnapshot is a coherent view of saved files and published

--- a/internal/vba/procedureir/resolution_overlay.go
+++ b/internal/vba/procedureir/resolution_overlay.go
@@ -62,6 +62,55 @@ type ResolvedDocumentView struct {
 	eventIDs   [][]int
 }
 
+// HasOverlay reports whether this view contains project-dependent facts. It
+// distinguishes a zero/compatibility view from a view built with a resolver.
+func (v ResolvedDocumentView) HasOverlay() bool { return v.hasOverlay }
+
+// ResolvedProcedure returns a procedure projection with project-dependent
+// call, access, and RaiseEvent facts applied. Syntax-local collections such as
+// declarations, statements, and expressions continue to alias the immutable
+// revision. Only the small fact slices are copied, so this is not the full IR
+// materialization performed by Materialize.
+//
+// The returned procedure and its fact slices are owned by the caller. The
+// nested syntax-local values remain immutable revision data.
+func (v ResolvedDocumentView) ResolvedProcedure(procedureIndex int) (ProcedureIR, bool) {
+	if !v.hasOverlay {
+		return ProcedureIR{}, false
+	}
+	if procedureIndex < 0 || procedureIndex >= len(v.document.Procedures) {
+		return ProcedureIR{}, false
+	}
+	procedure := v.document.Procedures[procedureIndex]
+	procedure.Calls = make([]CallSite, len(procedure.Calls))
+	for callIndex, call := range v.document.Procedures[procedureIndex].Calls {
+		call.Resolution = CallResolution{}
+		if resolved, ok := v.resolvedCallAt(procedureIndex, callIndex); ok {
+			call.Resolution = cloneCallResolution(resolved.Resolution)
+		}
+		if v.hasOverlay && !call.IsRaiseEvent && !isAssignmentTargetCall(call, procedure) {
+			call.NonCallableNames = append([]string(nil), declarationNames(v.document.Declarations, procedure.Declarations)...)
+		}
+		procedure.Calls[callIndex] = call
+	}
+	procedure.Accesses = make([]VariableAccess, len(procedure.Accesses))
+	for accessIndex, access := range v.document.Procedures[procedureIndex].Accesses {
+		if resolved, ok := v.resolvedAccessAt(procedureIndex, accessIndex); ok {
+			access.Scope = resolved.Scope
+			access.Resolution = cloneSymbolResolution(resolved.Resolution)
+		}
+		procedure.Accesses[accessIndex] = access
+	}
+	procedure.RaiseEvents = make([]RaiseEventReference, len(procedure.RaiseEvents))
+	for eventIndex, event := range v.document.Procedures[procedureIndex].RaiseEvents {
+		if resolved, ok := v.resolvedEventAt(procedureIndex, eventIndex); ok {
+			event.Resolution = cloneSymbolResolution(resolved.Resolution)
+		}
+		procedure.RaiseEvents[eventIndex] = event
+	}
+	return procedure, true
+}
+
 // ResolveView builds a read-only project-resolution view over in. The input
 // document and all of its nested slices remain untouched.
 func ResolveView(in DocumentIR, resolver Resolver) ResolvedDocumentView {

--- a/internal/vba/procedureir/resolution_overlay_test.go
+++ b/internal/vba/procedureir/resolution_overlay_test.go
@@ -85,6 +85,29 @@ func TestResolveViewUsesFactIDsWithoutMutatingInput(t *testing.T) {
 	}
 }
 
+func TestResolvedProcedureProjectsFactsWithoutCloningSyntaxPayload(t *testing.T) {
+	doc := overlayTestDocument()
+	view := ResolveView(doc, overlayTestResolver{})
+	sourceStatus := doc.Procedures[0].Calls[0].Resolution.Status
+	projected, ok := view.ResolvedProcedure(0)
+	if !ok {
+		t.Fatal("ResolvedProcedure returned no procedure")
+	}
+	if projected.Symbol.Name != doc.Procedures[0].Symbol.Name {
+		t.Fatalf("projected symbol = %q, want %q", projected.Symbol.Name, doc.Procedures[0].Symbol.Name)
+	}
+	if projected.Calls[0].Resolution.Status != ResolutionMatched || doc.Procedures[0].Calls[0].Resolution.Status != sourceStatus {
+		t.Fatalf("projected/source resolutions = %+v / %+v", projected.Calls[0].Resolution, doc.Procedures[0].Calls[0].Resolution)
+	}
+	if len(projected.Statements) == 0 || &projected.Statements[0] != &doc.Procedures[0].Statements[0] {
+		t.Fatal("syntax-local statement payload was unexpectedly copied")
+	}
+	projected.Calls[0].Resolution.Candidates[0].QualifiedName = "mutated"
+	if got, _ := view.ResolvedCall(0, 1); got.Resolution.Candidates[0].QualifiedName == "mutated" {
+		t.Fatal("projected call exposed mutable overlay storage")
+	}
+}
+
 func TestResolveViewUsesOrdinalFallbackForDuplicateHandBuiltIDs(t *testing.T) {
 	doc := overlayTestDocument()
 	doc.Procedures[0].Calls = append(doc.Procedures[0].Calls,


### PR DESCRIPTION
## Summary

- Keep the canonical syntax-local `DocumentIR` in LSP project snapshots and attach an immutable `ResolvedDocumentView` for project-dependent facts.
- Migrate capability, effects, realtime diagnostics, compile-equivalent diagnostics, and dependency consumers without removing the `Resolve`/`Materialize` compatibility path.
- Keep normal LSP `resolution_materializations` at zero and add regression coverage for view projections and realtime resolution-sensitive findings.
- Closes #736

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/dev/go.ps1 test ./... -count=1 -timeout=25m`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/dev/go.ps1 test ./internal/analyze ./internal/lspserver ./internal/vba/procedureir ./internal/vba/effects ./internal/vba/intel -count=1 -timeout=25m`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/dev/go.ps1 test -race ./internal/analyze ./internal/lspserver -count=1 -timeout=25m`
- `rtk task lint`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/dev/go.ps1 test ./internal/lspserver -run '^TestLSPStartupBenchmarkFixture$' -bench '^BenchmarkLSPStartup$' -benchmem -benchtime=1x -count=1 -timeout=25m`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/dev/go.ps1 test ./internal/vba/procedureir -run '^$' -bench '^BenchmarkResolutionOverlay$' -benchmem -benchtime=1x -count=1 -timeout=10m`
- `rtk proxy task review:codex`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory allocations during project analysis and LSP snapshots.
  * Project diagnostics and realtime analysis now avoid unnecessary document materialization while preserving existing results.
  * Resolution materialization telemetry remains at zero for standard LSP and full-diagnostic paths.

* **Bug Fixes**
  * Improved consistency when analyzing resolved calls, accesses, events, dependencies, and diagnostics.
  * Preserved canonical analysis data while applying project-specific resolution information safely.

* **Documentation**
  * Updated architecture and performance documentation to describe the revised resolution behavior and compatibility paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->