### PR TITLE
perf(lsp): replace whole-project ProcedureIR hashing with incremental fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Reduced LSP project dependency-update work by reusing canonical procedure
+  catalog fingerprints and maintaining file/procedure-level call and reverse
+  caller state incrementally. Body-only edits now revisit only changed
+  procedures; old and new reverse edges preserve invalidation for removed or
+  redirected calls. Module declaration dependencies and uncertain resolutions
+  fail open through module/project boundary nodes. Added opt-in dependency node,
+  edge, revisit, and fingerprint reuse counters; diagnostic and LSP response
+  contracts remain unchanged.
+
 - Reduced duplicate LSP project-resolution preparation by sharing one canonical
   symbol index between procedure-only and full resolver views, reusing
   revision-local overlay fact IDs, and preventing canceled resolution builds

--- a/docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md
+++ b/docs/adr/ADR-0048-revision-scoped-semantic-query-dag.md
@@ -66,6 +66,28 @@ explicit dependencies at the kernel boundary. This separation may reduce a
 dependency set only when the kernel does not read the removed leaf; it must not
 weaken fail-open behavior for incomplete or ambiguous input.
 
+### Amendment: incremental LSP dependency index (#738)
+
+The LSP project-change path consumes the immutable `ProcedureCatalog` produced
+by document analysis. It keeps compact procedure fingerprints, file revision
+tokens, outgoing call sets, and a reverse caller index; it must not serialize a
+complete `ProcedureIR` or rebuild every reverse edge for each project revision.
+
+A body-only change revisits only procedures in the changed file whose catalog
+fingerprint differs. A signature, visibility, module-context, declaration, or
+resolution change may refresh procedure resolution across the project, but the
+graph still replaces only changed nodes and edges. Old and new reverse edges
+are both used during caller-closure propagation so removed and redirected calls
+invalidate former callers. If catalog/IR correspondence or resolution
+completeness is not proven, the index fails open to the affected project
+boundary rather than reusing an uncertain entry. Module declaration references
+(including constants and enum members) target a compact module dependency node,
+so declaration-only changes invalidate their consumers. Dynamic, ambiguous, or
+incomplete resolutions also attach to a synthetic project boundary node; a
+revision change invalidates that uncertain closure before any narrower reuse is
+attempted. The compact index owns no parser trees or retired snapshots and is
+discarded with the workspace lifecycle.
+
 The store's internal identity is a comparable `Key` rather than a serialized
 string. Dependencies are canonicalized and deduplicated at publication, and
 reverse edges plus pending/epoch/eviction metadata use the same key. Exact

--- a/docs/specs/lsp-performance-profiling.md
+++ b/docs/specs/lsp-performance-profiling.md
@@ -59,30 +59,45 @@ zero values, so a profile can distinguish “not observed” from an omitted
 instrumentation field. The counters are stderr-only and never enter an LSP
 payload.
 
-| Counter                        | Meaning                                                    |
-| ------------------------------ | ---------------------------------------------------------- |
-| `workspace_files_discovered`   | Source files returned by workspace discovery.              |
-| `workspace_declaration_builds` | Successful per-file declaration builds.                    |
-| `workspace_semantic_builds`    | Successful per-file semantic builds.                       |
-| `project_snapshot_builds`      | Project snapshots assembled.                               |
-| `resolution_resolver_builds`   | Resolver constructions (revision cache misses).            |
-| `resolution_view_builds`       | Resolution views constructed (revision cache misses).      |
-| `canonical_resolver_builds`    | Canonical project resolver/index constructions.            |
-| `procedure_resolver_views`     | Procedure-only resolver views derived from the index.      |
-| `full_resolver_views`          | Full resolver views derived from the index.                |
-| `resolution_overlay_builds`    | Per-document resolution overlays built for both modes.     |
-| `resolution_materializations`  | Document IR materializations into resolution views.        |
-| `procedure_fingerprint_builds` | Procedure fingerprints computed for dependency comparison. |
-| `procedure_fingerprint_reuses` | Fingerprints served from a reusable dependency cache.      |
-| `fast_diagnostic_runs`         | Fast diagnostic runs started.                              |
-| `full_diagnostic_runs`         | Full diagnostic runs started.                              |
-| `background_permit_waits`      | Background workers that waited for an analysis permit.     |
-| `interactive_permit_waits`     | Interactive workers that waited for an analysis permit.    |
+| Counter                        | Meaning                                                       |
+| ------------------------------ | ------------------------------------------------------------- |
+| `workspace_files_discovered`   | Source files returned by workspace discovery.                 |
+| `workspace_declaration_builds` | Successful per-file declaration builds.                       |
+| `workspace_semantic_builds`    | Successful per-file semantic builds.                          |
+| `project_snapshot_builds`      | Project snapshots assembled.                                  |
+| `resolution_resolver_builds`   | Resolver constructions (revision cache misses).               |
+| `resolution_view_builds`       | Resolution views constructed (revision cache misses).         |
+| `canonical_resolver_builds`    | Canonical project resolver/index constructions.               |
+| `procedure_resolver_views`     | Procedure-only resolver views derived from the index.         |
+| `full_resolver_views`          | Full resolver views derived from the index.                   |
+| `resolution_overlay_builds`    | Per-document resolution overlays built for both modes.        |
+| `resolution_materializations`  | Document IR materializations into resolution views.           |
+| `procedure_fingerprint_builds` | Procedure fingerprints computed for dependency comparison.    |
+| `procedure_fingerprint_reuses` | Fingerprints served from a reusable dependency cache.         |
+| `dependency_nodes_updated`     | Procedure dependency entries replaced or removed.             |
+| `dependency_edges_updated`     | Reverse or outgoing call edges added or removed.              |
+| `procedures_revisited`         | Procedures inspected during an incremental dependency update. |
+| `fast_diagnostic_runs`         | Fast diagnostic runs started.                                 |
+| `full_diagnostic_runs`         | Full diagnostic runs started.                                 |
+| `background_permit_waits`      | Background workers that waited for an analysis permit.        |
+| `interactive_permit_waits`     | Interactive workers that waited for an analysis permit.       |
 
 `procedure_fingerprint_reuses` is reserved for reuse reporting and is emitted
 as zero until a reusable fingerprint cache is used. A counter increment is
 reported with the stage and path that caused it; the initial snapshot reports
 the accumulated totals.
+
+The LSP dependency index stores catalog fingerprints and call edges from the
+document analysis revision. A body-only edit should increment
+`dependency_nodes_updated` only for changed procedures and should report
+unchanged procedures through `procedure_fingerprint_reuses`; it must not invoke
+JSON serialization of a complete `ProcedureIR`. Signature, module-context, or
+resolution changes may revisit all procedures, while edge publication remains
+incremental. Module declaration references use a module-level dependency node;
+uncertain (dynamic, ambiguous, incomplete, or project-local unresolved)
+resolution attaches to a project boundary so its reverse closure is invalidated
+on the next revision. These counters are structural observations and are never copied
+into LSP responses, normal CLI JSON, corpus snapshots, or review ledgers.
 
 Delta counter records use `outcome="counter"` with the increment in `value`.
 The initial aggregate snapshot uses `outcome="counter_snapshot"`,

--- a/internal/lspserver/performance.go
+++ b/internal/lspserver/performance.go
@@ -44,6 +44,9 @@ const (
 	performanceCounterResolutionMaterializations = "resolution_materializations"
 	performanceCounterProcedureFingerprintBuilds = "procedure_fingerprint_builds"
 	performanceCounterProcedureFingerprintReuses = "procedure_fingerprint_reuses"
+	performanceCounterDependencyNodesUpdated     = "dependency_nodes_updated"
+	performanceCounterDependencyEdgesUpdated     = "dependency_edges_updated"
+	performanceCounterProceduresRevisited        = "procedures_revisited"
 	performanceCounterFastDiagnosticRuns         = "fast_diagnostic_runs"
 	performanceCounterFullDiagnosticRuns         = "full_diagnostic_runs"
 	performanceCounterBackgroundPermitWaits      = "background_permit_waits"
@@ -64,6 +67,9 @@ var performanceCounterNames = [...]string{
 	performanceCounterResolutionMaterializations,
 	performanceCounterProcedureFingerprintBuilds,
 	performanceCounterProcedureFingerprintReuses,
+	performanceCounterDependencyNodesUpdated,
+	performanceCounterDependencyEdgesUpdated,
+	performanceCounterProceduresRevisited,
 	performanceCounterFastDiagnosticRuns,
 	performanceCounterFullDiagnosticRuns,
 	performanceCounterBackgroundPermitWaits,

--- a/internal/lspserver/performance_test.go
+++ b/internal/lspserver/performance_test.go
@@ -185,6 +185,28 @@ func TestWorkspaceSymbolIndexPerformanceReportsInitialBuild(t *testing.T) {
 	}
 }
 
+func TestPerformanceRecorderRegistersDependencyCounters(t *testing.T) {
+	var output bytes.Buffer
+	recorder := newPerformanceRecorder(true, log.New(&output, "", 0))
+
+	for _, counter := range []string{
+		performanceCounterDependencyNodesUpdated,
+		performanceCounterDependencyEdgesUpdated,
+		performanceCounterProceduresRevisited,
+	} {
+		if got := recorder.counterTotal(counter); got != 0 {
+			t.Fatalf("counter %q initialized to %d, want 0", counter, got)
+		}
+		recorder.addCounter(counter, 1, "workspace/project", performanceStageDependencyUpdate, "background", "")
+		if got := recorder.counterTotal(counter); got != 1 {
+			t.Fatalf("counter %q total = %d, want 1", counter, got)
+		}
+		if !strings.Contains(output.String(), `counter="`+counter+`" value=1 total=1`) {
+			t.Fatalf("counter %q was not emitted:\n%s", counter, output.String())
+		}
+	}
+}
+
 func TestWorkspaceOverlayPerformanceReportsGenerationAndDiscard(t *testing.T) {
 	var output bytes.Buffer
 	s := &Server{opts: Options{PerformanceLog: true}, logger: log.New(&output, "", 0)}

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -2364,15 +2364,16 @@ func (s *Server) analyzeIndexedDocumentContextClass(ctx context.Context, doc int
 		return indexedFileAnalysis{}, err
 	}
 	result := indexedFileAnalysis{
-		path:           doc.Path,
-		version:        documentVersion(doc),
-		moduleKind:     doc.ModuleKind,
-		source:         doc.Source,
-		symbols:        syms,
-		callSites:      rawCalls.CallSites,
-		typeReferences: rawCalls.TypeReferences,
-		procedureIR:    procedureir.Clone(procedureIR),
-		controlFlow:    vbacfg.CloneDocument(controlFlow),
+		path:             doc.Path,
+		version:          documentVersion(doc),
+		moduleKind:       doc.ModuleKind,
+		source:           doc.Source,
+		symbols:          syms,
+		callSites:        rawCalls.CallSites,
+		typeReferences:   rawCalls.TypeReferences,
+		procedureIR:      procedureir.Clone(procedureIR),
+		controlFlow:      vbacfg.CloneDocument(controlFlow),
+		procedureCatalog: snapshot.ProcedureCatalog(),
 	}
 	semanticMeasurement.finish(len(procedureIR.Procedures), 0, nil)
 	s.performance.addCounter(performanceCounterWorkspaceSemanticBuilds, 1, "workspace/file", performanceStageSemanticIndexing, class, doc.Path)

--- a/internal/lspserver/workspace_analysis_index.go
+++ b/internal/lspserver/workspace_analysis_index.go
@@ -63,15 +63,17 @@ type workspaceAnalysisIndex struct {
 	// revision changes only when a complete effective entry is published or
 	// removed. Pending overlays make projectSnapshot incomplete and therefore
 	// cannot seed project-aware diagnostics.
-	revision            uint64
-	qualified           map[string][]symbolRef
-	all                 []symbolRef
-	allCalls            []callRef
-	byCaller            map[string][]callRef
-	byBaseName          map[string][]callRef
-	byText              map[string][]callRef
-	projectMu           sync.Mutex
-	lastProjectSnapshot intel.ProjectAnalysisSnapshot
+	revision   uint64
+	qualified  map[string][]symbolRef
+	all        []symbolRef
+	allCalls   []callRef
+	byCaller   map[string][]callRef
+	byBaseName map[string][]callRef
+	byText     map[string][]callRef
+	projectMu  sync.Mutex
+	// projectDependencies retains only compact procedure/dependency metadata;
+	// the previous full IR/CFG snapshot is intentionally not retained here.
+	projectDependencies projectDependencyView
 	declarations        *workspaceDeclarationIndex
 	initialWorkers      int
 	semanticWorkers     int
@@ -115,6 +117,7 @@ type indexedFileAnalysis struct {
 	typeReferences        []calls.TypeReference
 	procedureIR           procedureir.DocumentIR
 	controlFlow           vbacfg.Document
+	procedureCatalog      intel.ProcedureCatalog
 }
 
 // indexedAnalysisIncomplete reports whether an indexed entry was produced
@@ -937,10 +940,11 @@ func (x *workspaceAnalysisIndex) projectSnapshotClass(class string) intel.Projec
 	graphSymbols := make([]callgraph.Symbol, 0, symbolCapacity)
 	for _, raw := range rawEntries {
 		entry := indexedFileAnalysis{
-			path: raw.path, source: raw.source, procedureIR: procedureir.Clone(raw.procedureIR),
+			path: raw.path, version: raw.version, source: raw.source, procedureIR: procedureir.Clone(raw.procedureIR),
 			controlFlow: vbacfg.CloneDocument(raw.controlFlow),
 			callSites:   cloneCallSites(raw.callSites), typeReferences: cloneTypeReferences(raw.typeReferences),
-			symbols: append([]intel.Symbol(nil), raw.symbols...),
+			symbols:          append([]intel.Symbol(nil), raw.symbols...),
+			procedureCatalog: cloneProcedureCatalog(raw.procedureCatalog),
 		}
 		entries = append(entries, entry)
 		file := workspaceDisplayPath(x.root, entry.path)
@@ -973,7 +977,10 @@ func (x *workspaceAnalysisIndex) projectSnapshotClass(class string) intel.Projec
 	materializationMeasurement := x.performance.start("workspace/project", performanceStageResolutionMaterialize, class, x.root)
 	for _, entry := range entries {
 		resolution := procedureir.ResolveView(entry.procedureIR, resolver)
-		result.Documents = append(result.Documents, intel.ProjectAnalysisDocument{IR: entry.procedureIR, Resolution: resolution, CFG: entry.controlFlow, Source: entry.source})
+		result.Documents = append(result.Documents, intel.ProjectAnalysisDocument{
+			IR: entry.procedureIR, Resolution: resolution, CFG: entry.controlFlow, Source: entry.source,
+			Version: entry.version, ProcedureCatalog: entry.procedureCatalog,
+		})
 		sites = append(sites, entry.callSites...)
 		typeReferences = append(typeReferences, entry.typeReferences...)
 	}
@@ -1023,20 +1030,22 @@ func (x *workspaceAnalysisIndex) projectChangeClass(class string) (intel.Project
 		return current, nil
 	}
 	x.projectMu.Lock()
-	previous := x.lastProjectSnapshot
-	if previous.Complete && current.Revision <= previous.Revision {
+	if x.projectDependencies.revision != 0 && current.Revision <= x.projectDependencies.revision {
 		x.projectMu.Unlock()
 		changeMeasurement.finish(0, 0, nil)
 		return current, nil
 	}
-	x.lastProjectSnapshot = current
-	x.projectMu.Unlock()
-	if !previous.Complete {
+	if x.projectDependencies.revision == 0 {
+		x.projectDependencies = buildProjectDependencyViewWithPerformanceClass(current, x.performance, class)
+		x.projectDependencies.revision = current.Revision
+		x.projectMu.Unlock()
 		changeMeasurement.finish(0, 0, nil)
 		return current, nil
 	}
 	dependencyMeasurement := x.performance.start("workspace/project", performanceStageDependencyUpdate, class, x.root)
-	impacted := projectImpactPathsWithPerformanceClass(previous, current, x.performance, class)
+	impacted := updateProjectDependencyView(&x.projectDependencies, current, x.performance, class)
+	x.projectDependencies.revision = current.Revision
+	x.projectMu.Unlock()
 	dependencyMeasurement.finish(len(impacted), 0, nil)
 	changeMeasurement.finish(len(impacted), 0, nil)
 	return current, impacted

--- a/internal/lspserver/workspace_project_analysis.go
+++ b/internal/lspserver/workspace_project_analysis.go
@@ -567,37 +567,27 @@ func updateProjectDependencyView(view *projectDependencyView, snapshot intel.Pro
 	}
 	changedFiles := make(map[string]bool)
 	resolutionRefresh := false
-	for fileKey, oldFile := range view.files {
-		index, exists := currentDocuments[fileKey]
-		if !exists {
+	fileKeys := make(map[string]struct{}, len(view.files)+len(currentDocuments))
+	for fileKey := range view.files {
+		fileKeys[fileKey] = struct{}{}
+	}
+	for fileKey := range currentDocuments {
+		fileKeys[fileKey] = struct{}{}
+	}
+	for fileKey := range fileKeys {
+		oldFile, hasOld := view.files[fileKey]
+		index, hasCurrent := currentDocuments[fileKey]
+		if !hasOld || !hasCurrent {
 			changedFiles[fileKey] = true
 			resolutionRefresh = true
 			continue
 		}
 		document := snapshot.Documents[index]
-		if projectFileChanged(view, document, fileKey, oldFile, currentCatalogSafe[fileKey]) {
+		changed, refresh := projectFileNeedsWork(view, document, fileKey, oldFile, currentCatalogSafe[fileKey])
+		if changed {
 			changedFiles[fileKey] = true
 		}
-		if !oldFile.catalogSafe || !currentCatalogSafe[fileKey] {
-			resolutionRefresh = true
-		}
-		if oldFile.module != document.ProcedureCatalog.ModuleContextHash || oldFile.conditional != document.ProcedureCatalog.ConditionalHash || (oldFile.version != document.Version && len(document.IR.Procedures) == 0) {
-			resolutionRefresh = true
-		}
-	}
-	for fileKey, index := range currentDocuments {
-		if _, exists := view.files[fileKey]; !exists {
-			changedFiles[fileKey] = true
-			resolutionRefresh = true
-			continue
-		}
-		if projectFileChanged(view, snapshot.Documents[index], fileKey, view.files[fileKey], currentCatalogSafe[fileKey]) {
-			changedFiles[fileKey] = true
-		}
-		if !view.files[fileKey].catalogSafe || !currentCatalogSafe[fileKey] {
-			resolutionRefresh = true
-		}
-		if view.files[fileKey].module != snapshot.Documents[index].ProcedureCatalog.ModuleContextHash || view.files[fileKey].conditional != snapshot.Documents[index].ProcedureCatalog.ConditionalHash || (view.files[fileKey].version != snapshot.Documents[index].Version && len(snapshot.Documents[index].IR.Procedures) == 0) {
+		if refresh {
 			resolutionRefresh = true
 		}
 	}
@@ -758,6 +748,15 @@ func updateProjectDependencyView(view *projectDependencyView, snapshot intel.Pro
 	}
 
 	return projectImpactPathsFromIncrementalView(view, changed, oldReverse, impactFiles)
+}
+
+func projectFileNeedsWork(view *projectDependencyView, document intel.ProjectAnalysisDocument, fileKey string, oldFile projectFileState, catalogSafe bool) (changed, refresh bool) {
+	changed = projectFileChanged(view, document, fileKey, oldFile, catalogSafe)
+	refresh = !oldFile.catalogSafe || !catalogSafe ||
+		oldFile.module != document.ProcedureCatalog.ModuleContextHash ||
+		oldFile.conditional != document.ProcedureCatalog.ConditionalHash ||
+		(oldFile.version != document.Version && len(document.IR.Procedures) == 0)
+	return changed, refresh
 }
 
 func projectFileChanged(view *projectDependencyView, document intel.ProjectAnalysisDocument, fileKey string, oldFile projectFileState, catalogSafe bool) bool {

--- a/internal/lspserver/workspace_project_analysis.go
+++ b/internal/lspserver/workspace_project_analysis.go
@@ -2,8 +2,6 @@ package lspserver
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -12,19 +10,51 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
+// projectProcedureFingerprint is assembled from the canonical catalog owned by
+// document analysis. The LSP dependency index never marshals a complete
+// ProcedureIR to compare revisions.
+type projectProcedureFingerprint struct {
+	source      [sha256.Size]byte
+	signature   [sha256.Size]byte
+	module      [sha256.Size]byte
+	conditional [sha256.Size]byte
+	fallback    [sha256.Size]byte
+}
+
 type projectProcedureState struct {
 	file        string
-	fingerprint string
+	fingerprint projectProcedureFingerprint
+	callees     map[string]struct{}
+	resolution  string
+	uncertain   bool
+}
+
+type projectFileState struct {
+	version       string
+	procedureKeys []string
+	moduleKey     string
+	module        [sha256.Size]byte
+	conditional   [sha256.Size]byte
+	catalogSafe   bool
 }
 
 type projectDependencyView struct {
 	procedures map[string]projectProcedureState
-	reverse    map[string][]string
+	reverse    map[string]map[string]struct{}
+	files      map[string]projectFileState
+	lookup     projectProcedureLookup
+	revision   uint64
 }
 
-// projectImpactPaths returns the transitive caller files affected by changes
-// between two coherent snapshots. Both old and new reverse edges participate,
-// so removing or redirecting a call still refreshes the former callers.
+const projectDependencyRootKey = "\x00project-dependency-root"
+
+func projectModuleDependencyKey(file string) string {
+	return "module\x00" + symbolFileKey(file)
+}
+
+// projectImpactPaths retains the deterministic two-snapshot helper used by
+// compatibility callers. The workspace index uses updateProjectDependencyView
+// below so that unchanged files are not rebuilt.
 func projectImpactPaths(before, after intel.ProjectAnalysisSnapshot) []string {
 	return projectImpactPathsWithPerformance(before, after, nil)
 }
@@ -41,15 +71,42 @@ func projectImpactPathsWithPerformanceClass(before, after intel.ProjectAnalysisS
 	newView := buildProjectDependencyViewWithPerformanceClass(after, performance, class)
 	changed := make(map[string]bool)
 	for key, old := range oldView.procedures {
-		if current, ok := newView.procedures[key]; !ok || current.fingerprint != old.fingerprint {
+		if current, ok := newView.procedures[key]; !ok || projectProcedureStateChanged(old, current) {
 			changed[key] = true
 		}
 	}
 	for key, current := range newView.procedures {
-		if old, ok := oldView.procedures[key]; !ok || old.fingerprint != current.fingerprint {
+		if old, ok := oldView.procedures[key]; !ok || projectProcedureStateChanged(old, current) {
 			changed[key] = true
 		}
 	}
+	if projectDependencyViewHasUncertainty(oldView) || projectDependencyViewHasUncertainty(newView) {
+		changed[projectDependencyRootKey] = true
+	}
+	return projectImpactPathsFromViews(oldView, newView, changed)
+}
+
+func projectDependencyViewHasUncertainty(view projectDependencyView) bool {
+	for key, state := range view.procedures {
+		if key != projectDependencyRootKey && state.uncertain {
+			return true
+		}
+	}
+	return false
+}
+
+func projectStatesHaveUncertainty(states map[string]map[string]projectProcedureState) bool {
+	for _, fileStates := range states {
+		for _, state := range fileStates {
+			if state.uncertain {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func projectImpactPathsFromViews(oldView, newView projectDependencyView, changed map[string]bool) []string {
 	queue := make([]string, 0, len(changed))
 	for key := range changed {
 		queue = append(queue, key)
@@ -58,9 +115,13 @@ func projectImpactPathsWithPerformanceClass(before, after intel.ProjectAnalysisS
 	files := make(map[string]string)
 	for key := range changed {
 		if state, ok := newView.procedures[key]; ok {
-			files[symbolFileKey(state.file)] = state.file
+			if state.file != "" {
+				files[symbolFileKey(state.file)] = state.file
+			}
 		} else if state, ok := oldView.procedures[key]; ok {
-			files[symbolFileKey(state.file)] = state.file
+			if state.file != "" {
+				files[symbolFileKey(state.file)] = state.file
+			}
 		}
 	}
 	for len(queue) > 0 {
@@ -70,12 +131,22 @@ func projectImpactPathsWithPerformanceClass(before, after intel.ProjectAnalysisS
 			continue
 		}
 		seen[callee] = true
-		callers := append(append([]string(nil), oldView.reverse[callee]...), newView.reverse[callee]...)
-		for _, caller := range callers {
+		callers := make(map[string]struct{}, len(oldView.reverse[callee])+len(newView.reverse[callee]))
+		for caller := range oldView.reverse[callee] {
+			callers[caller] = struct{}{}
+		}
+		for caller := range newView.reverse[callee] {
+			callers[caller] = struct{}{}
+		}
+		for caller := range callers {
 			if state, ok := newView.procedures[caller]; ok {
-				files[symbolFileKey(state.file)] = state.file
+				if state.file != "" {
+					files[symbolFileKey(state.file)] = state.file
+				}
 			} else if state, ok := oldView.procedures[caller]; ok {
-				files[symbolFileKey(state.file)] = state.file
+				if state.file != "" {
+					files[symbolFileKey(state.file)] = state.file
+				}
 			}
 			if !seen[caller] {
 				queue = append(queue, caller)
@@ -91,46 +162,722 @@ func projectImpactPathsWithPerformanceClass(before, after intel.ProjectAnalysisS
 }
 
 func buildProjectDependencyViewWithPerformanceClass(snapshot intel.ProjectAnalysisSnapshot, performance *performanceRecorder, class string) projectDependencyView {
-	view := projectDependencyView{procedures: make(map[string]projectProcedureState), reverse: make(map[string][]string)}
+	view := newProjectDependencyView()
+	lookup := newProjectProcedureLookup(snapshot)
+	view.lookup = lookup
 	for _, document := range snapshot.Documents {
-		performance.addCounter(performanceCounterProcedureFingerprintBuilds, uint64(len(document.IR.Procedures)), "workspace/project", performanceStageDependencyUpdate, class, document.IR.Path)
-		for procedureIndex, sourceProcedure := range document.IR.Procedures {
-			procedure := sourceProcedure
-			if resolved, ok := document.Resolution.ResolvedProcedure(procedureIndex); ok {
-				procedure = resolved
-			}
-			key := projectProcedureKey(document.IR.Path, procedure.Symbol.QualifiedName, string(procedure.Symbol.Kind), procedure.Symbol.DeclarationRange.StartLine)
-			encoded, _ := json.Marshal(procedure)
-			sum := sha256.Sum256(encoded)
-			view.procedures[key] = projectProcedureState{file: document.IR.Path, fingerprint: hex.EncodeToString(sum[:])}
-			for _, call := range procedure.Calls {
-				if call.Resolution.Status != procedureir.ResolutionMatched || len(call.Resolution.Candidates) != 1 {
-					continue
-				}
-				candidate := call.Resolution.Candidates[0]
-				target := projectProcedureKey(candidate.File, candidate.QualifiedName, candidate.Kind, candidate.Line)
-				view.reverse[target] = appendUniqueString(view.reverse[target], key)
-			}
+		states, keys := buildProjectProcedureStates(document, lookup, nil, false, performance, class)
+		fileKey := symbolFileKey(document.IR.Path)
+		moduleKey := projectModuleDependencyKey(document.IR.Path)
+		view.procedures[moduleKey] = projectModuleState(document)
+		view.files[fileKey] = projectFileState{
+			version: document.Version, procedureKeys: keys,
+			moduleKey: moduleKey,
+			module:    document.ProcedureCatalog.ModuleContextHash, conditional: document.ProcedureCatalog.ConditionalHash,
+			catalogSafe: projectProcedureCatalogUsable(document),
+		}
+		for key, state := range states {
+			installProjectProcedureState(&view, key, state, nil, performance, class)
 		}
 	}
 	return view
 }
 
-func projectProcedureKey(file, qualifiedName, kind string, line int) string {
-	return strings.Join([]string{
-		strings.ToLower(filepath.ToSlash(filepath.Clean(file))),
-		strings.ToLower(strings.TrimSpace(qualifiedName)), strings.ToLower(strings.TrimSpace(kind)),
-		decimalString(line),
-	}, "\x00")
+func projectModuleState(document intel.ProjectAnalysisDocument) projectProcedureState {
+	fingerprint := projectProcedureFingerprint{
+		module:      document.ProcedureCatalog.ModuleContextHash,
+		conditional: document.ProcedureCatalog.ConditionalHash,
+	}
+	if !projectProcedureCatalogUsable(document) && len(document.IR.Declarations) > 0 {
+		hasher := sha256.New()
+		writeFingerprintText(hasher, document.Version, document.IR.Path, document.IR.ModuleName, document.IR.ModuleKind)
+		for _, declaration := range document.IR.Declarations {
+			writeFingerprintText(hasher, declaration.Name, declaration.Type, declaration.Visibility, declaration.Kind, declaration.Parent,
+				decimalString(declaration.Range.StartLine), decimalString(declaration.Range.StartColumn), decimalString(declaration.Range.EndLine), decimalString(declaration.Range.EndColumn))
+		}
+		copy(fingerprint.fallback[:], hasher.Sum(nil))
+	}
+	return projectProcedureState{file: document.IR.Path, fingerprint: fingerprint}
 }
 
-func appendUniqueString(values []string, value string) []string {
-	for _, current := range values {
-		if current == value {
-			return values
+func newProjectDependencyView() projectDependencyView {
+	view := projectDependencyView{
+		procedures: make(map[string]projectProcedureState),
+		reverse:    make(map[string]map[string]struct{}),
+		files:      make(map[string]projectFileState),
+		lookup:     projectProcedureLookup{byQualified: make(map[string][]projectProcedureLookupEntry)},
+	}
+	view.procedures[projectDependencyRootKey] = projectProcedureState{}
+	return view
+}
+
+type projectProcedureLookupEntry struct {
+	key  string
+	file string
+	line int
+}
+
+type projectProcedureLookup struct {
+	byQualified map[string][]projectProcedureLookupEntry
+}
+
+func newProjectProcedureLookup(snapshot intel.ProjectAnalysisSnapshot) projectProcedureLookup {
+	lookup := projectProcedureLookup{byQualified: make(map[string][]projectProcedureLookupEntry)}
+	for _, document := range snapshot.Documents {
+		moduleKey := projectModuleDependencyKey(document.IR.Path)
+		catalog := document.ProcedureCatalog
+		for index, procedure := range document.IR.Procedures {
+			identity := projectProcedureIdentity(catalog, index, procedure)
+			key := projectProcedureIdentityKey(document.IR.Path, identity)
+			line := procedure.Symbol.DeclarationRange.StartLine
+			if index < len(catalog.Entries) {
+				line = catalog.Entries[index].Range.Start.Line + 1
+			}
+			qualified := projectQualifiedKey(procedure.Symbol.QualifiedName, string(procedure.Symbol.Kind))
+			lookup.byQualified[qualified] = append(lookup.byQualified[qualified], projectProcedureLookupEntry{key: key, file: document.IR.Path, line: line})
+		}
+		for _, declaration := range document.IR.Declarations {
+			qualifiedName := declaration.Name
+			if document.IR.ModuleName != "" {
+				qualifiedName = document.IR.ModuleName + "." + declaration.Name
+			}
+			entry := projectProcedureLookupEntry{key: moduleKey, file: document.IR.Path, line: declaration.Range.StartLine}
+			lookup.byQualified[projectQualifiedKey(qualifiedName, declaration.Kind)] = append(lookup.byQualified[projectQualifiedKey(qualifiedName, declaration.Kind)], entry)
+			if declaration.Parent != "" && document.IR.ModuleName != "" {
+				qualifiedWithParent := document.IR.ModuleName + "." + declaration.Parent + "." + declaration.Name
+				lookup.byQualified[projectQualifiedKey(qualifiedWithParent, declaration.Kind)] = append(lookup.byQualified[projectQualifiedKey(qualifiedWithParent, declaration.Kind)], entry)
+			}
 		}
 	}
-	return append(values, value)
+	return lookup
+}
+
+func buildProjectProcedureStates(document intel.ProjectAnalysisDocument, lookup projectProcedureLookup, oldStates map[string]projectProcedureState, reuseUnchanged bool, performance *performanceRecorder, class string) (map[string]projectProcedureState, []string) {
+	states := make(map[string]projectProcedureState, len(document.IR.Procedures))
+	keys := make([]string, 0, len(document.IR.Procedures))
+	catalog := document.ProcedureCatalog
+	catalogSafe := projectProcedureCatalogUsable(document)
+	for index, sourceProcedure := range document.IR.Procedures {
+		identity := projectProcedureIdentity(catalog, index, sourceProcedure)
+		key := projectProcedureIdentityKey(document.IR.Path, identity)
+		fingerprint := projectProcedureFingerprintFor(catalog, index, sourceProcedure)
+		if reuseUnchanged && catalogSafe {
+			if previous, ok := oldStates[key]; ok && previous.fingerprint == fingerprint {
+				states[key] = previous
+				keys = append(keys, key)
+				performance.addCounter(performanceCounterProcedureFingerprintReuses, 1, "workspace/project", performanceStageDependencyUpdate, class, document.IR.Path)
+				continue
+			}
+		}
+		procedure := sourceProcedure
+		if resolved, ok := document.Resolution.ResolvedProcedure(index); ok {
+			procedure = resolved
+		}
+		callees, resolution, uncertain := projectProcedureDependencies(procedure, lookup)
+		if uncertain {
+			callees[projectDependencyRootKey] = struct{}{}
+		}
+		states[key] = projectProcedureState{file: document.IR.Path, fingerprint: fingerprint, callees: callees, resolution: resolution, uncertain: uncertain}
+		keys = append(keys, key)
+		performance.addCounter(performanceCounterProcedureFingerprintBuilds, 1, "workspace/project", performanceStageDependencyUpdate, class, document.IR.Path)
+		performance.addCounter(performanceCounterProceduresRevisited, 1, "workspace/project", performanceStageDependencyUpdate, class, document.IR.Path)
+	}
+	return states, keys
+}
+
+func projectProcedureIdentity(catalog intel.ProcedureCatalog, index int, procedure procedureir.ProcedureIR) intel.ProcedureIdentity {
+	if index < len(catalog.Entries) && projectCatalogEntryMatches(catalog.Entries[index], procedure) {
+		return catalog.Entries[index].Identity
+	}
+	name := strings.ToLower(strings.TrimSpace(procedure.Symbol.QualifiedName))
+	if name == "" {
+		name = strings.ToLower(strings.TrimSpace(procedure.Symbol.Name))
+	}
+	return intel.ProcedureIdentity{CanonicalName: name, Kind: strings.ToLower(strings.TrimSpace(string(procedure.Symbol.Kind))), Ordinal: index}
+}
+
+func projectProcedureIdentityKey(file string, identity intel.ProcedureIdentity) string {
+	return strings.Join([]string{symbolFileKey(file), strings.ToLower(strings.TrimSpace(identity.CanonicalName)), strings.ToLower(strings.TrimSpace(identity.Kind)), decimalString(identity.Ordinal)}, "\x00")
+}
+
+func projectProcedureFingerprintFor(catalog intel.ProcedureCatalog, index int, procedure procedureir.ProcedureIR) projectProcedureFingerprint {
+	if index < len(catalog.Entries) && projectCatalogEntryMatches(catalog.Entries[index], procedure) {
+		entry := catalog.Entries[index]
+		return projectProcedureFingerprint{source: entry.SourceHash, signature: entry.SignatureHash, module: catalog.ModuleContextHash, conditional: catalog.ConditionalHash}
+	}
+	// Compatibility callers may construct snapshots by hand without the
+	// document-owned catalog. The normal LSP path always takes the branch above.
+	hasher := sha256.New()
+	writeFingerprintText(hasher, procedure.Symbol.QualifiedName, string(procedure.Symbol.Kind), procedure.Symbol.Name)
+	for _, statement := range procedure.Statements {
+		writeFingerprintText(hasher, string(statement.Kind), statement.Text, decimalString(statement.ID), decimalString(statement.Range.StartLine), decimalString(statement.Range.EndLine))
+	}
+	var fallback [sha256.Size]byte
+	copy(fallback[:], hasher.Sum(nil))
+	return projectProcedureFingerprint{fallback: fallback}
+}
+
+// projectProcedureCatalogUsable is the guard for catalog-based reuse.  A
+// catalog is only authoritative when analysis marked it reusable and supplied
+// one entry for every IR procedure with a matching identity.  Otherwise the
+// dependency index rebuilds the affected project boundary conservatively.
+func projectProcedureCatalogUsable(document intel.ProjectAnalysisDocument) bool {
+	catalog := document.ProcedureCatalog
+	if !catalog.ReuseSafe || len(catalog.Entries) != len(document.IR.Procedures) {
+		return false
+	}
+	var zeroHash [sha256.Size]byte
+	if catalog.ModuleContextHash == zeroHash || catalog.ConditionalHash == zeroHash {
+		return false
+	}
+	identityCounts := make(map[string]int, len(catalog.Entries))
+	for _, entry := range catalog.Entries {
+		key := strings.ToLower(strings.TrimSpace(entry.Identity.CanonicalName)) + "\x00" + strings.ToLower(strings.TrimSpace(entry.Identity.Kind))
+		identityCounts[key]++
+	}
+	identityOrdinals := make(map[string]int, len(identityCounts))
+	for index, procedure := range document.IR.Procedures {
+		entry := catalog.Entries[index]
+		if entry.SourceHash == zeroHash || entry.SignatureHash == zeroHash || !projectCatalogEntryMatches(entry, procedure) {
+			return false
+		}
+		key := strings.ToLower(strings.TrimSpace(entry.Identity.CanonicalName)) + "\x00" + strings.ToLower(strings.TrimSpace(entry.Identity.Kind))
+		if identityCounts[key] > 1 && entry.Identity.Ordinal != identityOrdinals[key] {
+			return false
+		}
+		identityOrdinals[key]++
+	}
+	return true
+}
+
+func projectCatalogEntryMatches(entry intel.ProcedureCatalogEntry, procedure procedureir.ProcedureIR) bool {
+	canonical := strings.ToLower(strings.TrimSpace(entry.Identity.CanonicalName))
+	if canonical == "" || entry.Identity.Ordinal < 0 {
+		return false
+	}
+	name := strings.ToLower(strings.TrimSpace(procedure.Symbol.Name))
+	qualified := strings.ToLower(strings.TrimSpace(procedure.Symbol.QualifiedName))
+	if name == "" && qualified != "" {
+		name = qualified
+		if dot := strings.LastIndexByte(name, '.'); dot >= 0 {
+			name = name[dot+1:]
+		}
+	}
+	if canonical != name && canonical != qualified && !strings.HasSuffix(qualified, "."+canonical) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(entry.Identity.Kind), strings.TrimSpace(string(procedure.Symbol.Kind)))
+}
+
+func projectProcedureDependencies(procedure procedureir.ProcedureIR, lookup projectProcedureLookup) (map[string]struct{}, string, bool) {
+	callees := make(map[string]struct{})
+	var resolution strings.Builder
+	uncertain := procedure.Symbol.Recovered || len(procedure.Symbol.ConditionalBranches) != 0
+	for _, declaration := range procedure.Declarations {
+		if declaration.Recovered || len(declaration.ConditionalBranches) != 0 {
+			uncertain = true
+			break
+		}
+	}
+	for _, call := range procedure.Calls {
+		resolution.WriteString(strings.ToLower(string(call.Resolution.Status)))
+		resolution.WriteByte(':')
+		for _, candidate := range call.Resolution.Candidates {
+			key, ok := lookupCandidate(lookup, candidate)
+			if ok {
+				callees[key] = struct{}{}
+				resolution.WriteString(key)
+			} else {
+				resolution.WriteString(strings.ToLower(candidate.QualifiedName))
+				uncertain = true
+			}
+			resolution.WriteByte(';')
+		}
+		resolution.WriteByte('|')
+		switch call.Resolution.Status {
+		case procedureir.ResolutionAmbiguous, procedureir.ResolutionDynamic, procedureir.ResolutionIncomplete, procedureir.ResolutionNotAttempted:
+			uncertain = true
+		case procedureir.ResolutionUnresolved:
+			uncertain = uncertain || call.Resolution.ProjectLocal
+		case "":
+			uncertain = true
+		}
+	}
+	for _, access := range procedure.Accesses {
+		resolution.WriteString("access:")
+		uncertain = appendProjectSymbolResolution(&resolution, access.Resolution, lookup, callees, uncertain)
+	}
+	for _, event := range procedure.RaiseEvents {
+		resolution.WriteString("event:")
+		uncertain = appendProjectSymbolResolution(&resolution, event.Resolution, lookup, callees, uncertain)
+	}
+	return callees, resolution.String(), uncertain
+}
+
+func appendProjectSymbolResolution(resolution *strings.Builder, fact procedureir.SymbolResolution, lookup projectProcedureLookup, callees map[string]struct{}, uncertain bool) bool {
+	resolution.WriteString(strings.ToLower(string(fact.Status)))
+	resolution.WriteByte(':')
+	for _, candidate := range fact.Candidates {
+		key, ok := lookupCandidate(lookup, candidate)
+		if ok {
+			callees[key] = struct{}{}
+			resolution.WriteString(key)
+		} else {
+			resolution.WriteString(strings.ToLower(candidate.QualifiedName))
+			uncertain = true
+		}
+		resolution.WriteByte(';')
+	}
+	resolution.WriteByte('|')
+	switch fact.Status {
+	case procedureir.ResolutionAmbiguous, procedureir.ResolutionDynamic, procedureir.ResolutionIncomplete, procedureir.ResolutionNotAttempted:
+		uncertain = true
+	case procedureir.ResolutionUnresolved:
+		uncertain = uncertain || fact.Scope == procedureir.ScopeProject || fact.Scope == procedureir.ScopeUnresolved
+	case "":
+		uncertain = true
+	}
+	return uncertain
+}
+
+func lookupCandidate(lookup projectProcedureLookup, candidate procedureir.Candidate) (string, bool) {
+	entries := lookup.byQualified[projectQualifiedKey(candidate.QualifiedName, candidate.Kind)]
+	if len(entries) == 1 {
+		return entries[0].key, true
+	}
+	if len(entries) == 0 {
+		return "", false
+	}
+	for _, entry := range entries {
+		if candidate.Line == entry.line && candidateFileMatches(candidate.File, entry.file) {
+			return entry.key, true
+		}
+	}
+	return "", false
+}
+
+func projectQualifiedKey(name, kind string) string {
+	return strings.ToLower(strings.TrimSpace(name)) + "\x00" + strings.ToLower(strings.TrimSpace(kind))
+}
+
+func candidateFileMatches(candidate, actual string) bool {
+	candidate = filepath.ToSlash(filepath.Clean(strings.TrimSpace(candidate)))
+	actual = filepath.ToSlash(filepath.Clean(strings.TrimSpace(actual)))
+	if candidate == actual {
+		return true
+	}
+	return strings.HasSuffix(actual, "/"+candidate) || strings.HasSuffix(candidate, "/"+actual)
+}
+
+func projectProcedureStateChanged(old, current projectProcedureState) bool {
+	if old.fingerprint != current.fingerprint || old.resolution != current.resolution || old.uncertain != current.uncertain {
+		return true
+	}
+	return !sameProjectStringSet(old.callees, current.callees)
+}
+
+func sameProjectStringSet(left, right map[string]struct{}) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key := range left {
+		if _, ok := right[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func installProjectProcedureState(view *projectDependencyView, key string, state projectProcedureState, old *projectProcedureState, performance *performanceRecorder, class string) {
+	if old != nil {
+		for callee := range old.callees {
+			if _, keep := state.callees[callee]; keep {
+				continue
+			}
+			if callers := view.reverse[callee]; callers != nil {
+				if _, present := callers[key]; present {
+					removeProjectReverse(view.reverse, callee, key)
+					performance.addCounter(performanceCounterDependencyEdgesUpdated, 1, "workspace/project", performanceStageDependencyUpdate, class, state.file)
+				}
+			}
+		}
+	}
+	view.procedures[key] = state
+	for callee := range state.callees {
+		if old != nil {
+			if _, existed := old.callees[callee]; existed {
+				// Keep an unchanged reverse edge in place. If the view was
+				// externally damaged, restore the missing posting below.
+				if callers := view.reverse[callee]; callers != nil {
+					if _, present := callers[key]; present {
+						continue
+					}
+				}
+			}
+		}
+		if view.reverse[callee] == nil {
+			view.reverse[callee] = make(map[string]struct{})
+		}
+		if _, exists := view.reverse[callee][key]; !exists {
+			view.reverse[callee][key] = struct{}{}
+			performance.addCounter(performanceCounterDependencyEdgesUpdated, 1, "workspace/project", performanceStageDependencyUpdate, class, state.file)
+		}
+	}
+}
+
+func removeProjectReverse(reverse map[string]map[string]struct{}, callee, caller string) {
+	callers := reverse[callee]
+	if callers == nil {
+		return
+	}
+	delete(callers, caller)
+	if len(callers) == 0 {
+		delete(reverse, callee)
+	}
+}
+
+func removeProjectProcedureState(view *projectDependencyView, key string, performance *performanceRecorder, class string) {
+	state, exists := view.procedures[key]
+	if !exists {
+		return
+	}
+	for callee := range state.callees {
+		if callers := view.reverse[callee]; callers != nil {
+			if _, present := callers[key]; present {
+				performance.addCounter(performanceCounterDependencyEdgesUpdated, 1, "workspace/project", performanceStageDependencyUpdate, class, state.file)
+			}
+		}
+		removeProjectReverse(view.reverse, callee, key)
+	}
+	delete(view.procedures, key)
+	performance.addCounter(performanceCounterDependencyNodesUpdated, 1, "workspace/project", performanceStageDependencyUpdate, class, state.file)
+}
+
+// updateProjectDependencyView updates only changed files unless a declaration
+// change can alter project resolution. All states may be revisited in that
+// case, but only changed nodes and edges are published to the graph.
+func updateProjectDependencyView(view *projectDependencyView, snapshot intel.ProjectAnalysisSnapshot, performance *performanceRecorder, class string) []string {
+	lookup := view.lookup
+	currentDocuments := make(map[string]int, len(snapshot.Documents))
+	currentCatalogSafe := make(map[string]bool, len(snapshot.Documents))
+	for index, document := range snapshot.Documents {
+		fileKey := symbolFileKey(document.IR.Path)
+		currentDocuments[fileKey] = index
+		currentCatalogSafe[fileKey] = projectProcedureCatalogUsable(document)
+	}
+	changedFiles := make(map[string]bool)
+	resolutionRefresh := false
+	for fileKey, oldFile := range view.files {
+		index, exists := currentDocuments[fileKey]
+		if !exists {
+			changedFiles[fileKey] = true
+			resolutionRefresh = true
+			continue
+		}
+		document := snapshot.Documents[index]
+		if projectFileChanged(view, document, fileKey, oldFile, currentCatalogSafe[fileKey]) {
+			changedFiles[fileKey] = true
+		}
+		if !oldFile.catalogSafe || !currentCatalogSafe[fileKey] {
+			resolutionRefresh = true
+		}
+		if oldFile.module != document.ProcedureCatalog.ModuleContextHash || oldFile.conditional != document.ProcedureCatalog.ConditionalHash || (oldFile.version != document.Version && len(document.IR.Procedures) == 0) {
+			resolutionRefresh = true
+		}
+	}
+	for fileKey, index := range currentDocuments {
+		if _, exists := view.files[fileKey]; !exists {
+			changedFiles[fileKey] = true
+			resolutionRefresh = true
+			continue
+		}
+		if projectFileChanged(view, snapshot.Documents[index], fileKey, view.files[fileKey], currentCatalogSafe[fileKey]) {
+			changedFiles[fileKey] = true
+		}
+		if !view.files[fileKey].catalogSafe || !currentCatalogSafe[fileKey] {
+			resolutionRefresh = true
+		}
+		if view.files[fileKey].module != snapshot.Documents[index].ProcedureCatalog.ModuleContextHash || view.files[fileKey].conditional != snapshot.Documents[index].ProcedureCatalog.ConditionalHash || (view.files[fileKey].version != snapshot.Documents[index].Version && len(snapshot.Documents[index].IR.Procedures) == 0) {
+			resolutionRefresh = true
+		}
+	}
+	for fileKey := range changedFiles {
+		index, exists := currentDocuments[fileKey]
+		if exists && documentNeedsResolutionRefresh(view, snapshot.Documents[index], fileKey, currentCatalogSafe[fileKey]) {
+			resolutionRefresh = true
+		}
+	}
+	if resolutionRefresh {
+		lookup = newProjectProcedureLookup(snapshot)
+		view.lookup = lookup
+		for index := range snapshot.Documents {
+			changedFiles[symbolFileKey(snapshot.Documents[index].IR.Path)] = true
+		}
+	}
+	for fileKey, oldFile := range view.files {
+		if changedFiles[fileKey] {
+			continue
+		}
+		performance.addCounter(performanceCounterProcedureFingerprintReuses, uint64(len(oldFile.procedureKeys)), "workspace/project", performanceStageDependencyUpdate, class, "")
+	}
+
+	newStates := make(map[string]map[string]projectProcedureState, len(changedFiles))
+	newKeys := make(map[string][]string, len(changedFiles))
+	for fileKey := range changedFiles {
+		index, exists := currentDocuments[fileKey]
+		if !exists {
+			continue
+		}
+		oldStates := make(map[string]projectProcedureState, len(view.files[fileKey].procedureKeys))
+		for _, key := range view.files[fileKey].procedureKeys {
+			if state, ok := view.procedures[key]; ok {
+				oldStates[key] = state
+			}
+		}
+		states, keys := buildProjectProcedureStates(snapshot.Documents[index], lookup, oldStates, !resolutionRefresh, performance, class)
+		newStates[fileKey], newKeys[fileKey] = states, keys
+	}
+
+	changed := make(map[string]bool)
+	oldReverse := make(map[string]map[string]struct{})
+	for fileKey := range changedFiles {
+		oldFile := view.files[fileKey]
+		oldModuleKey := oldFile.moduleKey
+		if oldModuleKey == "" {
+			oldModuleKey = projectModuleDependencyKey(fileKey)
+		}
+		if oldModule, exists := view.procedures[oldModuleKey]; exists {
+			if index, currentExists := currentDocuments[fileKey]; currentExists {
+				currentDocument := snapshot.Documents[index]
+				currentModuleKey := projectModuleDependencyKey(currentDocument.IR.Path)
+				currentModule := projectModuleState(currentDocument)
+				if oldModuleKey != currentModuleKey {
+					changed[oldModuleKey] = true
+					oldReverse[oldModuleKey] = cloneProjectCallers(view.reverse[oldModuleKey])
+					changed[currentModuleKey] = true
+					oldReverse[currentModuleKey] = cloneProjectCallers(view.reverse[currentModuleKey])
+				} else if projectProcedureStateChanged(oldModule, currentModule) {
+					changed[oldModuleKey] = true
+					oldReverse[oldModuleKey] = cloneProjectCallers(view.reverse[oldModuleKey])
+				}
+			} else {
+				changed[oldModuleKey] = true
+				oldReverse[oldModuleKey] = cloneProjectCallers(view.reverse[oldModuleKey])
+			}
+		} else if index, currentExists := currentDocuments[fileKey]; currentExists {
+			currentModuleKey := projectModuleDependencyKey(snapshot.Documents[index].IR.Path)
+			changed[currentModuleKey] = true
+			oldReverse[currentModuleKey] = cloneProjectCallers(view.reverse[currentModuleKey])
+		}
+		for _, key := range oldFile.procedureKeys {
+			if state, ok := view.procedures[key]; ok {
+				if current, stillPresent := newStates[fileKey][key]; !stillPresent || projectProcedureStateChanged(state, current) {
+					changed[key] = true
+					oldReverse[key] = cloneProjectCallers(view.reverse[key])
+				}
+			}
+		}
+		for key := range newStates[fileKey] {
+			if _, exists := view.procedures[key]; !exists {
+				changed[key] = true
+				oldReverse[key] = cloneProjectCallers(view.reverse[key])
+			}
+		}
+	}
+	if projectDependencyViewHasUncertainty(*view) || projectStatesHaveUncertainty(newStates) {
+		changed[projectDependencyRootKey] = true
+		oldReverse[projectDependencyRootKey] = cloneProjectCallers(view.reverse[projectDependencyRootKey])
+	}
+	impactFiles := make(map[string]string)
+	for key := range changed {
+		if state, ok := view.procedures[key]; ok {
+			if state.file != "" {
+				impactFiles[symbolFileKey(state.file)] = state.file
+			}
+		}
+	}
+	for _, callers := range oldReverse {
+		for caller := range callers {
+			if state, ok := view.procedures[caller]; ok {
+				if state.file != "" {
+					impactFiles[symbolFileKey(state.file)] = state.file
+				}
+			}
+		}
+	}
+	for fileKey := range changedFiles {
+		oldFile := view.files[fileKey]
+		oldModuleKey := oldFile.moduleKey
+		if oldModuleKey == "" {
+			oldModuleKey = projectModuleDependencyKey(fileKey)
+		}
+		for _, key := range oldFile.procedureKeys {
+			if _, exists := newStates[fileKey][key]; exists {
+				continue
+			}
+			removeProjectProcedureState(view, key, performance, class)
+		}
+		if _, exists := currentDocuments[fileKey]; !exists {
+			removeProjectProcedureState(view, oldModuleKey, performance, class)
+		}
+		if index, exists := currentDocuments[fileKey]; exists {
+			currentDocument := snapshot.Documents[index]
+			currentModuleKey := projectModuleDependencyKey(currentDocument.IR.Path)
+			if oldModuleKey != currentModuleKey {
+				removeProjectProcedureState(view, oldModuleKey, performance, class)
+			}
+			moduleState := projectModuleState(currentDocument)
+			oldModule, hadOldModule := view.procedures[currentModuleKey]
+			if !hadOldModule || projectProcedureStateChanged(oldModule, moduleState) {
+				if hadOldModule {
+					installProjectProcedureState(view, currentModuleKey, moduleState, &oldModule, performance, class)
+				} else {
+					installProjectProcedureState(view, currentModuleKey, moduleState, nil, performance, class)
+				}
+				performance.addCounter(performanceCounterDependencyNodesUpdated, 1, "workspace/project", performanceStageDependencyUpdate, class, currentDocument.IR.Path)
+			}
+			for key, state := range newStates[fileKey] {
+				old, hadOld := view.procedures[key]
+				if !hadOld || projectProcedureStateChanged(old, state) {
+					if hadOld {
+						installProjectProcedureState(view, key, state, &old, performance, class)
+					} else {
+						installProjectProcedureState(view, key, state, nil, performance, class)
+					}
+					performance.addCounter(performanceCounterDependencyNodesUpdated, 1, "workspace/project", performanceStageDependencyUpdate, class, snapshot.Documents[index].IR.Path)
+				}
+			}
+			view.files[fileKey] = projectFileState{
+				version: currentDocument.Version, procedureKeys: newKeys[fileKey], moduleKey: currentModuleKey,
+				module: currentDocument.ProcedureCatalog.ModuleContextHash, conditional: currentDocument.ProcedureCatalog.ConditionalHash,
+				catalogSafe: currentCatalogSafe[fileKey],
+			}
+		} else {
+			delete(view.files, fileKey)
+		}
+	}
+
+	return projectImpactPathsFromIncrementalView(view, changed, oldReverse, impactFiles)
+}
+
+func projectFileChanged(view *projectDependencyView, document intel.ProjectAnalysisDocument, fileKey string, oldFile projectFileState, catalogSafe bool) bool {
+	if !oldFile.catalogSafe || !catalogSafe {
+		return true
+	}
+	if oldFile.version != document.Version || oldFile.module != document.ProcedureCatalog.ModuleContextHash || oldFile.conditional != document.ProcedureCatalog.ConditionalHash {
+		return true
+	}
+	// Hand-built compatibility snapshots may not carry a publication version.
+	// Compare their canonical procedure fields so a changed body is still
+	// detected without falling back to whole-IR serialization.
+	if document.Version == "" {
+		return documentHasProcedureChanges(view, document, fileKey)
+	}
+	return false
+}
+
+func documentHasProcedureChanges(view *projectDependencyView, document intel.ProjectAnalysisDocument, fileKey string) bool {
+	oldByKey := make(map[string]projectProcedureState, len(view.files[fileKey].procedureKeys))
+	for _, key := range view.files[fileKey].procedureKeys {
+		oldByKey[key] = view.procedures[key]
+	}
+	for index, procedure := range document.IR.Procedures {
+		identity := projectProcedureIdentity(document.ProcedureCatalog, index, procedure)
+		key := projectProcedureIdentityKey(document.IR.Path, identity)
+		old, ok := oldByKey[key]
+		if !ok || old.fingerprint != projectProcedureFingerprintFor(document.ProcedureCatalog, index, procedure) {
+			return true
+		}
+		delete(oldByKey, key)
+	}
+	return len(oldByKey) != 0
+}
+
+func projectImpactPathsFromIncrementalView(view *projectDependencyView, changed map[string]bool, oldReverse map[string]map[string]struct{}, impactFiles map[string]string) []string {
+	queue := make([]string, 0, len(changed))
+	for key := range changed {
+		queue = append(queue, key)
+	}
+	seen := make(map[string]bool, len(changed))
+	files := make(map[string]string, len(impactFiles))
+	for key, file := range impactFiles {
+		files[key] = file
+	}
+	for key := range changed {
+		if state, ok := view.procedures[key]; ok {
+			if state.file != "" {
+				files[symbolFileKey(state.file)] = state.file
+			}
+		}
+	}
+	for len(queue) > 0 {
+		callee := queue[0]
+		queue = queue[1:]
+		if seen[callee] {
+			continue
+		}
+		seen[callee] = true
+		callers := make(map[string]struct{}, len(oldReverse[callee])+len(view.reverse[callee]))
+		for caller := range oldReverse[callee] {
+			callers[caller] = struct{}{}
+		}
+		for caller := range view.reverse[callee] {
+			callers[caller] = struct{}{}
+		}
+		for caller := range callers {
+			if state, ok := view.procedures[caller]; ok {
+				if state.file != "" {
+					files[symbolFileKey(state.file)] = state.file
+				}
+			}
+			if !seen[caller] {
+				queue = append(queue, caller)
+			}
+		}
+	}
+	out := make([]string, 0, len(files))
+	for _, file := range files {
+		out = append(out, file)
+	}
+	sort.Slice(out, func(i, j int) bool { return symbolFileKey(out[i]) < symbolFileKey(out[j]) })
+	return out
+}
+
+func documentNeedsResolutionRefresh(view *projectDependencyView, document intel.ProjectAnalysisDocument, fileKey string, catalogSafe bool) bool {
+	if !view.files[fileKey].catalogSafe || !catalogSafe {
+		return true
+	}
+	oldKeys := view.files[fileKey].procedureKeys
+	oldByIdentity := make(map[string]projectProcedureState, len(oldKeys))
+	for _, key := range oldKeys {
+		oldByIdentity[key] = view.procedures[key]
+	}
+	for index, procedure := range document.IR.Procedures {
+		identity := projectProcedureIdentity(document.ProcedureCatalog, index, procedure)
+		key := projectProcedureIdentityKey(document.IR.Path, identity)
+		old, exists := oldByIdentity[key]
+		current := projectProcedureFingerprintFor(document.ProcedureCatalog, index, procedure)
+		if !exists || old.fingerprint.signature != current.signature || old.fingerprint.module != current.module || old.fingerprint.conditional != current.conditional {
+			return true
+		}
+		delete(oldByIdentity, key)
+	}
+	return len(oldByIdentity) != 0
+}
+
+func cloneProjectCallers(callers map[string]struct{}) map[string]struct{} {
+	clone := make(map[string]struct{}, len(callers))
+	for caller := range callers {
+		clone[caller] = struct{}{}
+	}
+	return clone
+}
+
+func writeFingerprintText(hasher interface{ Write([]byte) (int, error) }, values ...string) {
+	for _, value := range values {
+		_, _ = hasher.Write([]byte(value))
+		_, _ = hasher.Write([]byte{'\x00'})
+	}
 }
 
 func decimalString(value int) string {
@@ -145,4 +892,9 @@ func decimalString(value int) string {
 		value /= 10
 	}
 	return string(digits[i:])
+}
+
+func cloneProcedureCatalog(catalog intel.ProcedureCatalog) intel.ProcedureCatalog {
+	catalog.Entries = append([]intel.ProcedureCatalogEntry(nil), catalog.Entries...)
+	return catalog
 }

--- a/internal/lspserver/workspace_project_analysis_test.go
+++ b/internal/lspserver/workspace_project_analysis_test.go
@@ -2,7 +2,10 @@ package lspserver
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"io"
+	"log"
 	"path/filepath"
 	"testing"
 
@@ -43,6 +46,403 @@ func TestProjectImpactPathsUsesOldAndNewReverseGraphsTransitively(t *testing.T) 
 	if containsPath(got, d) {
 		t.Fatalf("impact paths = %#v, unrelated path %q was invalidated", got, d)
 	}
+}
+
+func TestIncrementalProjectDependencyViewReusesUnchangedProcedures(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "A.bas")
+	b := filepath.Join(root, "B.bas")
+	c := filepath.Join(root, "C.bas")
+
+	before := projectTestSnapshot(
+		projectTestProcedure(a, "A.Run", "B.Work", b, 1, "Run"),
+		projectTestProcedure(b, "B.Work", "C.Leaf", c, 1, "Work"),
+		projectTestProcedure(c, "C.Leaf", "", "", 1, "old"),
+	)
+	for i := range before.Documents {
+		before.Documents[i].Version = "v1"
+	}
+	view := buildProjectDependencyViewWithPerformanceClass(before, nil, "background")
+	view.revision = 1
+
+	after := projectTestSnapshot(
+		projectTestProcedure(a, "A.Run", "B.Work", b, 1, "Run"),
+		projectTestProcedure(b, "B.Work", "C.Leaf", c, 1, "Work"),
+		projectTestProcedure(c, "C.Leaf", "", "", 1, "new"),
+	)
+	for i := range after.Documents {
+		after.Documents[i].Version = "v1"
+	}
+	after.Documents[2].Version = "v2"
+	recorder := newPerformanceRecorder(true, log.New(io.Discard, "", 0))
+	impacted := updateProjectDependencyView(&view, after, recorder, "background")
+	if got := recorder.counterTotal(performanceCounterProcedureFingerprintBuilds); got != 1 {
+		t.Fatalf("fingerprint builds = %d, want only changed procedure", got)
+	}
+	if got := recorder.counterTotal(performanceCounterProcedureFingerprintReuses); got != 2 {
+		t.Fatalf("fingerprint reuses = %d, want unchanged procedures", got)
+	}
+	if got := recorder.counterTotal(performanceCounterDependencyNodesUpdated); got != 1 {
+		t.Fatalf("dependency nodes updated = %d, want changed procedure", got)
+	}
+	if !containsPath(impacted, a) || !containsPath(impacted, b) || !containsPath(impacted, c) {
+		t.Fatalf("incremental impact paths = %#v, want caller closure", impacted)
+	}
+}
+
+func TestIncrementalProjectDependencyViewPreservesUnchangedEdges(t *testing.T) {
+	root := t.TempDir()
+	caller := filepath.Join(root, "Caller.bas")
+	callee := filepath.Join(root, "Callee.bas")
+	before := projectTestSnapshot(
+		projectTestProcedure(caller, "Caller.Run", "Callee.Work", callee, 1, "old"),
+		projectTestProcedure(callee, "Callee.Work", "", "", 1, "Work"),
+	)
+	for i := range before.Documents {
+		before.Documents[i].Version = "v1"
+	}
+	view := buildProjectDependencyViewWithPerformanceClass(before, nil, "background")
+	after := projectTestSnapshot(
+		projectTestProcedure(caller, "Caller.Run", "Callee.Work", callee, 1, "new"),
+		projectTestProcedure(callee, "Callee.Work", "", "", 1, "Work"),
+	)
+	for i := range after.Documents {
+		after.Documents[i].Version = "v1"
+	}
+	after.Documents[0].Version = "v2"
+	recorder := newPerformanceRecorder(true, log.New(io.Discard, "", 0))
+	updateProjectDependencyView(&view, after, recorder, "background")
+	if got := recorder.counterTotal(performanceCounterDependencyEdgesUpdated); got != 0 {
+		t.Fatalf("unchanged dependency edges updated = %d, want 0", got)
+	}
+}
+
+func TestIncrementalProjectDependencyViewCountsDeletedProcedureEdges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Main.bas")
+	first := projectTestProcedure(path, "Main.First", "", "", 1, "First").procedure
+	second := projectTestProcedure(path, "Main.Second", "Main.First", path, 1, "Second").procedure
+	beforeIR := procedureir.DocumentIR{Path: path, ModuleName: "Main", ModuleKind: "standard", Procedures: []procedureir.ProcedureIR{first, second}}
+	before := intel.ProjectAnalysisSnapshot{Complete: true, Documents: []intel.ProjectAnalysisDocument{{
+		IR: beforeIR, Version: "v1", CFG: vbacfg.BuildDocument(beforeIR), ProcedureCatalog: projectTestProcedureCatalog(beforeIR.Procedures),
+	}}}
+	view := buildProjectDependencyViewWithPerformanceClass(before, nil, "background")
+	afterIR := procedureir.DocumentIR{Path: path, ModuleName: "Main", ModuleKind: "standard", Procedures: []procedureir.ProcedureIR{first}}
+	after := intel.ProjectAnalysisSnapshot{Complete: true, Documents: []intel.ProjectAnalysisDocument{{
+		IR: afterIR, Version: "v2", CFG: vbacfg.BuildDocument(afterIR), ProcedureCatalog: projectTestProcedureCatalog(afterIR.Procedures),
+	}}}
+	recorder := newPerformanceRecorder(true, log.New(io.Discard, "", 0))
+	updateProjectDependencyView(&view, after, recorder, "background")
+	if got := recorder.counterTotal(performanceCounterDependencyNodesUpdated); got != 1 {
+		t.Fatalf("deleted dependency nodes updated = %d, want 1", got)
+	}
+	if got := recorder.counterTotal(performanceCounterDependencyEdgesUpdated); got != 1 {
+		t.Fatalf("deleted dependency edges updated = %d, want 1", got)
+	}
+}
+
+func TestIncrementalProjectDependencyViewDoesNotReuseUnsafeCatalog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Main.bas")
+	procedure := projectTestProcedure(path, "Main.Run", "", "", 1, "Run").procedure
+	ir := procedureir.DocumentIR{Path: path, ModuleName: "Main", ModuleKind: "standard", Procedures: []procedureir.ProcedureIR{procedure}}
+	unsafeCatalog := projectTestProcedureCatalog(ir.Procedures)
+	unsafeCatalog.ReuseSafe = false
+	snapshot := intel.ProjectAnalysisSnapshot{Complete: true, Documents: []intel.ProjectAnalysisDocument{{
+		IR: ir, Version: "v1", CFG: vbacfg.BuildDocument(ir), ProcedureCatalog: unsafeCatalog,
+	}}}
+	view := buildProjectDependencyViewWithPerformanceClass(snapshot, nil, "background")
+	recorder := newPerformanceRecorder(true, log.New(io.Discard, "", 0))
+	updateProjectDependencyView(&view, snapshot, recorder, "background")
+	if got := recorder.counterTotal(performanceCounterProcedureFingerprintReuses); got != 0 {
+		t.Fatalf("unsafe catalog fingerprint reuses = %d, want 0", got)
+	}
+	if got := recorder.counterTotal(performanceCounterProcedureFingerprintBuilds); got != 1 {
+		t.Fatalf("unsafe catalog fingerprint builds = %d, want 1", got)
+	}
+}
+
+func TestIncrementalProjectDependencyViewIncludesDeletedFiles(t *testing.T) {
+	root := t.TempDir()
+	caller := filepath.Join(root, "Caller.bas")
+	callee := filepath.Join(root, "Callee.bas")
+	before := projectTestSnapshot(
+		projectTestProcedure(caller, "Caller.Run", "Callee.Work", callee, 1, "Run"),
+		projectTestProcedure(callee, "Callee.Work", "", "", 1, "Work"),
+	)
+	for i := range before.Documents {
+		before.Documents[i].Version = "v1"
+	}
+	view := buildProjectDependencyViewWithPerformanceClass(before, nil, "background")
+	view.revision = 1
+	after := projectTestSnapshot(projectTestProcedure(caller, "Caller.Run", "", "", 1, "Run"))
+	after.Documents[0].Version = "v2"
+
+	impacted := updateProjectDependencyView(&view, after, nil, "background")
+	if !containsPath(impacted, caller) || !containsPath(impacted, callee) {
+		t.Fatalf("deleted callee impact paths = %#v, want caller and deleted callee", impacted)
+	}
+}
+
+func TestProjectImpactPathsIncludesResolvedAccessChanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Main.bas")
+	makeSnapshot := func(target string) intel.ProjectAnalysisSnapshot {
+		procedure := procedureir.ProcedureIR{
+			Symbol: procedureir.ProcedureSymbol{Name: "Run", QualifiedName: "Main.Run", Kind: procedureir.ProcedureSub},
+			Accesses: []procedureir.VariableAccess{{
+				Name: "Value", Resolution: procedureir.SymbolResolution{Status: procedureir.ResolutionMatched, Candidates: []procedureir.Candidate{{QualifiedName: target, Kind: "enum_member"}}},
+			}},
+		}
+		ir := procedureir.DocumentIR{Path: path, ModuleName: "Main", ModuleKind: "standard", Procedures: []procedureir.ProcedureIR{procedure}}
+		return intel.ProjectAnalysisSnapshot{Complete: true, Documents: []intel.ProjectAnalysisDocument{{IR: ir, CFG: vbacfg.BuildDocument(ir)}}}
+	}
+	impacted := projectImpactPaths(makeSnapshot("Enums.First"), makeSnapshot("Enums.Second"))
+	if !containsPath(impacted, path) {
+		t.Fatalf("access resolution impact paths = %#v, want %q", impacted, path)
+	}
+}
+
+func TestProjectImpactPathsIncludesDeclarationModuleChanges(t *testing.T) {
+	root := t.TempDir()
+	callerPath := filepath.Join(root, "Caller.bas")
+	declarationPath := filepath.Join(root, "Enums.bas")
+	makeSnapshot := func(moduleHash byte) intel.ProjectAnalysisSnapshot {
+		callerProcedure := procedureir.ProcedureIR{
+			Symbol: procedureir.ProcedureSymbol{Name: "Run", QualifiedName: "Caller.Run", Kind: procedureir.ProcedureSub},
+			Accesses: []procedureir.VariableAccess{{
+				Name: "First", Resolution: procedureir.SymbolResolution{Status: procedureir.ResolutionMatched, Scope: procedureir.ScopeProject, Candidates: []procedureir.Candidate{{QualifiedName: "Enums.First", Kind: "enum_member", File: declarationPath, Line: 1}}},
+			}},
+		}
+		callerIR := procedureir.DocumentIR{Path: callerPath, ModuleName: "Caller", ModuleKind: "standard", Procedures: []procedureir.ProcedureIR{callerProcedure}}
+		declarationIR := procedureir.DocumentIR{Path: declarationPath, ModuleName: "Enums", ModuleKind: "standard", Declarations: []procedureir.Declaration{{Name: "First", Kind: "enum_member", Range: vbaast.Range{StartLine: 1}}}}
+		var contextHash [sha256.Size]byte
+		contextHash[0] = moduleHash
+		return intel.ProjectAnalysisSnapshot{Complete: true, Documents: []intel.ProjectAnalysisDocument{
+			{IR: callerIR, CFG: vbacfg.BuildDocument(callerIR)},
+			{IR: declarationIR, ProcedureCatalog: intel.ProcedureCatalog{ModuleContextHash: contextHash, ConditionalHash: sha256.Sum256([]byte("declaration-conditional")), ReuseSafe: true}, CFG: vbacfg.BuildDocument(declarationIR)},
+		}}
+	}
+	impacted := projectImpactPaths(makeSnapshot(1), makeSnapshot(2))
+	if !containsPath(impacted, callerPath) || !containsPath(impacted, declarationPath) {
+		t.Fatalf("declaration impact paths = %#v, want caller and declaration module", impacted)
+	}
+}
+
+func TestProjectImpactPathsFailsOpenForUncertainResolution(t *testing.T) {
+	root := t.TempDir()
+	callerPath := filepath.Join(root, "Caller.bas")
+	calleePath := filepath.Join(root, "Callee.bas")
+	makeSnapshot := func(text string) intel.ProjectAnalysisSnapshot {
+		caller := projectTestProcedure(callerPath, "Caller.Run", "", "", 1, "Run").procedure
+		caller.Calls = []procedureir.CallSite{{Resolution: procedureir.CallResolution{Status: procedureir.ResolutionDynamic}}}
+		callee := projectTestProcedure(calleePath, "Callee.Work", "", "", 1, text).procedure
+		return projectTestSnapshot(
+			projectTestProcedureInput{file: callerPath, procedure: caller},
+			projectTestProcedureInput{file: calleePath, procedure: callee},
+		)
+	}
+	impacted := projectImpactPaths(makeSnapshot("old"), makeSnapshot("new"))
+	if !containsPath(impacted, callerPath) {
+		t.Fatalf("uncertain resolution impact paths = %#v, want %q", impacted, callerPath)
+	}
+}
+
+func TestIncrementalProjectDependencyViewRefreshesForDeclarationOnlyModule(t *testing.T) {
+	root := t.TempDir()
+	callerPath := filepath.Join(root, "Caller.bas")
+	declarationPath := filepath.Join(root, "Enums.bas")
+	makeSnapshot := func(moduleHash byte, target string, declarationVersion string) intel.ProjectAnalysisSnapshot {
+		callerProcedure := procedureir.ProcedureIR{
+			Symbol: procedureir.ProcedureSymbol{Name: "Run", QualifiedName: "Caller.Run", Kind: procedureir.ProcedureSub},
+			Accesses: []procedureir.VariableAccess{{
+				Name: "Value", Resolution: procedureir.SymbolResolution{Status: procedureir.ResolutionMatched, Candidates: []procedureir.Candidate{{QualifiedName: target, Kind: "enum_member"}}},
+			}},
+		}
+		callerIR := procedureir.DocumentIR{Path: callerPath, ModuleName: "Caller", ModuleKind: "standard", Procedures: []procedureir.ProcedureIR{callerProcedure}}
+		declarationIR := procedureir.DocumentIR{Path: declarationPath, ModuleName: "Enums", ModuleKind: "standard"}
+		var contextHash [32]byte
+		contextHash[0] = moduleHash
+		return intel.ProjectAnalysisSnapshot{Complete: true, Documents: []intel.ProjectAnalysisDocument{
+			{IR: callerIR, Version: "v1", CFG: vbacfg.BuildDocument(callerIR)},
+			{IR: declarationIR, Version: declarationVersion, ProcedureCatalog: intel.ProcedureCatalog{ModuleContextHash: contextHash, ConditionalHash: sha256.Sum256([]byte("declaration-conditional")), ReuseSafe: true}, CFG: vbacfg.BuildDocument(declarationIR)},
+		}}
+	}
+	before := makeSnapshot(1, "Enums.First", "v1")
+	view := buildProjectDependencyViewWithPerformanceClass(before, nil, "background")
+	view.revision = 1
+	after := makeSnapshot(2, "Enums.Second", "v2")
+	impacted := updateProjectDependencyView(&view, after, nil, "background")
+	if !containsPath(impacted, callerPath) {
+		t.Fatalf("declaration-only module impact paths = %#v, want %q", impacted, callerPath)
+	}
+}
+
+func BenchmarkProjectDependencyIncrementalBodyEdit(b *testing.B) {
+	const procedureCount = 2000
+	before := largeProjectDependencyBenchmarkSnapshot(procedureCount, false)
+	after := largeProjectDependencyBenchmarkSnapshot(procedureCount, true)
+	benchmarkProjectDependencyUpdate(b, before, after)
+}
+
+func BenchmarkProjectDependencyIncrementalSignatureEdit(b *testing.B) {
+	before := largeProjectDependencyBenchmarkSnapshot(2000, false)
+	after := largeProjectDependencyBenchmarkSnapshot(2000, false)
+	after.Documents[0].Version = "v2"
+	after.Documents[0].ProcedureCatalog.Entries[1000].SignatureHash = sha256.Sum256([]byte("Private Sub"))
+	benchmarkProjectDependencyUpdate(b, before, after)
+}
+
+func BenchmarkProjectDependencyIncrementalHighFanIn(b *testing.B) {
+	before := highFanInProjectDependencyBenchmarkSnapshot(2000, false)
+	after := highFanInProjectDependencyBenchmarkSnapshot(2000, true)
+	benchmarkProjectDependencyUpdate(b, before, after)
+}
+
+func BenchmarkProjectDependencyIncrementalDeepCallChain(b *testing.B) {
+	before := deepCallChainProjectDependencyBenchmarkSnapshot(1000, false)
+	after := deepCallChainProjectDependencyBenchmarkSnapshot(1000, true)
+	benchmarkProjectDependencyUpdate(b, before, after)
+}
+
+func BenchmarkProjectDependencyIncrementalCallDeletion(b *testing.B) {
+	before := callChangeProjectDependencyBenchmarkSnapshot("Callee.Work", false)
+	after := callChangeProjectDependencyBenchmarkSnapshot("", true)
+	benchmarkProjectDependencyUpdate(b, before, after)
+}
+
+func BenchmarkProjectDependencyIncrementalCallTargetChange(b *testing.B) {
+	before := callChangeProjectDependencyBenchmarkSnapshot("Callee.First", false)
+	after := callChangeProjectDependencyBenchmarkSnapshot("Callee.Second", false)
+	after.Documents[0].Version = "v2"
+	benchmarkProjectDependencyUpdate(b, before, after)
+}
+
+// This synthetic 2k-procedure case is the default ROneCOne-scale dependency
+// update benchmark. The optional real-file ROneCOne fixture remains covered by
+// the existing opt-in LSP benchmark in issue491_benchmark_test.go.
+func BenchmarkProjectDependencyIncrementalROneCOneScale(b *testing.B) {
+	before := largeProjectDependencyBenchmarkSnapshot(2000, false)
+	after := largeProjectDependencyBenchmarkSnapshot(2000, true)
+	benchmarkProjectDependencyUpdate(b, before, after)
+}
+
+func benchmarkProjectDependencyUpdate(b *testing.B, before, after intel.ProjectAnalysisSnapshot) {
+	b.Helper()
+	base := buildProjectDependencyViewWithPerformanceClass(before, nil, "background")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		view := cloneProjectDependencyView(base)
+		b.StartTimer()
+		updateProjectDependencyView(&view, after, nil, "background")
+	}
+}
+
+func highFanInProjectDependencyBenchmarkSnapshot(count int, edited bool) intel.ProjectAnalysisSnapshot {
+	path := "FanIn.bas"
+	procedures := make([]procedureir.ProcedureIR, count)
+	procedures[0] = procedureir.ProcedureIR{
+		Symbol:     procedureir.ProcedureSymbol{Name: "Callee", QualifiedName: "FanIn.Callee", Kind: procedureir.ProcedureSub},
+		Statements: []procedureir.Statement{{ID: 1, Kind: procedureir.StatementCall, Text: map[bool]string{false: "same", true: "changed"}[edited]}},
+	}
+	for index := 1; index < count; index++ {
+		name := "Caller" + decimalString(index)
+		procedures[index] = procedureir.ProcedureIR{
+			Symbol:     procedureir.ProcedureSymbol{Name: name, QualifiedName: "FanIn." + name, Kind: procedureir.ProcedureSub},
+			Statements: []procedureir.Statement{{ID: index + 1, Kind: procedureir.StatementCall, Text: "Callee"}},
+			Calls: []procedureir.CallSite{{
+				ID: index + 1, Caller: procedureir.ProcedureRef{Name: name, QualifiedName: "FanIn." + name, Kind: procedureir.ProcedureSub},
+				Callee:     procedureir.Callee{Text: "Callee", BaseName: "Callee"},
+				Resolution: procedureir.CallResolution{Status: procedureir.ResolutionMatched, Candidates: []procedureir.Candidate{{QualifiedName: "FanIn.Callee", Kind: "sub", File: path, Line: 1}}},
+			}},
+		}
+	}
+	return benchmarkProjectDependencySnapshot(path, "FanIn", procedures, edited)
+}
+
+func deepCallChainProjectDependencyBenchmarkSnapshot(count int, edited bool) intel.ProjectAnalysisSnapshot {
+	path := "Chain.bas"
+	procedures := make([]procedureir.ProcedureIR, count)
+	for index := range procedures {
+		name := "Proc" + decimalString(index)
+		procedure := procedureir.ProcedureIR{Symbol: procedureir.ProcedureSymbol{Name: name, QualifiedName: "Chain." + name, Kind: procedureir.ProcedureSub}, Statements: []procedureir.Statement{{ID: index + 1, Kind: procedureir.StatementCall, Text: "same"}}}
+		if index < count-1 {
+			target := "Proc" + decimalString(index+1)
+			procedure.Calls = []procedureir.CallSite{{ID: index + 1, Caller: procedureir.ProcedureRef{Name: name, QualifiedName: "Chain." + name, Kind: procedureir.ProcedureSub}, Callee: procedureir.Callee{Text: target, BaseName: target}, Resolution: procedureir.CallResolution{Status: procedureir.ResolutionMatched, Candidates: []procedureir.Candidate{{QualifiedName: "Chain." + target, Kind: "sub", File: path, Line: 1}}}}}
+		}
+		if edited && index == count-1 {
+			procedure.Statements[0].Text = "changed"
+		}
+		procedures[index] = procedure
+	}
+	return benchmarkProjectDependencySnapshot(path, "Chain", procedures, edited)
+}
+
+func callChangeProjectDependencyBenchmarkSnapshot(target string, deleted bool) intel.ProjectAnalysisSnapshot {
+	path := "Caller.bas"
+	caller := procedureir.ProcedureIR{Symbol: procedureir.ProcedureSymbol{Name: "Run", QualifiedName: "Caller.Run", Kind: procedureir.ProcedureSub}, Statements: []procedureir.Statement{{ID: 1, Kind: procedureir.StatementCall, Text: target}}}
+	if !deleted {
+		caller.Calls = []procedureir.CallSite{{ID: 1, Caller: procedureir.ProcedureRef{Name: "Run", QualifiedName: "Caller.Run", Kind: procedureir.ProcedureSub}, Callee: procedureir.Callee{Text: target, BaseName: target}, Resolution: procedureir.CallResolution{Status: procedureir.ResolutionMatched, Candidates: []procedureir.Candidate{{QualifiedName: target, Kind: "sub", File: "Callee.bas", Line: 1}}}}}
+	}
+	callee := procedureir.ProcedureIR{Symbol: procedureir.ProcedureSymbol{Name: "First", QualifiedName: "Callee.First", Kind: procedureir.ProcedureSub}}
+	second := procedureir.ProcedureIR{Symbol: procedureir.ProcedureSymbol{Name: "Second", QualifiedName: "Callee.Second", Kind: procedureir.ProcedureSub}}
+	return benchmarkProjectDependencySnapshot(path, "Caller", []procedureir.ProcedureIR{caller, callee, second}, deleted)
+}
+
+func benchmarkProjectDependencySnapshot(path, module string, procedures []procedureir.ProcedureIR, edited bool) intel.ProjectAnalysisSnapshot {
+	ir := procedureir.DocumentIR{Path: path, ModuleName: module, ModuleKind: "standard", Procedures: procedures}
+	version := "v1"
+	if edited {
+		version = "v2"
+	}
+	return intel.ProjectAnalysisSnapshot{Revision: 1, Complete: true, Documents: []intel.ProjectAnalysisDocument{{IR: ir, Version: version, ProcedureCatalog: projectTestProcedureCatalog(procedures), CFG: vbacfg.BuildDocument(ir)}}}
+}
+
+func largeProjectDependencyBenchmarkSnapshot(count int, edited bool) intel.ProjectAnalysisSnapshot {
+	path := "Large.bas"
+	procedures := make([]procedureir.ProcedureIR, count)
+	entries := make([]intel.ProcedureCatalogEntry, count)
+	for i := range procedures {
+		text := "same"
+		if edited && i == count/2 {
+			text = "changed"
+		}
+		procedures[i] = procedureir.ProcedureIR{
+			Symbol: procedureir.ProcedureSymbol{
+				Name: qualifiedBenchmarkProcedureName(i), QualifiedName: "Large." + qualifiedBenchmarkProcedureName(i),
+				Kind: procedureir.ProcedureSub, DeclarationRange: vbaast.Range{StartLine: i * 3},
+			},
+			Statements: []procedureir.Statement{{ID: i + 1, Kind: procedureir.StatementCall, Text: text}},
+		}
+		entries[i] = intel.ProcedureCatalogEntry{
+			Identity:   intel.ProcedureIdentity{CanonicalName: "proc" + decimalString(i), Kind: "sub", Ordinal: i},
+			SourceHash: sha256.Sum256([]byte(text)), SignatureHash: sha256.Sum256([]byte("Public Sub")),
+		}
+	}
+	return intel.ProjectAnalysisSnapshot{Revision: 1, Complete: true, Documents: []intel.ProjectAnalysisDocument{{
+		IR: procedureir.DocumentIR{Path: path, ModuleName: "Large", ModuleKind: "standard", Procedures: procedures}, Version: map[bool]string{false: "v1", true: "v2"}[edited],
+		ProcedureCatalog: intel.ProcedureCatalog{Entries: entries, ModuleContextHash: sha256.Sum256([]byte("large-module")), ConditionalHash: sha256.Sum256([]byte("large-conditional")), ReuseSafe: true},
+	}}}
+}
+
+func qualifiedBenchmarkProcedureName(index int) string {
+	return "Proc" + decimalString(index)
+}
+
+func cloneProjectDependencyView(view projectDependencyView) projectDependencyView {
+	clone := newProjectDependencyView()
+	clone.revision = view.revision
+	for file, state := range view.files {
+		state.procedureKeys = append([]string(nil), state.procedureKeys...)
+		clone.files[file] = state
+	}
+	for key, state := range view.procedures {
+		state.callees = cloneProjectCallers(state.callees)
+		clone.procedures[key] = state
+	}
+	for callee, callers := range view.reverse {
+		clone.reverse[callee] = cloneProjectCallers(callers)
+	}
+	return clone
 }
 
 func TestWorkspaceProjectSnapshotHoldsResolvedIRAndDefensiveCFG(t *testing.T) {
@@ -153,11 +553,11 @@ func TestProjectChangeRejectsStaleSnapshotBaseline(t *testing.T) {
 		t.Fatal(err)
 	}
 	current := index.projectSnapshot()
-	index.lastProjectSnapshot = intel.ProjectAnalysisSnapshot{Revision: current.Revision + 1, Complete: true}
+	index.projectDependencies.revision = current.Revision + 1
 
 	_, impacted := index.projectChange()
-	if len(impacted) != 0 || index.lastProjectSnapshot.Revision != current.Revision+1 {
-		t.Fatalf("stale project change replaced baseline: impacted=%v baseline=%d", impacted, index.lastProjectSnapshot.Revision)
+	if len(impacted) != 0 || index.projectDependencies.revision != current.Revision+1 {
+		t.Fatalf("stale project change replaced baseline: impacted=%v baseline=%d", impacted, index.projectDependencies.revision)
 	}
 }
 
@@ -263,9 +663,34 @@ func projectTestSnapshot(procedures ...projectTestProcedureInput) intel.ProjectA
 	for _, input := range procedures {
 		procedure := input.procedure
 		ir := procedureir.DocumentIR{Path: input.file, ModuleName: moduleFromQualified(procedure.Symbol.QualifiedName), ModuleKind: "standard", Procedures: []procedureir.ProcedureIR{procedure}}
-		documents = append(documents, intel.ProjectAnalysisDocument{IR: ir, CFG: vbacfg.BuildDocument(ir)})
+		documents = append(documents, intel.ProjectAnalysisDocument{IR: ir, CFG: vbacfg.BuildDocument(ir), ProcedureCatalog: projectTestProcedureCatalog(ir.Procedures)})
 	}
 	return intel.ProjectAnalysisSnapshot{Complete: true, Documents: documents}
+}
+
+func projectTestProcedureCatalog(procedures []procedureir.ProcedureIR) intel.ProcedureCatalog {
+	catalog := intel.ProcedureCatalog{ModuleContextHash: sha256.Sum256([]byte("test-module")), ConditionalHash: sha256.Sum256([]byte("test-conditional")), ReuseSafe: true, Entries: make([]intel.ProcedureCatalogEntry, 0, len(procedures))}
+	for index, procedure := range procedures {
+		hasher := sha256.New()
+		writeFingerprintText(hasher, procedure.Symbol.QualifiedName, string(procedure.Symbol.Kind), procedure.Symbol.Name)
+		for _, statement := range procedure.Statements {
+			writeFingerprintText(hasher, string(statement.Kind), statement.Text, decimalString(statement.ID))
+		}
+		for _, call := range procedure.Calls {
+			writeFingerprintText(hasher, string(call.Resolution.Status), call.Callee.Text, call.Callee.BaseName)
+			for _, candidate := range call.Resolution.Candidates {
+				writeFingerprintText(hasher, candidate.QualifiedName, candidate.Kind, candidate.File, decimalString(candidate.Line))
+			}
+		}
+		var sourceHash [sha256.Size]byte
+		copy(sourceHash[:], hasher.Sum(nil))
+		catalog.Entries = append(catalog.Entries, intel.ProcedureCatalogEntry{
+			Identity:      intel.ProcedureIdentity{CanonicalName: procedure.Symbol.Name, Kind: string(procedure.Symbol.Kind), Ordinal: index},
+			SourceHash:    sourceHash,
+			SignatureHash: sha256.Sum256([]byte(procedure.Symbol.QualifiedName)),
+		})
+	}
+	return catalog
 }
 
 func projectTestProcedure(file, qualified, target, targetFile string, targetLine int, text string) projectTestProcedureInput {

--- a/internal/lspserver/workspace_project_analysis_test.go
+++ b/internal/lspserver/workspace_project_analysis_test.go
@@ -431,6 +431,7 @@ func qualifiedBenchmarkProcedureName(index int) string {
 func cloneProjectDependencyView(view projectDependencyView) projectDependencyView {
 	clone := newProjectDependencyView()
 	clone.revision = view.revision
+	clone.lookup = cloneProjectProcedureLookup(view.lookup)
 	for file, state := range view.files {
 		state.procedureKeys = append([]string(nil), state.procedureKeys...)
 		clone.files[file] = state
@@ -443,6 +444,28 @@ func cloneProjectDependencyView(view projectDependencyView) projectDependencyVie
 		clone.reverse[callee] = cloneProjectCallers(callers)
 	}
 	return clone
+}
+
+func cloneProjectProcedureLookup(lookup projectProcedureLookup) projectProcedureLookup {
+	clone := projectProcedureLookup{byQualified: make(map[string][]projectProcedureLookupEntry, len(lookup.byQualified))}
+	for qualified, entries := range lookup.byQualified {
+		clone.byQualified[qualified] = append([]projectProcedureLookupEntry(nil), entries...)
+	}
+	return clone
+}
+
+func TestCloneProjectDependencyViewPreservesLookup(t *testing.T) {
+	base := buildProjectDependencyViewWithPerformanceClass(callChangeProjectDependencyBenchmarkSnapshot("Callee.First", false), nil, "background")
+	clone := cloneProjectDependencyView(base)
+	qualified := projectQualifiedKey("Callee.First", "sub")
+	entries := clone.lookup.byQualified[qualified]
+	if len(entries) != 1 {
+		t.Fatalf("cloned lookup[%q] = %#v, want one entry", qualified, entries)
+	}
+	entries[0].key = "mutated"
+	if base.lookup.byQualified[qualified][0].key == "mutated" {
+		t.Fatal("cloned lookup shares entry storage with base view")
+	}
 }
 
 func TestWorkspaceProjectSnapshotHoldsResolvedIRAndDefensiveCFG(t *testing.T) {

--- a/internal/vba/intel/analysis_snapshot.go
+++ b/internal/vba/intel/analysis_snapshot.go
@@ -280,6 +280,22 @@ func (s *AnalysisSnapshot) SourceHash() string {
 	return hex.EncodeToString(s.sourceHash[:])
 }
 
+// ProcedureCatalog returns the canonical procedure identities and revision
+// fingerprints prepared for this immutable document revision.  Callers must
+// treat the returned catalog as read-only; its hashes are also used by
+// procedure artifact and diagnostic reuse.
+func (s *AnalysisSnapshot) ProcedureCatalog() ProcedureCatalog {
+	if s == nil {
+		return ProcedureCatalog{}
+	}
+	s.procedureCatalogOnce.Do(func() {
+		s.procedureCatalog = procedureCatalogForDocumentMode(s.Document(), true)
+	})
+	catalog := s.procedureCatalog
+	catalog.Entries = append([]ProcedureCatalogEntry(nil), catalog.Entries...)
+	return catalog
+}
+
 func (s *AnalysisSnapshot) sameRevision(doc Document) bool {
 	if s == nil || s.retired.Load() || s.uri != doc.URI || s.path != doc.Path ||
 		s.version != doc.Version || s.moduleKind != doc.ModuleKind ||

--- a/internal/vba/intel/analysis_snapshot_test.go
+++ b/internal/vba/intel/analysis_snapshot_test.go
@@ -59,6 +59,22 @@ func TestAnalysisSnapshotIdentityLinesAndProcedures(t *testing.T) {
 	}
 }
 
+func TestProcedureCatalogAccessorReturnsDefensiveEntries(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{
+		Path: "Main.bas", ModuleKind: "standard",
+		Source: "Public Sub Run()\nEnd Sub\n",
+	})
+	first := snapshot.ProcedureCatalog()
+	if len(first.Entries) != 1 {
+		t.Fatalf("catalog entries = %d, want 1", len(first.Entries))
+	}
+	first.Entries[0].Identity.CanonicalName = "mutated"
+	second := snapshot.ProcedureCatalog()
+	if second.Entries[0].Identity.CanonicalName == "mutated" {
+		t.Fatal("procedure catalog accessor shares its entries with the snapshot")
+	}
+}
+
 func TestAnalysisSnapshotMatchesSameBackingWithoutFullHash(t *testing.T) {
 	doc := Document{
 		URI: "file:///Main.bas", Path: "Main.bas", Version: 7,

--- a/internal/vba/intel/procedure_diagnostics.go
+++ b/internal/vba/intel/procedure_diagnostics.go
@@ -60,6 +60,12 @@ type ProjectAnalysisDocument struct {
 	Resolution procedureir.ResolvedDocumentView
 	CFG        vbacfg.Document
 	Source     string
+	// Version identifies the published source revision.  Procedure dependency
+	// indexes use it to skip unchanged files without walking their procedures.
+	Version string
+	// ProcedureCatalog is the canonical catalog prepared by document analysis.
+	// It is immutable input for project dependency bookkeeping.
+	ProcedureCatalog ProcedureCatalog
 }
 
 // ProjectAnalysisSnapshot is a coherent view of saved files and published


### PR DESCRIPTION
## Summary

- Replace whole-project `ProcedureIR` JSON serialization and hashing in LSP project impact detection with canonical procedure catalog fingerprints.
- Update procedure, module declaration, reverse caller, and conservative uncertain-resolution dependency state incrementally.
- Preserve impact propagation for added, removed, redirected, and deleted dependencies.

## Implementation

- Reuse `AnalysisSnapshot` procedure catalog fingerprints through indexed project snapshots, with defensive access and fail-open checks for unsafe or mismatched catalogs.
- Update only changed procedure entries and set-diff reverse edges; retain old and new relationships while computing affected caller closure.
- Track module declaration dependencies and a synthetic project root for ambiguous, recovered, incomplete, or unresolved project-local dependencies.
- Add dependency update counters, regression coverage, and benchmarks for body edits, signature edits, high fan-in, deep call chains, call deletion, call target changes, and ROneCOne-scale updates.
- Update the profiling specification, ADR, and changelog.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./...`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/lspserver ./internal/vba/intel -run 'Test(ProjectImpact|IncrementalProjectDependency|ProcedureCatalog|WorkspaceProjectSnapshot|PerformanceRecorderRegistersDependencyCounters)' -count=1 -timeout=10m`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/lspserver ./internal/vba/intel -count=1 -timeout=10m`
- `rtk golangci-lint run ./internal/lspserver/... ./internal/vba/intel/...`
- `rtk pnpm format:check`
- Dependency benchmarks with `-benchtime=1x` for all seven requested scenarios.

`task lint` reaches the documentation checks but reports the pre-existing unchanged `vitepress/reference/error-code-inventory.md` as stale; documentation contract and Markdown link checks pass. The stale generated file is outside this change.

Closes #738


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved LSP responsiveness for body-only edits by reprocessing only affected procedures.
  - Preserved dependency tracking when calls are removed, redirected, ambiguous, or unresolved.
  - Improved handling of module declaration changes and incremental project updates.

- **Diagnostics**
  - Existing diagnostic results and LSP response formats remain unchanged.

- **Documentation**
  - Added documentation describing incremental dependency tracking and performance measurements.
  - Added profiling counters for dependency updates, procedure revisits, and fingerprint reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->