### PR TITLE
fix(analyze): clarify cleanup diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ All notable changes to xlflow will be documented in this file.
   unpublished. Added project cache hit/miss/rebuild, dependency-invalidation,
   and reused-entry performance counters; diagnostic and LSP payload contracts
   remain unchanged.
+
+- Clarified `VBA203`, `VBA219`, and `VBA221` cleanup diagnostics. Findings now
+  distinguish recognized cleanup candidates from cleanup proven on every exit,
+  so existing `Close` and Application-state restore paths are described as
+  uncertain rather than reported as absent. Detection criteria, finding
+  locations, and suppression behavior are unchanged.
+
 - Fixed Windows Excel VBA imports so LF-only source, including `.cls` class
   modules, is normalized to CRLF before VBIDE import and is no longer
   misidentified as a standard module during `build` or `push`.

--- a/docs/adr/ADR-0023-procedure-effect-summaries.md
+++ b/docs/adr/ADR-0023-procedure-effect-summaries.md
@@ -64,9 +64,11 @@ Use the summary as a validation consumer for the existing
 `VBA203` Push/Pop helper exemption. Pair lookup prefers the same module, then
 requires exactly one project-visible Pop/Restore candidate. A direct or
 propagated matching restore effect permits the existing exemption; missing or
-ambiguous pairs remain unsafe. Diagnostic ID, severity, location, message,
-ordering, inline suppression, configuration, and CLI/LSP representation remain
-unchanged.
+ambiguous pairs remain unsafe. Diagnostic ID, severity, location, ordering,
+inline suppression, configuration, and CLI/LSP representation remain
+unchanged. Diagnostic explanations may identify a restore-like effect as a
+candidate, but that explanation is not an all-exit safety proof and does not
+suppress a root finding.
 
 `VBA221` reports a batch-only caller context at a uniquely resolved, reachable
 call only when the direct callee has direct Application-state evidence that

--- a/docs/adr/ADR-0024-procedure-local-vba-resource-lifetime-analysis.md
+++ b/docs/adr/ADR-0024-procedure-local-vba-resource-lifetime-analysis.md
@@ -30,6 +30,9 @@ Function exit.
 Release means a recognized `Workbook.Close`, `Close #handle`, or bare `Close`
 statement is reached. The rule intentionally does not model a Close call's own
 failure, arbitrary helper calls, ByRef ownership transfer, or dynamic dispatch.
+When a release is recognized on only some paths, the diagnostic may mention the
+release as explanation-only evidence while retaining the leak finding and its
+uncovered exit witness.
 
 ## Consequences
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -1472,7 +1472,7 @@ Higher-signal lint rules `VB019`, `VB020`, `VB022`, `VB023`, and `VB026` are ena
 - `VBA106`: removed `XlflowSetTraceFile` trace helper call
 - `VBA201`: a result assigned from `Excel.Range.Find` is dereferenced before a `Nothing` check when the `.Find` receiver resolves as `Excel.Range`; project-defined or unresolved `.Find` receivers are excluded
 - `VBA202`: object variable may be dereferenced before a definitely non-`Nothing` value is proven on every reachable path
-- `VBA203`: a change to `Application.ScreenUpdating`, `Application.EnableEvents`, `Application.DisplayAlerts`, `Application.Calculation`, `Application.StatusBar`, `Application.Cursor`, `Application.Interactive`, `Application.AskToUpdateLinks`, `Application.AutomationSecurity`, or `Application.CutCopyMode` can reach an exit without restoring its previous value
+- `VBA203`: a change to `Application.ScreenUpdating`, `Application.EnableEvents`, `Application.DisplayAlerts`, `Application.Calculation`, `Application.StatusBar`, `Application.Cursor`, `Application.Interactive`, `Application.AskToUpdateLinks`, `Application.AutomationSecurity`, or `Application.CutCopyMode` cannot be proven restored to its previous value on every exit; the reason may identify a restore-like assignment without treating it as an all-exit proof
 - `VBA204`: normal execution can fall through into an error-handler label
 - `VBA205`: ambiguous Excel workbook or worksheet scope: active UI objects, unqualified worksheet members (`Range`, `Cells`, `Rows`, and `Columns`), unqualified sheet collections, positional workbook/window access, uncaptured `Workbooks.Open`, or `ThisWorkbook` in an add-in standard module
 - `VBA206`: runtime-safety warning for temporary, parenthesized, property/member, or indirect ByRef argument forms; it remains configurable and inline-suppressible
@@ -1489,9 +1489,9 @@ Higher-signal lint rules `VB019`, `VB020`, `VB022`, `VB023`, and `VB026` are ena
 - `VBA216`: a range expression provably mixes explicit worksheet roots
 - `VBA217`: a last-row calculation depends on an implicit worksheet root or unstable boundary pattern
 - `VBA218`: a resolved Excel API call can raise a runtime error or return `Variant/Error` when no result exists, but its documented failure contract is not handled
-- `VBA219`: an explicitly acquired local Workbook or VBA file handle can reach a CFG exit without a matching Close
+- `VBA219`: an explicitly acquired local Workbook or VBA file handle cannot be proven closed on every exit; the reason may identify a matching Close recognized on only some paths
 - `VBA220`: a supported event handler can re-enter itself or trigger a related event chain; unresolved calls are reported as uncertainty
-- `VBA221`: a direct project-local call can leave an `Application` property changed because its callee does not restore it on every exit
+- `VBA221`: a direct project-local call can leave an `Application` property changed because cleanup is not proven on every exit; the reason may identify a restore-like callee assignment without treating it as an all-exit proof
 - `VBA222`: a public API exposes an inaccessible, ambiguous, or unresolved type
 - `VBA223`: a credential-like value appears directly in VBA source; structural matches are reported without exposing the value
 - `VBA224`: conservative procedure-local analysis finds potentially untrusted data flowing into a sensitive API

--- a/docs/specs/vba-effect-analysis.md
+++ b/docs/specs/vba-effect-analysis.md
@@ -245,8 +245,10 @@ model.
 
 The integration preserves the `VBA203` diagnostic ID, severity, ordering,
 inline suppression, configuration, and `analyze --json` field shape. Its
-message and reason now name the affected property and an available uncovered
-exit witness.
+message and reason name the affected property and an available uncovered exit
+witness. A restore-like direct effect may be included as explanation-only
+evidence when a procedure contains one, but it never clears the CFG leak origin
+or proves that the saved value is the value being restored on every exit.
 
 ## Boundaries
 
@@ -255,8 +257,10 @@ guarantee. Issue #431 provides procedure-local all-path restoration through the
 CFG. `VBA221` consumes the direct callee summary only when its direct
 Application-state evidence matches a `VBA203` leak origin. It reports that
 immediate call boundary once per property, names the originating procedure, and
-preserves any callee uncertainty; it never repeats the same leak at transitive
-ancestors or treats a later restore helper as an all-path proof.
+preserves any callee uncertainty. If the direct callee also has a restore-like
+effect for that property, the finding may identify it as a candidate while
+stating that it is not an all-exit proof. It never repeats the same leak at
+transitive ancestors or treats a later restore helper as an all-path proof.
 
 `VBA220` consumes these summaries for supported event handlers. It classifies
 cell writes, explicit recalculation, selection changes, workbook lifecycle and

--- a/docs/specs/vba-resource-lifecycle-analysis.md
+++ b/docs/specs/vba-resource-lifecycle-analysis.md
@@ -39,7 +39,10 @@ The analyzer traverses normal, exceptional, termination, and unknown CFG exits.
 Cleanup labels and error handlers require no name-based exception: a release is
 safe whenever the CFG proves it is reached. A reached release statement is the
 cleanup boundary even if the release call itself could fail; modeling failures
-inside Close is outside this rule.
+inside Close is outside this rule. When a matching Close is recognized on some
+path but not proven on every exit, the diagnostic explains both facts. It must
+not imply that no cleanup source exists, and it must not attribute the remaining
+uncertainty specifically to `On Error Resume Next`.
 
 Unreachable acquisitions and recovered statements are never used as ownership,
 release, transfer, or alias evidence. Alias assignments take effect only on
@@ -47,7 +50,8 @@ their normal CFG edges, so exception handlers retain the pre-assignment alias
 state.
 
 Each finding is located at the acquisition and its reason identifies the
-uncovered exit witness. The rule is default-enabled, warning-only,
+uncovered exit witness and, when available, the recognized cleanup statement.
+The rule is default-enabled, warning-only,
 non-blocking, realtime, and inline suppressible. Disable it project-wide with
 `[analyze].disabled_rules = ["VBA219"]`; the legacy
 `detect_resource_leaks` boolean remains accepted with a deprecation warning.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -3772,14 +3772,42 @@ func (a Analyzer) applicationStateFindings(file parsedFile, proc sourceProcedure
 	}
 	for _, origin := range origins {
 		property := applicationStatePropertyName(origin.Property)
+		message := "Application." + property + " cannot be proven restored to its previous value on every exit."
+		reason := "The changed Application." + property + " value can leave this procedure through " + origin.Witness.description() + "."
+		if lines := applicationStateRestoreEvidence(proc, origin.Property); len(lines) > 0 {
+			reason += " A restore-like assignment is recognized at line " + strconvItoa(lines[0]) + ", but this analysis cannot prove that it restores this value on every exit."
+		}
 		findings = append(findings, a.simpleFinding(
 			file, proc, origin.Line, "VBA203", "warning",
-			"Application."+property+" can reach "+origin.Witness.Kind+" without restoring its previous value.",
-			"The changed Application."+property+" value can leave this procedure through "+origin.Witness.description()+".",
-			"Save the previous Application."+property+" value and restore it in a cleanup path.",
+			message,
+			reason,
+			"Ensure that the previous Application."+property+" value is restored on every normal, error, termination, and unknown exit, or avoid forced termination and suppress this warning when the remaining path is intentional.",
 		))
 	}
 	return findings
+}
+
+// applicationStateRestoreEvidence is explanation-only evidence. A restore
+// effect is a useful clue for the diagnostic, but it is deliberately not used
+// to clear an origin from the CFG all-exit analysis.
+func applicationStateRestoreEvidence(proc sourceProcedure, property string) []int {
+	if proc.Effects == nil {
+		return nil
+	}
+	target := "application." + strings.ToLower(property)
+	lines := map[int]bool{}
+	for _, evidence := range proc.Effects.Direct {
+		if evidence.Effect != effects.RestoresApplicationState || !strings.EqualFold(evidence.Target, target) || evidence.Range.StartLine <= 0 {
+			continue
+		}
+		lines[evidence.Range.StartLine] = true
+	}
+	out := make([]int, 0, len(lines))
+	for line := range lines {
+		out = append(out, line)
+	}
+	sort.Ints(out)
+	return out
 }
 
 type applicationStateProperty struct {

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -1122,7 +1122,7 @@ End Sub
 	want := map[string]int{"WorkbookLeak": 14, "FileLeak": 55, "NestedBranchLeak": 62, "ReassignedWorkbookLeak": 69, "FailedTransfer": 101, "OverwrittenTransfer": 109}
 	for _, finding := range got {
 		line, ok := want[finding.Procedure]
-		if !ok || finding.Line != line || !strings.Contains(finding.Reason, "without a matching Close") || !strings.Contains(finding.Suggestion, "cleanup path") {
+		if !ok || finding.Line != line || !strings.Contains(finding.Message, "cannot be proven closed on every exit") || !strings.Contains(finding.Reason, "without a proven matching Close") || !strings.Contains(finding.Suggestion, "every normal, error, termination, and unknown exit") {
 			t.Fatalf("unexpected VBA219 finding: %+v", finding)
 		}
 	}
@@ -1154,6 +1154,47 @@ End Sub
 	}
 	if got := findingsByCode(realtime, "VBA219"); len(got) != 0 {
 		t.Fatalf("disabled VBA219 should not report in realtime: %+v", got)
+	}
+}
+
+func TestVBA219ExplainsRecognizedCleanupWithoutChangingLeakDecision(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "FileReader.bas", `Option Explicit
+
+Public Function ReadInput(ByVal filePath As String) As String
+  Dim fileNo As Integer
+  Dim fileOpen As Boolean
+  On Error GoTo ErrorHandler
+  fileNo = FreeFile
+  Open filePath For Input As #fileNo
+  fileOpen = True
+  ReadInput = "ok"
+CleanExit:
+  On Error Resume Next
+  If fileOpen Then Close #fileNo
+  On Error GoTo 0
+  Exit Function
+ErrorHandler:
+  ReadInput = vbNullString
+  On Error Resume Next
+  If fileOpen Then Close #fileNo
+  On Error GoTo 0
+End Function
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA219")
+	if len(got) != 1 {
+		t.Fatalf("VBA219 findings = %+v, want one conservative leak finding", got)
+	}
+	if !strings.Contains(got[0].Message, "cannot be proven closed on every exit") ||
+		!strings.Contains(got[0].Reason, "A matching Close is recognized at line") ||
+		!strings.Contains(got[0].Reason, "cannot prove that it is reached on every exit") {
+		t.Fatalf("VBA219 should explain the recognized conditional cleanup: %+v", got[0])
 	}
 }
 
@@ -2443,6 +2484,67 @@ End Sub
 	}
 	if got := findingsByCode(findings, "VBA221"); len(got) != 0 {
 		t.Fatalf("VBA221 should not report a paired Push/Pop helper: %+v", got)
+	}
+}
+
+func TestApplicationStateDiagnosticsExplainRestoreLikeCleanup(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeModule(t, dir, "ExcelStateGuard.bas", `Option Explicit
+
+Private savedScreenUpdating As Boolean
+Private savedStateAvailable As Boolean
+
+Public Sub BeginBatch()
+  savedScreenUpdating = Application.ScreenUpdating
+  savedStateAvailable = True
+  On Error GoTo BeginBatchError
+  Application.ScreenUpdating = False
+  Exit Sub
+BeginBatchError:
+  RestoreSavedState
+  savedStateAvailable = False
+  Err.Raise 5
+End Sub
+
+Private Sub RestoreSavedState()
+  If Not savedStateAvailable Then Exit Sub
+  On Error Resume Next
+  Application.ScreenUpdating = savedScreenUpdating
+  On Error GoTo 0
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: dir, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateFindings := findingsByCode(findings, "VBA203")
+	if len(stateFindings) != 2 {
+		t.Fatalf("VBA203 findings = %+v, want the BeginBatch and helper root findings", stateFindings)
+	}
+	var helperFinding *Finding
+	for index := range stateFindings {
+		finding := &stateFindings[index]
+		if finding.Procedure == "RestoreSavedState" {
+			helperFinding = finding
+		}
+		if !strings.Contains(finding.Message, "cannot be proven restored to its previous value on every exit") {
+			t.Fatalf("VBA203 should use the precise all-exit message: %+v", finding)
+		}
+	}
+	if helperFinding == nil || !strings.Contains(helperFinding.Reason, "A restore-like assignment is recognized at line") ||
+		!strings.Contains(helperFinding.Reason, "cannot prove that it restores this value on every exit") {
+		t.Fatalf("VBA203 should explain the restore-like assignment: %+v", stateFindings)
+	}
+	callFindings := findingsByCode(findings, "VBA221")
+	if len(callFindings) != 1 {
+		t.Fatalf("VBA221 findings = %+v, want one immediate caller finding", callFindings)
+	}
+	if !strings.Contains(callFindings[0].Message, "cleanup is not proven on every exit") ||
+		!strings.Contains(callFindings[0].Reason, "restore-like assignment is also recognized at line") ||
+		!strings.Contains(callFindings[0].Reason, "not an all-exit proof") {
+		t.Fatalf("VBA221 should explain the helper cleanup evidence: %+v", callFindings[0])
 	}
 }
 

--- a/internal/analyze/application_state_calls.go
+++ b/internal/analyze/application_state_calls.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"sort"
 	"strings"
 
 	vbacfg "github.com/harumiWeb/xlflow/internal/vba/cfg"
@@ -148,18 +149,39 @@ func (a Analyzer) applicationStateCallEffectFindings(file parsedFile, proc sourc
 			if originName == "" {
 				originName = origin.Identity.Name
 			}
-			reason := "This call propagates the un-restored " + property + " change introduced by " + originName + " at line " + strconvItoa(origin.Line) + "."
+			message := "Call to " + call.Callee.Text + " can leave " + property + " changed; cleanup is not proven on every exit."
+			reason := "This call propagates an " + property + " change introduced by " + originName + " at line " + strconvItoa(origin.Line) + ". The callee's cleanup is not proven to restore the previous value on every exit."
+			if lines := applicationStateRestoreEvidenceFromSummary(callee, origin.Property); len(lines) > 0 {
+				reason += " A restore-like assignment is also recognized at line " + strconvItoa(lines[0]) + ", but it is not an all-exit proof."
+			}
 			if uncertainty := applicationStateCallUncertainty(callee); uncertainty != "" {
 				reason += " The callee's final state is also uncertain because it reaches " + uncertainty + " call dispatch."
 			}
 			out = append(out, a.simpleFinding(
 				file, proc, call.Range.StartLine, "VBA221", "warning",
-				"Call to "+call.Callee.Text+" can leave "+property+" changed.",
+				message,
 				reason,
-				"Restore the previous "+property+" value in the owning cleanup path, or make the helper's state ownership explicit.",
+				"Ensure that the callee restores the previous "+property+" value on every normal, error, termination, and unknown exit, or make the helper's state ownership explicit.",
 			))
 		}
 	}
+	return out
+}
+
+func applicationStateRestoreEvidenceFromSummary(summary effects.ProcedureSummary, property string) []int {
+	target := "application." + strings.ToLower(property)
+	lines := map[int]bool{}
+	for _, evidence := range summary.Direct {
+		if evidence.Effect != effects.RestoresApplicationState || !strings.EqualFold(evidence.Target, target) || evidence.Range.StartLine <= 0 {
+			continue
+		}
+		lines[evidence.Range.StartLine] = true
+	}
+	out := make([]int, 0, len(lines))
+	for line := range lines {
+		out = append(out, line)
+	}
+	sort.Ints(out)
 	return out
 }
 

--- a/internal/analyze/resource_leaks.go
+++ b/internal/analyze/resource_leaks.go
@@ -42,6 +42,12 @@ type resourceExitWitness struct {
 	Line int
 }
 
+type resourceLeakAnalysis struct {
+	Witness     resourceExitWitness
+	Leaked      bool
+	CleanupLine int
+}
+
 func (w resourceExitWitness) description() string {
 	if w.Line > 0 {
 		return w.Kind + " at line " + strconvItoa(w.Line)
@@ -55,19 +61,27 @@ func (a Analyzer) resourceLeakFindings(file parsedFile, proc sourceProcedure) []
 	}
 	var findings []Finding
 	for _, acquisition := range resourceAcquisitions(proc) {
-		witness, leaked := resourceLeakWitness(proc, acquisition)
-		if !leaked {
+		analysis := resourceLeakAnalysisFor(proc, acquisition)
+		if !analysis.Leaked {
 			continue
 		}
 		resource := "Workbook"
 		if acquisition.Kind == resourceFileHandle {
 			resource = "VBA file handle"
 		}
+		message := resource + " acquired here cannot be proven closed on every exit."
+		reason := "The " + string(acquisition.Kind) + " acquired at line " + strconvItoa(acquisition.Line) +
+			" can leave this procedure through " + analysis.Witness.description() +
+			" without a proven matching Close."
+		if analysis.CleanupLine > 0 {
+			reason += " A matching Close is recognized at line " + strconvItoa(analysis.CleanupLine) +
+				", but this analysis cannot prove that it is reached on every exit."
+		}
 		findings = append(findings, a.simpleFinding(
 			file, proc, acquisition.Line, "VBA219", "warning",
-			resource+" acquired here can reach "+witness.Kind+" without Close.",
-			"The "+string(acquisition.Kind)+" acquired at line "+strconvItoa(acquisition.Line)+" can leave this procedure through "+witness.description()+" without a matching Close.",
-			"Close the "+string(acquisition.Kind)+" in a cleanup path that every exit reaches.",
+			message,
+			reason,
+			"Ensure that the "+string(acquisition.Kind)+" is closed on every normal, error, termination, and unknown exit, or avoid forced termination and suppress this warning when the remaining path is intentional.",
 		))
 	}
 	return findings
@@ -95,13 +109,18 @@ func resourceAcquisitions(proc sourceProcedure) []resourceAcquisition {
 }
 
 func resourceLeakWitness(proc sourceProcedure, acquisition resourceAcquisition) (resourceExitWitness, bool) {
+	analysis := resourceLeakAnalysisFor(proc, acquisition)
+	return analysis.Witness, analysis.Leaked
+}
+
+func resourceLeakAnalysisFor(proc sourceProcedure, acquisition resourceAcquisition) resourceLeakAnalysis {
 	graph := proc.Graph
 	block, ok := graph.BlockForStatement(acquisition.StatementID)
 	if !ok {
-		return resourceExitWitness{}, false
+		return resourceLeakAnalysis{}
 	}
 	if !graph.IsReachable(block.ID, vbacfg.EdgeFilter{}) {
-		return resourceExitWitness{}, false
+		return resourceLeakAnalysis{}
 	}
 	initialAliases := map[string]bool{acquisition.Owner: true}
 	if acquisition.Kind == resourceFileHandle {
@@ -112,6 +131,7 @@ func resourceLeakWitness(proc sourceProcedure, acquisition resourceAcquisition) 
 	queue := make([]int, 0)
 	var witness resourceExitWitness
 	found := false
+	cleanupLine := 0
 
 	for _, edge := range graph.Edges {
 		if edge.From != block.ID || edge.Class != vbacfg.EdgeNormal {
@@ -139,6 +159,9 @@ func resourceLeakWitness(proc sourceProcedure, acquisition resourceAcquisition) 
 		}
 		if current.Statement != nil && !current.Statement.Recovered {
 			if resourceStatementReleases(acquisition.Kind, current.Statement.Text, aliases) {
+				if line := current.Statement.Range.StartLine; cleanupLine == 0 || line < cleanupLine {
+					cleanupLine = line
+				}
 				continue
 			}
 		}
@@ -161,7 +184,7 @@ func resourceLeakWitness(proc sourceProcedure, acquisition resourceAcquisition) 
 			resourceMergeAliases(in, queued, &queue, int(edge.To), out)
 		}
 	}
-	return witness, found
+	return resourceLeakAnalysis{Witness: witness, Leaked: found, CleanupLine: cleanupLine}
 }
 
 // resourceFileAliasesBefore finds local numeric aliases that are definitely

--- a/internal/staticanalysis/rules/registry.json
+++ b/internal/staticanalysis/rules/registry.json
@@ -1060,7 +1060,7 @@
     {
       "id": "VBA203",
       "title": "Application state not restored",
-      "description": "An Application state change can reach an exit without restoring its previous value.",
+      "description": "An Application state change cannot be proven restored to its previous value on every exit; a restore-like assignment may still be present.",
       "family": "analyze",
       "category": "reliability",
       "evidence_class": "inference",
@@ -1412,7 +1412,7 @@
     {
       "id": "VBA219",
       "title": "Unreleased workbook or VBA file handle",
-      "description": "A procedure-local Workbook or VBA file handle acquired by an explicit Open call can reach an exit without a matching Close.",
+      "description": "A procedure-local Workbook or VBA file handle acquired by an explicit Open call cannot be proven closed on every exit; a matching Close may still be present on some paths.",
       "family": "analyze",
       "category": "reliability",
       "evidence_class": "inference",
@@ -1456,7 +1456,7 @@
     {
       "id": "VBA221",
       "title": "Application state changed by local helper",
-      "description": "A direct project-local call can leave an Application property changed because the callee does not restore it on every exit.",
+      "description": "A direct project-local call can leave an Application property changed because cleanup is not proven on every exit; a restore-like assignment may still be present.",
       "family": "analyze",
       "category": "reliability",
       "evidence_class": "inference",

--- a/vitepress/reference/diagnostics.md
+++ b/vitepress/reference/diagnostics.md
@@ -1668,7 +1668,7 @@ Use [`xlflow rules`](../commands/rules) to inspect the same metadata from an ins
 
 ## VBA203
 
-**Application state not restored.** An Application state change can reach an exit without restoring its previous value.
+**Application state not restored.** An Application state change cannot be proven restored to its previous value on every exit; a restore-like assignment may still be present.
 
 | Property                    | Value                              |
 | --------------------------- | ---------------------------------- |
@@ -2020,7 +2020,7 @@ Use [`xlflow rules`](../commands/rules) to inspect the same metadata from an ins
 
 ## VBA219
 
-**Unreleased workbook or VBA file handle.** A procedure-local Workbook or VBA file handle acquired by an explicit Open call can reach an exit without a matching Close.
+**Unreleased workbook or VBA file handle.** A procedure-local Workbook or VBA file handle acquired by an explicit Open call cannot be proven closed on every exit; a matching Close may still be present on some paths.
 
 | Property                    | Value                   |
 | --------------------------- | ----------------------- |
@@ -2064,7 +2064,7 @@ Use [`xlflow rules`](../commands/rules) to inspect the same metadata from an ins
 
 ## VBA221
 
-**Application state changed by local helper.** A direct project-local call can leave an Application property changed because the callee does not restore it on every exit.
+**Application state changed by local helper.** A direct project-local call can leave an Application property changed because cleanup is not proven on every exit; a restore-like assignment may still be present.
 
 | Property                    | Value                                   |
 | --------------------------- | --------------------------------------- |


### PR DESCRIPTION
## Summary

- Clarify `VBA203`, `VBA219`, and `VBA221` so recognized cleanup candidates are distinguished from cleanup proven on every exit.
- Preserve diagnostic codes, locations, counts, suppression behavior, and JSON contracts while adding regression coverage for the Issue #745 patterns.
- Update the analyzer specifications, ADRs, diagnostic registry, generated reference, and changelog.

Closes #745

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/analyze -count=1`
- `rtk task test`
- `rtk task lint`
- `rtk task corpus:test`
- `rtk pnpm docs:check`
- `rtk git diff --check`
- `rtk proxy task review:codex` (initial P2 fixed; convergence review clean)
