### PR TITLE
perf(vscode): reduce language-client startup critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.11.0
+          package_json_file: editors/vscode/package.json
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,29 @@ jobs:
       - run: dotnet test bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/Xlflow.ExcelBridge.Tests.csproj
       - run: go vet ./...
 
+  vscode:
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.11.0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: editors/vscode/pnpm-lock.yaml
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+        working-directory: editors/vscode
+      - name: Run VS Code extension tests
+        run: xvfb-run -a pnpm test
+        working-directory: editors/vscode
+
   security:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Reduced VS Code language-intelligence startup latency by starting the LSP
+  without a blocking CLI availability preflight, running project and UI detail
+  refreshes asynchronously, and adding opt-in end-to-end startup/readiness
+  correlation for the first usable hover, definition, and completion results.
+
 - Reduced interactive VBA LSP latency by adding snapshot-scoped declaration
   indexes for hover, definition, completion, and signature help. Interactive
   lookups now reuse immutable procedure catalogs, avoid procedure IR/CFG and

--- a/docs/adr/ADR-0014-reusable-vba-lsp-server.md
+++ b/docs/adr/ADR-0014-reusable-vba-lsp-server.md
@@ -123,6 +123,27 @@ queries, full document-symbol builds, and interactive full-symbol fallbacks.
 These counters are developer telemetry only and do not alter LSP responses,
 symbol visibility, ordering, or cancellation and generation safety.
 
+### Amendment: end-to-end startup critical path (Issue #757)
+
+The extension must not make language intelligence wait for a separate
+`xlflow version` preflight or for project/sidebar detail refreshes. The
+language client starts optimistically after the workspace and LSP configuration
+metadata needed to construct its document selector are available. Process
+spawn or initialization failure remains actionable through the existing
+availability and restart paths; the short availability timeout is not applied
+to the complete LSP initialization because TypeLib preparation can be a valid
+cold-start cost.
+
+Startup timing is opt-in developer telemetry. A client-generated anonymous ID
+correlates client lifecycle records with server lifecycle and readiness records
+through the child process environment. Monotonic elapsed times are interpreted
+within each process, with wall-clock timestamps used only for correlation. The
+telemetry does not add protocol fields or requests, and a non-empty hover,
+definition, or completion response is required before reporting a first usable
+language feature. The CLI invokes best-effort TypeLib preparation through the
+server's pre-construction hook after the server baseline is captured, so that
+cold preparation remains part of the measured startup interval.
+
 The VS Code extension should remain a thin language client that launches:
 
 ```ts

--- a/docs/specs/lsp-performance-profiling.md
+++ b/docs/specs/lsp-performance-profiling.md
@@ -27,6 +27,40 @@ postings are complete, while semantic preparation publishes the existing
 `operation="workspaceSymbols/index/initial"` after IR/CFG/call-site entries are
 complete. Neither record changes LSP response fields.
 
+## End-to-end startup correlation
+
+When performance logging is enabled, the VS Code client creates an anonymous
+`startup_id` for each language-client start attempt and passes it to the child
+process through `XLFLOW_LSP_STARTUP_ID`. Manual and automatic process restarts
+begin a fresh attempt with a new ID. The client writes records with
+`operation="lsp/startup"`, `side="client"`, `event`, `elapsed_ms`, and
+`wall_time_unix_ms`. The server writes the same operation and ID with its local
+monotonic elapsed time and `wall_time_unix_ns`. IDs are omitted when performance
+logging is disabled, and no source, workspace name, or user-identifying data is
+included.
+
+The client records `extensionActivationStart`, CLI availability start and
+completion, workspace/configuration discovery, `languageClientStart`, the
+nearest public process-spawn boundary, `initializeResponseReceived`,
+`initializedSent`, and the first successful `didOpen`. The
+`vscode-languageclient` API does not expose every JSON-RPC boundary, so the
+initialize and process events are explicitly nearest stable boundaries; the
+server lifecycle events provide the precise server-side counterparts.
+
+The server records `serverProcessStart`, `serverConstructed`,
+`initializeHandled`, `initializedHandled`, `didOpenHandled`, declaration and
+semantic index start/ready events, and the first non-empty hover, definition,
+and completion result. The CLI captures the server baseline before its
+best-effort TypeLib preparation hook, so that cold preparation remains visible
+in the server startup interval. An empty result, error, or cancellation is not
+a first-success event. Each event is emitted at most once per startup ID.
+
+Startup telemetry is observational only. It does not add an LSP notification,
+change a response, delay document lifecycle handling, or change availability,
+restart, generation, or cancellation behavior. `wall_time_unix_*` is used only
+to correlate the two processes; elapsed durations are compared within the
+process that produced them.
+
 ## Stage names
 
 The following names are stable and intended for benchmark/profile scripts:

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Start the language client without a blocking duplicate `xlflow version`
+  preflight and keep update, capability, project, and sidebar refreshes off the
+  activation critical path. Opt-in startup logs correlate LSP lifecycle stages
+  and the first usable hover, definition, and completion results.
+
 ## v0.10.0
 
 - Fixed VBA hover documentation for procedures in currently open modules.

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -6,11 +6,35 @@ import {
   Trace,
   TransportKind,
 } from "vscode-languageclient/node";
-import { XlflowCliAvailabilityService } from "./cliAvailability";
+import type { XlflowCliAvailabilityService } from "./cliAvailability";
 import { readConfig, TraceServer, XlflowConfig } from "./config";
 import { XlflowChannels } from "./logging";
 import { readFormsRootFromToml } from "./sidebar";
+import {
+  hasCompletionResult,
+  hasDefinitionResult,
+  hasHoverResult,
+  completionResultCount,
+  StartupTelemetry,
+} from "./startupTelemetry";
 import { resolveWorkspaceRoot } from "./xlflow";
+
+class StartupLanguageClient extends LanguageClient {
+  public constructor(
+    id: string,
+    name: string,
+    serverOptions: ServerOptions,
+    clientOptions: LanguageClientOptions,
+    private readonly onInitialized: () => void,
+  ) {
+    super(id, name, serverOptions, clientOptions);
+  }
+
+  public override async start(): Promise<void> {
+    await super.start();
+    this.onInitialized();
+  }
+}
 
 export function userFormSpecLSPGlob(formsRoot = "src/forms"): string {
   const normalizedRoot = formsRoot.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
@@ -21,42 +45,70 @@ export class XlflowLanguageClientManager implements vscode.Disposable {
   private client: LanguageClient | undefined;
   private workspaceFolderKey: string | undefined;
   private suggestTimer: NodeJS.Timeout | undefined;
+  private stateSubscription: vscode.Disposable | undefined;
+  private hasStarted = false;
+  private startup: StartupTelemetry | undefined;
 
   public constructor(
     private readonly channels: XlflowChannels,
-    private readonly cliAvailability: XlflowCliAvailabilityService,
-  ) {}
+    cliAvailabilityOrStartup?: XlflowCliAvailabilityService | StartupTelemetry,
+    startup?: StartupTelemetry,
+  ) {
+    // Keep the pre-#757 constructor shape source-compatible for callers that
+    // still pass the availability service. The service is no longer a startup
+    // dependency because process launch is the availability check.
+    this.startup =
+      startup ??
+      (cliAvailabilityOrStartup instanceof StartupTelemetry ? cliAvailabilityOrStartup : undefined);
+  }
 
   public async start(): Promise<void> {
     const config = readConfig();
     if (!config.lspEnabled) {
+      this.hasStarted = true;
       this.channels.output.info("xlflow LSP is disabled by xlflow.lsp.enabled.");
       return;
     }
     if (this.client !== undefined) {
       return;
     }
-    const availability = await this.cliAvailability.refresh();
-    if (!availability.ok) {
-      this.channels.output.info(
-        `Skipping xlflow lsp --stdio startup because ${availability.executable} is unavailable: ${availability.message}`,
-      );
-      return;
+    if (this.startup !== undefined) {
+      if (this.startup.isEnabled !== config.lspPerformanceLogging) {
+        this.startup = this.startup.withEnabled(config.lspPerformanceLogging);
+      } else if (this.hasStarted) {
+        this.startup = this.startup.newAttempt();
+      }
     }
+    this.hasStarted = true;
+
+    this.startup?.mark("workspaceResolutionStart");
 
     const folder = await resolveWorkspaceRoot({ prompt: false, fallbackToFirst: true });
     const cwd = folder?.uri.fsPath;
     const workspaceFolderKey = folder?.uri.toString();
-    const xlflowProject = await hasXlflowConfig(folder);
-    const formSpecGlob = await userFormSpecGlobForWorkspace(folder);
+    this.startup?.mark("workspaceResolutionComplete");
+    this.startup?.mark("projectConfigDiscoveryStart");
+    const [xlflowProject, formSpecGlob] = await Promise.all([
+      hasXlflowConfig(folder),
+      userFormSpecGlobForWorkspace(folder),
+    ]);
+    this.startup?.mark("projectConfigDiscoveryComplete");
     const args = lspServerArgsForProject(config, xlflowProject);
     const codeLens = lspCodeLensOptions(config, xlflowProject);
+    const startupEnv =
+      this.startup?.isEnabled === true
+        ? { ...process.env, XLFLOW_LSP_STARTUP_ID: this.startup.id }
+        : undefined;
     const serverOptions: ServerOptions = {
       command: config.path,
       args,
       transport: TransportKind.stdio,
-      options: cwd === undefined ? undefined : { cwd },
+      options:
+        cwd === undefined && startupEnv === undefined
+          ? undefined
+          : { ...(cwd === undefined ? {} : { cwd }), env: startupEnv },
     };
+    let telemetry = this.startup;
     const clientOptions: LanguageClientOptions = {
       documentSelector: [
         { scheme: "file", language: "vba" },
@@ -74,13 +126,86 @@ export class XlflowLanguageClientManager implements vscode.Disposable {
       initializationOptions: {
         codeLens,
       },
+      middleware: {
+        didOpen: (document, next) => {
+          const requestTelemetry = telemetry;
+          return next(document).then(() => {
+            requestTelemetry?.mark("firstDidOpenSent");
+          });
+        },
+        provideHover: async (document, position, token, next) => {
+          const requestTelemetry = telemetry;
+          const result = await next(document, position, token);
+          if (!token.isCancellationRequested && hasHoverResult(result)) {
+            requestTelemetry?.mark("firstHoverHandled", { resultCount: 1 });
+          }
+          return result;
+        },
+        provideDefinition: async (document, position, token, next) => {
+          const requestTelemetry = telemetry;
+          const result = await next(document, position, token);
+          if (!token.isCancellationRequested && hasDefinitionResult(result)) {
+            const resultCount = Array.isArray(result) ? result.length : 1;
+            requestTelemetry?.mark("firstDefinitionHandled", { resultCount });
+          }
+          return result;
+        },
+        provideCompletionItem: async (document, position, context, token, next) => {
+          const requestTelemetry = telemetry;
+          const result = await next(document, position, context, token);
+          if (!token.isCancellationRequested && hasCompletionResult(result)) {
+            requestTelemetry?.mark("firstCompletionHandled", {
+              resultCount: completionResultCount(result),
+            });
+          }
+          return result;
+        },
+      },
     };
 
-    const client = new LanguageClient("xlflow-vscode", "xlflow", serverOptions, clientOptions);
+    const client = new StartupLanguageClient(
+      "xlflow-vscode",
+      "xlflow",
+      serverOptions,
+      clientOptions,
+      () => telemetry?.mark("initializedSent"),
+    );
     this.client = client;
+    let processStartObserved = false;
+    this.stateSubscription = client.onDidChangeState((event) => {
+      // State.Starting is the closest public boundary to child-process spawn;
+      // the language-client package does not expose the enum from its node entrypoint.
+      if (event.newState === 3) {
+        const restarting = processStartObserved;
+        if (restarting && telemetry?.isEnabled === true) {
+          telemetry = telemetry.newAttempt();
+          this.startup = telemetry;
+          if (startupEnv !== undefined) {
+            startupEnv.XLFLOW_LSP_STARTUP_ID = telemetry.id;
+          }
+          telemetry.mark("languageClientStart");
+        }
+        processStartObserved = true;
+        telemetry?.mark("serverProcessSpawned");
+        if (restarting) {
+          telemetry?.mark("initializeRequestSent");
+        }
+      } else if (event.newState === 2) {
+        telemetry?.mark("initializeResponseReceived");
+      } else if (event.newState === 4) {
+        telemetry?.mark("languageClientStartFailed", { outcome: "error" });
+      }
+    });
 
+    const startAttemptTelemetry = telemetry;
     try {
-      await client.start();
+      startAttemptTelemetry?.mark("languageClientStart");
+      // start() publishes State.Starting before its first asynchronous
+      // connection step, so the process boundary is observed before the
+      // initialize request is recorded below.
+      const startPromise = client.start();
+      startAttemptTelemetry?.mark("initializeRequestSent");
+      await startPromise;
       this.workspaceFolderKey = workspaceFolderKey;
       await client.setTrace(toProtocolTrace(config.lspTraceServer));
       const logDescription = args.includes("--log-file")
@@ -92,6 +217,9 @@ export class XlflowLanguageClientManager implements vscode.Disposable {
     } catch (error) {
       this.client = undefined;
       this.workspaceFolderKey = undefined;
+      this.stateSubscription.dispose();
+      this.stateSubscription = undefined;
+      startAttemptTelemetry?.mark("languageClientStartFailed", { outcome: "error" });
       this.channels.output.error(`Failed to start xlflow lsp --stdio: ${String(error)}`);
       throw error;
     }
@@ -101,6 +229,8 @@ export class XlflowLanguageClientManager implements vscode.Disposable {
     const client = this.client;
     this.client = undefined;
     this.workspaceFolderKey = undefined;
+    this.stateSubscription?.dispose();
+    this.stateSubscription = undefined;
     this.clearPendingSuggest();
     await client?.stop();
   }

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -172,7 +172,7 @@ export class XlflowLanguageClientManager implements vscode.Disposable {
     );
     this.client = client;
     let processStartObserved = false;
-    this.stateSubscription = client.onDidChangeState((event) => {
+    const stateSubscription = client.onDidChangeState((event) => {
       // State.Starting is the closest public boundary to child-process spawn;
       // the language-client package does not expose the enum from its node entrypoint.
       if (event.newState === 3) {
@@ -196,6 +196,7 @@ export class XlflowLanguageClientManager implements vscode.Disposable {
         telemetry?.mark("languageClientStartFailed", { outcome: "error" });
       }
     });
+    this.stateSubscription = stateSubscription;
 
     const startAttemptTelemetry = telemetry;
     try {
@@ -215,10 +216,14 @@ export class XlflowLanguageClientManager implements vscode.Disposable {
         `Started xlflow lsp --stdio${cwd === undefined ? "" : ` in ${cwd}`}${logDescription}`,
       );
     } catch (error) {
-      this.client = undefined;
-      this.workspaceFolderKey = undefined;
-      this.stateSubscription.dispose();
-      this.stateSubscription = undefined;
+      if (this.client === client) {
+        this.client = undefined;
+        this.workspaceFolderKey = undefined;
+      }
+      stateSubscription.dispose();
+      if (this.stateSubscription === stateSubscription) {
+        this.stateSubscription = undefined;
+      }
       startAttemptTelemetry?.mark("languageClientStartFailed", { outcome: "error" });
       this.channels.output.error(`Failed to start xlflow lsp --stdio: ${String(error)}`);
       throw error;

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -8,9 +8,11 @@ import { XlflowLanguageClientManager } from "./client";
 import { registerCommands } from "./commands";
 import { checkVbaLanguageAssociation } from "./languageAssociation";
 import { createChannels } from "./logging";
+import { readConfig } from "./config";
 import { selectedWorkspaceFolder, XlflowProjectStateService } from "./projectState";
 import { SessionManager } from "./session";
 import { XlflowSidebar } from "./sidebar";
+import { StartupTelemetry } from "./startupTelemetry";
 import { XlflowUpdateService } from "./updateCheck";
 import { XlflowTestController } from "./testing";
 import { XlflowCapabilitiesService } from "./capabilities";
@@ -27,10 +29,19 @@ let updateService: XlflowUpdateService | undefined;
 let capabilitiesService: XlflowCapabilitiesService | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const activationStarted = performance.now();
   const channels = createChannels();
+  const startup = new StartupTelemetry(
+    readConfig().lspPerformanceLogging,
+    (record) => channels.output.info(`performance ${JSON.stringify(record)}`),
+    undefined,
+    undefined,
+    activationStarted,
+  );
+  startup.mark("extensionActivationStart");
   cliAvailability = new XlflowCliAvailabilityService();
   setXlflowCliAvailabilityService(cliAvailability);
-  clientManager = new XlflowLanguageClientManager(channels, cliAvailability);
+  clientManager = new XlflowLanguageClientManager(channels, startup);
   testController = new XlflowTestController(channels);
   sessionManager = new SessionManager(channels);
   capabilitiesService = new XlflowCapabilitiesService(channels, {
@@ -194,7 +205,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await updateService?.checkAutomatic(cliAvailability?.current());
       }
       if (pathChanged || lspChanged) {
-        await clientManager?.restart();
+        try {
+          await clientManager?.restart();
+        } catch (error) {
+          channels.output.error(`xlflow language server restart failed: ${String(error)}`);
+        }
       }
       if (pathChanged) {
         await refreshSelectedProject();
@@ -204,6 +219,41 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
     }),
   );
+
+  const availabilityPromise = (async () => {
+    startup.mark("cliAvailabilityStart");
+    const availability = await cliAvailability!.refresh();
+    startup.mark("cliAvailabilityComplete", { outcome: availability.ok ? "ok" : "error" });
+    return availability;
+  })();
+  const projectRefreshPromise = refreshSelectedProject({ restartLsp: false });
+  const projectRefreshState = projectRefreshPromise.then(
+    () => projectState?.current(),
+    () => projectState?.current(),
+  );
+  void availabilityPromise
+    .then(async (availability) => {
+      await updateService?.checkAutomatic(availability);
+      const state = await projectRefreshState;
+      if (state?.kind === "ready") {
+        await showProjectCliUnavailableNotice(context, state.workspaceFolder, availability);
+      }
+    })
+    .catch((error) =>
+      channels.output.error(`xlflow CLI availability refresh failed: ${String(error)}`),
+    );
+  void rulesRegistry.load().catch((error) => {
+    channels.output.error(`xlflow rules refresh failed: ${String(error)}`);
+  });
+  void capabilitiesService.load().catch((error) => {
+    channels.output.error(`xlflow capabilities refresh failed: ${String(error)}`);
+  });
+  void projectRefreshPromise.catch((error) => {
+    channels.output.error(`xlflow project refresh failed: ${String(error)}`);
+  });
+  void checkVbaLanguageAssociation(context).catch((error) => {
+    channels.output.error(`xlflow VBA language association check failed: ${String(error)}`);
+  });
 
   try {
     await clientManager.start();
@@ -215,12 +265,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       ),
     );
   }
-  await cliAvailability.refresh();
-  void rulesRegistry.load().catch(() => undefined);
-  void capabilitiesService.load();
-  await updateService.checkAutomatic(cliAvailability.current());
-  await refreshSelectedProject({ restartLsp: false });
-  await checkVbaLanguageAssociation(context);
 }
 
 export async function deactivate(): Promise<void> {

--- a/editors/vscode/src/startupTelemetry.ts
+++ b/editors/vscode/src/startupTelemetry.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from "crypto";
+
+export interface StartupTelemetryRecord {
+  operation: "lsp/startup";
+  side: "client";
+  startup_id: string;
+  event: string;
+  elapsed_ms: number;
+  wall_time_unix_ms: number;
+  outcome: "ok" | "error";
+  result_count?: number;
+}
+
+export type StartupClock = () => number;
+
+export class StartupTelemetry {
+  private readonly seen = new Set<string>();
+  private readonly idFactory: () => string;
+  private readonly started: number;
+
+  public readonly id: string;
+
+  public constructor(
+    private readonly enabled: boolean,
+    private readonly sink: (record: StartupTelemetryRecord) => void,
+    private readonly clock: StartupClock = () => performance.now(),
+    idFactory: () => string = randomUUID,
+    started?: number,
+  ) {
+    this.idFactory = idFactory;
+    this.id = enabled ? idFactory() : "";
+    this.started = started ?? (enabled ? clock() : 0);
+  }
+
+  public newAttempt(started?: number): StartupTelemetry {
+    const attemptStarted = started ?? (this.enabled ? this.clock() : undefined);
+    return new StartupTelemetry(
+      this.enabled,
+      this.sink,
+      this.clock,
+      this.idFactory,
+      attemptStarted,
+    );
+  }
+
+  public withEnabled(enabled: boolean, started?: number): StartupTelemetry {
+    const attemptStarted = started ?? (enabled ? this.clock() : undefined);
+    return new StartupTelemetry(enabled, this.sink, this.clock, this.idFactory, attemptStarted);
+  }
+
+  public get isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  public mark(
+    event: string,
+    options: { outcome?: "ok" | "error"; resultCount?: number; once?: boolean } = {},
+  ): void {
+    if (!this.enabled || event.length === 0) {
+      return;
+    }
+    const once = options.once !== false;
+    if (once && this.seen.has(event)) {
+      return;
+    }
+    if (once) {
+      this.seen.add(event);
+    }
+    const now = this.clock();
+    const record: StartupTelemetryRecord = {
+      operation: "lsp/startup",
+      side: "client",
+      startup_id: this.id,
+      event,
+      elapsed_ms: Math.max(0, now - this.started),
+      wall_time_unix_ms: Date.now(),
+      outcome: options.outcome ?? "ok",
+    };
+    if (options.resultCount !== undefined) {
+      record.result_count = options.resultCount;
+    }
+    this.sink(record);
+  }
+}
+
+export function hasHoverResult(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const contents = (value as { contents?: unknown }).contents;
+  if (Array.isArray(contents)) {
+    return contents.some(hasHoverContent);
+  }
+  return hasHoverContent(contents);
+}
+
+function hasHoverContent(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as { value?: unknown };
+  if (record.value !== undefined) {
+    return typeof record.value === "string" ? record.value.trim().length > 0 : false;
+  }
+  return Object.keys(value).length > 0;
+}
+
+export function hasDefinitionResult(value: unknown): boolean {
+  return Array.isArray(value) ? value.length > 0 : value !== undefined && value !== null;
+}
+
+export function hasCompletionResult(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const items = (value as { items?: unknown }).items;
+  return Array.isArray(items) && items.length > 0;
+}
+
+export function completionResultCount(value: unknown): number {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  if (typeof value !== "object" || value === null) {
+    return 0;
+  }
+  const items = (value as { items?: unknown }).items;
+  return Array.isArray(items) ? items.length : 0;
+}

--- a/editors/vscode/test/suite/extension.test.ts
+++ b/editors/vscode/test/suite/extension.test.ts
@@ -40,6 +40,12 @@ import {
   userFormSpecLSPGlob,
 } from "../../src/client";
 import {
+  hasCompletionResult,
+  hasDefinitionResult,
+  hasHoverResult,
+  StartupTelemetry,
+} from "../../src/startupTelemetry";
+import {
   isVbaSourcePath,
   mismatchedVbaLanguageDocuments,
   vbaFilesAssociationUpdate,
@@ -270,6 +276,63 @@ async function runAssertions(config: vscode.WorkspaceConfiguration): Promise<voi
 
   assert.strictEqual(config.get<string>("path"), "xlflow");
   assert.strictEqual(config.get<boolean>("lsp.performanceLogging"), false);
+  let startupClock = 0;
+  const startupRecords: Array<{ event: string; elapsed_ms: number; startup_id: string }> = [];
+  const startupTelemetry = new StartupTelemetry(
+    true,
+    (record) => startupRecords.push(record),
+    () => startupClock,
+    () => "test-startup",
+    0,
+  );
+  startupClock = 12;
+  startupTelemetry.mark("extensionActivationStart");
+  startupTelemetry.mark("firstHoverHandled", { resultCount: 1 });
+  startupTelemetry.mark("firstHoverHandled", { resultCount: 2 });
+  assert.deepStrictEqual(
+    startupRecords.map((record) => [record.startup_id, record.event, record.elapsed_ms]),
+    [
+      ["test-startup", "extensionActivationStart", 12],
+      ["test-startup", "firstHoverHandled", 12],
+    ],
+  );
+  let nextStartupId = 0;
+  const attemptTelemetry = new StartupTelemetry(
+    true,
+    () => undefined,
+    () => 0,
+    () => `attempt-${++nextStartupId}`,
+    0,
+  );
+  const restartedTelemetry = attemptTelemetry.newAttempt(1);
+  assert.notStrictEqual(attemptTelemetry.id, restartedTelemetry.id);
+  assert.strictEqual(hasHoverResult({ contents: [] }), false);
+  assert.strictEqual(hasHoverResult({ contents: ["  "] }), false);
+  assert.strictEqual(hasHoverResult({ contents: "  " }), false);
+  assert.strictEqual(hasHoverResult({ contents: "target" }), true);
+  assert.strictEqual(hasHoverResult(undefined), false);
+  assert.strictEqual(hasDefinitionResult([]), false);
+  assert.strictEqual(hasDefinitionResult({ uri: "file:///target" }), true);
+  assert.strictEqual(hasCompletionResult({ items: [] }), false);
+  assert.strictEqual(hasCompletionResult({ items: [{ label: "target" }] }), true);
+  const disabledStartupRecords: unknown[] = [];
+  let disabledClockCalls = 0;
+  const disabledStartup = new StartupTelemetry(
+    false,
+    (record) => disabledStartupRecords.push(record),
+    () => {
+      disabledClockCalls += 1;
+      return 0;
+    },
+  );
+  disabledStartup.mark("ignored");
+  disabledStartup.newAttempt();
+  assert.strictEqual(disabledStartupRecords.length, 0);
+  assert.strictEqual(disabledClockCalls, 0);
+  const reconfiguredStartup = disabledStartup.withEnabled(true, 0);
+  reconfiguredStartup.mark("enabled");
+  assert.strictEqual(reconfiguredStartup.isEnabled, true);
+  assert.strictEqual(disabledStartupRecords.length, 1);
   assert.strictEqual(
     buildTerminalCommandLine("xlflow", ["run", "--interactive", "Sheet1.Sample"]),
     "xlflow run --interactive Sheet1.Sample",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7294,7 +7294,7 @@ func (a *app) lspCommand() *cobra.Command {
 				env.Logs = []string{"lsp pre-launch check passed"}
 				return a.write(env, output.ExitSuccess)
 			}
-			a.ensureLSPTypeDBGenerated()
+			opts.BeforeStart = a.ensureLSPTypeDBGenerated
 			return lspserver.RunStdio(opts)
 		},
 	}

--- a/internal/lspserver/performance.go
+++ b/internal/lspserver/performance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -12,6 +13,24 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
 )
+
+const startupIDEnv = "XLFLOW_LSP_STARTUP_ID"
+
+type startupContext struct {
+	id      string
+	started time.Time
+}
+
+func startupContextFromEnvironment(enabled bool) *startupContext {
+	if !enabled {
+		return nil
+	}
+	id := strings.TrimSpace(os.Getenv(startupIDEnv))
+	if id == "" {
+		return nil
+	}
+	return &startupContext{id: id, started: time.Now()}
+}
 
 // Performance stage names are intentionally stable: they are consumed by
 // developer benchmark and profile scripts, but never enter an LSP payload.
@@ -113,10 +132,32 @@ var performanceCounterNames = [...]string{
 // nil-safe pointer and therefore do not pay a clock, lock, or map cost on the
 // normal path.
 type performanceRecorder struct {
-	logger   *log.Logger
-	enabled  bool
-	mu       sync.Mutex
+	logger  *log.Logger
+	enabled bool
+	mu      sync.Mutex
+	// startup is only populated for a server process started by the VS Code
+	// client with a per-attempt correlation ID. It remains nil for ordinary
+	// callers and for performance logging without startup correlation.
+	startup  *startupTelemetry
 	counters map[string]uint64
+}
+
+type startupTelemetry struct {
+	logger  *log.Logger
+	id      string
+	started time.Time
+	mu      sync.Mutex
+	events  map[string]struct{}
+}
+
+func newStartupTelemetry(logger *log.Logger, startup *startupContext) *startupTelemetry {
+	if logger == nil || startup == nil || startup.id == "" {
+		return nil
+	}
+	return &startupTelemetry{
+		logger: logger, id: startup.id, started: startup.started,
+		events: make(map[string]struct{}),
+	}
 }
 
 func newPerformanceRecorder(enabled bool, logger *log.Logger) *performanceRecorder {
@@ -128,6 +169,61 @@ func newPerformanceRecorder(enabled bool, logger *log.Logger) *performanceRecord
 		counters[name] = 0
 	}
 	return &performanceRecorder{logger: logger, enabled: true, counters: counters}
+}
+
+func (p *performanceRecorder) setStartup(startup *startupContext) {
+	if p == nil || !p.enabled {
+		return
+	}
+	p.startup = newStartupTelemetry(p.logger, startup)
+}
+
+func (p *performanceRecorder) startupEvent(event string) {
+	if p == nil || !p.enabled || p.startup == nil {
+		return
+	}
+	p.startup.event(event)
+}
+
+func (p *performanceRecorder) firstSuccessfulInteractive(operation string, resultCount int) {
+	if p == nil || !p.enabled || p.startup == nil || resultCount <= 0 {
+		return
+	}
+	event := ""
+	switch operation {
+	case "textDocument/hover":
+		event = "firstHoverHandled"
+	case "textDocument/definition":
+		event = "firstDefinitionHandled"
+	case "textDocument/completion":
+		event = "firstCompletionHandled"
+	default:
+		return
+	}
+	p.startup.event(event, resultCount)
+}
+
+func (t *startupTelemetry) event(event string, resultCount ...int) {
+	if t == nil || t.logger == nil || event == "" {
+		return
+	}
+	t.mu.Lock()
+	if _, ok := t.events[event]; ok {
+		t.mu.Unlock()
+		return
+	}
+	t.events[event] = struct{}{}
+	t.mu.Unlock()
+	now := time.Now()
+	count := 0
+	if len(resultCount) != 0 {
+		count = resultCount[0]
+	}
+	t.logger.Printf(
+		"performance operation=%q startup_id=%q event=%q elapsed_ms=%.3f wall_time_unix_ns=%d result_count=%d outcome=%q",
+		"lsp/startup", t.id, event,
+		float64(now.Sub(t.started))/float64(time.Millisecond), now.UnixNano(), count, "ok",
+	)
 }
 
 type performanceStageMeasurement struct {
@@ -390,6 +486,9 @@ func (m *performanceMeasurement) finish(resultCount int, err error) {
 		resultCount,
 		outcome,
 	)
+	if err == nil {
+		m.server.performance.firstSuccessfulInteractive(m.operation, resultCount)
+	}
 }
 
 func (m *performanceMeasurement) finishDiagnostics(resultCount int, generation uint64, discarded bool) {
@@ -441,6 +540,9 @@ func (s *Server) logInitialWorkspaceIndexPerformance(fileCount int, started time
 	if !s.opts.PerformanceLog {
 		return
 	}
+	if err == nil {
+		s.performance.startupEvent("semanticIndexReady")
+	}
 	outcome := "ok"
 	if err != nil {
 		outcome = "error"
@@ -458,6 +560,9 @@ func (s *Server) logInitialWorkspaceIndexPerformance(fileCount int, started time
 func (s *Server) logInitialWorkspaceDeclarationPerformance(fileCount int, started time.Time, err error) {
 	if !s.opts.PerformanceLog {
 		return
+	}
+	if err == nil {
+		s.performance.startupEvent("declarationIndexReady")
 	}
 	outcome := "ok"
 	if err != nil {

--- a/internal/lspserver/performance_test.go
+++ b/internal/lspserver/performance_test.go
@@ -73,6 +73,113 @@ func TestPerformanceLoggingIncludesStableDocumentFields(t *testing.T) {
 	}
 }
 
+func TestStartupTelemetryCorrelatesLifecycleReadinessAndInteractiveSuccess(t *testing.T) {
+	fixture := makeLSPStartupBenchmarkFixture(t)
+	var output bytes.Buffer
+	s, cleanup, err := New(Options{
+		RootDir:        fixture.root,
+		Config:         config.Default(),
+		Stderr:         &output,
+		PerformanceLog: true,
+		startup:        &startupContext{id: "attempt-test", started: time.Now()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleaned := false
+	defer func() {
+		if !cleaned {
+			cleanup()
+		}
+	}()
+
+	if _, err := s.initialize(nil, &protocol.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.initialized(nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	completionSource := fixture.sourceA
+	if err := s.didOpen(nil, &protocol.DidOpenTextDocumentParams{TextDocument: protocol.TextDocumentItem{
+		URI: protocol.DocumentUri(fixture.moduleAURI), Version: 1, Text: completionSource,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.analysis.waitReady(); err != nil {
+		t.Fatal(err)
+	}
+
+	line := benchmarkSourceLine(completionSource, "    Call CrossFileTarget(1)")
+	if _, err := s.hover(nil, &protocol.HoverParams{TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(fixture.moduleAURI)},
+		Position:     protocol.Position{Line: protocol.UInteger(line), Character: protocol.UInteger(len("    Call "))},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.definition(nil, &protocol.DefinitionParams{TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(fixture.moduleAURI)},
+		Position:     protocol.Position{Line: protocol.UInteger(line), Character: protocol.UInteger(len("    Call "))},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	completionLine := benchmarkSourceLine(completionSource, "    Worksheets(\"Input\").Ra")
+	if _, err := s.completion(nil, &protocol.CompletionParams{TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(fixture.moduleAURI)},
+		Position:     protocol.Position{Line: protocol.UInteger(completionLine), Character: 27},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+	cleaned = true
+
+	logOutput := output.String()
+	for _, event := range []string{
+		"serverProcessStart", "serverConstructed", "initializeHandled", "initializedHandled",
+		"didOpenHandled", "declarationIndexStarted", "declarationIndexReady", "semanticIndexStarted", "semanticIndexReady",
+		"firstHoverHandled", "firstDefinitionHandled", "firstCompletionHandled",
+	} {
+		needle := `event="` + event + `"`
+		if count := strings.Count(logOutput, needle); count != 1 {
+			t.Fatalf("startup event %q count = %d, want one:\n%s", event, count, logOutput)
+		}
+	}
+	for _, field := range []string{`startup_id="attempt-test"`, `elapsed_ms=`, `wall_time_unix_ns=`} {
+		if !strings.Contains(logOutput, field) {
+			t.Fatalf("startup telemetry missing %q:\n%s", field, logOutput)
+		}
+	}
+}
+
+func TestStartupTelemetryIsDisabledWithoutPerformanceLogging(t *testing.T) {
+	var output bytes.Buffer
+	_, cleanup, err := New(Options{
+		RootDir: t.TempDir(), Config: config.Default(), Stderr: &output,
+		startup: &startupContext{id: "attempt-disabled", started: time.Now()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if strings.Contains(output.String(), `operation="lsp/startup"`) {
+		t.Fatalf("startup telemetry emitted while performance logging was disabled: %s", output.String())
+	}
+}
+
+func TestStartupContextReadsAnonymousEnvironmentIDWhenEnabled(t *testing.T) {
+	t.Setenv(startupIDEnv, "attempt-from-client")
+	if startup := startupContextFromEnvironment(false); startup != nil {
+		t.Fatal("startup context was created while performance logging was disabled")
+	}
+	startup := startupContextFromEnvironment(true)
+	if startup == nil || startup.id != "attempt-from-client" || startup.started.IsZero() {
+		t.Fatalf("startup context = %+v, want enabled environment context", startup)
+	}
+	t.Setenv(startupIDEnv, " ")
+	if startup := startupContextFromEnvironment(true); startup != nil {
+		t.Fatalf("startup context = %+v, want nil for missing environment ID", startup)
+	}
+}
+
 func TestDiagnosticsPerformanceLoggingIncludesGenerationAndDiscardStatus(t *testing.T) {
 	var output bytes.Buffer
 	s, cleanup, err := New(Options{

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -67,6 +67,11 @@ type Options struct {
 	Stderr         io.Writer
 	TypeDBDir      string
 	PerformanceLog bool
+	// BeforeStart runs after the process startup baseline is captured and
+	// before server construction. The CLI uses it for best-effort TypeLib
+	// preparation so that cold-start cost remains in startup telemetry.
+	BeforeStart func()
+	startup     *startupContext
 }
 
 type Server struct {
@@ -196,6 +201,10 @@ func Check(opts Options) error {
 }
 
 func RunStdio(opts Options) error {
+	opts.startup = startupContextFromEnvironment(opts.PerformanceLog)
+	if opts.BeforeStart != nil {
+		opts.BeforeStart()
+	}
 	s, cleanup, err := New(opts)
 	if err != nil {
 		return err
@@ -254,6 +263,10 @@ func New(opts Options) (*Server, func(), error) {
 		semanticInvalidationPaths: make(map[string]struct{}),
 		analysisPermits:           make(chan struct{}, max(1, runtime.GOMAXPROCS(0)/2)),
 		analysisPermitChanged:     make(chan struct{}),
+	}
+	if opts.startup != nil {
+		s.performance.setStartup(opts.startup)
+		s.performance.startupEvent("serverProcessStart")
 	}
 	s.analysis = s.newWorkspaceAnalysisIndex()
 	s.analyzer.DocumentSymbolsFunc = s.cachedDocumentSourceSymbols
@@ -395,6 +408,7 @@ func New(opts Options) (*Server, func(), error) {
 		TextDocumentSemanticTokensFullDelta: s.semanticTokensFullDelta,
 		TextDocumentCodeLens:                s.codeLens,
 	}
+	s.performance.startupEvent("serverConstructed")
 	return s, func() {
 		s.stopDiagnostics()
 		if s.analysis != nil {
@@ -727,17 +741,20 @@ func (s *Server) initialize(_ *glsp.Context, params *protocol.InitializeParams) 
 	if version == "" {
 		version = "dev"
 	}
-	return protocol.InitializeResult{
+	result := protocol.InitializeResult{
 		Capabilities: capabilities,
 		ServerInfo: &protocol.InitializeResultServerInfo{
 			Name:    serverName,
 			Version: &version,
 		},
-	}, nil
+	}
+	s.performance.startupEvent("initializeHandled")
+	return result, nil
 }
 
 func (s *Server) initialized(_ *glsp.Context, _ *protocol.InitializedParams) error {
 	s.analysis.start()
+	s.performance.startupEvent("initializedHandled")
 	s.logger.Printf("initialized")
 	return nil
 }
@@ -803,6 +820,7 @@ func (s *Server) didOpen(ctx *glsp.Context, params *protocol.DidOpenTextDocument
 	s.openDiagnostics(ctx, doc)
 	unlock()
 	measurement.finish(0, nil)
+	s.performance.startupEvent("didOpenHandled")
 	return nil
 }
 
@@ -1263,7 +1281,7 @@ func (s *Server) hover(_ *glsp.Context, params *protocol.HoverParams) (*protocol
 	measurement.setDocument(doc)
 	if s.documentKind(doc) == DocumentKindUserFormYAML {
 		hover := formsintel.HoverYAML(doc.Source, formsintel.Position{Line: int(params.Position.Line), Character: int(params.Position.Character)})
-		if hover == nil {
+		if hover == nil || strings.TrimSpace(hover.Contents) == "" {
 			measurement.finish(0, nil)
 			return nil, nil
 		}
@@ -1278,7 +1296,7 @@ func (s *Server) hover(_ *glsp.Context, params *protocol.HoverParams) (*protocol
 		return nil, nil
 	}
 	hover, err := s.analyzer.Hover(doc, fromProtocolPosition(params.Position), s.docs.openDocuments())
-	if err != nil || hover == nil {
+	if err != nil || hover == nil || strings.TrimSpace(hover.Contents) == "" {
 		measurement.finish(0, err)
 		return nil, err
 	}

--- a/internal/lspserver/server_benchmark_test.go
+++ b/internal/lspserver/server_benchmark_test.go
@@ -616,7 +616,7 @@ func makeLSPStartupBenchmarkFixture(tb testing.TB) lspStartupBenchmarkFixture {
 	moduleB := filepath.Join(moduleDir, "00_ModuleB.bas")
 	moduleA := filepath.Join(moduleDir, "01_ModuleA.bas")
 	sourceB := "Attribute VB_Name = \"ModuleB\"\nOption Explicit\n\nPublic Function CrossFileTarget(ByVal value As Long) As Long\n    CrossFileTarget = value + 1\nEnd Function\n"
-	sourceA := "Attribute VB_Name = \"ModuleA\"\nOption Explicit\n\nPublic Sub CallB()\n    Call CrossFileTarget(1)\nEnd Sub\n"
+	sourceA := "Attribute VB_Name = \"ModuleA\"\nOption Explicit\n\nPublic Sub CallB()\n    Call CrossFileTarget(1)\nEnd Sub\n\nPublic Sub CompletionTarget()\n    Worksheets(\"Input\").Ra\nEnd Sub\n"
 	if err := os.WriteFile(moduleB, []byte(sourceB), 0o644); err != nil {
 		tb.Fatal(err)
 	}
@@ -651,7 +651,7 @@ func TestLSPStartupBenchmarkFixture(t *testing.T) {
 	}
 }
 
-func startupInteractiveQueries(b *testing.B, s *Server, fixture lspStartupBenchmarkFixture) (int, int) {
+func startupInteractiveQueries(b *testing.B, s *Server, fixture lspStartupBenchmarkFixture) (int, int, int) {
 	b.Helper()
 	line := benchmarkSourceLine(fixture.sourceA, "    Call CrossFileTarget(1)")
 	character := len("    Call ")
@@ -683,7 +683,19 @@ func startupInteractiveQueries(b *testing.B, s *Server, fixture lspStartupBenchm
 			hovers = 1
 		}
 	}
-	return hovers, definitions
+	completionLine := benchmarkSourceLine(fixture.sourceA, "    Worksheets(\"Input\").Ra")
+	completion, err := s.completion(nil, &protocol.CompletionParams{TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(fixture.moduleAURI)},
+		Position:     protocol.Position{Line: protocol.UInteger(completionLine), Character: 27},
+	}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	completions := 0
+	if list, ok := completion.(protocol.CompletionList); ok && len(list.Items) > 0 {
+		completions = 1
+	}
+	return hovers, definitions, completions
 }
 
 func waitLSPStartupEvent(b *testing.B, events <-chan struct{}) {
@@ -759,14 +771,15 @@ func BenchmarkLSPStartup(b *testing.B) {
 
 	b.Run("ImmediateInteractive", func(b *testing.B) {
 		b.ReportAllocs()
-		var hovers, definitions int
+		var hovers, definitions, completions int
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
 			s, cleanup := startLSPStartupServer(b, fixture)
 			b.StartTimer()
-			hover, definition := startupInteractiveQueries(b, s, fixture)
+			hover, definition, completion := startupInteractiveQueries(b, s, fixture)
 			hovers += hover
 			definitions += definition
+			completions += completion
 			b.StopTimer()
 			if err := s.analysis.waitReady(); err != nil {
 				b.Fatal(err)
@@ -775,11 +788,12 @@ func BenchmarkLSPStartup(b *testing.B) {
 		}
 		b.ReportMetric(float64(hovers)/float64(b.N), "hover_results/op")
 		b.ReportMetric(float64(definitions)/float64(b.N), "definition_results/op")
+		b.ReportMetric(float64(completions)/float64(b.N), "completion_results/op")
 	})
 
 	b.Run("WhileIndexing", func(b *testing.B) {
 		b.ReportAllocs()
-		var hovers, definitions int
+		var hovers, definitions, completions int
 		for i := 0; i < b.N; i++ {
 			func() {
 				b.StopTimer()
@@ -812,9 +826,10 @@ func BenchmarkLSPStartup(b *testing.B) {
 				}
 				waitLSPStartupEvent(b, active)
 				b.StartTimer()
-				hover, definition := startupInteractiveQueries(b, s, fixture)
+				hover, definition, completion := startupInteractiveQueries(b, s, fixture)
 				hovers += hover
 				definitions += definition
+				completions += completion
 				b.StopTimer()
 				release()
 				if err := s.analysis.waitReady(); err != nil {
@@ -824,11 +839,12 @@ func BenchmarkLSPStartup(b *testing.B) {
 		}
 		b.ReportMetric(float64(hovers)/float64(b.N), "hover_results/op")
 		b.ReportMetric(float64(definitions)/float64(b.N), "definition_results/op")
+		b.ReportMetric(float64(completions)/float64(b.N), "completion_results/op")
 	})
 
 	b.Run("AfterDeclarationBeforeSemantic", func(b *testing.B) {
 		b.ReportAllocs()
-		var hovers, definitions int
+		var hovers, definitions, completions int
 		for i := 0; i < b.N; i++ {
 			func() {
 				b.StopTimer()
@@ -869,12 +885,13 @@ func BenchmarkLSPStartup(b *testing.B) {
 				// corresponding posting publication before measuring the query itself.
 				waitForWorkspaceSymbol(b, s.analysis, "CrossFileTarget")
 				b.StartTimer()
-				hover, definition := startupInteractiveQueries(b, s, fixture)
+				hover, definition, completion := startupInteractiveQueries(b, s, fixture)
 				if hover != 1 || definition != 1 {
 					b.Fatalf("declaration-ready interactive results = hover %d, definition %d; want 1/1", hover, definition)
 				}
 				hovers += hover
 				definitions += definition
+				completions += completion
 				b.StopTimer()
 				release()
 				if err := s.analysis.waitReady(); err != nil {
@@ -884,11 +901,12 @@ func BenchmarkLSPStartup(b *testing.B) {
 		}
 		b.ReportMetric(float64(hovers)/float64(b.N), "hover_results/op")
 		b.ReportMetric(float64(definitions)/float64(b.N), "definition_results/op")
+		b.ReportMetric(float64(completions)/float64(b.N), "completion_results/op")
 	})
 
 	b.Run("AfterSemanticReady", func(b *testing.B) {
 		b.ReportAllocs()
-		var hovers, definitions int
+		var hovers, definitions, completions int
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
 			s, cleanup := newLSPStartupServer(b, fixture)
@@ -917,13 +935,15 @@ func BenchmarkLSPStartup(b *testing.B) {
 				b.Fatal(err)
 			}
 			b.StartTimer()
-			hover, definition := startupInteractiveQueries(b, s, fixture)
+			hover, definition, completion := startupInteractiveQueries(b, s, fixture)
 			hovers += hover
 			definitions += definition
+			completions += completion
 			b.StopTimer()
 			cleanup()
 		}
 		b.ReportMetric(float64(hovers)/float64(b.N), "hover_results/op")
 		b.ReportMetric(float64(definitions)/float64(b.N), "definition_results/op")
+		b.ReportMetric(float64(completions)/float64(b.N), "completion_results/op")
 	})
 }

--- a/internal/lspserver/workspace_analysis_index.go
+++ b/internal/lspserver/workspace_analysis_index.go
@@ -305,6 +305,7 @@ func (x *workspaceAnalysisIndex) buildInitial() {
 		// The declaration phase is intentionally complete before semantic
 		// preparation starts.  This makes the symbol index useful as soon as
 		// possible and keeps heavyweight IR/CFG work from delaying it.
+		x.performance.startupEvent("declarationIndexStarted")
 		declarationStarted := time.Now()
 		sources := x.buildInitialDeclarations(files)
 		err = x.initialCtx.Err()
@@ -394,6 +395,7 @@ sendJobs:
 }
 
 func (x *workspaceAnalysisIndex) buildInitialSemantics(files []symbols.SourceFile, sources map[string]initialSource) {
+	x.performance.startupEvent("semanticIndexStarted")
 	workers := max(1, x.semanticWorkers)
 	jobs := make(chan symbols.SourceFile)
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Summary

- Remove the blocking `xlflow version` preflight from VS Code language client startup and defer nonessential CLI and project refresh work so LSP initialization reaches readiness sooner.
- Add opt-in client/server startup telemetry correlation with per-attempt IDs and first successful interactive request metrics.
- Include TypeLib preparation in the server startup baseline and extend tests, benchmarks, documentation, and VS Code CI coverage.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./... -count=1 -timeout 25m`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 vet ./...`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test -race ./internal/lspserver -run 'TestStartupTelemetry' -count=1 -timeout 25m`
- `rtk pnpm check` (from `editors/vscode`)
- `rtk pnpm lint` (from `editors/vscode`)
- `rtk pnpm test` (from `editors/vscode`)
- `rtk pnpm format:check`
- `rtk pnpm docs:check`
- `rtk task bench:lsp-startup`
- `rtk git diff --check`

## Notes

- Fixes #757.
- Excel COM/VBE E2E was not run because this change is limited to VS Code/LSP startup orchestration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved VS Code language-intelligence startup by removing blocking preflight checks and moving refresh tasks off the activation path.
  * Language features become available sooner, with faster hover, definition, and completion readiness.
  * Added optional startup performance logging to correlate extension and language-server readiness stages.

* **Bug Fixes**
  * Improved handling and logging of language-server startup and restart failures.
  * Empty hover results are now handled consistently.

* **Tests**
  * Added automated coverage for startup telemetry, lifecycle readiness, and interactive language features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->