### PR TITLE
fix(lsp): complete cancellation-safe interactive scheduling

### DIFF
--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -127,9 +127,12 @@ type Server struct {
 	resolutionTypeLibSymbols   []procedureir.ResolverSymbol
 	// Interactive requests are dispatched separately so a $/cancelRequest can
 	// reach a request waiting for an analysis permit.
-	requestMu       sync.Mutex
-	requestContexts map[*glsp.Context]context.Context
-	requestCancels  map[jsonrpc2.ID]context.CancelFunc
+	requestMu             sync.Mutex
+	requestContexts       map[*glsp.Context]context.Context
+	requestCancels        map[jsonrpc2.ID]context.CancelFunc
+	requestCancelContexts map[*glsp.Context]context.CancelFunc
+	requestWait           sync.WaitGroup
+	requestStopping       bool
 }
 
 type projectConstantsResult struct {
@@ -270,6 +273,7 @@ func New(opts Options) (*Server, func(), error) {
 		semanticInvalidationPaths: make(map[string]struct{}),
 		requestContexts:           make(map[*glsp.Context]context.Context),
 		requestCancels:            make(map[jsonrpc2.ID]context.CancelFunc),
+		requestCancelContexts:     make(map[*glsp.Context]context.CancelFunc),
 		analysisScheduler:         newAnalysisScheduler(max(1, runtime.GOMAXPROCS(0)/2)),
 	}
 	if opts.startup != nil {
@@ -420,6 +424,7 @@ func New(opts Options) (*Server, func(), error) {
 	s.codeActions = newCodeActionRequests()
 	s.performance.startupEvent("serverConstructed")
 	return s, func() {
+		s.cancelInteractiveRequestsAndWait()
 		s.codeActions.stop()
 		s.stopDiagnostics()
 		if s.analysis != nil {
@@ -863,6 +868,7 @@ func codeLensConfigFromInitialize(params *protocol.InitializeParams) intel.CodeL
 }
 
 func (s *Server) shutdown(_ *glsp.Context) error {
+	s.cancelInteractiveRequestsAndWait()
 	s.codeActions.stop()
 	s.stopDiagnostics()
 	if s.analysis != nil {
@@ -879,22 +885,31 @@ func (s *Server) exit(_ *glsp.Context) error {
 	return nil
 }
 
-func (s *Server) registerRequest(req *jsonrpc2.Request, glspCtx *glsp.Context, requestCtx context.Context, cancel context.CancelFunc) {
+func (s *Server) registerRequest(req *jsonrpc2.Request, glspCtx *glsp.Context, requestCtx context.Context, cancel context.CancelFunc) bool {
 	if s == nil || req == nil || glspCtx == nil {
-		return
+		return false
 	}
 	s.requestMu.Lock()
+	defer s.requestMu.Unlock()
+	if s.requestStopping {
+		return false
+	}
 	if s.requestContexts == nil {
 		s.requestContexts = make(map[*glsp.Context]context.Context)
 	}
 	if s.requestCancels == nil {
 		s.requestCancels = make(map[jsonrpc2.ID]context.CancelFunc)
 	}
+	if s.requestCancelContexts == nil {
+		s.requestCancelContexts = make(map[*glsp.Context]context.CancelFunc)
+	}
 	s.requestContexts[glspCtx] = requestCtx
+	s.requestCancelContexts[glspCtx] = cancel
 	if !req.Notif {
 		s.requestCancels[req.ID] = cancel
 	}
-	s.requestMu.Unlock()
+	s.requestWait.Add(1)
+	return true
 }
 
 func (s *Server) unregisterRequest(req *jsonrpc2.Request, glspCtx *glsp.Context) {
@@ -902,11 +917,16 @@ func (s *Server) unregisterRequest(req *jsonrpc2.Request, glspCtx *glsp.Context)
 		return
 	}
 	s.requestMu.Lock()
+	_, registered := s.requestContexts[glspCtx]
 	delete(s.requestContexts, glspCtx)
+	delete(s.requestCancelContexts, glspCtx)
 	if req != nil && !req.Notif {
 		delete(s.requestCancels, req.ID)
 	}
 	s.requestMu.Unlock()
+	if registered {
+		s.requestWait.Done()
+	}
 }
 
 func (s *Server) requestContext(glspCtx *glsp.Context) context.Context {
@@ -932,6 +952,25 @@ func (s *Server) cancelRequest(id jsonrpc2.ID) {
 	if cancel != nil {
 		cancel()
 	}
+}
+
+func (s *Server) cancelInteractiveRequestsAndWait() {
+	if s == nil {
+		return
+	}
+	s.requestMu.Lock()
+	s.requestStopping = true
+	cancels := make([]context.CancelFunc, 0, len(s.requestCancelContexts))
+	for _, cancel := range s.requestCancelContexts {
+		if cancel != nil {
+			cancels = append(cancels, cancel)
+		}
+	}
+	s.requestMu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+	s.requestWait.Wait()
 }
 
 func (s *Server) didOpen(ctx *glsp.Context, params *protocol.DidOpenTextDocumentParams) error {
@@ -4207,7 +4246,13 @@ func (h rpcHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrp
 	}
 	if h.server != nil && interactiveAnalysisRequest(req.Method) {
 		requestCtx, cancel := context.WithCancel(ctx)
-		h.server.registerRequest(req, glspCtx, requestCtx, cancel)
+		if !h.server.registerRequest(req, glspCtx, requestCtx, cancel) {
+			cancel()
+			if !req.Notif {
+				_ = conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{Code: -32800, Message: context.Canceled.Error()})
+			}
+			return
+		}
 		go h.handle(ctx, cancel, conn, req, glspCtx)
 		return
 	}

--- a/internal/lspserver/server_test.go
+++ b/internal/lspserver/server_test.go
@@ -1277,7 +1277,7 @@ func TestServerShutdownCancelsAndJoinsInteractiveRequests(t *testing.T) {
 	s.cancelInteractiveRequestsAndWait()
 	select {
 	case <-joined:
-	default:
+	case <-time.After(jsonrpcIntegrationTimeout):
 		t.Fatal("shutdown returned before interactive request joined")
 	}
 	if got := len(s.requestContexts); got != 0 {

--- a/internal/lspserver/server_test.go
+++ b/internal/lspserver/server_test.go
@@ -1260,6 +1260,37 @@ func TestJSONRPCInteractiveCancellationReleasesAnalysisWaiter(t *testing.T) {
 	}
 }
 
+func TestServerShutdownCancelsAndJoinsInteractiveRequests(t *testing.T) {
+	s := &Server{}
+	req := &jsonrpc2.Request{Method: "textDocument/hover", ID: jsonrpc2.ID{Num: 1}}
+	glspCtx := &glsp.Context{}
+	requestCtx, cancel := context.WithCancel(context.Background())
+	if !s.registerRequest(req, glspCtx, requestCtx, cancel) {
+		t.Fatal("interactive request was not registered")
+	}
+	joined := make(chan struct{})
+	go func() {
+		<-requestCtx.Done()
+		s.unregisterRequest(req, glspCtx)
+		close(joined)
+	}()
+	s.cancelInteractiveRequestsAndWait()
+	select {
+	case <-joined:
+	default:
+		t.Fatal("shutdown returned before interactive request joined")
+	}
+	if got := len(s.requestContexts); got != 0 {
+		t.Fatalf("active request contexts after shutdown = %d, want 0", got)
+	}
+	newCtx, newCancel := context.WithCancel(context.Background())
+	if s.registerRequest(&jsonrpc2.Request{Method: "textDocument/hover", ID: jsonrpc2.ID{Num: 2}}, &glsp.Context{}, newCtx, newCancel) {
+		newCancel()
+		t.Fatal("shutdown accepted a new interactive request")
+	}
+	newCancel()
+}
+
 func TestCodeActionRequestsBoundedQueueAndAutomaticSupersession(t *testing.T) {
 	q := newCodeActionRequests()
 	defer q.stop()

--- a/internal/vba/ast/ast.go
+++ b/internal/vba/ast/ast.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"runtime"
 	"sync"
+	"sync/atomic"
 
 	tree_sitter_vba "github.com/harumiWeb/tree-sitter-vba/bindings/go"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
@@ -101,24 +103,42 @@ func parseDocumentContext(ctx context.Context, path string, source []byte, oldTr
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	parser, err := NewParser()
 	if err != nil {
 		return nil, err
 	}
 	defer parser.Close()
 	copySource := append([]byte(nil), source...)
-	var options *tree_sitter.ParseOptions
+	// go-tree-sitter v0.25.0 leaks the cgo handle for a non-nil
+	// ParseOptions. Use the parser's cancellation flag with Parse (which passes
+	// nil options) until a released binding is available, and join the watcher
+	// before closing the parser so it cannot touch freed parser state.
+	var parseDone chan struct{}
+	var cancelDone chan struct{}
 	if ctx.Done() != nil {
-		options = &tree_sitter.ParseOptions{ProgressCallback: func(tree_sitter.ParseState) bool {
-			return ctx.Err() != nil
-		}}
+		cancellationFlag := new(uintptr)
+		//nolint:staticcheck // ParseWithOptions leaks non-nil ParseOptions handles in v0.25.0.
+		parser.parser.SetCancellationFlag(cancellationFlag)
+		parseDone = make(chan struct{})
+		cancelDone = make(chan struct{})
+		go func() {
+			defer close(cancelDone)
+			select {
+			case <-ctx.Done():
+				atomic.StoreUintptr(cancellationFlag, 1)
+			case <-parseDone:
+			}
+		}()
+		defer func() {
+			close(parseDone)
+			<-cancelDone
+			runtime.KeepAlive(cancellationFlag)
+		}()
 	}
-	tree := parser.parser.ParseWithOptions(func(index int, _ tree_sitter.Point) []byte {
-		if index < len(copySource) {
-			return copySource[index:]
-		}
-		return []byte{}
-	}, oldTree, options)
+	tree := parser.parser.Parse(copySource, oldTree)
 	if tree == nil {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/internal/vba/ast/ast.go
+++ b/internal/vba/ast/ast.go
@@ -56,7 +56,13 @@ type ParsedDocument struct {
 // supplied source is copied so callers cannot mutate the bytes backing a
 // shared parsed document after construction.
 func ParseDocument(path string, source []byte) (*ParsedDocument, error) {
-	return parseDocument(path, source, nil)
+	return ParseDocumentContext(context.Background(), path, source)
+}
+
+// ParseDocumentContext parses immutable source while allowing tree-sitter to
+// stop at a cooperative cancellation checkpoint.
+func ParseDocumentContext(ctx context.Context, path string, source []byte) (*ParsedDocument, error) {
+	return parseDocumentContext(ctx, path, source, nil)
 }
 
 // ParseDocumentIncremental parses source using an edited clone of previous's
@@ -73,7 +79,7 @@ func ParseDocumentIncremental(path string, source []byte, previous *ParsedDocume
 		return nil, err
 	}
 	defer oldTree.Close()
-	return parseDocument(path, source, oldTree)
+	return parseDocumentContext(context.Background(), path, source, oldTree)
 }
 
 // ParseDocumentIncrementalIfAvailable performs an incremental parse only when
@@ -88,19 +94,40 @@ func ParseDocumentIncrementalIfAvailable(path string, source, previousSource []b
 		return nil, err
 	}
 	defer oldTree.Close()
-	return parseDocument(path, source, oldTree)
+	return parseDocumentContext(context.Background(), path, source, oldTree)
 }
 
-func parseDocument(path string, source []byte, oldTree *tree_sitter.Tree) (*ParsedDocument, error) {
+func parseDocumentContext(ctx context.Context, path string, source []byte, oldTree *tree_sitter.Tree) (*ParsedDocument, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	parser, err := NewParser()
 	if err != nil {
 		return nil, err
 	}
 	defer parser.Close()
 	copySource := append([]byte(nil), source...)
-	tree := parser.parser.Parse(copySource, oldTree)
+	var options *tree_sitter.ParseOptions
+	if ctx.Done() != nil {
+		options = &tree_sitter.ParseOptions{ProgressCallback: func(tree_sitter.ParseState) bool {
+			return ctx.Err() != nil
+		}}
+	}
+	tree := parser.parser.ParseWithOptions(func(index int, _ tree_sitter.Point) []byte {
+		if index < len(copySource) {
+			return copySource[index:]
+		}
+		return []byte{}
+	}, oldTree, options)
 	if tree == nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		return nil, ErrIncrementalParseUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		tree.Close()
+		return nil, err
 	}
 	root := tree.RootNode()
 	if root == nil {

--- a/internal/vba/ast/ast.go
+++ b/internal/vba/ast/ast.go
@@ -120,6 +120,8 @@ func parseDocumentContext(ctx context.Context, path string, source []byte, oldTr
 	var cancelDone chan struct{}
 	if ctx.Done() != nil {
 		cancellationFlag := new(uintptr)
+		var pinner runtime.Pinner
+		pinner.Pin(cancellationFlag)
 		//nolint:staticcheck // ParseWithOptions leaks non-nil ParseOptions handles in v0.25.0.
 		parser.parser.SetCancellationFlag(cancellationFlag)
 		parseDone = make(chan struct{})
@@ -136,6 +138,7 @@ func parseDocumentContext(ctx context.Context, path string, source []byte, oldTr
 			close(parseDone)
 			<-cancelDone
 			runtime.KeepAlive(cancellationFlag)
+			pinner.Unpin()
 		}()
 	}
 	tree := parser.parser.Parse(copySource, oldTree)

--- a/internal/vba/intel/analysis_snapshot.go
+++ b/internal/vba/intel/analysis_snapshot.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
@@ -98,6 +99,7 @@ type AnalysisSnapshot struct {
 	parsedDocument        *ast.ParsedDocument
 	parsedErr             error
 	parseDocument         func(string, []byte) (*ast.ParsedDocument, error)
+	parseDocumentContext  func(context.Context, string, []byte) (*ast.ParsedDocument, error)
 	parseCount            atomic.Uint64
 	fullHashCount         atomic.Uint64
 	procedureIRBuildCount atomic.Uint64
@@ -131,18 +133,18 @@ func NewAnalysisSnapshot(doc Document) *AnalysisSnapshot {
 	normalized = strings.ReplaceAll(normalized, "\r", "\n")
 	lineStarts, lineEnds := buildSourceLineMap(source)
 	return &AnalysisSnapshot{
-		uri:           doc.URI,
-		path:          doc.Path,
-		version:       doc.Version,
-		moduleKind:    doc.ModuleKind,
-		source:        source,
-		sourceHash:    sha256.Sum256([]byte(source)),
-		lines:         strings.Split(normalized, "\n"),
-		lineStarts:    lineStarts,
-		lineEnds:      lineEnds,
-		parseDocument: ast.ParseDocument,
-		artifacts:     newProcedureArtifactStore(),
-		retireDone:    make(chan struct{}),
+		uri:                  doc.URI,
+		path:                 doc.Path,
+		version:              doc.Version,
+		moduleKind:           doc.ModuleKind,
+		source:               source,
+		sourceHash:           sha256.Sum256([]byte(source)),
+		lines:                strings.Split(normalized, "\n"),
+		lineStarts:           lineStarts,
+		lineEnds:             lineEnds,
+		parseDocumentContext: ast.ParseDocumentContext,
+		artifacts:            newProcedureArtifactStore(),
+		retireDone:           make(chan struct{}),
 	}
 }
 
@@ -753,26 +755,82 @@ func (s *AnalysisSnapshot) identifiers() [][]byteSpan {
 // most once for this document revision. Callers must not close the returned
 // document; the snapshot owns its lifecycle and retires it exactly once.
 func (s *AnalysisSnapshot) ParsedDocument() (*ast.ParsedDocument, error) {
+	return s.ParsedDocumentContext(context.Background())
+}
+
+// ParsedDocumentContext is the cancellable form of ParsedDocument. It avoids
+// holding an analysis permit while waiting for another goroutine to finish
+// constructing the snapshot's tree and propagates cancellation into
+// tree-sitter when this caller owns the parse.
+func (s *AnalysisSnapshot) ParsedDocumentContext(ctx context.Context) (*ast.ParsedDocument, error) {
 	if s == nil {
 		return nil, errAnalysisSnapshotRetired
 	}
-	s.parsedMu.Lock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := lockMutexContext(ctx, &s.parsedMu); err != nil {
+		return nil, err
+	}
 	defer s.parsedMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if s.parsedDocument != nil || s.parsedErr != nil {
 		return s.parsedDocument, s.parsedErr
 	}
 	if s.retired.Load() {
 		return nil, errAnalysisSnapshotRetired
 	}
-	parse := s.parseDocument
-	if parse == nil {
-		parse = ast.ParseDocument
+	var parsed *ast.ParsedDocument
+	var err error
+	if s.parseDocument != nil {
+		parsed, err = s.parseDocument(s.path, []byte(s.source))
+	} else {
+		parse := s.parseDocumentContext
+		if parse == nil {
+			parse = ast.ParseDocumentContext
+		}
+		parsed, err = parse(ctx, s.path, []byte(s.source))
 	}
-	s.parsedDocument, s.parsedErr = parse(s.path, []byte(s.source))
-	if s.parsedDocument != nil {
+	if err != nil {
+		if isRetryableContextError(err) {
+			return nil, err
+		}
+		s.parsedErr = err
+		return nil, err
+	}
+	s.parsedDocument = parsed
+	if parsed != nil {
 		s.parseCount.Add(1)
 	}
-	return s.parsedDocument, s.parsedErr
+	if err := ctx.Err(); err != nil {
+		return s.parsedDocument, err
+	}
+	return s.parsedDocument, nil
+}
+
+func lockMutexContext(ctx context.Context, mu *sync.Mutex) error {
+	for {
+		if mu.TryLock() {
+			return nil
+		}
+		timer := time.NewTimer(time.Millisecond)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		}
+	}
 }
 
 // ParsedDocumentIfReady returns the already-created parsed document without
@@ -878,12 +936,26 @@ func analysisSnapshotForDocument(doc Document) *AnalysisSnapshot {
 }
 
 func parsedDocumentForDocument(doc Document) (*ast.ParsedDocument, func(), error) {
+	return parsedDocumentForDocumentContext(context.Background(), doc)
+}
+
+func parsedDocumentForDocumentContext(ctx context.Context, doc Document) (*ast.ParsedDocument, func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, func() {}, err
+	}
 	if snapshot := analysisSnapshotForDocument(doc); snapshot != nil {
-		parsed, err := snapshot.ParsedDocument()
+		parsed, err := snapshot.ParsedDocumentContext(ctx)
 		return parsed, func() {}, err
 	}
-	parsed, err := ast.ParseDocument(doc.Path, []byte(doc.Source))
+	parsed, err := ast.ParseDocumentContext(ctx, doc.Path, []byte(doc.Source))
 	if err != nil {
+		return nil, func() {}, err
+	}
+	if err := ctx.Err(); err != nil {
+		parsed.Close()
 		return nil, func() {}, err
 	}
 	return parsed, parsed.Close, nil

--- a/internal/vba/intel/analysis_snapshot_test.go
+++ b/internal/vba/intel/analysis_snapshot_test.go
@@ -257,6 +257,44 @@ func TestAnalysisSnapshotParsedDocumentIfReadyDoesNotWaitForConstruction(t *test
 	snapshot.Retire()
 }
 
+func TestAnalysisSnapshotParsedDocumentContextCancelsParseWait(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{Path: "Main.bas", Source: "Sub Main()\nEnd Sub\n"})
+	started := make(chan struct{})
+	release := make(chan struct{})
+	snapshot.parseDocument = func(path string, source []byte) (*vbaast.ParsedDocument, error) {
+		close(started)
+		<-release
+		return vbaast.ParseDocument(path, source)
+	}
+	parseDone := make(chan error, 1)
+	go func() {
+		_, err := snapshot.ParsedDocument()
+		parseDone <- err
+	}()
+	<-started
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := snapshot.ParsedDocumentContext(ctx)
+		result <- err
+	}()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled parse waiter = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("canceled parse waiter did not return")
+	}
+	close(release)
+	if err := <-parseDone; err != nil {
+		t.Fatal(err)
+	}
+	snapshot.RetireAndWait()
+}
+
 func TestAnalysisSnapshotRetireDoesNotWaitForParseConstruction(t *testing.T) {
 	snapshot := NewAnalysisSnapshot(Document{Path: "Main.bas", Source: "Sub Main()\nEnd Sub\n"})
 	started := make(chan struct{})

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -580,11 +580,20 @@ func (a Analyzer) DocumentSymbols(doc Document) ([]Symbol, error) {
 // DocumentSymbolsContext extracts source symbols with cooperative CST-walk
 // cancellation while preserving the snapshot's retryable lazy cache.
 func (a Analyzer) DocumentSymbolsContext(ctx context.Context, doc Document) ([]Symbol, error) {
-	parsed, closeParsed, err := parsedDocumentForDocument(doc)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	parsed, closeParsed, err := parsedDocumentForDocumentContext(ctx, doc)
 	if err != nil {
 		return nil, err
 	}
 	defer closeParsed()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return a.documentSymbolsParsedContext(ctx, doc, parsed)
 }
 

--- a/internal/vba/intel/intel_test.go
+++ b/internal/vba/intel/intel_test.go
@@ -32,6 +32,24 @@ func TestDiagnosticsContextReturnsNoPartialResultsWhenAlreadyCanceled(t *testing
 	}
 }
 
+func TestDocumentSymbolsContextChecksCancellationBeforeParsing(t *testing.T) {
+	snapshot := NewAnalysisSnapshot(Document{Path: "Main.bas", Source: "Sub Main()\nEnd Sub\n"})
+	parsed := false
+	snapshot.parseDocument = func(path string, source []byte) (*vbaast.ParsedDocument, error) {
+		parsed = true
+		return vbaast.ParseDocument(path, source)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := (Analyzer{}).DocumentSymbolsContext(ctx, snapshot.Document())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled document symbols = %v, want context.Canceled", err)
+	}
+	if parsed {
+		t.Fatal("canceled document symbols started parsing")
+	}
+}
+
 func TestDiagnosticsWrapperMatchesDiagnosticsContext(t *testing.T) {
 	analyzer := newTestAnalyzer(t)
 	doc := Document{


### PR DESCRIPTION
## Summary

- Follow up on #762 by joining asynchronous interactive LSP requests during shutdown and canceling them promptly, preventing late responses and retired-snapshot access.
- Add context-aware parsing and lock wait checkpoints so canceled document-symbol work releases analysis resources without starting unnecessary parsing.
- Preserve deterministic diagnostics, symbol results, and existing bounded scheduling behavior.

## Tests

- `rtk task test`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test -race ./internal/vba/ast ./internal/vba/intel ./internal/lspserver -count=1 -timeout 15m`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 vet ./...`
- `rtk task lint`
- `rtk git diff --check`

## Review follow-up

- Addresses the valid post-merge review findings from #762 (interactive request lifecycle and cancellation-aware document parsing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interactive analysis requests now cancel cleanly when the language server shuts down.
  - New requests are rejected while shutdown is in progress.
  - Document parsing and symbol analysis now respond promptly to cancellation.
  - Prevents in-flight requests from delaying server shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->