### PR TITLE
fix: remove ineffective scaffold suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Removed ineffective `VBA227` inline suppressions from scaffolded `XlflowAssert`,
+  `XlflowUI`, and `XlflowDebug` helpers so `xlflow analyze` no longer reports
+  `unused_inline_suppression` warnings for new projects or installed helper modules.
+
 ## v0.31.1
 
 - Kept LSP completion, signature help, hover, and definition responsive while

--- a/internal/project/scaffold.go
+++ b/internal/project/scaffold.go
@@ -939,25 +939,25 @@ Public Sub AssertArrayEquals(ByVal expected As Variant, ByVal actual As Variant,
   End If
 
   Dim dimension As Long
-  For dimension = 1 To expectedDims ' xlflow:disable-line VBA227
-    If LBound(expected, dimension) <> LBound(actual, dimension) Or UBound(expected, dimension) <> UBound(actual, dimension) Then ' xlflow:disable-line VBA227
-      RaiseAssertFailure message, "array bounds differ on dimension " & CStr(dimension) & vbCrLf & "expected <" & CStr(LBound(expected, dimension)) & " To " & CStr(UBound(expected, dimension)) & ">" & vbCrLf & "actual   <" & CStr(LBound(actual, dimension)) & " To " & CStr(UBound(actual, dimension)) & ">", source ' xlflow:disable-line VBA227
+  For dimension = 1 To expectedDims
+    If LBound(expected, dimension) <> LBound(actual, dimension) Or UBound(expected, dimension) <> UBound(actual, dimension) Then
+      RaiseAssertFailure message, "array bounds differ on dimension " & CStr(dimension) & vbCrLf & "expected <" & CStr(LBound(expected, dimension)) & " To " & CStr(UBound(expected, dimension)) & ">" & vbCrLf & "actual   <" & CStr(LBound(actual, dimension)) & " To " & CStr(UBound(actual, dimension)) & ">", source
     End If
   Next dimension
 
   Dim i As Long
   Dim j As Long
   If expectedDims = 1 Then
-    For i = LBound(expected, 1) To UBound(expected, 1) ' xlflow:disable-line VBA227
-      If Not ScalarArrayValuesEqual(expected(i), actual(i)) Then ' xlflow:disable-line VBA227
-        RaiseAssertFailure message, "array mismatch at (" & CStr(i) & ")" & vbCrLf & "expected " & FormatAssertValue(expected(i)) & vbCrLf & "actual   " & FormatAssertValue(actual(i)), source ' xlflow:disable-line VBA227
+    For i = LBound(expected, 1) To UBound(expected, 1)
+      If Not ScalarArrayValuesEqual(expected(i), actual(i)) Then
+        RaiseAssertFailure message, "array mismatch at (" & CStr(i) & ")" & vbCrLf & "expected " & FormatAssertValue(expected(i)) & vbCrLf & "actual   " & FormatAssertValue(actual(i)), source
       End If
     Next i
   Else
-    For i = LBound(expected, 1) To UBound(expected, 1) ' xlflow:disable-line VBA227
-      For j = LBound(expected, 2) To UBound(expected, 2) ' xlflow:disable-line VBA227
-        If Not ScalarArrayValuesEqual(expected(i, j), actual(i, j)) Then ' xlflow:disable-line VBA227
-          RaiseAssertFailure message, "array mismatch at (" & CStr(i) & ", " & CStr(j) & ")" & vbCrLf & "expected " & FormatAssertValue(expected(i, j)) & vbCrLf & "actual   " & FormatAssertValue(actual(i, j)), source ' xlflow:disable-line VBA227
+    For i = LBound(expected, 1) To UBound(expected, 1)
+      For j = LBound(expected, 2) To UBound(expected, 2)
+        If Not ScalarArrayValuesEqual(expected(i, j), actual(i, j)) Then
+          RaiseAssertFailure message, "array mismatch at (" & CStr(i) & ", " & CStr(j) & ")" & vbCrLf & "expected " & FormatAssertValue(expected(i, j)) & vbCrLf & "actual   " & FormatAssertValue(actual(i, j)), source
         End If
       Next j
     Next i
@@ -1028,8 +1028,8 @@ Public Sub AssertRangeEquals(ByVal expected As Variant, ByVal actualRange As Obj
 
   Dim expectedRows As Long
   Dim expectedColumns As Long
-  expectedRows = UBound(expected, 1) - LBound(expected, 1) + 1 ' xlflow:disable-line VBA227
-  expectedColumns = UBound(expected, 2) - LBound(expected, 2) + 1 ' xlflow:disable-line VBA227
+  expectedRows = UBound(expected, 1) - LBound(expected, 1) + 1
+  expectedColumns = UBound(expected, 2) - LBound(expected, 2) + 1
   If expectedRows <> rowCount Or expectedColumns <> columnCount Then
     RaiseAssertFailure message, "range size differs; expected <" & CStr(expectedRows) & " x " & CStr(expectedColumns) & "> but got <" & CStr(rowCount) & " x " & CStr(columnCount) & ">", source
   End If
@@ -1038,12 +1038,12 @@ Public Sub AssertRangeEquals(ByVal expected As Variant, ByVal actualRange As Obj
   Dim columnIndex As Long
   Dim expectedRow As Long
   Dim expectedColumn As Long
-  For rowIndex = 1 To rowCount ' xlflow:disable-line VBA227
-    expectedRow = LBound(expected, 1) + rowIndex - 1 ' xlflow:disable-line VBA227
-    For columnIndex = 1 To columnCount ' xlflow:disable-line VBA227
-      expectedColumn = LBound(expected, 2) + columnIndex - 1 ' xlflow:disable-line VBA227
-      If Not ScalarArrayValuesEqual(expected(expectedRow, expectedColumn), actualValues(rowIndex, columnIndex)) Then ' xlflow:disable-line VBA227
-        RaiseAssertFailure message, "range mismatch at " & RangeCellLabel(actualRange, rowIndex, columnIndex) & vbCrLf & "expected " & FormatAssertValue(expected(expectedRow, expectedColumn)) & vbCrLf & "actual   " & FormatAssertValue(actualValues(rowIndex, columnIndex)), source ' xlflow:disable-line VBA227
+  For rowIndex = 1 To rowCount
+    expectedRow = LBound(expected, 1) + rowIndex - 1
+    For columnIndex = 1 To columnCount
+      expectedColumn = LBound(expected, 2) + columnIndex - 1
+      If Not ScalarArrayValuesEqual(expected(expectedRow, expectedColumn), actualValues(rowIndex, columnIndex)) Then
+        RaiseAssertFailure message, "range mismatch at " & RangeCellLabel(actualRange, rowIndex, columnIndex) & vbCrLf & "expected " & FormatAssertValue(expected(expectedRow, expectedColumn)) & vbCrLf & "actual   " & FormatAssertValue(actualValues(rowIndex, columnIndex)), source
       End If
     Next columnIndex
   Next rowIndex
@@ -1240,10 +1240,10 @@ Private Function ArrayDimensionCount(ByVal value As Variant) As Long
   Dim dimension As Long
   Dim lowerBound As Long ' xlflow:disable-line VB020
   Dim probeFailed As Boolean
-  For dimension = 1 To 60 ' xlflow:disable-line VBA227
+  For dimension = 1 To 60
     On Error Resume Next
     Err.Clear
-    lowerBound = LBound(value, dimension) ' xlflow:disable-line VBA227
+    lowerBound = LBound(value, dimension)
     probeFailed = Err.Number <> 0
     Err.Clear
     On Error GoTo 0
@@ -1745,8 +1745,8 @@ Private Function NormalizeFileDialogResponse(ByVal Kind As String, ByVal Id As S
 	If count <> 1 Then
 		Err.Raise xlflowErrInvalidFileDialogResponse, FileDialogSourceName(Kind), "File dialog '" & Id & "' expected one scripted path but received " & CStr(count) & "."
 	End If
-	DisplayValue = CStr(values(LBound(values))) ' xlflow:disable-line VBA227
-	NormalizeFileDialogResponse = CStr(values(LBound(values))) ' xlflow:disable-line VBA227
+	DisplayValue = CStr(values(LBound(values)))
+	NormalizeFileDialogResponse = CStr(values(LBound(values)))
 End Function
 
 Private Function NormalizeFileDialogDefault(ByVal Kind As String, ByVal Id As String, ByVal MultiSelect As Boolean, ByVal DefaultValue As Variant, Optional ByRef DisplayValue As String = "") As Variant
@@ -1772,8 +1772,8 @@ Private Function NormalizeFileDialogDefault(ByVal Kind As String, ByVal Id As St
 		If count <> 1 Then
 			Err.Raise xlflowErrInvalidFileDialogResponse, FileDialogSourceName(Kind), "File dialog '" & Id & "' default value must contain exactly one path."
 		End If
-		DisplayValue = CStr(values(LBound(values))) ' xlflow:disable-line VBA227
-		NormalizeFileDialogDefault = CStr(values(LBound(values))) ' xlflow:disable-line VBA227
+		DisplayValue = CStr(values(LBound(values)))
+		NormalizeFileDialogDefault = CStr(values(LBound(values)))
 		Exit Function
 	End If
 
@@ -1843,8 +1843,8 @@ Private Function SplitFileDialogValues(ByVal MarkerValue As String) As Variant
 		Err.Raise xlflowErrInvalidFileDialogResponse, "XlflowUI.FileDialog", "Scripted file dialog response must contain at least one path."
 	End If
 	values = Split(normalizedValue, vbLf)
-	For i = LBound(values) To UBound(values) ' xlflow:disable-line VBA227
-		If Len(CStr(values(i))) = 0 Then ' xlflow:disable-line VBA227
+	For i = LBound(values) To UBound(values)
+		If Len(CStr(values(i))) = 0 Then
 			Err.Raise xlflowErrInvalidFileDialogResponse, "XlflowUI.FileDialog", "Scripted file dialog response contains an empty path entry."
 		End If
 	Next i
@@ -1856,8 +1856,8 @@ Private Function VariantArrayToStringArray(ByVal Values As Variant) As Variant
 	Dim i As Long
 
 	ReDim result(LBound(Values) To UBound(Values))
-	For i = LBound(Values) To UBound(Values) ' xlflow:disable-line VBA227
-		result(i) = CStr(Values(i)) ' xlflow:disable-line VBA227
+	For i = LBound(Values) To UBound(Values)
+		result(i) = CStr(Values(i))
 		If Len(result(i)) = 0 Then
 			Err.Raise xlflowErrInvalidFileDialogResponse, "XlflowUI.FileDialog", "File dialog default values cannot contain empty paths."
 		End If
@@ -1866,17 +1866,17 @@ Private Function VariantArrayToStringArray(ByVal Values As Variant) As Variant
 End Function
 
 Private Function FileDialogValueCount(ByVal Values As Variant) As Long
-	FileDialogValueCount = UBound(Values) - LBound(Values) + 1 ' xlflow:disable-line VBA227
+	FileDialogValueCount = UBound(Values) - LBound(Values) + 1
 End Function
 
 Private Function JoinStringArray(ByVal Values As Variant, ByVal Separator As String) As String
 	Dim i As Long
 	JoinStringArray = ""
-	For i = LBound(Values) To UBound(Values) ' xlflow:disable-line VBA227
-		If i > LBound(Values) Then ' xlflow:disable-line VBA227
+	For i = LBound(Values) To UBound(Values)
+		If i > LBound(Values) Then
 			JoinStringArray = JoinStringArray & Separator
 		End If
-		JoinStringArray = JoinStringArray & CStr(Values(i)) ' xlflow:disable-line VBA227
+		JoinStringArray = JoinStringArray & CStr(Values(i))
 	Next i
 End Function
 
@@ -2095,15 +2095,15 @@ Public Sub Log(ParamArray Parts() As Variant)
 	Dim errorDescription As String
 
 	On Error GoTo EmptyParts
-	lowerBound = LBound(Parts) ' xlflow:disable-line VBA227
-	upperBound = UBound(Parts) ' xlflow:disable-line VBA227
+	lowerBound = LBound(Parts)
+	upperBound = UBound(Parts)
 	On Error GoTo 0
 
-	For index = lowerBound To upperBound ' xlflow:disable-line VBA227
+	For index = lowerBound To upperBound
 		If index > lowerBound Then
 			message = message & " "
 		End If
-		message = message & StringifyValue(Parts(index)) ' xlflow:disable-line VBA227
+		message = message & StringifyValue(Parts(index))
 	Next index
 
 GoTo PrintMessage

--- a/internal/project/scaffold_test.go
+++ b/internal/project/scaffold_test.go
@@ -314,18 +314,21 @@ func TestInstallHelperModulesAnalyzeCleanly(t *testing.T) {
 		t.Fatal(err)
 	}
 	helperRoot := filepath.Clean(filepath.Join(dir, "src", "modules", "Xlflow"))
-	findings, err := (analyze.Analyzer{
+	result, err := (analyze.Analyzer{
 		RootDir: dir,
 		Config:  config.Default(),
 		PathFilter: func(path string) bool {
 			return filepath.Clean(filepath.Dir(path)) == helperRoot
 		},
-	}).Run()
+	}).RunResult()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("installed helper modules should analyze cleanly (diagnostic code/file details): %+v", findings)
+	if len(result.Findings) != 0 {
+		t.Fatalf("installed helper modules should analyze cleanly (diagnostic code/file details): %+v", result.Findings)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("installed helper modules should analyze without warnings: %+v", result.Warnings)
 	}
 }
 
@@ -871,20 +874,23 @@ func TestNewScaffoldLintsWithoutIssuesOrWarnings(t *testing.T) {
 	}
 }
 
-func TestNewScaffoldAnalyzesWithoutFindings(t *testing.T) {
+func TestNewScaffoldAnalyzesWithoutFindingsOrWarnings(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := New(dir, "Book", fakeWorkbookCreator); err != nil {
 		t.Fatal(err)
 	}
-	findings, err := (analyze.Analyzer{
+	result, err := (analyze.Analyzer{
 		RootDir: dir,
 		Config:  config.Default(),
-	}).Run()
+	}).RunResult()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("new scaffold should analyze cleanly (diagnostic code/file details): %+v", findings)
+	if len(result.Findings) != 0 {
+		t.Fatalf("new scaffold should analyze cleanly (diagnostic code/file details): %+v", result.Findings)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("new scaffold should analyze without warnings: %+v", result.Warnings)
 	}
 }
 

--- a/internal/project/scaffold_test.go
+++ b/internal/project/scaffold_test.go
@@ -308,7 +308,7 @@ func TestInstallHelperModulesUsesConfiguredModuleRoot(t *testing.T) {
 	}
 }
 
-func TestInstallHelperModulesAnalyzeCleanly(t *testing.T) {
+func TestInstallHelperModulesAnalyzeWithoutUnusedSuppressionWarnings(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := InstallHelperModules(dir, config.SourceConfig{}); err != nil {
 		t.Fatal(err)
@@ -327,8 +327,8 @@ func TestInstallHelperModulesAnalyzeCleanly(t *testing.T) {
 	if len(result.Findings) != 0 {
 		t.Fatalf("installed helper modules should analyze cleanly (diagnostic code/file details): %+v", result.Findings)
 	}
-	if len(result.Warnings) != 0 {
-		t.Fatalf("installed helper modules should analyze without warnings: %+v", result.Warnings)
+	if hasWarningCode(result.Warnings, "unused_inline_suppression") {
+		t.Fatalf("installed helper modules should not emit unused suppression warnings: %+v", result.Warnings)
 	}
 }
 
@@ -874,7 +874,7 @@ func TestNewScaffoldLintsWithoutIssuesOrWarnings(t *testing.T) {
 	}
 }
 
-func TestNewScaffoldAnalyzesWithoutFindingsOrWarnings(t *testing.T) {
+func TestNewScaffoldAnalyzesWithoutUnusedSuppressionWarnings(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := New(dir, "Book", fakeWorkbookCreator); err != nil {
 		t.Fatal(err)
@@ -889,8 +889,8 @@ func TestNewScaffoldAnalyzesWithoutFindingsOrWarnings(t *testing.T) {
 	if len(result.Findings) != 0 {
 		t.Fatalf("new scaffold should analyze cleanly (diagnostic code/file details): %+v", result.Findings)
 	}
-	if len(result.Warnings) != 0 {
-		t.Fatalf("new scaffold should analyze without warnings: %+v", result.Warnings)
+	if hasWarningCode(result.Warnings, "unused_inline_suppression") {
+		t.Fatalf("new scaffold should not emit unused suppression warnings: %+v", result.Warnings)
 	}
 }
 
@@ -1314,6 +1314,15 @@ func TestGenerateTestModuleDefaultsToTestsDirWhenModulesEmpty(t *testing.T) {
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasWarningCode(warnings []map[string]any, code string) bool {
+	for _, warning := range warnings {
+		if warning["code"] == code {
 			return true
 		}
 	}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -137,3 +137,4 @@
 - Every CFG transformation that mutates cloned block or edge elements in place must rebuild the query index before publication; slice identity checks cannot detect element edits.
 - LSP の体感性能確認では初回表示だけでなく、巨大ファイルを編集して診断開始後に再編集する経路も実機計測する。`didChange` が旧 snapshot の tree lease を同期取得すると、バックグラウンド解析の終了まで JSON-RPC 受信ループを止めるため、旧 revision が使用中なら差分パースを待たず新 revision を公開する。
 - 巨大モジュールの LSP Full 診断は `analyze` の所要時間だけで推測せず、project-aware realtime 経路を実 VS Code で計測する。式ごとの document/UserForm index 再構築、procedure ごとの helper summary・project constant 正規化、batch と realtime の並列境界差を CPU profile と goroutine stack で確認する。
+- Cross-platform analysis tests that inspect `RunResult().Warnings` should assert the relevant warning code rather than require an empty warning set; Linux may legitimately lack the generated TypeLib manifest and emit `type_db_load_warning`.


### PR DESCRIPTION
## Summary

- Remove 36 ineffective `VBA227` inline suppressions from scaffolded `XlflowAssert`, `XlflowUI`, and `XlflowDebug` modules.
- Extend scaffold and helper-module analysis tests to assert that no unused-suppression warnings are emitted.
- Add an `Unreleased` changelog entry.

## Tests

- `rtk pnpm format:check`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/project ./internal/analyze ./internal/lint -count=1`
- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./... -count=1`
- `rtk proxy task review:codex`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed ineffective inline lint suppressions from scaffolded VBA helper modules.
  * New projects and installed helper modules no longer produce unnecessary `unused_inline_suppression` warnings during analysis.

* **Documentation**
  * Updated the changelog and testing guidance to document the warning reduction and platform-specific analysis behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->