### PR TITLE
fix: polish docs, spelling and remove shadowed max/min helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pull → fmt → edit → push → lint → test/run → inspect
 | Diffing                                           | Compare workbook cell values, formulas, sheet structure, and exported VBA source                                                                                             |
 | AI agents                                         | Return stable JSON and install bundled Skills for Codex, Claude, Cursor, Gemini, GitHub Copilot-style agent workflows, and other agents                                      |
 | LSP Server                                        | Provides features like code completion, jump-to-definition, and real-time diagnostics                                                                                        |
-| [VS Code Extension](<(editors/vscode/README.md)>) | Graphical user interface for all xlflow operations, offering an enhanced development experience with the LSP server                                                          |
+| [VS Code Extension](editors/vscode/README.md) | Graphical user interface for all xlflow operations, offering an enhanced development experience with the LSP server                                                          |
 
 Formula snapshots can also be created outside an xlflow workspace:
 

--- a/example/maze-chase/.agents/skills/xlflow/references/xlflow-ui.md
+++ b/example/maze-chase/.agents/skills/xlflow/references/xlflow-ui.md
@@ -75,7 +75,7 @@ Supported `--filedialog` kinds:
 - `save-as`
 - `folder`
 
-Repeat the same `kind:id=value` flag to supply multi-select paths in order. Use `@cancel` to represent a cancelled file dialog.
+Repeat the same `kind:id=value` flag to supply multi-select paths in order. Use `@cancel` to represent a canceled file dialog.
 
 `--ui-stream` writes realtime `XlflowUI` summaries to stderr, not stdout, so `--json` stdout remains machine-readable. Example stderr lines:
 

--- a/internal/agentskill/templates/xlflow/references/object-model-traps.md
+++ b/internal/agentskill/templates/xlflow/references/object-model-traps.md
@@ -66,7 +66,7 @@ their counts can exceed the number of cells; both are right at once and the
 totals will not reconcile, with no error to notice.
 
 **Safe rule.** Do not derive one criterion from another by negation. When a
-column may hold text that looks numeric, either normalise the column before
+column may hold text that looks numeric, either normalize the column before
 counting, or state the comparison you actually mean and verify both halves
 against the row count.
 

--- a/internal/agentskill/templates/xlflow/references/xlflow-ui.md
+++ b/internal/agentskill/templates/xlflow/references/xlflow-ui.md
@@ -75,7 +75,7 @@ Supported `--filedialog` kinds:
 - `save-as`
 - `folder`
 
-Repeat the same `kind:id=value` flag to supply multi-select paths in order. Use `@cancel` to represent a cancelled file dialog.
+Repeat the same `kind:id=value` flag to supply multi-select paths in order. Use `@cancel` to represent a canceled file dialog.
 
 `--ui-stream` writes realtime `XlflowUI` summaries to stderr, not stdout, so `--json` stdout remains machine-readable. Example stderr lines:
 

--- a/internal/cli/coordination.go
+++ b/internal/cli/coordination.go
@@ -344,7 +344,7 @@ func (a *app) acquireWorkbookCoordination(ctx context.Context, commandID coordin
 				return nil, nil, a.writeWorkbookWaitFailure(descriptor, identity, coordination.WorkbookBusyTimeoutCode, fmt.Sprintf("The workbook did not become available within %s.", a.waitTimeout), acquireErr)
 			}
 			if a.wait && errors.Is(acquireErr, context.Canceled) {
-				return nil, nil, a.writeWorkbookWaitFailure(descriptor, identity, coordination.WorkbookBusyCancelledCode, "Waiting for the workbook was cancelled.", acquireErr)
+				return nil, nil, a.writeWorkbookWaitFailure(descriptor, identity, coordination.WorkbookBusyCancelledCode, "Waiting for the workbook was canceled.", acquireErr)
 			}
 			if errors.As(acquireErr, &busy) {
 				return nil, nil, a.writeWorkbookBusyFailure(descriptor, busy)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4831,7 +4831,7 @@ func (a *app) typeDBInitCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&dir, "dir", "", "override generated type database directory")
-	cmd.Flags().StringSliceVar(&libraries, "library", []string{"excel"}, "TypeLib library to import (repeat or comma-separate; use all for every known library present; default: excel)")
+	cmd.Flags().StringSliceVar(&libraries, "library", []string{"excel"}, "TypeLib library to import (repeat or comma-separated; use all for every known library present; default: excel)")
 	return cmd
 }
 
@@ -4848,7 +4848,7 @@ func (a *app) typeDBRefreshCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&dir, "dir", "", "override generated type database directory")
-	cmd.Flags().StringSliceVar(&libraries, "library", []string{"excel"}, "TypeLib library to import (repeat or comma-separate; use all for every known library present; default: excel)")
+	cmd.Flags().StringSliceVar(&libraries, "library", []string{"excel"}, "TypeLib library to import (repeat or comma-separated; use all for every known library present; default: excel)")
 	cmd.Flags().BoolVar(&force, "force", false, "deprecated compatibility flag; refresh always regenerates")
 	return cmd
 }
@@ -4943,9 +4943,9 @@ unsaved workbooks or active work. Use with extreme caution.`,
 				}
 				if !confirmPrompt(os.Stdin, a.stderrWriter(), "This will forcibly terminate ALL Excel processes. Unsaved work will be lost. Continue? [y/N] ") {
 					env := output.New("process cleanup")
-					env.Error = &output.Error{Code: "process_cancelled", Message: "cleanup --all cancelled by user"}
+					env.Error = &output.Error{Code: "process_cancelled", Message: "cleanup --all canceled by user"}
 					env.Status = output.StatusFailed
-					env.Logs = []string{"cleanup --all cancelled"}
+					env.Logs = []string{"cleanup --all canceled"}
 					return a.write(env, output.ExitSuccess)
 				}
 			}

--- a/internal/coordination/lock.go
+++ b/internal/coordination/lock.go
@@ -46,7 +46,7 @@ type OwnerMetadata struct {
 
 // AcquireRequest identifies the workbook operation to coordinate. Wait=false
 // performs one authoritative acquisition attempt. Wait=true retries until the
-// context is cancelled.
+// context is canceled.
 type AcquireRequest struct {
 	Identity      WorkbookIdentity
 	Command       CommandID

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -320,10 +320,3 @@ func sortedKeys[T any](m map[string]T) []string {
 	sort.Strings(keys)
 	return keys
 }
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/internal/excel/forms/intel/yaml.go
+++ b/internal/excel/forms/intel/yaml.go
@@ -362,16 +362,3 @@ func quotedEnd(line string, start int) int {
 func linePrefix(line string, character int) string {
 	return line[:byteOffsetForUTF16(line, character)]
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/internal/lint/select_case_diagnostics.go
+++ b/internal/lint/select_case_diagnostics.go
@@ -28,7 +28,7 @@ type selectCaseSyntaxIssue struct {
 }
 
 // selectCaseSyntaxIssues identifies only high-confidence Select/Case ordering
-// errors.  It recognises statement boundaries lexically (including colon
+// errors.  It recognizes statement boundaries lexically (including colon
 // separated statements), while using the parser root as a recovery gate.  If
 // the tree contains any error or missing node, the construct is ambiguous and
 // the generic parser-recovery diagnostic remains the sole owner.

--- a/internal/lspserver/dependency_cache.go
+++ b/internal/lspserver/dependency_cache.go
@@ -21,7 +21,7 @@ import (
 // dependencyCache stores immutable project products by their content
 // dependency key. Unlike revisionCache, adjacent workspace revisions may
 // share entries when the inputs that product actually reads are unchanged.
-// One build is shared per key and failed or cancelled builds are retryable.
+// One build is shared per key and failed or canceled builds are retryable.
 type dependencyCache[T any] struct {
 	mu         sync.Mutex
 	values     map[string]T

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -4148,13 +4148,6 @@ func completionTriggerCharacters() []string {
 	return []string{".", "\"", "'", "@"}
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func firstNonEmpty(values ...string) string {
 	for _, value := range values {
 		if strings.TrimSpace(value) != "" {

--- a/internal/staticanalysis/corpus/manifest.go
+++ b/internal/staticanalysis/corpus/manifest.go
@@ -1,5 +1,5 @@
 // Package corpus owns the pinned, third-party static-analysis corpus manifest
-// and the developer-only synchronisation operation used to materialise it.
+// and the developer-only synchronization operation used to materialize it.
 //
 // The package deliberately has no production CLI dependencies.  Callers that
 // want to update the vendored tree must invoke Sync explicitly; loading and

--- a/internal/staticanalysis/corpus/sync.go
+++ b/internal/staticanalysis/corpus/sync.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-// SyncOptions controls the developer-only corpus materialisation operation.
+// SyncOptions controls the developer-only corpus materialization operation.
 // UpstreamCheckout is intended for offline, locally reviewed updates. When it
 // is empty, Sync fetches the exact commit recorded by the manifest.
 type SyncOptions struct {
@@ -22,7 +22,7 @@ type SyncOptions struct {
 	UpstreamCheckout string
 }
 
-// Sync validates the manifest, materialises every listed project in a private
+// Sync validates the manifest, materializes every listed project in a private
 // staging tree, and atomically replaces projects/third_party. It verifies each
 // staged project's source_counts contract before publication. It never edits
 // the manifest and does not perform network access when UpstreamCheckout is

--- a/internal/vba/doccomments/doccomments.go
+++ b/internal/vba/doccomments/doccomments.go
@@ -616,10 +616,3 @@ func writeParagraph(b *strings.Builder, text string) {
 	}
 	b.WriteString(text)
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/internal/vba/effects/provenance.go
+++ b/internal/vba/effects/provenance.go
@@ -39,7 +39,7 @@ func semanticApplicationTarget(target string) string {
 		return target
 	default:
 		// Keep the compact state bounded even if a future extractor accepts an
-		// unrecognised Application member. Its direct evidence remains available
+		// unrecognized Application member. Its direct evidence remains available
 		// to the lazy compatibility projection.
 		return ""
 	}

--- a/internal/vba/intel/intel.go
+++ b/internal/vba/intel/intel.go
@@ -6931,20 +6931,6 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func DisplayPath(root, path string) string {
 	if root != "" {
 		if rel, err := filepath.Rel(root, path); err == nil {

--- a/vitepress/commands/run.md
+++ b/vitepress/commands/run.md
@@ -97,7 +97,7 @@ For VBA-internal debugging, add `XlflowDebug.Log` in workbook code and inspect `
 If the macro uses `XlflowUI.MsgBox`, `XlflowUI.InputBox`, or `XlflowUI` file dialog wrappers, prefer `--msgbox`, `--inputbox`, and `--filedialog` to keep the run headless. Add `--ui-stream` when you want realtime terminal visibility into which dialog ids resolved from scripted responses versus workbook defaults.
 
 ::: tip
-Supported `--filedialog` kinds are `get-open`, `file-open`, `save-as`, and `folder`. Repeat the same `kind:id=value` flag to simulate multi-select results, and use `@cancel` to simulate a cancelled dialog.
+Supported `--filedialog` kinds are `get-open`, `file-open`, `save-as`, and `folder`. Repeat the same `kind:id=value` flag to simulate multi-select results, and use `@cancel` to simulate a canceled dialog.
 :::
 :::
 

--- a/vitepress/commands/type-db.md
+++ b/vitepress/commands/type-db.md
@@ -17,7 +17,7 @@ xlflow type db clean
 | Option      | Description                                                                                                      | Default             |
 | ----------- | ---------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `--dir`     | Override the generated type DB directory.                                                                        | `~/.xlflow/typelib` |
-| `--library` | TypeLib library to import. Repeat, comma-separate, or use `all` for every known library present on this machine. | `excel`             |
+| `--library` | TypeLib library to import. Repeat, comma-separated, or use `all` for every known library present on this machine. | `excel`             |
 | `--force`   | Deprecated compatibility flag; `refresh` always regenerates.                                                     | `false`             |
 
 `status` reports manifest presence, generated files, library LIBID/version metadata, stale state, and the LSP database search order.

--- a/vitepress/guides/testing.md
+++ b/vitepress/guides/testing.md
@@ -17,4 +17,4 @@ xlflow analyze --json
 xlflow test --json
 ```
 
-Keep source-only checks before Excel-backed checks. Use `--session` for fast iteration and `--no-save` when the test is exploratory. After a behavior test, use `inspect` or `export-image` for the one workbook result a human would recognise; then `save --session` only when that result should persist.
+Keep source-only checks before Excel-backed checks. Use `--session` for fast iteration and `--no-save` when the test is exploratory. After a behavior test, use `inspect` or `export-image` for the one workbook result a human would recognize; then `save --session` only when that result should persist.

--- a/vitepress/reference/config-file.md
+++ b/vitepress/reference/config-file.md
@@ -11,7 +11,7 @@ The `[fmt]` table controls the source formatter. These options are read by `fmt`
 | `keyword_casing`      | Normalize VBA keyword casing.                                        |
 | `builtin_casing`      | Normalize curated built-in names without recasing user declarations. |
 
-xlflow reads `xlflow.toml` from the project root. It is the single source of truth for workbook paths, source directories, VBE behaviour, and static analysis rules.
+xlflow reads `xlflow.toml` from the project root. It is the single source of truth for workbook paths, source directories, VBE behavior, and static analysis rules.
 
 ## Full annotated example
 

--- a/vitepress/reference/xlflow-ui.md
+++ b/vitepress/reference/xlflow-ui.md
@@ -113,7 +113,7 @@ Supported `--filedialog` kinds:
 File dialog values use these rules:
 
 - Repeat the same `kind:id=value` flag to supply multiple selected paths in order.
-- Use `@cancel` to represent a cancelled dialog.
+- Use `@cancel` to represent a canceled dialog.
 - `GetOpenFilename` and `FileDialogOpen` return a Variant string array when `MultiSelect=True`.
 - Non-multi-select wrappers return a single string or `False` on cancel.
 

--- a/vitepress/tutorials/existing-workbook.md
+++ b/vitepress/tutorials/existing-workbook.md
@@ -40,7 +40,7 @@ xlflow analyze --json
 
 These commands do not require Excel. A lint or preflight error should be fixed in source before `push` opens Excel.
 
-Choose a change you can recognise—for example, alter a constant or write a clear value to a result cell. This makes the later verification meaningful. Do not edit the same procedure in VBE and VS Code at the same time: if you do edit in VBE, stop and `pull` first.
+Choose a change you can recognize—for example, alter a constant or write a clear value to a result cell. This makes the later verification meaningful. Do not edit the same procedure in VBE and VS Code at the same time: if you do edit in VBE, stop and `pull` first.
 
 ## 4. Push, run, and verify
 

--- a/vitepress/vscode/completion.md
+++ b/vitepress/vscode/completion.md
@@ -2,6 +2,6 @@
 
 The language server provides VBA keywords, built-in VBA/Excel/Office/MSForms metadata, project symbols, UserForm controls, and ProgID completion inside `CreateObject`/`GetObject` strings. Late-bound variables can acquire a curated type from known ProgIDs, enabling member completion and hover.
 
-For example, type `CreateObject("Scripting.Dictionary")` and assign it to a variable. xlflow can recognise that well-known ProgID and suggest dictionary members even though VBA would otherwise treat the variable as late-bound. Suggestions are guidance, not a guarantee that a specific Office installation exposes every member; still run the macro to verify behavior.
+For example, type `CreateObject("Scripting.Dictionary")` and assign it to a variable. xlflow can recognize that well-known ProgID and suggest dictionary members even though VBA would otherwise treat the variable as late-bound. Suggestions are guidance, not a guarantee that a specific Office installation exposes every member; still run the macro to verify behavior.
 
 When completion is missing, confirm the file is a supported source type, the workspace has `xlflow.toml`, and the language server is running. `xlflow type db status` reports generated TypeLib data; restart the server after refreshing type data. See [VS Code troubleshooting](./troubleshooting) for the exact checks.


### PR DESCRIPTION
## Summary

Two small, low-risk changes to clean up documentation and code.

1. **Docs & US English wording**
   - Fix the broken VS Code extension link in the README (extra parens/brackets prevented the link from resolving).
   - Correct \comma-separate\ to \comma-separated\ in the \	ype db\ CLI help and docs.
   - Normalize British spellings to US English in comments, docs, and user-facing messages (e.g. \ehaviour\, \ecognise\, \
ormalise\, \synchronisation\, \materialise\, \cancelled\). Protocol identifiers are left untouched.

2. **Code cleanup**
   - The module targets Go 1.26, which provides the predeclared \max\/\min\ builtins, so the seven local two-arg \int\ helpers that shadowed them were removed. The builtin behaves identically for \int\ operands, so existing call sites compile and run unchanged.

## Verification

- \go build ./...\, \go vet ./...\, \gofmt -l .\, and \goimports -l .\ all pass.
- Tests for the affected packages pass (\internal/diff\, \internal/vba/doccomments\, \internal/staticanalysis/corpus\, \internal/vba/effects\, \internal/lint\, \internal/coordination\, \internal/cli\, \internal/excel/forms/intel\, \internal/vba/intel\, \internal/lspserver\).

No behavior changes intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling, grammar, and terminology throughout the documentation and command-line help.
  - Updated file-dialog cancellation wording and related examples for consistency.
  - Fixed the VS Code Extension documentation link formatting.
  - Improved descriptions for library options and configuration behavior.

- **Refactor**
  - Simplified internal calculations by using built-in utilities without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->