### PR TITLE
fix(ci): compare pull requests against event base SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,12 @@ jobs:
           set -euo pipefail
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base_ref="origin/${{ github.base_ref }}"
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only "$base_ref...HEAD")"
+            # Use the base recorded in this PR event. The checked-out HEAD is
+            # a synthetic merge commit, and the live base branch may advance
+            # while a fork PR is waiting for approval.
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            git fetch --no-tags origin "$base_sha"
+            changed_files="$(git diff --name-only "$base_sha...HEAD")"
           else
             before_sha="${{ github.event.before }}"
             if [[ -z "$before_sha" || "$before_sha" == "0000000000000000000000000000000000000000" ]]; then


### PR DESCRIPTION
## Summary

- Fix the `changes` job to compare pull requests against the base SHA recorded in the pull request event.
- Remove the shallow fetch of the mutable `origin/main` ref, which could hide the merge base for delayed fork PR checks.
- Keep the synthetic merge commit as the comparison endpoint so the existing changed-file detection behavior is preserved.

## Tests

- `actionlint .github/workflows/ci.yml`
- `pnpm format:check`
- `git diff --check origin/main..HEAD`
- Verified PR #765's synthetic merge diff against its event base SHA and confirmed it matches the PR changed-file list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request change detection by comparing against the correct base revision.
  * Ensured markdown-only change checks remain accurate even when the target branch advances during review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->