### PR TITLE
feat: add in-memory VBA source project model (#640)

### DIFF
--- a/docs/adr/ADR-0050-in-memory-vba-source-project.md
+++ b/docs/adr/ADR-0050-in-memory-vba-source-project.md
@@ -1,0 +1,96 @@
+# ADR-0050: Protocol-Neutral In-Memory VBA Source Project
+
+## Status
+
+`accepted`
+
+## Background
+
+The batch analyzer discovers configured source directories, reads VBA files,
+classifies their component kinds, and performs static analysis in one entry
+point. LSP buffers and several lower analysis layers already accept source in
+memory, but there is no common project-level input that callers can construct
+without a filesystem.
+
+Issue #599 requires one production analysis boundary for the CLI, LSP, tests,
+and future browser or embedded consumers. Issue #640 establishes only the
+source model needed by that work; filesystem loading and analyzer extraction
+remain separate follow-up issues.
+
+Existing models have narrower ownership. `symbols.SourceFile` describes a file
+found by configured filesystem discovery and has no source bytes.
+`intel.Document` carries LSP-oriented URI, version, and snapshot state. The
+packer's `vbaproject.Project` models binary VBA project streams and references
+for read-modify-write operations.
+
+## Decision
+
+Add `internal/vba/sourceproject` as a dependency-light package containing a
+`SourceProject` collection and caller-supplied `SourceFile` values. Each file
+retains a logical path, explicit source bytes, and one of the existing
+`standard`, `class`, `form`, or `document` component kinds.
+
+Treat test role independently from VBA component kind. A test module remains a
+standard module and carries `IsTest`, preserving the standard-module lookup
+semantics used by test discovery and project resolution.
+
+Treat paths as logical source identities rather than proof of filesystem
+existence. The model performs no discovery, reads, path normalization, module
+classification, parsing, or validation. It contains no configuration, LSP,
+Excel, COM, or OS-specific dependency. Callers own source byte slices and keep
+them immutable while a consumer uses the project.
+
+Future filesystem and editor adapters construct this model. The future common
+analysis entry point validates and consumes it through the existing parser,
+procedure IR, CFG, and semantic implementations.
+
+## Consequences
+
+Positive consequences:
+
+- Multi-module VBA projects can be represented completely in memory.
+- Source acquisition and protocol lifecycle stay outside the analysis input.
+- Explicit component kinds avoid filesystem inspection and extension guesses.
+- Test modules retain both their test role and standard-module semantics.
+
+Negative consequences:
+
+- The source model temporarily coexists with discovery and LSP document types
+  until the adapters in issues #641 and #642 adopt it.
+- Callers must preserve source byte immutability or make their own snapshot.
+- Validation cannot occur until a consumer applies its input requirements.
+
+## Alternatives Considered
+
+1. **Extend `symbols.SourceFile` with source bytes.** Rejected because its
+   package and meaning are tied to configured filesystem discovery.
+2. **Reuse `intel.Document`.** Rejected because URI, revision, and analysis
+   snapshot lifecycle are editor concerns rather than source-project inputs.
+3. **Reuse the packer's binary project model.** Rejected because binary stream,
+   reference, and protection metadata are unrelated to static source analysis.
+4. **Represent tests as a fifth module kind.** Rejected because xlflow tests are
+   standard VBA modules and must retain standard-module resolution behavior.
+
+## Evidence
+
+- Requirements: xlflow issues #599 and #640.
+- Existing source discovery: `internal/vba/symbols/symbols.go`.
+- Existing LSP source ownership: `internal/vba/intel/intel.go` and
+  `internal/lspserver/workspace_analysis_index.go`.
+- Existing analysis input construction: `internal/analyze/analyzer.go`.
+- Model contract and tests: `docs/specs/vba-source-project.md` and
+  `internal/vba/sourceproject`.
+
+## Supersedes
+
+- None.
+
+## Superseded by
+
+- None.
+
+## Related
+
+- `docs/adr/ADR-0014-reusable-vba-lsp-server.md`
+- `docs/adr/ADR-0021-procedure-analysis-ir.md`
+- xlflow issues #641, #642, #644, and #645

--- a/docs/specs/vba-source-project.md
+++ b/docs/specs/vba-source-project.md
@@ -1,0 +1,72 @@
+# In-Memory VBA Source Project
+
+This specification defines the protocol-neutral source input model introduced
+by issue #640. The model is the common representation that filesystem, editor,
+test, and future embedded adapters can construct before invoking static
+analysis. ADR-0050 records the architectural rationale.
+
+## Model
+
+`internal/vba/sourceproject` exposes these Go-owned values:
+
+```go
+type ModuleKind string
+
+const (
+    ModuleKindStandard ModuleKind = "standard"
+    ModuleKindClass    ModuleKind = "class"
+    ModuleKindForm     ModuleKind = "form"
+    ModuleKindDocument ModuleKind = "document"
+)
+
+type SourceFile struct {
+    Path       string
+    Source     []byte
+    ModuleKind ModuleKind
+    IsTest     bool
+}
+
+type SourceProject struct {
+    Files []SourceFile
+}
+```
+
+The module kinds retain the existing analyzer vocabulary. Workbook and
+worksheet code modules both use `document`; their logical path and VBA source
+retain their individual module identity. UserForm code uses `form` regardless
+of whether a filesystem adapter acquired it from an exported `.frm` file or a
+sidecar source file.
+
+A test module remains a VBA `standard` module and sets `IsTest`. Test role is
+orthogonal to VBA component semantics so project name resolution continues to
+treat test helpers and procedures as standard-module declarations.
+
+## Path and Source Contract
+
+`Path` is a caller-provided logical identity used for diagnostics and as a
+module-name fallback. It can be relative, absolute, or virtual and does not
+need to name an existing file. The model does not clean, resolve, stat, read,
+or classify the path.
+
+`Source` contains the exact source bytes supplied by the caller. The model does
+not read source from `Path` and does not make an implicit copy. Callers must not
+mutate the bytes while a consumer is using the project. Consumers that retain
+source beyond a call boundary own any snapshotting they require.
+
+The model package does not import configuration, parser, LSP, Excel, COM, or
+OS-specific packages.
+
+## Validation and Adapters
+
+The model is a passive value contract and performs no construction-time
+validation. The analysis entry point that consumes it is responsible for
+reporting unsupported kinds, duplicate identities, or other invalid inputs.
+
+Filesystem discovery and source loading remain adapter responsibilities. The
+existing `symbols.SourceFile` is a discovery descriptor containing a path and
+inferred kind; it is not a loaded source project. Issue #641 will convert such
+descriptors into this model after reading source bytes. Issue #642 will add the
+common analysis entry point.
+
+This contract does not introduce a virtual filesystem, change CLI or LSP wire
+formats, refactor the analyzer, or provide browser/Wasm integration.

--- a/internal/vba/sourceproject/model.go
+++ b/internal/vba/sourceproject/model.go
@@ -1,0 +1,32 @@
+// Package sourceproject defines the filesystem-independent input model for a
+// VBA source project.
+package sourceproject
+
+// ModuleKind identifies the VBA component semantics that cannot be inferred
+// reliably from source text alone.
+type ModuleKind string
+
+const (
+	ModuleKindStandard ModuleKind = "standard"
+	ModuleKindClass    ModuleKind = "class"
+	ModuleKindForm     ModuleKind = "form"
+	ModuleKindDocument ModuleKind = "document"
+)
+
+// SourceFile is one caller-supplied VBA source module.
+//
+// Path is a logical identity used for diagnostics and module-name fallback. It
+// does not need to exist on disk. Source is caller-owned and must not be
+// mutated while a consumer is using the project. IsTest describes the role of
+// a standard module without changing its VBA module semantics.
+type SourceFile struct {
+	Path       string
+	Source     []byte
+	ModuleKind ModuleKind
+	IsTest     bool
+}
+
+// SourceProject is a caller-supplied collection of VBA source modules.
+type SourceProject struct {
+	Files []SourceFile
+}

--- a/internal/vba/sourceproject/model_test.go
+++ b/internal/vba/sourceproject/model_test.go
@@ -1,0 +1,78 @@
+package sourceproject_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/vba/sourceproject"
+)
+
+func TestSourceProjectRepresentsVirtualMultiModuleProject(t *testing.T) {
+	project := sourceproject.SourceProject{Files: []sourceproject.SourceFile{
+		{
+			Path:       "Module1.bas",
+			Source:     []byte("Public Sub Run()\nEnd Sub\n"),
+			ModuleKind: sourceproject.ModuleKindStandard,
+		},
+		{
+			Path:       "Customer.cls",
+			Source:     []byte("Public Name As String\n"),
+			ModuleKind: sourceproject.ModuleKindClass,
+		},
+		{
+			Path:       "LoginForm.frm",
+			Source:     []byte("Private Sub Submit_Click()\nEnd Sub\n"),
+			ModuleKind: sourceproject.ModuleKindForm,
+		},
+		{
+			Path:       "ThisWorkbook.cls",
+			Source:     []byte("Private Sub Workbook_Open()\nEnd Sub\n"),
+			ModuleKind: sourceproject.ModuleKindDocument,
+		},
+		{
+			Path:       "Sheet1.cls",
+			Source:     []byte("Private Sub Worksheet_Change(ByVal Target As Range)\nEnd Sub\n"),
+			ModuleKind: sourceproject.ModuleKindDocument,
+		},
+		{
+			Path:       "tests/Module1Tests.bas",
+			Source:     []byte("Public Sub TestRun()\nEnd Sub\n"),
+			ModuleKind: sourceproject.ModuleKindStandard,
+			IsTest:     true,
+		},
+	}}
+
+	if len(project.Files) != 6 {
+		t.Fatalf("files = %d, want 6", len(project.Files))
+	}
+
+	testModule := project.Files[5]
+	if testModule.Path != "tests/Module1Tests.bas" {
+		t.Fatalf("test module path = %q", testModule.Path)
+	}
+	if testModule.ModuleKind != sourceproject.ModuleKindStandard || !testModule.IsTest {
+		t.Fatalf("test module metadata = %+v", testModule)
+	}
+	if !bytes.Equal(testModule.Source, []byte("Public Sub TestRun()\nEnd Sub\n")) {
+		t.Fatalf("test module source = %q", testModule.Source)
+	}
+
+	if project.Files[3].ModuleKind != sourceproject.ModuleKindDocument ||
+		project.Files[4].ModuleKind != sourceproject.ModuleKindDocument {
+		t.Fatalf("document module kinds = %q, %q", project.Files[3].ModuleKind, project.Files[4].ModuleKind)
+	}
+}
+
+func TestModuleKindValuesMatchExistingAnalysisVocabulary(t *testing.T) {
+	tests := map[sourceproject.ModuleKind]string{
+		sourceproject.ModuleKindStandard: "standard",
+		sourceproject.ModuleKindClass:    "class",
+		sourceproject.ModuleKindForm:     "form",
+		sourceproject.ModuleKindDocument: "document",
+	}
+	for kind, want := range tests {
+		if string(kind) != want {
+			t.Errorf("module kind = %q, want %q", kind, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add a dependency-light `internal/vba/sourceproject` model for caller-supplied, multi-module VBA source projects.
- Preserve standard, class, UserForm, and workbook/worksheet document module kinds without filesystem inspection.
- Represent test modules as standard modules with an orthogonal `IsTest` flag.
- Document the source-project contract and architectural rationale in the specification and ADR.

## Scope

- This change adds the passive model and its tests only.
- Filesystem loading, analyzer integration, filesystem-free diagnostics, and parity coverage remain scoped to follow-up issues #641, #642, #644, and #645.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/sourceproject`
- `rtk pnpm format:check`
- `rtk task lint`
- `rtk task test`
- Final independent Codex review: no findings

Closes #640


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-memory model for representing multi-module VBA source projects.
  * Supports standard, class, form, and document modules, including test-module markers.
  * Preserves logical source paths and caller-provided source content without requiring filesystem access.

* **Documentation**
  * Added specifications and an architectural decision record describing the source-project model and its boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->