### PR TITLE
refactor: separate filesystem source loading

### DIFF
--- a/docs/specs/vba-source-project.md
+++ b/docs/specs/vba-source-project.md
@@ -71,6 +71,11 @@ their module kind. When a path is reachable through both production discovery
 and `tests`, the production entry takes precedence. Results are deduplicated
 and sorted deterministically by path before source is read.
 
+Filesystem reads and deduplication use absolute physical paths internally.
+Returned logical paths and path-filter inputs preserve the form implied by
+`RootDir`: absolute roots produce absolute paths, while relative or empty roots
+produce relative paths as in the existing batch analyzer contract.
+
 UserForm source selection follows the configured code-source mode. In sidecar
 mode an authoritative `forms/code/<Name>.bas` entry is classified as `form` and
 the matching exported `.frm` code is not loaded. A `.frm` remains eligible when
@@ -90,8 +95,8 @@ reporting unsupported kinds, duplicate identities, or other invalid inputs.
 Filesystem discovery and source loading remain adapter responsibilities. The
 existing `symbols.SourceFile` is a discovery descriptor containing a path and
 inferred kind; it is not a loaded source project. The filesystem adapter
-converts those descriptors into this model after reading source bytes. Issue
-#642 will add the common analysis entry point, while issue #644 owns
+converts those descriptors into this model after reading source bytes. Issue #642
+will add the common analysis entry point, while issue #644 owns
 filesystem-free diagnostic and suppression behavior.
 
 This contract does not introduce a virtual filesystem, change CLI or LSP wire

--- a/docs/specs/vba-source-project.md
+++ b/docs/specs/vba-source-project.md
@@ -56,6 +56,31 @@ source beyond a call boundary own any snapshotting they require.
 The model package does not import configuration, parser, LSP, Excel, COM, or
 OS-specific packages.
 
+## Filesystem Adapter
+
+`internal/vba/sourceprojectfs` is the filesystem-backed adapter for batch
+static analysis. It discovers configured module, class, form, and workbook
+roots through the canonical `symbols` discovery contract, also includes the
+legacy top-level `tests` tree, applies an optional path filter, reads the
+selected files, and returns a `SourceProject`.
+
+The adapter preserves source bytes exactly and uses the module kind assigned by
+canonical discovery. A standard module discovered through the legacy `tests`
+tree sets `IsTest`; class, form, and document semantics remain represented by
+their module kind. When a path is reachable through both production discovery
+and `tests`, the production entry takes precedence. Results are deduplicated
+and sorted deterministically by path before source is read.
+
+UserForm source selection follows the configured code-source mode. In sidecar
+mode an authoritative `forms/code/<Name>.bas` entry is classified as `form` and
+the matching exported `.frm` code is not loaded. A `.frm` remains eligible when
+there is no authoritative sidecar.
+
+The optional path filter runs before `os.ReadFile`, so excluded files are not
+loaded into the returned project. Missing configured roots and a missing
+legacy `tests` tree contribute no files; discovery, read, and cancellation
+errors are returned to the caller.
+
 ## Validation and Adapters
 
 The model is a passive value contract and performs no construction-time
@@ -64,9 +89,10 @@ reporting unsupported kinds, duplicate identities, or other invalid inputs.
 
 Filesystem discovery and source loading remain adapter responsibilities. The
 existing `symbols.SourceFile` is a discovery descriptor containing a path and
-inferred kind; it is not a loaded source project. Issue #641 will convert such
-descriptors into this model after reading source bytes. Issue #642 will add the
-common analysis entry point.
+inferred kind; it is not a loaded source project. The filesystem adapter
+converts those descriptors into this model after reading source bytes. Issue
+#642 will add the common analysis entry point, while issue #644 owns
+filesystem-free diagnostic and suppression behavior.
 
 This contract does not introduce a virtual filesystem, change CLI or LSP wire
 formats, refactor the analyzer, or provide browser/Wasm integration.

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -119,6 +119,7 @@ type Analyzer struct {
 	visibleConstants           map[string]bool
 	visibleConstantValues      map[string]constexpr.Value
 	byRefSymbolIndex           *intel.WorkspaceResolutionView
+	physicalRootDir            string
 	errorGuardAliases          map[string]bool
 	errorValueWrappers         map[string]bool
 	eventSafeProcedures        map[string]bool
@@ -651,15 +652,6 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	if err := ctx.Err(); err != nil {
 		return Result{}, err
 	}
-	rootDir := a.RootDir
-	if rootDir == "" {
-		rootDir = "."
-	}
-	rootDir, err = filepath.Abs(rootDir)
-	if err != nil {
-		return Result{}, err
-	}
-	a.RootDir = filepath.Clean(rootDir)
 	project, err := sourceprojectfs.LoadContext(ctx, sourceprojectfs.Options{
 		RootDir:    a.RootDir,
 		Config:     a.Config,
@@ -668,6 +660,15 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	if err != nil {
 		return Result{}, err
 	}
+	physicalRootDir := a.RootDir
+	if physicalRootDir == "" {
+		physicalRootDir = "."
+	}
+	physicalRootDir, err = filepath.Abs(physicalRootDir)
+	if err != nil {
+		return Result{}, err
+	}
+	a.physicalRootDir = filepath.Clean(physicalRootDir)
 	files := make([]string, 0, len(project.Files))
 	// Compile-equivalent argument, Set, ByRef, and local-type findings are
 	// always enabled because they represent VBE compile rejections and cannot
@@ -1189,7 +1190,7 @@ func (a Analyzer) byRefArgumentDiagnosticsContext(ctx context.Context, file pars
 		return batchByRefDiagnostics{computed: true}
 	}
 	diagnostics := (intel.Analyzer{
-		RootDir:                    a.RootDir,
+		RootDir:                    a.intelRootDir(),
 		Config:                     a.Config,
 		DB:                         a.typeDB,
 		TypeDBResolutionIncomplete: a.typeDBResolutionIncomplete,
@@ -1241,7 +1242,7 @@ func (a Analyzer) compileEquivalentFindings(file parsedFile) ([]Finding, []Findi
 
 func (a Analyzer) compileEquivalentFindingsContext(ctx context.Context, file parsedFile, byRefDiagnostics batchByRefDiagnostics) ([]Finding, []Finding) {
 	intelAnalyzer := intel.Analyzer{
-		RootDir:                    a.RootDir,
+		RootDir:                    a.intelRootDir(),
 		Config:                     a.Config,
 		DB:                         a.typeDB,
 		TypeDBResolutionIncomplete: a.typeDBResolutionIncomplete,
@@ -1364,20 +1365,32 @@ func projectByRefSymbolIndex(ctx context.Context, rootDir string, cfg config.Con
 	}
 
 	var projectSymbols []intel.Symbol
+	physicalRootDir := rootDir
+	if physicalRootDir == "" {
+		physicalRootDir = "."
+	}
+	physicalRootDir, err := filepath.Abs(physicalRootDir)
+	if err != nil {
+		return nil, 0, err
+	}
+	physicalRootDir = filepath.Clean(physicalRootDir)
 	if pathFilter != nil {
-		var err error
-		projectSymbols, err = (intel.Analyzer{RootDir: rootDir, Config: cfg}).WorkspaceSymbolsContext(ctx, nil, "")
+		projectSymbols, err = (intel.Analyzer{RootDir: physicalRootDir, Config: cfg}).WorkspaceSymbolsContext(ctx, nil, "")
 		if err != nil {
 			return nil, 0, err
 		}
 	} else {
-		symbolAnalyzer := intel.Analyzer{RootDir: rootDir, Config: cfg}
+		symbolAnalyzer := intel.Analyzer{RootDir: physicalRootDir, Config: cfg}
 		seen := make(map[string]struct{}, len(parsedFiles))
 		for _, file := range parsedFiles {
 			if err := ctx.Err(); err != nil {
 				return nil, len(projectSymbols), err
 			}
-			_, included, err := symbols.SourceFileForPath(rootDir, cfg, file.Path)
+			classificationPath, err := filepath.Abs(file.Path)
+			if err != nil {
+				return nil, len(projectSymbols), err
+			}
+			_, included, err := symbols.SourceFileForPath(rootDir, cfg, classificationPath)
 			if err != nil {
 				return nil, len(projectSymbols), err
 			}
@@ -1433,6 +1446,13 @@ func projectByRefSourcePathKey(path string) (string, error) {
 	return key, nil
 }
 
+func (a Analyzer) intelRootDir() string {
+	if a.physicalRootDir != "" {
+		return a.physicalRootDir
+	}
+	return a.RootDir
+}
+
 func (a Analyzer) byRefWorkspaceSymbolQuery(_ []intel.Document, query intel.WorkspaceSymbolQuery) ([]intel.Symbol, error) {
 	if a.byRefSymbolIndex == nil || (query.Mode != intel.WorkspaceSymbolQueryExact && query.Mode != intel.WorkspaceSymbolQueryQualified) {
 		return nil, nil
@@ -1449,7 +1469,7 @@ func (a Analyzer) statefulExcelCallArgumentFindingsContext(ctx context.Context, 
 	if !a.Config.Analyze.DetectStatefulExcelCallArguments || a.typeDB == nil {
 		return nil, nil
 	}
-	diagnostics, err := (intel.Analyzer{RootDir: a.RootDir, Config: a.Config, DB: a.typeDB}).StatefulExcelCallArgumentDiagnosticsContext(ctx, file.intelDocument())
+	diagnostics, err := (intel.Analyzer{RootDir: a.intelRootDir(), Config: a.Config, DB: a.typeDB}).StatefulExcelCallArgumentDiagnosticsContext(ctx, file.intelDocument())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/analyze/analyzer.go
+++ b/internal/analyze/analyzer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/harumiWeb/xlflow/internal/vba/effects"
 	"github.com/harumiWeb/xlflow/internal/vba/intel"
 	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
+	"github.com/harumiWeb/xlflow/internal/vba/sourceprojectfs"
 	"github.com/harumiWeb/xlflow/internal/vba/symbols"
 	"github.com/harumiWeb/xlflow/internal/vbadb"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
@@ -650,12 +651,24 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	if err := ctx.Err(); err != nil {
 		return Result{}, err
 	}
-	finishStage := analysisstats.Measure(ctx, "source_discovery")
-	files, err := a.files()
-	finishStage(len(files), err)
+	rootDir := a.RootDir
+	if rootDir == "" {
+		rootDir = "."
+	}
+	rootDir, err = filepath.Abs(rootDir)
 	if err != nil {
 		return Result{}, err
 	}
+	a.RootDir = filepath.Clean(rootDir)
+	project, err := sourceprojectfs.LoadContext(ctx, sourceprojectfs.Options{
+		RootDir:    a.RootDir,
+		Config:     a.Config,
+		PathFilter: a.PathFilter,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	files := make([]string, 0, len(project.Files))
 	// Compile-equivalent argument, Set, ByRef, and local-type findings are
 	// always enabled because they represent VBE compile rejections and cannot
 	// be disabled by the legacy VBA206 runtime-safety setting.
@@ -663,33 +676,23 @@ func (a Analyzer) RunResultContext(ctx context.Context) (result Result, err erro
 	needsTypedExcelAnalysis := a.Config.Analyze.DetectRangeFindNothingCheck || a.Config.Analyze.DetectStatefulExcelCallArguments || a.Config.Analyze.DetectExcelAPIFailureContracts || needsByRefAnalysis || a.Config.Analyze.DetectExcelCellAccessInLoops || a.Config.Analyze.DetectLoopInvariantExcelObjectResolution || a.Config.Analyze.DetectExpensiveFullRangeOperations || a.Config.Analyze.DetectValue2PerformanceOpportunities
 	needsDataFlowInputs := dataFlowInputsEnabled(a.Config.Analyze)
 	needsTypeDB := needsTypedExcelAnalysis || a.Config.Analyze.DetectPublicAPITypeSafety || needsDataFlowInputs
-	parsedFiles := make([]parsedFile, 0, len(files))
-	for _, file := range files {
+	parsedFiles := make([]parsedFile, 0, len(project.Files))
+	var finishStage func(int, error)
+	for _, sourceFile := range project.Files {
 		if err := ctx.Err(); err != nil {
 			closeParsedFiles(parsedFiles)
 			return Result{}, err
 		}
-		finishStage = analysisstats.Measure(ctx, "file_read")
-		source, err := os.ReadFile(file)
-		finishStage(len(source), err)
-		if err != nil {
-			closeParsedFiles(parsedFiles)
-			return Result{}, err
-		}
+		file := sourceFile.Path
+		source := sourceFile.Source
+		moduleKind := string(sourceFile.ModuleKind)
+		files = append(files, file)
 		finishStage = analysisstats.Measure(ctx, "parse")
 		parsed, err := vbaast.ParseDocument(file, source)
 		finishStage(1, err)
 		if err != nil {
 			closeParsedFiles(parsedFiles)
 			return Result{}, err
-		}
-		moduleKind := ""
-		if sourceFile, included, classifyErr := symbols.SourceFileForPath(a.RootDir, a.Config, file); classifyErr != nil {
-			parsed.Close()
-			closeParsedFiles(parsedFiles)
-			return Result{}, classifyErr
-		} else if included {
-			moduleKind = sourceFile.ModuleKind
 		}
 		finishStage = analysisstats.Measure(ctx, "procedure_ir")
 		ir, err := procedureir.BuildParsed(procedureir.BuildOptions{
@@ -2282,63 +2285,6 @@ func (a Analyzer) sourceRealtimeProcedureFindingsContext(ctx context.Context, fi
 		findings = append(findings, a.value2PerformanceFindings(file, proc)...)
 	}
 	return findings, ctx.Err()
-}
-
-func (a Analyzer) files() ([]string, error) {
-	dirs := []string{a.Config.Src.Modules, a.Config.Src.Classes, a.Config.Src.Forms, a.Config.Src.Workbook, "tests"}
-	var files []string
-	for _, dir := range dirs {
-		root := filepath.Join(a.RootDir, dir)
-		if _, err := os.Stat(root); err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, err
-		}
-		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if d.IsDir() {
-				return nil
-			}
-			switch strings.ToLower(filepath.Ext(path)) {
-			case ".bas", ".cls", ".frm":
-				if !a.shouldIncludeFile(path) {
-					return nil
-				}
-				files = append(files, path)
-			}
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	sort.Strings(files)
-	return files, nil
-}
-
-func (a Analyzer) shouldIncludeFile(path string) bool {
-	if a.PathFilter != nil && !a.PathFilter(path) {
-		return false
-	}
-	if !strings.EqualFold(filepath.Ext(path), ".frm") {
-		return true
-	}
-	if !strings.EqualFold(a.Config.UserForm.CodeSource, "sidecar") {
-		return true
-	}
-	formsRoot := filepath.Clean(filepath.Join(a.RootDir, a.Config.Src.Forms))
-	cleanPath := filepath.Clean(path)
-	if !isPathInsideRoot(cleanPath, formsRoot) {
-		return true
-	}
-	sidecarPath := filepath.Join(formsRoot, "code", strings.TrimSuffix(filepath.Base(cleanPath), filepath.Ext(cleanPath))+".bas")
-	if _, err := os.Stat(sidecarPath); err == nil {
-		return false
-	}
-	return true
 }
 
 func buildResolutionResolver(files []parsedFile, complete bool, typeDB *vbadb.DB) procedureir.Resolver {
@@ -5696,19 +5642,6 @@ func isVBAIdentifierRune(r rune) bool {
 		return true
 	}
 	return r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z'
-}
-
-func isPathInsideRoot(path, root string) bool {
-	path = filepath.Clean(path)
-	root = filepath.Clean(root)
-	if strings.EqualFold(path, root) {
-		return true
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return false
-	}
-	return rel != "." && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)
 }
 
 func sortFindings(findings []Finding) {

--- a/internal/analyze/analyzer_test.go
+++ b/internal/analyze/analyzer_test.go
@@ -5306,6 +5306,42 @@ End Sub
 	}
 }
 
+func TestAnalyzerByRefUsesProjectLocalSignaturesWithRelativeRoot(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, err := os.MkdirTemp(cwd, ".analyze-relative-byref-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	relativeRoot, err := filepath.Rel(cwd, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeModule(t, dir, "Receiver.bas", `Option Explicit
+Public Sub ReplaceText(ByRef target As String)
+End Sub
+`)
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim count As Long
+  Receiver.ReplaceText count
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: relativeRoot, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA228")
+	wantFile := filepath.ToSlash(filepath.Join("src", "modules", "Main.bas"))
+	if len(got) != 1 || got[0].Line != 4 || got[0].File != wantFile || !strings.Contains(got[0].Message, "requires String") {
+		t.Fatalf("relative-root project-local ByRef finding = %+v", got)
+	}
+}
+
 func TestAnalyzerByRefPathFilterRetainsExcludedProjectCandidates(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -9608,6 +9644,39 @@ End Sub
 	}
 }
 
+func TestAnalyzerVBA216DetectsWorksheetCodenamesWithRelativeRoot(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, err := os.MkdirTemp(cwd, ".analyze-relative-vba216-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	relativeRoot, err := filepath.Rel(cwd, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeWorkbookModule(t, dir, "InputSheet.bas")
+	writeWorkbookModule(t, dir, "OutputSheet.bas")
+	writeModule(t, dir, "Main.bas", `Option Explicit
+Public Sub Run()
+  Dim lastRow As Long
+  lastRow = InputSheet.Cells(OutputSheet.Rows.Count, 1).End(xlUp).Row
+End Sub
+`)
+
+	findings, err := Analyzer{RootDir: relativeRoot, Config: config.Default()}.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA216")
+	if len(got) != 1 || got[0].Line != 4 {
+		t.Fatalf("relative-root worksheet-codename VBA216 findings = %+v", got)
+	}
+}
+
 func TestAnalyzerVBA216OnlyComparesProvableRootIdentities(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -9903,6 +9972,37 @@ End Sub
 	got := findingsByCode(findings, "VBA220")
 	if len(got) != 1 || !strings.Contains(got[0].Message, "same-event") {
 		t.Fatalf("UserForm control change should remain a same-event VBA220 hazard: %+v", got)
+	}
+}
+
+func TestAnalyzerWithEmptyRootResolvesSidecarUserFormControls(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeFormSidecar(t, dir, "Dialog.bas", `Option Explicit
+Private Sub NeedsString(ByRef target As String)
+End Sub
+
+Private Sub CustomInput_Change()
+  NeedsString CustomInput
+End Sub
+`)
+	designer := `VERSION 5.00
+Begin {C62A69F0-16DC-11CE-9E98-00AA00574A4F} Dialog
+   Begin MSForms.TextBox CustomInput
+   End
+End
+`
+	if err := os.WriteFile(filepath.Join(dir, "src", "forms", "Dialog.frm"), []byte(designer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := (Analyzer{Config: config.Default()}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findingsByCode(findings, "VBA228")
+	if len(got) != 1 || !strings.Contains(got[0].Message, "requires String") {
+		t.Fatalf("empty-root UserForm control should retain its designer type: %+v", got)
 	}
 }
 

--- a/internal/analyze/module_state.go
+++ b/internal/analyze/module_state.go
@@ -326,16 +326,25 @@ func moduleStateResolveField(rootDir string, access procedureir.VariableAccess, 
 	if access.Resolution.Scope == procedureir.ScopeProject && len(access.Resolution.Candidates) == 1 {
 		candidate := access.Resolution.Candidates[0]
 		candidateFile := candidate.File
+		for _, field := range byName[strings.ToLower(strings.TrimSpace(access.Name))] {
+			if moduleStateSameFile(field.File, candidateFile) && field.Line == candidate.Line {
+				return field
+			}
+		}
 		if candidateFile != "" && !filepath.IsAbs(candidateFile) && rootDir != "" {
 			candidateFile = filepath.Join(rootDir, filepath.FromSlash(candidateFile))
-		}
-		for _, field := range byName[strings.ToLower(strings.TrimSpace(access.Name))] {
-			if strings.EqualFold(moduleStatePathKey(field.File), moduleStatePathKey(candidateFile)) && field.Line == candidate.Line {
-				return field
+			for _, field := range byName[strings.ToLower(strings.TrimSpace(access.Name))] {
+				if moduleStateSameFile(field.File, candidateFile) && field.Line == candidate.Line {
+					return field
+				}
 			}
 		}
 	}
 	return moduleStateResolveName(access.Name, procedure, byFileName, byName)
+}
+
+func moduleStateSameFile(left, right string) bool {
+	return strings.EqualFold(moduleStatePathKey(left), moduleStatePathKey(right))
 }
 
 func moduleStateResolveName(name string, procedure moduleStateProcedure, byFileName map[string]*moduleStateField, byName map[string][]*moduleStateField) *moduleStateField {

--- a/internal/analyze/module_state_test.go
+++ b/internal/analyze/module_state_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/procedureir"
 )
 
 func TestVBA240ReportsCrossEntryMutableCollectionAndMetrics(t *testing.T) {
@@ -67,6 +68,29 @@ End Sub
 	}
 	if !seenRun {
 		t.Fatalf("procedure metrics missing Main.Run: %#v", procedures)
+	}
+}
+
+func TestModuleStateResolveFieldPreservesRelativeCandidateIdentity(t *testing.T) {
+	rootDir := ".analyze-relative-vba240"
+	alpha := &moduleStateField{File: filepath.Join(rootDir, "src", "modules", "Alpha.bas"), Module: "Alpha", ModuleKind: "standard", Name: "sharedItems", Scope: procedureir.ScopeProject, Line: 2}
+	zulu := &moduleStateField{File: filepath.Join(rootDir, "src", "modules", "Zulu.bas"), Module: "Zulu", ModuleKind: "standard", Name: "sharedItems", Scope: procedureir.ScopeProject, Line: 2}
+	byName := map[string][]*moduleStateField{"shareditems": {alpha, zulu}}
+	access := procedureir.VariableAccess{
+		Name:  "sharedItems",
+		Scope: procedureir.ScopeProject,
+		Resolution: procedureir.SymbolResolution{
+			Scope: procedureir.ScopeProject,
+			Candidates: []procedureir.Candidate{{
+				File: zulu.File,
+				Line: zulu.Line,
+			}},
+		},
+	}
+
+	got := moduleStateResolveField(rootDir, access, moduleStateProcedure{File: "Main.bas", Module: "Main"}, nil, byName)
+	if got != zulu {
+		t.Fatalf("relative candidate resolved to %+v, want Zulu field %+v", got, zulu)
 	}
 }
 

--- a/internal/analyze/procedure_boundaries_test.go
+++ b/internal/analyze/procedure_boundaries_test.go
@@ -19,13 +19,15 @@ End Sub
 
 func TestAnalyzerAcceptsVBEAcceptedPropertyGetTerminatorRecovery(t *testing.T) {
 	cases := []struct {
-		name string
-		rel  string
+		name         string
+		rel          string
+		relativeRoot bool
 	}{
 		{name: "standard", rel: filepath.Join("src", "modules", "Probe.bas")},
 		{name: "class", rel: filepath.Join("src", "classes", "Probe.cls")},
 		{name: "workbook document", rel: filepath.Join("src", "workbook", "ThisWorkbook.bas")},
 		{name: "worksheet document", rel: filepath.Join("src", "workbook", "Sheet1.bas")},
+		{name: "worksheet document with relative root", rel: filepath.Join("src", "workbook", "Sheet1.bas"), relativeRoot: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -38,7 +40,22 @@ func TestAnalyzerAcceptsVBEAcceptedPropertyGetTerminatorRecovery(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result, err := (Analyzer{RootDir: dir, Config: config.Default()}).RunResult()
+			rootDir := dir
+			if tc.relativeRoot {
+				cwd, cwdErr := os.Getwd()
+				if cwdErr != nil {
+					t.Fatal(cwdErr)
+				}
+				relativeRoot, relErr := filepath.Rel(cwd, dir)
+				if relErr != nil {
+					t.Fatal(relErr)
+				}
+				rootDir = relativeRoot
+				if filepath.IsAbs(rootDir) {
+					t.Fatalf("relative test root = %q, want relative path", rootDir)
+				}
+			}
+			result, err := (Analyzer{RootDir: rootDir, Config: config.Default()}).RunResult()
 			if err != nil {
 				var parseErr *ParseError
 				if errors.As(err, &parseErr) {

--- a/internal/analyze/procedure_boundaries_test.go
+++ b/internal/analyze/procedure_boundaries_test.go
@@ -32,6 +32,17 @@ func TestAnalyzerAcceptsVBEAcceptedPropertyGetTerminatorRecovery(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
+			if tc.relativeRoot {
+				cwd, cwdErr := os.Getwd()
+				if cwdErr != nil {
+					t.Fatal(cwdErr)
+				}
+				dir, cwdErr = os.MkdirTemp(cwd, ".analyze-relative-root-")
+				if cwdErr != nil {
+					t.Fatal(cwdErr)
+				}
+				t.Cleanup(func() { _ = os.RemoveAll(dir) })
+			}
 			path := filepath.Join(dir, tc.rel)
 			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 				t.Fatal(err)
@@ -67,6 +78,40 @@ func TestAnalyzerAcceptsVBEAcceptedPropertyGetTerminatorRecovery(t *testing.T) {
 				t.Fatalf("analyzed files = %d, want 1 for %s", result.AnalyzedFiles, path)
 			}
 		})
+	}
+}
+
+func TestAnalyzerPreservesRelativeParseErrorPath(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, err := os.MkdirTemp(cwd, ".analyze-relative-parse-error-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	relativeRoot, err := filepath.Rel(cwd, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	relativePath := filepath.Join(relativeRoot, "src", "modules", "Probe.bas")
+	absolutePath := filepath.Join(cwd, relativePath)
+	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(absolutePath, []byte("Public Sub Broken(\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = (Analyzer{RootDir: relativeRoot, Config: config.Default()}).RunResult()
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("malformed source error = %v, want ParseError", err)
+	}
+	if parseErr.Path != relativePath {
+		t.Fatalf("parse error path = %q, want logical relative path %q", parseErr.Path, relativePath)
 	}
 }
 

--- a/internal/vba/sourceprojectfs/loader.go
+++ b/internal/vba/sourceprojectfs/loader.go
@@ -1,0 +1,179 @@
+// Package sourceprojectfs adapts a configured xlflow source tree to the
+// filesystem-independent sourceproject model.
+package sourceprojectfs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+	"github.com/harumiWeb/xlflow/internal/vba/sourceproject"
+	"github.com/harumiWeb/xlflow/internal/vba/symbols"
+)
+
+// Options controls loading a source project from a configured filesystem
+// workspace. RootDir is the project root used to resolve configured source
+// directories and the legacy tests directory. PathFilter, when present, is
+// called with an absolute source path before the file is read.
+type Options struct {
+	RootDir    string
+	Config     config.Config
+	PathFilter func(string) bool
+}
+
+type candidate struct {
+	path   string
+	kind   sourceproject.ModuleKind
+	isTest bool
+}
+
+// Load loads a source project using a background context.
+func Load(opts Options) (sourceproject.SourceProject, error) {
+	return LoadContext(context.Background(), opts)
+}
+
+// LoadContext is the cancellable variant of Load. It discovers configured
+// production roots and the legacy tests directory, reads selected files, and
+// returns their exact source bytes in a sourceproject.SourceProject.
+func LoadContext(ctx context.Context, opts Options) (project sourceproject.SourceProject, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return sourceproject.SourceProject{}, err
+	}
+
+	finishDiscovery := analysisstats.Measure(ctx, "source_discovery")
+	discoveryFinished := false
+	defer func() {
+		if !discoveryFinished {
+			finishDiscovery(0, err)
+		}
+	}()
+	production, discoveryErr := symbols.DiscoverSourceFilesContext(ctx, symbols.Options{
+		RootDir: opts.RootDir,
+		Config:  opts.Config,
+	})
+	if discoveryErr != nil {
+		return sourceproject.SourceProject{}, discoveryErr
+	}
+	tests, discoveryErr := symbols.DiscoverSourceFilesContext(ctx, symbols.Options{
+		RootDir: opts.RootDir,
+		Config:  opts.Config,
+		Path:    "tests",
+	})
+	if discoveryErr != nil {
+		return sourceproject.SourceProject{}, discoveryErr
+	}
+
+	candidates := make([]candidate, 0, len(production)+len(tests))
+	seen := make(map[string]struct{}, cap(candidates))
+	appendCandidates := func(files []symbols.SourceFile, isTest bool) error {
+		for _, file := range files {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			path, err := absoluteCleanPath(file.Path)
+			if err != nil {
+				return err
+			}
+			key := dedupeKey(path)
+			if _, ok := seen[key]; ok {
+				// Production candidates are appended first, so they retain
+				// precedence if a configured root overlaps tests.
+				continue
+			}
+			kind, err := convertModuleKind(file.ModuleKind)
+			if err != nil {
+				return err
+			}
+			seen[key] = struct{}{}
+			candidates = append(candidates, candidate{path: path, kind: kind, isTest: isTest && kind == sourceproject.ModuleKindStandard})
+		}
+		return nil
+	}
+	if err := appendCandidates(production, false); err != nil {
+		return sourceproject.SourceProject{}, err
+	}
+	if err := appendCandidates(tests, true); err != nil {
+		return sourceproject.SourceProject{}, err
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].path == candidates[j].path {
+			return !candidates[i].isTest && candidates[j].isTest
+		}
+		return candidates[i].path < candidates[j].path
+	})
+
+	selected := candidates[:0]
+	for _, file := range candidates {
+		if err := ctx.Err(); err != nil {
+			return sourceproject.SourceProject{}, err
+		}
+		if opts.PathFilter != nil && !opts.PathFilter(file.path) {
+			continue
+		}
+		selected = append(selected, file)
+	}
+	finishDiscovery(len(selected), nil)
+	discoveryFinished = true
+
+	files := make([]sourceproject.SourceFile, 0, len(selected))
+	for _, file := range selected {
+		if err := ctx.Err(); err != nil {
+			return sourceproject.SourceProject{}, err
+		}
+		finishRead := analysisstats.Measure(ctx, "file_read")
+		source, readErr := os.ReadFile(file.path)
+		finishRead(len(source), readErr)
+		if readErr != nil {
+			return sourceproject.SourceProject{}, readErr
+		}
+		files = append(files, sourceproject.SourceFile{
+			Path:       file.path,
+			Source:     source,
+			ModuleKind: file.kind,
+			IsTest:     file.isTest,
+		})
+	}
+	if err := ctx.Err(); err != nil {
+		return sourceproject.SourceProject{}, err
+	}
+	return sourceproject.SourceProject{Files: files}, nil
+}
+
+func absoluteCleanPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+func dedupeKey(path string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(path)
+	}
+	return path
+}
+
+func convertModuleKind(kind string) (sourceproject.ModuleKind, error) {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case string(sourceproject.ModuleKindStandard):
+		return sourceproject.ModuleKindStandard, nil
+	case string(sourceproject.ModuleKindClass):
+		return sourceproject.ModuleKindClass, nil
+	case string(sourceproject.ModuleKindForm):
+		return sourceproject.ModuleKindForm, nil
+	case string(sourceproject.ModuleKindDocument):
+		return sourceproject.ModuleKindDocument, nil
+	default:
+		return "", fmt.Errorf("unsupported VBA module kind %q", kind)
+	}
+}

--- a/internal/vba/sourceprojectfs/loader.go
+++ b/internal/vba/sourceprojectfs/loader.go
@@ -20,7 +20,8 @@ import (
 // Options controls loading a source project from a configured filesystem
 // workspace. RootDir is the project root used to resolve configured source
 // directories and the legacy tests directory. PathFilter, when present, is
-// called with an absolute source path before the file is read.
+// called with the source's logical path before the file is read. Logical paths
+// preserve the absolute or relative form implied by RootDir.
 type Options struct {
 	RootDir    string
 	Config     config.Config
@@ -28,9 +29,10 @@ type Options struct {
 }
 
 type candidate struct {
-	path   string
-	kind   sourceproject.ModuleKind
-	isTest bool
+	physicalPath string
+	logicalPath  string
+	kind         sourceproject.ModuleKind
+	isTest       bool
 }
 
 // Load loads a source project using a background context.
@@ -46,6 +48,14 @@ func LoadContext(ctx context.Context, opts Options) (project sourceproject.Sourc
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
+		return sourceproject.SourceProject{}, err
+	}
+	rootDir := opts.RootDir
+	if rootDir == "" {
+		rootDir = "."
+	}
+	absoluteRoot, err := absoluteCleanPath(rootDir)
+	if err != nil {
 		return sourceproject.SourceProject{}, err
 	}
 
@@ -79,11 +89,12 @@ func LoadContext(ctx context.Context, opts Options) (project sourceproject.Sourc
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			path, err := absoluteCleanPath(file.Path)
+			physicalPath, err := absoluteCleanPath(file.Path)
 			if err != nil {
 				return err
 			}
-			key := dedupeKey(path)
+			logicalPath := logicalSourcePath(opts.RootDir, absoluteRoot, physicalPath)
+			key := dedupeKey(physicalPath)
 			if _, ok := seen[key]; ok {
 				// Production candidates are appended first, so they retain
 				// precedence if a configured root overlaps tests.
@@ -94,7 +105,12 @@ func LoadContext(ctx context.Context, opts Options) (project sourceproject.Sourc
 				return err
 			}
 			seen[key] = struct{}{}
-			candidates = append(candidates, candidate{path: path, kind: kind, isTest: isTest && kind == sourceproject.ModuleKindStandard})
+			candidates = append(candidates, candidate{
+				physicalPath: physicalPath,
+				logicalPath:  logicalPath,
+				kind:         kind,
+				isTest:       isTest && kind == sourceproject.ModuleKindStandard,
+			})
 		}
 		return nil
 	}
@@ -105,10 +121,10 @@ func LoadContext(ctx context.Context, opts Options) (project sourceproject.Sourc
 		return sourceproject.SourceProject{}, err
 	}
 	sort.Slice(candidates, func(i, j int) bool {
-		if candidates[i].path == candidates[j].path {
+		if candidates[i].logicalPath == candidates[j].logicalPath {
 			return !candidates[i].isTest && candidates[j].isTest
 		}
-		return candidates[i].path < candidates[j].path
+		return candidates[i].logicalPath < candidates[j].logicalPath
 	})
 
 	selected := candidates[:0]
@@ -116,7 +132,7 @@ func LoadContext(ctx context.Context, opts Options) (project sourceproject.Sourc
 		if err := ctx.Err(); err != nil {
 			return sourceproject.SourceProject{}, err
 		}
-		if opts.PathFilter != nil && !opts.PathFilter(file.path) {
+		if opts.PathFilter != nil && !opts.PathFilter(file.logicalPath) {
 			continue
 		}
 		selected = append(selected, file)
@@ -130,13 +146,13 @@ func LoadContext(ctx context.Context, opts Options) (project sourceproject.Sourc
 			return sourceproject.SourceProject{}, err
 		}
 		finishRead := analysisstats.Measure(ctx, "file_read")
-		source, readErr := os.ReadFile(file.path)
+		source, readErr := os.ReadFile(file.physicalPath)
 		finishRead(len(source), readErr)
 		if readErr != nil {
 			return sourceproject.SourceProject{}, readErr
 		}
 		files = append(files, sourceproject.SourceFile{
-			Path:       file.path,
+			Path:       file.logicalPath,
 			Source:     source,
 			ModuleKind: file.kind,
 			IsTest:     file.isTest,
@@ -146,6 +162,16 @@ func LoadContext(ctx context.Context, opts Options) (project sourceproject.Sourc
 		return sourceproject.SourceProject{}, err
 	}
 	return sourceproject.SourceProject{Files: files}, nil
+}
+
+func logicalSourcePath(rootDir, absoluteRoot, physicalPath string) string {
+	relativePath, err := filepath.Rel(absoluteRoot, physicalPath)
+	if err != nil {
+		// A configured absolute source root may be on another Windows volume.
+		// filepath.WalkDir historically returned an absolute path in this case.
+		return physicalPath
+	}
+	return filepath.Clean(filepath.Join(rootDir, relativePath))
 }
 
 func absoluteCleanPath(path string) (string, error) {

--- a/internal/vba/sourceprojectfs/loader_test.go
+++ b/internal/vba/sourceprojectfs/loader_test.go
@@ -1,0 +1,263 @@
+package sourceprojectfs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/harumiWeb/xlflow/internal/config"
+	"github.com/harumiWeb/xlflow/internal/vba/analysisstats"
+	"github.com/harumiWeb/xlflow/internal/vba/sourceproject"
+)
+
+func TestLoadClassifiesConfiguredRootsAndLegacyTests(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.UserForm.CodeSource = "frm"
+
+	writeSource(t, root, filepath.Join("src", "modules", "nested", "Standard.bas"), "standard")
+	writeSource(t, root, filepath.Join("src", "classes", "Service.cls"), "class")
+	writeSource(t, root, filepath.Join("src", "forms", "UserForm1.frm"), "form")
+	writeSource(t, root, filepath.Join("src", "workbook", "ThisWorkbook.cls"), "document")
+	writeSource(t, root, filepath.Join("tests", "StandardTest.bas"), "test")
+
+	project, err := Load(Options{RootDir: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(project.Files) != 5 {
+		t.Fatalf("loaded %d files, want 5: %+v", len(project.Files), project.Files)
+	}
+
+	wantPaths := []string{
+		filepath.Join(root, "src", "classes", "Service.cls"),
+		filepath.Join(root, "src", "forms", "UserForm1.frm"),
+		filepath.Join(root, "src", "modules", "nested", "Standard.bas"),
+		filepath.Join(root, "src", "workbook", "ThisWorkbook.cls"),
+		filepath.Join(root, "tests", "StandardTest.bas"),
+	}
+	sort.Strings(wantPaths)
+	gotPaths := make([]string, len(project.Files))
+	for i, file := range project.Files {
+		gotPaths[i] = file.Path
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("paths = %v, want sorted %v", gotPaths, wantPaths)
+	}
+
+	wantKinds := map[string]sourceproject.ModuleKind{
+		"Service.cls":      sourceproject.ModuleKindClass,
+		"UserForm1.frm":    sourceproject.ModuleKindForm,
+		"Standard.bas":     sourceproject.ModuleKindStandard,
+		"ThisWorkbook.cls": sourceproject.ModuleKindDocument,
+		"StandardTest.bas": sourceproject.ModuleKindStandard,
+	}
+	for _, file := range project.Files {
+		wantKind, ok := wantKinds[filepath.Base(file.Path)]
+		if !ok {
+			t.Fatalf("unexpected file %q", file.Path)
+		}
+		wantTest := filepath.Base(file.Path) == "StandardTest.bas"
+		if file.ModuleKind != wantKind || file.IsTest != wantTest {
+			t.Fatalf("file %q = kind %q, isTest=%v; want kind %q, isTest=%v", file.Path, file.ModuleKind, file.IsTest, wantKind, wantTest)
+		}
+	}
+}
+
+func TestLoadUsesSidecarFormSourceAndSkipsDesignerArtifact(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.UserForm.CodeSource = "sidecar"
+	writeSource(t, root, filepath.Join("src", "forms", "UserForm1.frm"), "designer")
+	sidecarPath := filepath.Join("src", "forms", "code", "UserForm1.bas")
+	sidecarSource := []byte("Option Explicit\r\nPublic Sub Initialize_日本語()\r\nEnd Sub\r\n")
+	writeBytes(t, root, sidecarPath, sidecarSource)
+
+	project, err := Load(Options{RootDir: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(project.Files) != 1 {
+		t.Fatalf("loaded %d files, want one sidecar: %+v", len(project.Files), project.Files)
+	}
+	file := project.Files[0]
+	if file.Path != filepath.Join(root, sidecarPath) || file.ModuleKind != sourceproject.ModuleKindForm || file.IsTest {
+		t.Fatalf("sidecar file = %+v", file)
+	}
+	if !bytes.Equal(file.Source, sidecarSource) {
+		t.Fatalf("sidecar source bytes changed: %q", file.Source)
+	}
+}
+
+func TestLoadAppliesPathFilterBeforeReading(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	keepPath := filepath.Join(root, "src", "modules", "Keep.bas")
+	dropPath := filepath.Join(root, "src", "modules", "Drop.bas")
+	writeBytes(t, root, filepath.Join("src", "modules", "Keep.bas"), []byte("keep"))
+	writeBytes(t, root, filepath.Join("src", "modules", "Drop.bas"), []byte("drop"))
+
+	var filtered []string
+	recorder := analysisstats.NewRecorder()
+	ctx := analysisstats.WithRecorder(context.Background(), recorder)
+	project, err := LoadContext(ctx, Options{
+		RootDir: root,
+		Config:  cfg,
+		PathFilter: func(path string) bool {
+			filtered = append(filtered, path)
+			return filepath.Clean(path) == filepath.Clean(keepPath)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(project.Files) != 1 || project.Files[0].Path != keepPath {
+		t.Fatalf("filtered project = %+v, want only %q", project.Files, keepPath)
+	}
+	if !reflect.DeepEqual(filtered, []string{dropPath, keepPath}) {
+		t.Fatalf("filter paths = %v, want sorted absolute paths %v", filtered, []string{dropPath, keepPath})
+	}
+	stages, _ := recorder.Totals()
+	foundDiscovery := false
+	for _, stage := range stages {
+		if stage.Name == "source_discovery" {
+			foundDiscovery = true
+			if stage.ResultCount != 1 {
+				t.Fatalf("source discovery result count = %d, want one selected file", stage.ResultCount)
+			}
+		}
+	}
+	if !foundDiscovery {
+		t.Fatalf("missing source_discovery stage: %+v", stages)
+	}
+}
+
+func TestLoadDeduplicatesWithProductionPrecedenceAndSorts(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	// Pointing a configured production root at tests deliberately creates an
+	// overlap. The production candidate must win and therefore must not be
+	// marked IsTest.
+	cfg.Src.Modules = "tests"
+	writeSource(t, root, filepath.Join("tests", "z.bas"), "z")
+	writeSource(t, root, filepath.Join("tests", "a.bas"), "a")
+
+	project, err := Load(Options{RootDir: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(project.Files) != 2 {
+		t.Fatalf("loaded %d files, want 2 after dedupe: %+v", len(project.Files), project.Files)
+	}
+	if project.Files[0].Path >= project.Files[1].Path {
+		t.Fatalf("files are not sorted: %q then %q", project.Files[0].Path, project.Files[1].Path)
+	}
+	for _, file := range project.Files {
+		if file.IsTest {
+			t.Fatalf("overlapping production file marked as test: %+v", file)
+		}
+	}
+}
+
+func TestLoadPreservesSourceBytesAndRecordsStages(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	want := []byte("Attribute VB_Name = \"Bytes\"\r\n' Unicode: 日本語\x00\r\n")
+	path := filepath.Join("src", "modules", "Bytes.bas")
+	writeBytes(t, root, path, want)
+
+	recorder := analysisstats.NewRecorder()
+	ctx := analysisstats.WithRecorder(context.Background(), recorder)
+	project, err := LoadContext(ctx, Options{RootDir: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(project.Files) != 1 || !bytes.Equal(project.Files[0].Source, want) {
+		t.Fatalf("source bytes = %q, want exact %q", project.Files[0].Source, want)
+	}
+	stages, _ := recorder.Totals()
+	byName := make(map[string]analysisstats.Stage, len(stages))
+	for _, stage := range stages {
+		byName[stage.Name] = stage
+	}
+	if byName["source_discovery"].ResultCount != 1 || byName["file_read"].Calls != 1 || byName["file_read"].ResultCount != len(want) {
+		t.Fatalf("loader stages = %+v, want one discovered file and one byte-counted read", byName)
+	}
+}
+
+func TestLoadMissingRootsProduceEmptyProject(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	cfg.Src.Modules = "missing/modules"
+	cfg.Src.Classes = "missing/classes"
+	cfg.Src.Forms = "missing/forms"
+	cfg.Src.Workbook = "missing/workbook"
+
+	project, err := Load(Options{RootDir: root, Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(project.Files) != 0 {
+		t.Fatalf("missing roots project = %+v, want empty project", project)
+	}
+}
+
+func TestLoadPropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	project, err := LoadContext(ctx, Options{RootDir: t.TempDir(), Config: config.Default()})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(project.Files) != 0 {
+		t.Fatalf("project = %+v, want zero value on cancellation", project)
+	}
+}
+
+func TestLoadPropagatesReadError(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Default()
+	path := filepath.Join(root, "src", "modules", "ReadError.bas")
+	writeBytes(t, root, filepath.Join("src", "modules", "ReadError.bas"), []byte("source"))
+	project, err := Load(Options{
+		RootDir: root,
+		Config:  cfg,
+		PathFilter: func(got string) bool {
+			if strings.EqualFold(filepath.Clean(got), filepath.Clean(path)) {
+				return os.Remove(got) == nil
+			}
+			return true
+		},
+	})
+	if len(project.Files) != 0 {
+		t.Fatalf("project = %+v, want zero value on read error", project)
+	}
+	if err == nil {
+		t.Fatal("Load returned nil error after filtered file was removed")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("error = %v, want file read error", err)
+	}
+}
+
+func writeSource(t *testing.T, root, relative, marker string) {
+	t.Helper()
+	writeBytes(t, root, relative, []byte("Option Explicit\n' "+marker+"\n"))
+}
+
+func writeBytes(t *testing.T, root, relative string, source []byte) {
+	t.Helper()
+	path := filepath.Join(root, relative)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, source, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/vba/sourceprojectfs/loader_test.go
+++ b/internal/vba/sourceprojectfs/loader_test.go
@@ -138,6 +138,58 @@ func TestLoadAppliesPathFilterBeforeReading(t *testing.T) {
 	}
 }
 
+func TestLoadPreservesRelativeLogicalPaths(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp(cwd, ".sourceprojectfs-relative-root-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	relativeRoot, err := filepath.Rel(cwd, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	relativeSource := filepath.Join(relativeRoot, "src", "modules", "Relative.bas")
+	writeSource(t, root, filepath.Join("src", "modules", "Relative.bas"), "relative")
+
+	var filteredPath string
+	project, err := Load(Options{
+		RootDir: relativeRoot,
+		Config:  config.Default(),
+		PathFilter: func(path string) bool {
+			filteredPath = path
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(project.Files) != 1 || project.Files[0].Path != relativeSource {
+		t.Fatalf("relative project files = %+v, want logical path %q", project.Files, relativeSource)
+	}
+	if filteredPath != relativeSource {
+		t.Fatalf("path filter received %q, want logical path %q", filteredPath, relativeSource)
+	}
+}
+
+func TestLoadWithEmptyRootUsesWorkingDirectoryRelativeLogicalPaths(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	relativeSource := filepath.Join("src", "modules", "WorkingDirectory.bas")
+	writeSource(t, root, relativeSource, "working directory")
+
+	project, err := Load(Options{Config: config.Default()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(project.Files) != 1 || project.Files[0].Path != relativeSource {
+		t.Fatalf("empty-root project files = %+v, want logical path %q", project.Files, relativeSource)
+	}
+}
+
 func TestLoadDeduplicatesWithProductionPrecedenceAndSorts(t *testing.T) {
 	root := t.TempDir()
 	cfg := config.Default()

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -138,3 +138,5 @@
 - LSP の体感性能確認では初回表示だけでなく、巨大ファイルを編集して診断開始後に再編集する経路も実機計測する。`didChange` が旧 snapshot の tree lease を同期取得すると、バックグラウンド解析の終了まで JSON-RPC 受信ループを止めるため、旧 revision が使用中なら差分パースを待たず新 revision を公開する。
 - 巨大モジュールの LSP Full 診断は `analyze` の所要時間だけで推測せず、project-aware realtime 経路を実 VS Code で計測する。式ごとの document/UserForm index 再構築、procedure ごとの helper summary・project constant 正規化、batch と realtime の並列境界差を CPU profile と goroutine stack で確認する。
 - Cross-platform analysis tests that inspect `RunResult().Warnings` should assert the relevant warning code rather than require an empty warning set; Linux may legitimately lack the generated TypeLib manifest and emit `type_db_load_warning`.
+- On Windows, tests that need a path relative to the working directory must create their temporary directory on the working directory's volume; `t.TempDir()` may be on another drive where `filepath.Rel` cannot produce a relative path.
+- Filesystem adapters must keep absolute physical paths for discovery, deduplication, and reads separate from logical source paths used by filters, diagnostics, and public results; preserve the caller's absolute or relative `RootDir` form.


### PR DESCRIPTION
## Summary

- Add a filesystem-backed source project loader that produces the common in-memory `SourceProject` model.
- Move configured source discovery, UserForm sidecar selection, path filtering, module classification, and source reads out of `Analyzer.RunResultContext`.
- Preserve existing CLI analysis results and performance stages, including relative `RootDir` behavior and filtered discovery counts.
- Document the filesystem adapter contract. The in-memory analysis entry point and filesystem-free suppression behavior remain scoped to #642 and #644.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./internal/vba/sourceprojectfs ./internal/analyze`
- `rtk task lint`
- `rtk task test`
- `rtk pnpm format:check`
- `rtk proxy task review:codex` (two-pass final review; no unresolved findings)

Closes #641


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filesystem-based loading for VBA modules, classes, forms, worksheets, workbooks, and tests.
  * Added path filtering, cancellation, deterministic ordering, duplicate handling, and production-file precedence.
  * Added configurable UserForm source selection between sidecar and exported form files.
  * Analysis now supports relative and empty project root paths while preserving logical source paths.

* **Bug Fixes**
  * Improved handling of missing directories, read errors, and source discovery failures.
  * Improved project-local signature, worksheet codename, UserForm control, and module-state resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->