### PR TITLE
feat: support tree-sitter-vba v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+- Updated the `tree-sitter-vba` parser dependency to v0.13.0. Print-family
+  output lists now support trailing `;` / `,` controls and explicit `Write #`
+  statements; call extraction and linting ignore `char_position` nodes while
+  preserving semantic output values and existing diagnostic contracts.
+
 - Removed ineffective `VBA227` inline suppressions from scaffolded `XlflowAssert`,
   `XlflowUI`, and `XlflowDebug` helpers so `xlflow analyze` no longer reports
   `unused_inline_suppression` warnings for new projects or installed helper modules.

--- a/THIRD_PARTY_LICENCES.md
+++ b/THIRD_PARTY_LICENCES.md
@@ -14,7 +14,7 @@ This file is provided for attribution and licence review. It is not a substitute
 | `github.com/bmatcuk/doublestar/v4`      | `v4.10.0` | MIT               | `https://github.com/bmatcuk/doublestar/blob/v4.10.0/LICENSE`         |
 | `github.com/charmbracelet/bubbletea`    | `v1.3.10` | MIT               | `https://github.com/charmbracelet/bubbletea/blob/v1.3.10/LICENSE`    |
 | `github.com/charmbracelet/lipgloss`     |  `v1.1.0` | MIT               | `https://github.com/charmbracelet/lipgloss/blob/v1.1.0/LICENSE`      |
-| `github.com/harumiWeb/tree-sitter-vba`  | `v0.12.2` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.12.2/LICENSE`  |
+| `github.com/harumiWeb/tree-sitter-vba`  | `v0.13.0` | MIT               | `https://github.com/harumiWeb/tree-sitter-vba/blob/v0.13.0/LICENSE`  |
 | `github.com/sourcegraph/jsonrpc2`       |  `v0.2.0` | MIT               | `https://github.com/sourcegraph/jsonrpc2/blob/v0.2.0/LICENSE`        |
 | `github.com/spf13/cobra`                | `v1.10.2` | Apache-2.0        | `https://github.com/spf13/cobra/blob/v1.10.2/LICENSE.txt`            |
 | `github.com/tliron/glsp`                |  `v0.2.2` | Apache-2.0        | `https://github.com/tliron/glsp/blob/v0.2.2/LICENSE`                 |

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/harumiWeb/tree-sitter-vba v0.12.2
+	github.com/harumiWeb/tree-sitter-vba v0.13.0
 	github.com/richardlehane/mscfb v1.0.7
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-github.com/harumiWeb/tree-sitter-vba v0.12.2 h1:P2ytCKrhTU/iCK8FIhlbuVN9rnRydd3otCC/bADFjgI=
-github.com/harumiWeb/tree-sitter-vba v0.12.2/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
+github.com/harumiWeb/tree-sitter-vba v0.13.0 h1:9U9JSF1uDQdj+Q0hm1vIu9ia83B8R+PzcXJVhodPpB4=
+github.com/harumiWeb/tree-sitter-vba v0.13.0/go.mod h1:Ha+Vy78byu+qLq80EkfbePiGeDJG+LG+oxQpyStqfMM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/internal/lint/call_syntax_diagnostics.go
+++ b/internal/lint/call_syntax_diagnostics.go
@@ -356,7 +356,7 @@ func (w *callSyntaxWalker) bareFunctionIdentifier(node *tree_sitter.Node) {
 		return
 	}
 	parent := node.Parent()
-	if parent == nil || parent.Kind() != "unparenthesized_argument_list" {
+	if parent == nil || (parent.Kind() != "unparenthesized_argument_list" && parent.Kind() != "output_list") {
 		return
 	}
 	if !looksLikeBareFunctionArguments(sourceTailAfter(w.source, int(node.EndByte()))) {

--- a/internal/vba/calls/calls.go
+++ b/internal/vba/calls/calls.go
@@ -825,7 +825,7 @@ func argumentsFromCallNode(callNode, target *tree_sitter.Node, source []byte) Ar
 		if child == nil || sameNode(child, target) {
 			continue
 		}
-		if child.Kind() == "argument_list" {
+		if isSemanticArgumentNode(child) && (child.Kind() == "argument_list" || child.Kind() == "output_list") {
 			return argumentsFromArgumentList(child, source)
 		}
 	}
@@ -867,7 +867,7 @@ func argumentsFromArgumentList(node *tree_sitter.Node, source []byte) Arguments 
 	args := Arguments{Named: []NamedArgument{}}
 	for i := uint(0); i < node.NamedChildCount(); i++ {
 		child := node.NamedChild(i)
-		if child == nil {
+		if !isSemanticArgumentNode(child) {
 			continue
 		}
 		args.Count++
@@ -876,6 +876,10 @@ func argumentsFromArgumentList(node *tree_sitter.Node, source []byte) Arguments 
 		}
 	}
 	return args
+}
+
+func isSemanticArgumentNode(node *tree_sitter.Node) bool {
+	return node != nil && node.Kind() != "line_continuation" && node.Kind() != "char_position"
 }
 
 func namedArgument(node *tree_sitter.Node, source []byte) NamedArgument {

--- a/internal/vba/procedureir/builder.go
+++ b/internal/vba/procedureir/builder.go
@@ -1133,7 +1133,11 @@ func argumentsFromArgumentList(node *tree_sitter.Node, source []byte) Arguments 
 }
 
 func isSemanticArgumentNode(node *tree_sitter.Node) bool {
-	return node != nil && node.Kind() != "line_continuation"
+	return node != nil && node.Kind() != "line_continuation" && node.Kind() != "char_position"
+}
+
+func isArgumentContainerNode(node *tree_sitter.Node) bool {
+	return node != nil && (node.Kind() == "argument_list" || node.Kind() == "output_list")
 }
 
 func namedArgument(node *tree_sitter.Node, source []byte) NamedArgument {

--- a/internal/vba/procedureir/builder_test.go
+++ b/internal/vba/procedureir/builder_test.go
@@ -987,6 +987,32 @@ End Sub
 	}
 }
 
+func TestPrintOutputListPositionsAreNotArguments(t *testing.T) {
+	t.Parallel()
+	doc, err := BuildSource(BuildOptions{Path: "Module1.bas"}, []byte(`Public Sub Run()
+	Debug.Print first; second("value"), third;
+End Sub
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Procedures) != 1 || len(doc.Procedures[0].Calls) != 2 {
+		t.Fatalf("Debug.Print call was not captured: %+v", doc.Procedures)
+	}
+	call := doc.Procedures[0].Calls[0]
+	if call.Arguments.Count != 3 || len(call.Arguments.ExpressionIDs) != 3 {
+		t.Fatalf("output positions must not become argument slots: %+v", call.Arguments)
+	}
+	for _, expressionID := range call.Arguments.ExpressionIDs {
+		if expressionID == 0 {
+			t.Fatalf("output expression lacks canonical expression link: %+v", call.Arguments)
+		}
+	}
+	if nested := doc.Procedures[0].Calls[1]; !strings.EqualFold(nested.Callee.BaseName, "second") {
+		t.Fatalf("nested output expression call was not captured: %+v", nested)
+	}
+}
+
 func TestFunctionAndPropertyGetNamesResolveAsLocalReturnSlots(t *testing.T) {
 	t.Parallel()
 	doc, err := BuildSource(BuildOptions{Path: "Thing.cls", ModuleKind: "class"}, []byte(`Public Function Compute(ByVal input As Long) As Long

--- a/internal/vba/procedureir/visitor.go
+++ b/internal/vba/procedureir/visitor.go
@@ -137,8 +137,8 @@ func (v *singleVisitor) visit(node *tree_sitter.Node, ctx visitContext) {
 		v.visitBlock(node, ctx)
 		return
 	}
-	if node.Kind() == "argument_list" && procedure != nil && ctx.callIndex >= 0 {
-		v.visitArgumentList(node, ctx)
+	if isArgumentContainerNode(node) && procedure != nil && ctx.callIndex >= 0 {
+		v.visitArgumentContainer(node, ctx)
 		return
 	}
 	if node.Kind() == "named_argument" && procedure != nil && ctx.callIndex >= 0 {
@@ -527,7 +527,7 @@ func (v *singleVisitor) argumentsForCall(node *tree_sitter.Node) (Arguments, []a
 	if list == nil {
 		for i := uint(0); i < node.NamedChildCount(); i++ {
 			child := node.NamedChild(i)
-			if child != nil && child.Kind() == "argument_list" {
+			if isArgumentContainerNode(child) {
 				list = child
 				break
 			}
@@ -654,7 +654,7 @@ func (v *singleVisitor) visitBlock(node *tree_sitter.Node, ctx visitContext) {
 	}
 }
 
-func (v *singleVisitor) visitArgumentList(node *tree_sitter.Node, ctx visitContext) {
+func (v *singleVisitor) visitArgumentContainer(node *tree_sitter.Node, ctx visitContext) {
 	for i := uint(0); i < node.NamedChildCount(); i++ {
 		if v.builder.err != nil {
 			return

--- a/testdata/static-analysis-corpus/snapshots/analyze/third_party/vba-web.jsonl
+++ b/testdata/static-analysis-corpus/snapshots/analyze/third_party/vba-web.jsonl
@@ -93,7 +93,7 @@
 {"project":"third_party/vba-web","file":"examples/gmail/Gmail.bas","surface":"analyze","code":"VBA206","severity":"warning","line":69,"column":27}
 {"project":"third_party/vba-web","file":"examples/linkedin/LinkedInSheet.cls","surface":"analyze","code":"VBA206","severity":"warning","line":15,"column":5}
 {"project":"third_party/vba-web","file":"examples/maps/Maps.bas","surface":"analyze","code":"VBA202","severity":"warning","line":37,"column":0}
-{"project":"third_party/vba-web","file":"examples/maps/Maps.bas","surface":"analyze","code":"VBA202","severity":"warning","line":51,"column":0}
+{"project":"third_party/vba-web","file":"examples/maps/Maps.bas","surface":"analyze","code":"VBA202","severity":"warning","line":52,"column":0}
 {"project":"third_party/vba-web","file":"examples/maps/MapsSheet.cls","surface":"analyze","code":"VBA206","severity":"warning","line":16,"column":5}
 {"project":"third_party/vba-web","file":"examples/maps/MapsSheet.cls","surface":"analyze","code":"VBA206","severity":"warning","line":16,"column":51}
 {"project":"third_party/vba-web","file":"examples/maps/MapsSheet.cls","surface":"analyze","code":"VBA206","severity":"warning","line":16,"column":51}

--- a/vitepress/reference/error-code-inventory.md
+++ b/vitepress/reference/error-code-inventory.md
@@ -154,6 +154,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `changes_controls`
 - `changes_selection`
 - `changes_workbook`
+- `char_position`
 - `check_dialog`
 - `check_failed`
 - `classes_dir`
@@ -790,6 +791,7 @@ Generated from structured error-code literals in `internal/`. Descriptions and r
 - `original_workbook_path`
 - `output_file_exists`
 - `output_file_missing`
+- `output_list`
 - `output_missing`
 - `output_path`
 - `p1_compiled`


### PR DESCRIPTION
## Summary

- Update the `tree-sitter-vba` Go dependency from v0.12.2 to v0.13.0.
- Teach call extraction, ProcedureIR construction, and call-syntax diagnostics about the shared Print-family `output_list` CST.
- Ignore `char_position` nodes when counting semantic output values so trailing `;` / `,` do not become arguments or alter diagnostic contracts.
- Record the parser compatibility update in the changelog and regenerate the reference inventory.

## Compatibility

- Existing call, lint, procedure, source-range, and diagnostic contracts remain unchanged for ordinary procedure calls.
- Print-family calls may expose `output_list` under `call_statement.arguments`; output expressions remain semantic arguments while `char_position` nodes are layout controls.
- The dependency is pinned to the released v0.13.0 module and its checksums are recorded in `go.sum`.

## Tests

- Focused: `scripts/dev/go.ps1 test ./internal/vba/procedureir ./internal/vba/calls ./internal/lint`
- Full: `scripts/dev/go.ps1 test ./...`
- `scripts/dev/go.ps1 vet ./...`
- `go mod verify`
- `pnpm format:check`
- `pnpm docs:check`
- Pre-commit lefthook checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `Debug.Print` and `Write #` output, including trailing semicolon and comma controls.
  * Corrected call extraction so formatting markers are excluded while meaningful argument values remain intact.
  * Improved lint diagnostics for function expressions within output statements.

* **Documentation**
  * Added newly recognized syntax categories to the error-code reference.
  * Updated the unreleased changes documentation with parser and output-handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->