### PR TITLE
fix(vscode): restore inline suppression quick fixes

### DIFF
--- a/docs/adr/ADR-0024-shared-static-analysis-rule-registry.md
+++ b/docs/adr/ADR-0024-shared-static-analysis-rule-registry.md
@@ -56,13 +56,15 @@ The registry is authoritative for these projections:
 - VS Code suppression Quick Fix eligibility; and
 - the generated static-analysis diagnostic catalog.
 
-`xlflow rules --json` publishes schema version 1 and the sorted registry items
-inside the normal success envelope. Version 1 evolves additively: consumers
-must ignore unknown fields and rule IDs, and breaking field changes require a
-new `schema_version`. The VS Code extension caches successful metadata by
-resolved CLI path and fails closed when retrieval fails, the schema is
-unsupported, or a diagnostic ID is unknown. It must not offer an inline
-suppression Quick Fix without affirmative registry metadata.
+`xlflow rules --json` publishes schema version 2 and the sorted registry items
+inside the normal success envelope. Version 2 adds the `information` severity
+while retaining the fields and suppression semantics used by the extension;
+consumers must ignore unknown fields and rule IDs, and breaking field changes
+require a new `schema_version`. The VS Code extension accepts schema versions 1
+and 2 because it consumes the stable `inline_suppressible` field, caches
+successful metadata by resolved CLI path, and fails closed when retrieval
+fails, the schema is unsupported, or a diagnostic ID is unknown. It must not
+offer an inline suppression Quick Fix without affirmative registry metadata.
 
 The JSON file is embedded so the installed binary remains self-contained, while
 the documentation generator reads the same repository file directly and does

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -756,7 +756,7 @@ integrations must treat an unavailable, invalid, failed, or unsupported-version
 response as unavailable advisory metadata, not infer safety from command names.
 See `docs/specs/workbook-coordination.md` for the complete capability contract.
 
-`rules --json` returns top-level `rules` with `schema_version: 1` and an `items`
+`rules --json` returns top-level `rules` with `schema_version: 2` and an `items`
 array sorted by diagnostic ID. The command is project-independent and is
 registered in the coordination policy as a source-scoped read operation that is
 parallel-safe, does not require Excel, and is not subject to workbook wait or
@@ -771,18 +771,20 @@ Each item publishes the canonical rule `id`, `title`, `description`, `family`,
 `surfaces` identifies the supported `lint`, `analyze`, and `lsp` projections;
 `supported_severities` is constrained by evidence class: compile-equivalent
 and runtime-error rules expose only `error`, while advisory evidence classes
-expose only `warning`. Compile-equivalent errors are unsuppressible and block
-source preflight; runtime-error errors remain inline-suppressible and
-non-blocking because the source may compile and fail only when the expression
-executes. Version 1 evolves additively: new rule entries
-and fields may be added, clients must ignore fields and IDs they do not recognize, and a
-field removal or incompatible meaning change requires a new `schema_version`.
+expose `warning` or `information` as declared by each rule. Compile-equivalent
+errors are unsuppressible and block source preflight; runtime-error errors
+remain inline-suppressible and non-blocking because the source may compile and
+fail only when the expression executes. Version 2 evolves additively from the
+original catalog: new rule
+entries and fields may be added, clients must ignore fields and IDs they do not
+recognize, and a field removal or incompatible meaning change requires a new
+`schema_version`.
 Unavailable, failed, malformed, or unsupported-version metadata must be treated
 as unknown; a client must not infer that an unknown rule is suppressible.
 
 The registry covers normal `VB...` lint/LSP rules and `VBA...` analyzer rules.
 `VBA000` is a synthetic analysis-failure diagnostic rather than a rule, and
-UserForm `FRM...` / `UFY...` diagnostics remain outside schema version 1.
+UserForm `FRM...` / `UFY...` diagnostics remain outside schema version 2.
 
 Workbook lock contention uses the stable error code `workbook_busy`. It fails
 immediately by default and uses the same envelope for every workbook-bound

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fixed inline-suppression Quick Fix discovery with the current v2 rule
+  metadata while retaining fail-closed behavior for unsupported schemas.
+
 ## v0.10.1
 
 - Keep completion, signature help, hover, and definition responsive while Full

--- a/editors/vscode/src/rulesRegistry.ts
+++ b/editors/vscode/src/rulesRegistry.ts
@@ -29,6 +29,11 @@ export type ExecutableResolver = (configured: string) => ResolvedExecutable;
 const rulesTimeoutMs = 5000;
 const resolutionTtlMs = 1000;
 
+// The inline_suppressible field is stable across the v1 and v2 catalog
+// schemas. Keep compatibility with older installed CLIs while rejecting
+// future schemas until their suppression semantics have been reviewed.
+const supportedRulesSchemaVersions = new Set([1, 2]);
+
 export class XlflowRulesRegistryService {
   private cache: { identity: string; rules: ReadonlyMap<string, RuleMetadata> } | undefined;
   private pending:
@@ -198,7 +203,8 @@ export function parseRulesEnvelope(value: unknown): ReadonlyMap<string, RuleMeta
     value.status !== "ok" ||
     value.command !== "rules" ||
     !isObject(rules) ||
-    rules.schema_version !== 1 ||
+    typeof rules.schema_version !== "number" ||
+    !supportedRulesSchemaVersions.has(rules.schema_version) ||
     !Array.isArray(rules.items)
   ) {
     throw new Error("xlflow rules returned an unsupported response schema.");

--- a/editors/vscode/test/suite/extension.test.ts
+++ b/editors/vscode/test/suite/extension.test.ts
@@ -1046,7 +1046,12 @@ async function assertRulesRegistryBehavior(): Promise<void> {
   assert.strictEqual(parsed.get("VB020")?.inlineSuppressible, true);
   assert.strictEqual(parsed.get("VB029")?.inlineSuppressible, false);
   assert.strictEqual(parsed.get("VB059")?.inlineSuppressible, false);
-  assert.throws(() => parseRulesEnvelope(rulesEnvelope([], 2)), /unsupported response schema/);
+  assert.throws(() => parseRulesEnvelope(rulesEnvelope([], 3)), /unsupported response schema/);
+  assert.strictEqual(
+    parseRulesEnvelope(rulesEnvelope([{ id: "VB020", inline_suppressible: true }], 1)).get("VB020")
+      ?.inlineSuppressible,
+    true,
+  );
 
   let executable = "xlflow-one";
   const calls: string[] = [];
@@ -1059,6 +1064,10 @@ async function assertRulesRegistryBehavior(): Promise<void> {
           { id: "VB020", inline_suppressible: true },
           { id: "VB029", inline_suppressible: false },
           { id: "VB059", inline_suppressible: false },
+          { id: "VB066", inline_suppressible: true },
+          { id: "VBA201", inline_suppressible: true },
+          { id: "VBA216", inline_suppressible: false },
+          { id: "VBA249", inline_suppressible: true },
         ]),
       ),
       stderr: "",
@@ -1068,8 +1077,23 @@ async function assertRulesRegistryBehavior(): Promise<void> {
   assert.strictEqual(await service.isInlineSuppressible("vb020"), true);
   assert.strictEqual(await service.isInlineSuppressible("VB029"), false);
   assert.strictEqual(await service.isInlineSuppressible("VB059"), false);
+  assert.strictEqual(await service.isInlineSuppressible("VB066"), true);
+  assert.strictEqual(await service.isInlineSuppressible("VBA201"), true);
+  assert.strictEqual(await service.isInlineSuppressible("VBA216"), false);
+  assert.strictEqual(await service.isInlineSuppressible("VBA249"), true);
   assert.strictEqual(await service.isInlineSuppressible("VB999"), false);
   assert.deepStrictEqual(calls, ["xlflow-one --json rules"]);
+
+  const metadataDiagnostics = ["VB066", "VBA201", "VBA216", "VBA249"].map((code) => {
+    const diagnostic = new vscode.Diagnostic(new vscode.Range(0, 0, 0, 1), code);
+    diagnostic.source = "xlflow";
+    diagnostic.code = code;
+    return diagnostic;
+  });
+  assert.deepStrictEqual(
+    (await inlineSuppressibleDiagnostics(service, metadataDiagnostics)).map(({ code }) => code),
+    ["VB066", "VBA201", "VBA249"],
+  );
 
   executable = "xlflow-two";
   assert.strictEqual(await service.isInlineSuppressible("VB020"), true);
@@ -1119,7 +1143,7 @@ async function assertRulesRegistryBehavior(): Promise<void> {
         exitCode: 0,
         stdout: JSON.stringify(
           attempts === 1
-            ? rulesEnvelope([], 2)
+            ? rulesEnvelope([], 3)
             : rulesEnvelope([{ id: "VBA200", inline_suppressible: true }]),
         ),
         stderr: "",
@@ -1148,7 +1172,7 @@ async function assertRulesRegistryBehavior(): Promise<void> {
   assert.strictEqual(attempts, 1, "one provider batch must attempt registry discovery once");
 }
 
-function rulesEnvelope(items: unknown[], schemaVersion = 1): unknown {
+function rulesEnvelope(items: unknown[], schemaVersion = 2): unknown {
   return {
     status: "ok",
     command: "rules",

--- a/internal/cli/rules_test.go
+++ b/internal/cli/rules_test.go
@@ -10,7 +10,7 @@ import (
 	staticrules "github.com/harumiWeb/xlflow/internal/staticanalysis/rules"
 )
 
-func TestRulesCommandWritesV1JSONEnvelope(t *testing.T) {
+func TestRulesCommandWritesV2JSONEnvelope(t *testing.T) {
 	var stdout bytes.Buffer
 	a := &app{cwd: t.TempDir(), stdout: &stdout, stderr: &bytes.Buffer{}}
 	root := a.rootCommand()

--- a/internal/cli/rules_test.go
+++ b/internal/cli/rules_test.go
@@ -27,7 +27,7 @@ func TestRulesCommandWritesV2JSONEnvelope(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("decode rules JSON: %v\n%s", err, stdout.String())
 	}
-	if got.Status != output.StatusOK || got.Command != "rules" || got.Rules.SchemaVersion != staticrules.SchemaVersion {
+	if got.Status != output.StatusOK || got.Command != "rules" || got.Rules.SchemaVersion != 2 {
 		t.Fatalf("rules envelope = %#v", got)
 	}
 	if len(got.Rules.Items) == 0 || got.Rules.Items[0].ID == "" {

--- a/vitepress/commands/rules.md
+++ b/vitepress/commands/rules.md
@@ -22,7 +22,7 @@ automation needs the complete metadata contract.
   "status": "ok",
   "command": "rules",
   "rules": {
-    "schema_version": 1,
+    "schema_version": 2,
     "items": [
       {
         "id": "VB001",

--- a/vitepress/reference/json-output.md
+++ b/vitepress/reference/json-output.md
@@ -344,7 +344,7 @@ by `id`.
   "status": "ok",
   "command": "rules",
   "rules": {
-    "schema_version": 1,
+    "schema_version": 2,
     "items": [
       {
         "id": "VB001",
@@ -372,7 +372,8 @@ by `id`.
 }
 ```
 
-Version 1 is additive: new rules and fields may appear without changing
+Version 2 adds the `information` severity while retaining the catalog fields and
+suppression semantics. New rules and fields may appear without changing
 `schema_version`, and consumers must ignore fields they do not recognize. A
 breaking field removal or meaning change requires a new version. An unavailable
 command, malformed response, unsupported version, or unknown rule ID means the


### PR DESCRIPTION
## Summary

- Restore VS Code inline per-rule suppression Quick Fix discovery for the current `xlflow rules --json` schema v2.
- Keep compatibility with schema v1 and fail closed for unsupported future schemas.
- Add regression coverage and align the CLI/rule-registry documentation with schema v2.

## Root cause

The CLI publishes `rules.schema_version = 2`, while the extension accepted only schema version 1. Rule metadata loading therefore failed, causing the provider to return no inline suppression actions even for rules marked `inline_suppressible`.

## Tests

- `pnpm --dir editors/vscode test`
- `pnpm --dir editors/vscode run check`
- `pnpm --dir editors/vscode run lint`
- `pnpm run format:check`
- `pnpm run docs:check`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\dev\\go.ps1 test ./internal/cli ./internal/staticanalysis/rules`
- `git diff --check`
- `task review:codex -- -ReviewMode uncommitted` (no findings)

## Notes

- Preflight-blocking rules remain excluded from inline suppression.
- Batch-only rules without LSP diagnostics are unchanged and require separate LSP support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rule catalog schema version 2.
  * Added `information` severity for advisory diagnostics.
  * Preserved inline-suppression behavior across supported schema versions.

* **Bug Fixes**
  * Fixed inline-suppression Quick Fix discovery in VS Code.
  * VS Code now fails safely when metadata is unsupported, unavailable, or lacks confirmed suppression details.

* **Documentation**
  * Updated CLI and JSON output documentation for schema version 2 and the new severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->