### PR TITLE
chore: prepare v0.31.2 and v0.10.2 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to xlflow will be documented in this file.
 
 ## Unreleased
 
+## v0.31.2
+
 - Fixed false-positive `VBA229` findings for early-bound Outlook COM types such
   as `Outlook.Application` and `Outlook.MailItem`. The embedded COM database
   now includes a practical Outlook surface, and

--- a/README.ja.md
+++ b/README.ja.md
@@ -654,8 +654,9 @@ module_top_n = 0
 procedure_score_threshold = 0
 module_score_threshold = 0
 
-# 自動バックアップ保持はデフォルトで無効です。コメントを外すと、設定されたワークブックに対する
-# バックアップ生成を伴うpushとrollbackの成功後に、古いメタデータ付きバックアップを削除します。
+# 自動バックアップ保持はデフォルトで無効です。セクションのコメントを外し、enabled = true にすると、
+# 設定されたワークブックに対するバックアップ生成を伴うpushとrollbackの成功後に、古いメタデータ付き
+# バックアップを削除します。
 # [backup.retention]
 # enabled = false
 # max_count = 20
@@ -715,7 +716,10 @@ disabled_rules = []
 # ]
 disabled_rules = []
 
-# 開発用途で明示的に許可するplain HTTP origin。
+# この正規化された http://host[:port] のorigin完全一致allowlistは、VBA246の
+# plain_http_credentials 検出だけを抑制します。HTTPリクエストを許可するものではなく、
+# credentials_in_url、authorization_logging、TLS/証明書、sensitive_module_constant、
+# download_and_execute の検出は抑制しません。
 development_http_origins = []
 
 # オプションのdataflow対応 analyzerルールはデフォルトで無効です。

--- a/README.ja.md
+++ b/README.ja.md
@@ -135,7 +135,7 @@ pull → fmt → edit → push → lint → test/run → inspect
 > `lint`、`fmt`、一部の `diff`、Go のユニットテストなど、Excel COM を使わない処理は非 Excel 環境でも検証できます。
 
 > [!NOTE]
-> xlflow は COM 操作を .NET bridge で行います。レガシー PowerShell bridge は v0.15.0 で deprecated になり、互換性のための明示 opt-in としてのみ利用できます。v0.16.0 で削除予定です。
+> xlflow は COM 操作を .NET bridge で行います。レガシー PowerShell bridge は v0.16.0 で削除され、対応する bridge mode は `auto` と `dotnet` です。
 
 > [!WARNING]
 > Excel の設定で **VBA プロジェクト オブジェクト モデルへのアクセスを信頼する** を有効にしてください。これが無効だと、Excel がインストールされていても `pull` / `push` / `run` などが失敗する場合があります。
@@ -578,7 +578,7 @@ path = "build/Book.xlsm"
 visible = false
 # Excelの警告ダイアログ（上書き確認など）を抑制します。
 display_alerts = false
-# Excel bridge mode。Valid values: "auto", "dotnet"。"powershell" は deprecated で、v0.16.0 で削除予定です。
+# Excel bridge mode。指定可能な値は "auto" と "dotnet" です。
 bridge = "auto"
 
 # ソースツリーのディレクトリ
@@ -605,6 +605,11 @@ folder_annotation = "update"
 # ソースパスに基づいてデフォルトのフォルダアノテーションを自動的に割り当てます。
 default_component_folders = true
 
+# オプションのErl計測。有効にすると、push時の一時インポートコピーにのみ
+# 行番号を付与し、追跡対象のソースは番号なしのまま維持します。
+# [vba.line_numbers]
+# enabled = true
+
 # ユーザーフォームのソースモード
 [userform]
 # ユーザーフォームのコードビハインドがソースツリーのどこに配置されるか。
@@ -613,14 +618,109 @@ default_component_folders = true
 #   "sidecar" – コードは src/forms/code/<フォーム名>.bas に分離されます。
 code_source = "sidecar"
 
+# リリース用ビルドのソースフィルタリング。これは `build` のみに適用され、
+# `push` と `pack` では常にソースツリー全体が使用されます。
+[build]
+# `xlflow build` から除外するプロジェクトルート相対のdoublestar glob。
+exclude = [
+  "src/modules/Tests/**",
+  "src/modules/Xlflow/XlflowAssert.bas",
+]
+
+# procedureの複雑度メトリクス。
+[metrics]
+# メトリクス収集から除外するプロジェクトルート相対のdoublestar glob。
+exclude = []
+
+# 0はその閾値を無効化し、正の値は厳密な上限値として扱われます。
+[metrics.thresholds]
+cyclomatic_complexity = 0
+max_nesting_depth = 0
+statement_count = 0
+source_line_count = 0
+branch_count = 0
+loop_count = 0
+goto_count = 0
+exit_point_count = 0
+parameter_count = 0
+byref_parameter_count = 0
+local_variable_count = 0
+call_fan_out = 0
+
+# オプションのhotspotランキング。top-Nまたはスコア閾値が0の場合は無効です。
+[metrics.hotspots]
+procedure_top_n = 0
+module_top_n = 0
+procedure_score_threshold = 0
+module_score_threshold = 0
+
+# 自動バックアップ保持はデフォルトで無効です。コメントを外すと、設定されたワークブックに対する
+# バックアップ生成を伴うpushとrollbackの成功後に、古いメタデータ付きバックアップを削除します。
+# [backup.retention]
+# enabled = false
+# max_count = 20
+# max_age_days = 30
+# min_keep = 5
+# max_total_size_mb = 2048
+
+# VBA formatterの設定
+[fmt]
+# xlflow fmtで安全な二項演算子の前後の空白を正規化します。
+operator_spacing = true
+# xlflow fmtで安全なVBA宣言の空白を正規化します。
+declaration_spacing = true
+# VBAキーワードの大文字・小文字を正規化します。
+keyword_casing = true
+# 既知のVBA/Excel/Office組み込み識別子の大文字・小文字を正規化します。
+builtin_casing = true
+
+# source-preflight診断のwaiver
+[preflight]
+# ここで許可した診断も表示されますが、source-preflightをブロックする効果だけを
+# 解除します。Excel/VBEのコンパイルが失敗する可能性は残ります。
+allowed_diagnostics = []
+
 # 静的解析ルール
 [lint]
 # 診断 ID で特定の lint ルールを無効化します。
+#
+# 例:
+# disabled_rules = [
+#   "VB006", # このレガシープロジェクトでpublicなモジュールフィールドを許可します。
+# ]
 disabled_rules = []
 
+# VB020（未使用ローカル変数）の警告はデフォルトで有効です。
+# スクラッチ用ローカル変数を意図的に残すプロジェクトでは disabled_rules に "VB020" を追加します。
+#
+# プロジェクト全体に適用するオプションのlintルールです。callback中心または
+# workbook駆動のVBAではノイズになりやすいため、デフォルトでは無効です。
+# 個別の設定のコメントを外して有効化してください。
+# detect_scope_shadowing = true          # VB018
+# detect_unused_private_procedures = true # VB021
+# detect_nested_with_ambiguity = true    # VB027
+
+# オプションのprocedure名定数チェック（VB044）。
+# [lint.procedure_name_constant]
+# enabled = true
+# constant_name = "PROCEDURE_NAME"
+
+# runtime-risk analyzerルール
 [analyze]
 # 診断 ID で特定の analyzer ルールを無効化します。
+#
+# 例:
+# disabled_rules = [
+#   "VBA205", # このレガシープロジェクトでactive worksheet依存を許可します。
+# ]
 disabled_rules = []
+
+# 開発用途で明示的に許可するplain HTTP origin。
+development_http_origins = []
+
+# オプションのdataflow対応 analyzerルールはデフォルトで無効です。
+# FunctionおよびProperty Getのreturn pathを検査するには、次の設定のコメントを外してください。
+# detect_function_return_path = true # VBA210
 ```
 
 `project.entry` は `xlflow run` の macro 名を省略した場合に使われます。

--- a/README.md
+++ b/README.md
@@ -683,9 +683,9 @@ module_top_n = 0
 procedure_score_threshold = 0
 module_score_threshold = 0
 
-# Automatic backup retention is disabled by default. Uncomment to prune old
-# metadata-backed backups for the configured workbook after successful backup-
-# producing push and rollback operations.
+# Automatic backup retention is disabled by default. Uncomment the section and
+# set enabled = true to prune old metadata-backed backups for the configured
+# workbook after successful backup-producing push and rollback operations.
 # [backup.retention]
 # enabled = false
 # max_count = 20
@@ -740,7 +740,10 @@ disabled_rules = []
 # Disable specific analyzer rules by diagnostic ID.
 disabled_rules = []
 
-# Plain HTTP origins explicitly allowed for development use.
+# This exact normalized http://host[:port] allowlist only suppresses VBA246
+# plain_http_credentials findings. It does not permit HTTP requests or suppress
+# credentials_in_url, authorization_logging, TLS/certificate,
+# sensitive_module_constant, or download_and_execute findings.
 development_http_origins = []
 
 # Optional dataflow-sensitive analyzer rules are disabled by default.

--- a/README.md
+++ b/README.md
@@ -634,6 +634,11 @@ folder_annotation = "update"
 # Automatically assign default folder annotations based on source paths.
 default_component_folders = true
 
+# Optional Erl instrumentation. When enabled, push numbers only temporary
+# import copies; tracked source remains unnumbered.
+# [vba.line_numbers]
+# enabled = true
+
 # UserForm source mode.
 [userform]
 # Where UserForm code-behind lives in the source tree.
@@ -642,7 +647,45 @@ default_component_folders = true
 #   "sidecar" – code is split into src/forms/code/<FormName>.bas.
 code_source = "sidecar"
 
-# Automatic backup retention is disabled by default.
+# Release build source filtering. This affects `build` only; `push` and `pack`
+# always use the complete source tree.
+[build]
+# Project-root-relative doublestar globs excluded from `xlflow build`.
+exclude = [
+  "src/modules/Tests/**",
+  "src/modules/Xlflow/XlflowAssert.bas",
+]
+
+# Procedure complexity metrics.
+[metrics]
+# Project-root-relative doublestar globs excluded from metric collection.
+exclude = []
+
+# A value of zero disables that threshold; positive values are strict upper bounds.
+[metrics.thresholds]
+cyclomatic_complexity = 0
+max_nesting_depth = 0
+statement_count = 0
+source_line_count = 0
+branch_count = 0
+loop_count = 0
+goto_count = 0
+exit_point_count = 0
+parameter_count = 0
+byref_parameter_count = 0
+local_variable_count = 0
+call_fan_out = 0
+
+# Optional hotspot ranking. A zero top-N or score threshold disables it.
+[metrics.hotspots]
+procedure_top_n = 0
+module_top_n = 0
+procedure_score_threshold = 0
+module_score_threshold = 0
+
+# Automatic backup retention is disabled by default. Uncomment to prune old
+# metadata-backed backups for the configured workbook after successful backup-
+# producing push and rollback operations.
 # [backup.retention]
 # enabled = false
 # max_count = 20
@@ -650,14 +693,59 @@ code_source = "sidecar"
 # min_keep = 5
 # max_total_size_mb = 2048
 
+# VBA formatter settings.
+[fmt]
+# Normalize spacing around safe binary operators in xlflow fmt.
+operator_spacing = true
+# Normalize spacing in safe VBA declarations in xlflow fmt.
+declaration_spacing = true
+# Normalize VBA keyword casing in xlflow fmt.
+keyword_casing = true
+# Normalize known VBA/Excel/Office built-in identifier casing in xlflow fmt.
+builtin_casing = true
+
+# Source-preflight diagnostic waivers.
+[preflight]
+# Diagnostics remain enabled and visible when allowed here; only their
+# source-preflight blocking effect is waived. Excel/VBE compilation may still fail.
+allowed_diagnostics = []
+
 # Static analysis rules.
 [lint]
 # Disable specific lint rules by diagnostic ID.
+#
+# Example:
+# disabled_rules = [
+#   "VB006", # Allow public module-level fields in this legacy project.
+# ]
 disabled_rules = []
 
+# VB020 unused-local-variable warnings are enabled by default.
+# Add "VB020" to disabled_rules if a project intentionally keeps scratch locals.
+#
+# Optional project-wide lint rules. They are disabled by default because
+# they can be noisy in projects with callback-heavy or workbook-driven VBA.
+# Uncomment individual rules to enable them.
+# detect_scope_shadowing = true          # VB018
+# detect_unused_private_procedures = true # VB021
+# detect_nested_with_ambiguity = true    # VB027
+
+# Optional local procedure-name constant check (VB044).
+# [lint.procedure_name_constant]
+# enabled = true
+# constant_name = "PROCEDURE_NAME"
+
+# Runtime-risk analysis rules.
 [analyze]
 # Disable specific analyzer rules by diagnostic ID.
 disabled_rules = []
+
+# Plain HTTP origins explicitly allowed for development use.
+development_http_origins = []
+
+# Optional dataflow-sensitive analyzer rules are disabled by default.
+# Uncomment the following setting to check Function and Property Get return paths.
+# detect_function_return_path = true # VBA210
 ```
 
 `project.entry` is used when `xlflow run` is invoked without a macro name.

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.10.2
+
 - Fixed inline-suppression Quick Fix discovery with the current v2 rule
   metadata while retaining fail-closed behavior for unsupported schemas.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xlflow-vscode",
   "displayName": "%extension.displayName%",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "%extension.description%",
   "categories": [
     "Formatters",


### PR DESCRIPTION
## Summary

- Update the `xlflow.toml` examples in `README.md` and `README.ja.md` to match the current scaffold output, including build, metrics, formatting, preflight, lint, analyze, backup, and line-number settings.
- Correct the stale Japanese documentation for the supported bridge modes.
- Prepare the patch releases `xlflow v0.31.2` and VS Code extension `v0.10.2` by updating both changelogs and the extension package version.

## Tests

- `rtk pnpm format:check`
- `rtk pnpm docs:check`
- `rtk proxy powershell -NoProfile -ExecutionPolicy Bypass -Command '& .\\scripts\\dev\\go.ps1 test ./... -count=1'`
- `rtk proxy dotnet test bridge/dotnet/tests/Xlflow.ExcelBridge.Tests/Xlflow.ExcelBridge.Tests.csproj` (437 passed)
- `rtk pnpm --dir editors/vscode check`
- `rtk pnpm --dir editors/vscode lint`
- `rtk pnpm --dir editors/vscode test`
- `rtk pnpm --dir editors/vscode package` (VSIX manifest verified as `0.10.2`; generated artifact removed after inspection)

## Release notes

- After merge, create the CLI tag `v0.31.2` for the tag-driven release workflow.
- Publish the VS Code extension package at version `0.10.2` after merge.
- This PR does not create a tag, GitHub Release, or Marketplace publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded configuration guidance for build filtering, complexity metrics, hotspot analysis, formatting, preflight checks, backup retention, linting, and analysis options.
  - Documented optional Erl line-number instrumentation.
  - Clarified supported bridge modes and the limited scope of the development HTTP origins allowlist.

- **Release Updates**
  - Added release entries for the main project and VS Code extension.
  - Updated the VS Code extension version to 0.10.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->