### PR TITLE
refactor: modernize coordination sorting

### DIFF
--- a/internal/coordination/recovery.go
+++ b/internal/coordination/recovery.go
@@ -1,13 +1,14 @@
 package coordination
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 )
@@ -157,7 +158,7 @@ func (m *Manager) ListRecoveries() ([]RecoveryEntry, error) {
 		}
 		result = append(result, RecoveryEntry{LockID: lockID, State: state})
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i].LockID < result[j].LockID })
+	slices.SortFunc(result, func(a, b RecoveryEntry) int { return cmp.Compare(a.LockID, b.LockID) })
 	return result, nil
 }
 

--- a/internal/coordination/registry.go
+++ b/internal/coordination/registry.go
@@ -1,8 +1,9 @@
 package coordination
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -109,7 +110,7 @@ func All() []Descriptor {
 	for i, descriptor := range descriptors {
 		result[i] = cloneDescriptor(descriptor)
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	slices.SortFunc(result, func(a, b Descriptor) int { return cmp.Compare(a.ID, b.ID) })
 	return result
 }
 
@@ -126,7 +127,7 @@ func PublicCapabilities() Capabilities {
 		for _, selector := range descriptor.CLI {
 			paths = append(paths, normalizeCLIPath(selector.Path))
 		}
-		sort.Strings(paths)
+		slices.Sort(paths)
 		result.Commands[descriptor.ID] = CommandCapability{
 			CLIPaths:          paths,
 			ResourceScope:     descriptor.Policy.ResourceScope,
@@ -178,7 +179,7 @@ func bridgeDisplayValue(command string, args map[string]string) string {
 	for key := range args {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	parts := make([]string, 0, len(keys)+1)
 	parts = append(parts, command)
 	for _, key := range keys {
@@ -250,7 +251,7 @@ func bridgeSelectorKey(selector BridgeSelector) string {
 	for key := range selector.Args {
 		keys = append(keys, strings.ToLower(strings.TrimSpace(key)))
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	parts := []string{strings.ToLower(strings.TrimSpace(selector.Command))}
 	for _, key := range keys {
 		var value string


### PR DESCRIPTION
## Summary

- Modernize coordination sorting for Go 1.26.6 with typed `slices.SortFunc` and `cmp.Compare`.
- Replace type-specific string sorting with generic `slices.Sort` while preserving deterministic ordering and defensive-copy behavior.

## Tests

- `rtk powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\go.ps1 test ./... -count=1`
- `rtk task lint`
- `rtk pnpm format:check`
- `rtk git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal sorting implementation while preserving existing ordering and behavior.
  * No user-visible functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->